### PR TITLE
feat: business metrics, analyst bootstrap, metadata writer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,7 +170,7 @@ Auth providers in `app/auth/` (FastAPI-based):
 ## Key Implementation Details
 
 ### DuckDB Schema (src/db.py)
-- Schema v3 with auto-migration from v1→v2→v3
+- Schema v4 with auto-migration from v1→v2→v3→v4
 - `table_registry`: id, name, source_type, bucket, source_table, query_mode, sync_schedule, etc.
 - `sync_state`, `sync_history`: track extraction progress
 - `users`, `dataset_permissions`, `audit_log`: auth + RBAC

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,22 @@ curl -X POST http://localhost:8000/api/sync/trigger
 docker compose up
 ```
 
+## Business Metrics
+
+Standardized metric definitions live in DuckDB (`metric_definitions` table). Import starter pack:
+
+```bash
+da metrics import docs/metrics/
+```
+
+### For AI agents analyzing data:
+Before computing any business metric, look up the canonical definition:
+1. `da metrics list` — find the relevant metric
+2. `da metrics show revenue/mrr` — read the SQL and business rules
+3. Use the SQL from the metric definition, adapt to the specific question
+
+Never invent metric calculations — always use the canonical definitions.
+
 ## Extensibility
 
 ### Data Sources (extract.duckdb contract)

--- a/app/api/catalog.py
+++ b/app/api/catalog.py
@@ -1,11 +1,9 @@
 """Catalog endpoints — table profiles, metrics."""
 
 import json
-import re
 
 from fastapi import APIRouter, Depends, HTTPException
 import duckdb
-import yaml
 
 from app.auth.dependencies import get_current_user, _get_db
 from app.utils import get_data_dir as _get_data_dir
@@ -70,30 +68,15 @@ async def list_catalog_tables(
     return {"tables": tables, "count": len(tables)}
 
 
-@router.get("/metrics/{metric_path:path}")
+@router.get("/metrics/{metric_path:path}", deprecated=True)
 async def get_metric(
     metric_path: str,
     user: dict = Depends(get_current_user),
 ):
-    """Get a metric YAML definition parsed as structured JSON."""
-    if not re.match(r"^[a-z_]+/[a-z_]+\.yml$", metric_path):
-        raise HTTPException(status_code=400, detail="Invalid metric path")
-
-    docs_dir = _get_data_dir() / "docs" / "metrics"
-    file_path = docs_dir / metric_path
-
-    if not file_path.is_file():
-        raise HTTPException(status_code=404, detail="Metric file not found")
-
-    # Security: ensure path doesn't escape docs dir
-    if not file_path.resolve().is_relative_to(docs_dir.resolve()):
-        raise HTTPException(status_code=400, detail="Invalid path")
-
-    try:
-        content = yaml.safe_load(file_path.read_text())
-        return content
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error parsing metric: {e}")
+    """Deprecated: use GET /api/metrics/{metric_id} instead."""
+    from fastapi.responses import RedirectResponse
+    metric_id = metric_path.replace(".yml", "")
+    return RedirectResponse(url=f"/api/metrics/{metric_id}", status_code=301)
 
 
 @router.post("/profile/{table_name}/refresh")

--- a/app/api/metadata.py
+++ b/app/api/metadata.py
@@ -97,32 +97,33 @@ async def push_metadata_to_source(
     pushed = 0
     errors = []
 
-    for col in columns:
-        column_name = col["column_name"]
-        metadata_payload = []
+    async with httpx.AsyncClient() as client:
+        for col in columns:
+            column_name = col["column_name"]
+            metadata_payload = []
 
-        if col.get("basetype"):
-            metadata_payload.append({"key": "KBC.datatype.basetype", "value": col["basetype"]})
-        if col.get("description"):
-            metadata_payload.append({"key": "KBC.description", "value": col["description"]})
+            if col.get("basetype"):
+                metadata_payload.append({"key": "KBC.datatype.basetype", "value": col["basetype"]})
+            if col.get("description"):
+                metadata_payload.append({"key": "KBC.description", "value": col["description"]})
 
-        if not metadata_payload:
-            continue
+            if not metadata_payload:
+                continue
 
-        endpoint = f"{stack_url}/v2/storage/tables/{source_table}/columns/{column_name}/metadata"
-        try:
-            resp = httpx.post(
-                endpoint,
-                headers={"X-StorageApi-Token": token},
-                json={"provider": "ai-metadata-enrichment", "metadata": metadata_payload},
-                timeout=30,
-            )
-            if resp.status_code in (200, 201):
-                pushed += 1
-            else:
-                errors.append(f"{column_name}: {resp.status_code} {resp.text[:200]}")
-        except httpx.RequestError as e:
-            errors.append(f"{column_name}: request error — {e}")
+            endpoint = f"{stack_url}/v2/storage/tables/{source_table}/columns/{column_name}/metadata"
+            try:
+                resp = await client.post(
+                    endpoint,
+                    headers={"X-StorageApi-Token": token},
+                    json={"provider": "ai-metadata-enrichment", "metadata": metadata_payload},
+                    timeout=30,
+                )
+                if resp.status_code in (200, 201):
+                    pushed += 1
+                else:
+                    errors.append(f"{column_name}: {resp.status_code} {resp.text[:200]}")
+            except httpx.RequestError as e:
+                errors.append(f"{column_name}: request error — {e}")
 
     result = {"status": "ok", "pushed": pushed}
     if errors:

--- a/app/api/metadata.py
+++ b/app/api/metadata.py
@@ -1,0 +1,130 @@
+"""Column metadata API endpoints — CRUD and Keboola push."""
+
+import logging
+import os
+from typing import List, Optional
+
+import duckdb
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from app.auth.dependencies import get_current_user, require_admin, _get_db
+from src.repositories.column_metadata import ColumnMetadataRepository
+from src.repositories.table_registry import TableRegistryRepository
+
+logger = logging.getLogger(__name__)
+router = APIRouter(tags=["metadata"])
+
+
+class ColumnMetadataItem(BaseModel):
+    column_name: str
+    basetype: Optional[str] = None
+    description: Optional[str] = None
+    confidence: str = "manual"
+
+
+class ColumnMetadataSave(BaseModel):
+    columns: List[ColumnMetadataItem]
+
+
+@router.get("/api/admin/metadata/{table_id}")
+async def get_table_metadata(
+    table_id: str,
+    user: dict = Depends(get_current_user),
+    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
+):
+    """Return column metadata for a table."""
+    repo = ColumnMetadataRepository(conn)
+    columns = repo.list_for_table(table_id)
+    return {"table_id": table_id, "columns": columns}
+
+
+@router.post("/api/admin/metadata/{table_id}")
+async def save_table_metadata(
+    table_id: str,
+    body: ColumnMetadataSave,
+    user: dict = Depends(require_admin),
+    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
+):
+    """Save column metadata for a table. Admin only."""
+    repo = ColumnMetadataRepository(conn)
+    for item in body.columns:
+        repo.save(
+            table_id=table_id,
+            column_name=item.column_name,
+            basetype=item.basetype,
+            description=item.description,
+            confidence=item.confidence,
+        )
+    return {"status": "ok", "count": len(body.columns)}
+
+
+@router.post("/api/admin/metadata/{table_id}/push")
+async def push_metadata_to_source(
+    table_id: str,
+    user: dict = Depends(require_admin),
+    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
+):
+    """Push column metadata to Keboola Storage API. Admin only."""
+    registry_repo = TableRegistryRepository(conn)
+    table = registry_repo.get(table_id)
+    if not table:
+        raise HTTPException(status_code=404, detail=f"Table not found: {table_id}")
+
+    source_type = table.get("source_type", "")
+    if source_type != "keboola":
+        raise HTTPException(
+            status_code=400,
+            detail=f"Push is only supported for keboola tables (table source_type={source_type!r})",
+        )
+
+    source_table = table.get("source_table") or table_id
+    stack_url = os.environ.get("KBC_STACK_URL", "").rstrip("/")
+    token = os.environ.get("KBC_STORAGE_TOKEN", "")
+
+    if not stack_url or not token:
+        raise HTTPException(
+            status_code=500,
+            detail="KBC_STACK_URL and KBC_STORAGE_TOKEN must be set",
+        )
+
+    metadata_repo = ColumnMetadataRepository(conn)
+    columns = metadata_repo.list_for_table(table_id)
+    if not columns:
+        return {"status": "ok", "pushed": 0, "message": "No column metadata to push"}
+
+    pushed = 0
+    errors = []
+
+    for col in columns:
+        column_name = col["column_name"]
+        metadata_payload = []
+
+        if col.get("basetype"):
+            metadata_payload.append({"key": "KBC.datatype.basetype", "value": col["basetype"]})
+        if col.get("description"):
+            metadata_payload.append({"key": "KBC.description", "value": col["description"]})
+
+        if not metadata_payload:
+            continue
+
+        endpoint = f"{stack_url}/v2/storage/tables/{source_table}/columns/{column_name}/metadata"
+        try:
+            resp = httpx.post(
+                endpoint,
+                headers={"X-StorageApi-Token": token},
+                json={"provider": "ai-metadata-enrichment", "metadata": metadata_payload},
+                timeout=30,
+            )
+            if resp.status_code in (200, 201):
+                pushed += 1
+            else:
+                errors.append(f"{column_name}: {resp.status_code} {resp.text[:200]}")
+        except httpx.RequestError as e:
+            errors.append(f"{column_name}: request error — {e}")
+
+    result = {"status": "ok", "pushed": pushed}
+    if errors:
+        result["errors"] = errors
+    return result

--- a/app/api/metrics.py
+++ b/app/api/metrics.py
@@ -1,9 +1,12 @@
 """Metrics API endpoints — CRUD for metric definitions stored in DuckDB."""
 
+import os
+import tempfile
 from typing import List, Optional
 
 import duckdb
-from fastapi import APIRouter, Depends, HTTPException
+import yaml
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from pydantic import BaseModel
 
 from app.auth.dependencies import get_current_user, require_admin, _get_db
@@ -106,3 +109,24 @@ async def delete_metric(
     if not deleted:
         raise HTTPException(status_code=404, detail=f"Metric '{metric_id}' not found")
     return {"status": "deleted", "id": metric_id}
+
+
+@router.post("/api/admin/metrics/import", status_code=200)
+async def import_metrics(
+    file: UploadFile = File(...),
+    user: dict = Depends(require_admin),
+    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
+):
+    """Import metrics from uploaded YAML file."""
+    content = await file.read()
+
+    with tempfile.NamedTemporaryFile(suffix=".yml", delete=False, mode="wb") as tmp:
+        tmp.write(content)
+        tmp_path = tmp.name
+
+    try:
+        repo = MetricRepository(conn)
+        count = repo.import_from_yaml(tmp_path)
+        return {"status": "imported", "count": count}
+    finally:
+        os.unlink(tmp_path)

--- a/app/api/metrics.py
+++ b/app/api/metrics.py
@@ -1,7 +1,5 @@
 """Metrics API endpoints — CRUD for metric definitions stored in DuckDB."""
 
-import os
-import tempfile
 from typing import List, Optional
 
 import duckdb
@@ -119,14 +117,60 @@ async def import_metrics(
 ):
     """Import metrics from uploaded YAML file."""
     content = await file.read()
-
-    with tempfile.NamedTemporaryFile(suffix=".yml", delete=False, mode="wb") as tmp:
-        tmp.write(content)
-        tmp_path = tmp.name
-
     try:
-        repo = MetricRepository(conn)
-        count = repo.import_from_yaml(tmp_path)
-        return {"status": "imported", "count": count}
-    finally:
-        os.unlink(tmp_path)
+        data = yaml.safe_load(content)
+    except yaml.YAMLError as e:
+        raise HTTPException(status_code=400, detail=f"Invalid YAML: {e}")
+
+    if not data:
+        raise HTTPException(status_code=400, detail="Empty YAML file")
+
+    metric_list = data if isinstance(data, list) else [data]
+    repo = MetricRepository(conn)
+    count = 0
+
+    for metric in metric_list:
+        if not isinstance(metric, dict):
+            continue
+        name = metric.get("name")
+        category = metric.get("category")
+        if not name or not category:
+            raise HTTPException(
+                status_code=400,
+                detail="Each metric must have 'name' and 'category' fields",
+            )
+
+        metric_id = f"{category}/{name}"
+        table_name = metric.pop("table", None) or metric.get("table_name")
+
+        # Collect sql_by_* variants
+        sql_variants = {}
+        for key in list(metric.keys()):
+            if key.startswith("sql_by_"):
+                sql_variants[key[4:]] = metric.pop(key)
+
+        repo.create(
+            id=metric_id,
+            name=name,
+            display_name=metric.get("display_name", name),
+            category=category,
+            description=metric.get("description"),
+            type=metric.get("type", "sum"),
+            unit=metric.get("unit"),
+            grain=metric.get("grain", "monthly"),
+            table_name=table_name,
+            tables=metric.get("tables"),
+            expression=metric.get("expression"),
+            time_column=metric.get("time_column"),
+            dimensions=metric.get("dimensions"),
+            filters=metric.get("filters"),
+            synonyms=metric.get("synonyms"),
+            notes=metric.get("notes"),
+            sql=metric.get("sql", ""),
+            sql_variants=sql_variants if sql_variants else None,
+            validation=metric.get("validation"),
+            source="yaml_import",
+        )
+        count += 1
+
+    return {"status": "imported", "count": count}

--- a/app/api/metrics.py
+++ b/app/api/metrics.py
@@ -1,0 +1,108 @@
+"""Metrics API endpoints — CRUD for metric definitions stored in DuckDB."""
+
+from typing import List, Optional
+
+import duckdb
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from app.auth.dependencies import get_current_user, require_admin, _get_db
+from src.repositories.metrics import MetricRepository
+
+router = APIRouter(tags=["metrics"])
+
+
+class MetricCreate(BaseModel):
+    id: str
+    name: str
+    display_name: str
+    category: str
+    sql: str
+    description: Optional[str] = None
+    type: str = "sum"
+    unit: Optional[str] = None
+    grain: str = "monthly"
+    table_name: Optional[str] = None
+    tables: Optional[List[str]] = None
+    expression: Optional[str] = None
+    time_column: Optional[str] = None
+    dimensions: Optional[List[str]] = None
+    filters: Optional[List[str]] = None
+    synonyms: Optional[List[str]] = None
+    notes: Optional[List[str]] = None
+    sql_variants: Optional[dict] = None
+    validation: Optional[dict] = None
+    source: str = "manual"
+
+
+@router.get("/api/metrics")
+async def list_metrics(
+    category: Optional[str] = None,
+    user: dict = Depends(get_current_user),
+    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
+):
+    """List all metric definitions, optionally filtered by category."""
+    repo = MetricRepository(conn)
+    metrics = repo.list(category=category)
+    return {"metrics": metrics, "count": len(metrics)}
+
+
+@router.get("/api/metrics/{metric_id:path}")
+async def get_metric(
+    metric_id: str,
+    user: dict = Depends(get_current_user),
+    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
+):
+    """Get a single metric definition by ID."""
+    repo = MetricRepository(conn)
+    metric = repo.get(metric_id)
+    if metric is None:
+        raise HTTPException(status_code=404, detail=f"Metric '{metric_id}' not found")
+    return metric
+
+
+@router.post("/api/admin/metrics", status_code=201)
+async def create_or_update_metric(
+    body: MetricCreate,
+    user: dict = Depends(require_admin),
+    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
+):
+    """Create or update a metric definition (admin only)."""
+    repo = MetricRepository(conn)
+    metric = repo.create(
+        id=body.id,
+        name=body.name,
+        display_name=body.display_name,
+        category=body.category,
+        sql=body.sql,
+        description=body.description,
+        type=body.type,
+        unit=body.unit,
+        grain=body.grain,
+        table_name=body.table_name,
+        tables=body.tables,
+        expression=body.expression,
+        time_column=body.time_column,
+        dimensions=body.dimensions,
+        filters=body.filters,
+        synonyms=body.synonyms,
+        notes=body.notes,
+        sql_variants=body.sql_variants,
+        validation=body.validation,
+        source=body.source,
+    )
+    return metric
+
+
+@router.delete("/api/admin/metrics/{metric_id:path}")
+async def delete_metric(
+    metric_id: str,
+    user: dict = Depends(require_admin),
+    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
+):
+    """Delete a metric definition by ID (admin only)."""
+    repo = MetricRepository(conn)
+    deleted = repo.delete(metric_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail=f"Metric '{metric_id}' not found")
+    return {"status": "deleted", "id": metric_id}

--- a/app/auth/dependencies.py
+++ b/app/auth/dependencies.py
@@ -80,3 +80,13 @@ def require_role(minimum_role: Role):
             )
         return user
     return _check
+
+
+async def require_admin(user: dict = Depends(get_current_user)) -> dict:
+    """Dependency: require user is an admin. Raises 403 otherwise."""
+    if user.get("role") != "admin":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin access required",
+        )
+    return user

--- a/app/main.py
+++ b/app/main.py
@@ -27,6 +27,7 @@ from app.api.admin import router as admin_router
 from app.api.permissions import router as permissions_router
 from app.api.access_requests import router as access_requests_router
 from app.api.jira_webhooks import router as jira_webhooks_router
+from app.api.metrics import router as metrics_router
 from app.web.router import router as web_router
 
 logger = logging.getLogger(__name__)
@@ -133,6 +134,7 @@ def create_app() -> FastAPI:
     app.include_router(permissions_router)
     app.include_router(access_requests_router)
     app.include_router(jira_webhooks_router)
+    app.include_router(metrics_router)
 
     # Web UI router (must be last — has catch-all routes)
     app.include_router(web_router)

--- a/app/main.py
+++ b/app/main.py
@@ -28,6 +28,7 @@ from app.api.permissions import router as permissions_router
 from app.api.access_requests import router as access_requests_router
 from app.api.jira_webhooks import router as jira_webhooks_router
 from app.api.metrics import router as metrics_router
+from app.api.metadata import router as metadata_router
 from app.web.router import router as web_router
 
 logger = logging.getLogger(__name__)
@@ -135,6 +136,7 @@ def create_app() -> FastAPI:
     app.include_router(access_requests_router)
     app.include_router(jira_webhooks_router)
     app.include_router(metrics_router)
+    app.include_router(metadata_router)
 
     # Web UI router (must be last — has catch-all routes)
     app.include_router(web_router)

--- a/cli/commands/admin.py
+++ b/cli/commands/admin.py
@@ -161,3 +161,82 @@ def list_tables(as_json: bool = typer.Option(False, "--json")):
         typer.echo(f"Registered tables: {data['count']}")
         for t in data["tables"]:
             typer.echo(f"  {t['name']:30s} src={t.get('source_type','?'):10s} mode={t.get('query_mode','?'):6s} bucket={t.get('bucket',''):20s}")
+
+
+@admin_app.command("metadata-show")
+def metadata_show(
+    table_id: str = typer.Argument(..., help="Table ID to show metadata for"),
+    as_json: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Show column metadata for a table."""
+    resp = api_get(f"/api/admin/metadata/{table_id}")
+    if resp.status_code != 200:
+        typer.echo(f"Failed: {resp.json().get('detail', resp.text)}", err=True)
+        raise typer.Exit(1)
+
+    data = resp.json()
+    if as_json:
+        typer.echo(json.dumps(data, indent=2))
+    else:
+        columns = data.get("columns", [])
+        if not columns:
+            typer.echo(f"No column metadata for table: {table_id}")
+            return
+        typer.echo(f"Column metadata for table: {table_id} ({len(columns)} columns)")
+        typer.echo(f"  {'COLUMN':<30s} {'BASETYPE':<12s} {'CONFIDENCE':<12s} DESCRIPTION")
+        typer.echo("  " + "-" * 80)
+        for col in columns:
+            typer.echo(
+                f"  {col['column_name']:<30s} {col.get('basetype') or '':^12s} "
+                f"{col.get('confidence') or '':^12s} {col.get('description') or ''}"
+            )
+
+
+@admin_app.command("metadata-apply")
+def metadata_apply(
+    proposal_path: str = typer.Argument(..., help="Path to proposal JSON file"),
+    push_to_source: bool = typer.Option(False, "--push-to-source", help="Push metadata to Keboola after import"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Show what would change without applying"),
+):
+    """Apply a metadata proposal JSON to DuckDB."""
+    import os
+
+    if not os.path.exists(proposal_path):
+        typer.echo(f"Proposal file not found: {proposal_path}", err=True)
+        raise typer.Exit(1)
+
+    with open(proposal_path, "r", encoding="utf-8") as f:
+        proposal = json.load(f)
+
+    tables = proposal.get("tables", {})
+    total = sum(len(t.get("columns", {})) for t in tables.values())
+
+    if dry_run:
+        typer.echo(f"[DRY RUN] Would import {total} column(s) from {len(tables)} table(s):")
+        for table_id, table_data in tables.items():
+            columns = table_data.get("columns", {})
+            for col_name, col_data in columns.items():
+                typer.echo(
+                    f"  {table_id}.{col_name}: basetype={col_data.get('basetype')} "
+                    f"description={col_data.get('description')}"
+                )
+        return
+
+    from src.repositories.column_metadata import ColumnMetadataRepository
+    from src.db import get_system_db
+
+    conn = get_system_db()
+    try:
+        repo = ColumnMetadataRepository(conn)
+        count = repo.import_proposal(proposal_path)
+        typer.echo(f"Imported {count} column(s) from proposal.")
+    finally:
+        conn.close()
+
+    if push_to_source:
+        for table_id in tables:
+            resp = api_post(f"/api/admin/metadata/{table_id}/push")
+            if resp.status_code == 200:
+                typer.echo(f"Pushed metadata for {table_id} to source.")
+            else:
+                typer.echo(f"Failed to push {table_id}: {resp.json().get('detail', resp.text)}", err=True)

--- a/cli/commands/analyst.py
+++ b/cli/commands/analyst.py
@@ -1,0 +1,424 @@
+"""Analyst bootstrap commands — da analyst setup, da analyst status."""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlparse
+
+import typer
+
+analyst_app = typer.Typer(help="Analyst workspace bootstrap and status")
+
+# ---------------------------------------------------------------------------
+# Helper: detect existing workspace
+# ---------------------------------------------------------------------------
+
+_CLAUDE_MD_MARKER = "AI Data Analyst"
+
+
+def _detect_existing_project(workspace: Path) -> bool:
+    """Return True if CLAUDE.md with the analyst identifier already exists."""
+    claude_md = workspace / "CLAUDE.md"
+    if claude_md.exists():
+        content = claude_md.read_text(encoding="utf-8")
+        return _CLAUDE_MD_MARKER in content
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Helper: connect to instance (health check + authenticate)
+# ---------------------------------------------------------------------------
+
+def _connect_to_instance(server_url: str) -> str:
+    """Health-check the server, prompt for credentials, save config, return JWT."""
+    import httpx
+    from cli.config import save_config, save_token
+
+    server_url = server_url.rstrip("/")
+
+    # Health check
+    try:
+        resp = httpx.get(f"{server_url}/api/health", timeout=10.0)
+        resp.raise_for_status()
+    except Exception as e:
+        typer.echo(f"Cannot reach {server_url}: {e}", err=True)
+        raise typer.Exit(1)
+
+    typer.echo(f"Connected to {server_url}")
+
+    # Authenticate
+    email = typer.prompt("Email")
+    password = typer.prompt("Password", hide_input=True)
+
+    try:
+        resp = httpx.post(
+            f"{server_url}/auth/token",
+            json={"email": email, "password": password},
+            timeout=15.0,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as e:
+        typer.echo(f"Authentication failed: {e}", err=True)
+        raise typer.Exit(1)
+
+    token = data["access_token"]
+    role = data.get("role", "analyst")
+
+    save_config({"server": server_url})
+    save_token(token, email, role)
+    typer.echo(f"Authenticated as {email} (role: {role})")
+    return token
+
+
+# ---------------------------------------------------------------------------
+# Helper: create workspace directory structure
+# ---------------------------------------------------------------------------
+
+def _create_workspace(workspace: Path) -> None:
+    """Create the analyst workspace directory layout."""
+    dirs = [
+        workspace / "data" / "parquet",
+        workspace / "data" / "duckdb",
+        workspace / "data" / "metadata",
+        workspace / "user" / "artifacts",
+        workspace / "user" / "sessions",
+        workspace / ".claude",
+    ]
+    for d in dirs:
+        d.mkdir(parents=True, exist_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Helper: download metadata
+# ---------------------------------------------------------------------------
+
+def _download_metadata(workspace: Path, server_url: str, token: str) -> None:
+    """Fetch catalog tables and metrics from the server; save as JSON files."""
+    import httpx
+
+    server_url = server_url.rstrip("/")
+    headers = {"Authorization": f"Bearer {token}"}
+    metadata_dir = workspace / "data" / "metadata"
+
+    # Catalog tables
+    try:
+        resp = httpx.get(f"{server_url}/api/catalog/tables", headers=headers, timeout=30.0)
+        resp.raise_for_status()
+        tables = resp.json()
+    except Exception as e:
+        typer.echo(f"Warning: could not fetch catalog tables: {e}", err=True)
+        tables = []
+
+    (metadata_dir / "schema.json").write_text(
+        json.dumps(tables, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+
+    # Metrics
+    try:
+        resp = httpx.get(f"{server_url}/api/metrics", headers=headers, timeout=30.0)
+        resp.raise_for_status()
+        metrics = resp.json()
+    except Exception as e:
+        typer.echo(f"Warning: could not fetch metrics: {e}", err=True)
+        metrics = []
+
+    (metadata_dir / "metrics.json").write_text(
+        json.dumps(metrics, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+
+    # Write last_sync timestamp
+    last_sync = {"synced_at": datetime.now(timezone.utc).isoformat()}
+    (metadata_dir / "last_sync.json").write_text(
+        json.dumps(last_sync, indent=2), encoding="utf-8"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper: download parquet data
+# ---------------------------------------------------------------------------
+
+def _download_data(workspace: Path, server_url: str, token: str) -> int:
+    """Stream parquets for each registered table. Returns count of files downloaded."""
+    import httpx
+
+    server_url = server_url.rstrip("/")
+    headers = {"Authorization": f"Bearer {token}"}
+    parquet_dir = workspace / "data" / "parquet"
+
+    # Fetch manifest to know which tables exist
+    try:
+        resp = httpx.get(f"{server_url}/api/sync/manifest", headers=headers, timeout=30.0)
+        resp.raise_for_status()
+        manifest = resp.json()
+    except Exception as e:
+        typer.echo(f"Warning: could not fetch data manifest: {e}", err=True)
+        return 0
+
+    tables = manifest.get("tables", {})
+    downloaded = 0
+
+    for table_id in tables:
+        target = parquet_dir / f"{table_id}.parquet"
+        if target.exists():
+            typer.echo(f"  Skipping {table_id} (already exists)")
+            continue
+
+        try:
+            with httpx.stream(
+                "GET",
+                f"{server_url}/api/data/{table_id}/download",
+                headers=headers,
+                timeout=300.0,
+            ) as stream_resp:
+                stream_resp.raise_for_status()
+                with open(target, "wb") as fh:
+                    for chunk in stream_resp.iter_bytes(chunk_size=65536):
+                        fh.write(chunk)
+            downloaded += 1
+            typer.echo(f"  Downloaded {table_id}")
+        except Exception as e:
+            typer.echo(f"  Warning: could not download {table_id}: {e}", err=True)
+
+    return downloaded
+
+
+# ---------------------------------------------------------------------------
+# Helper: initialise DuckDB
+# ---------------------------------------------------------------------------
+
+def _initialize_duckdb(workspace: Path) -> int:
+    """Create DuckDB views over parquets. Returns total row count across all views."""
+    import duckdb
+
+    parquet_dir = workspace / "data" / "parquet"
+    db_path = workspace / "data" / "duckdb" / "analytics.duckdb"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    conn = duckdb.connect(str(db_path))
+    total_rows = 0
+
+    for pq_file in parquet_dir.glob("*.parquet"):
+        view_name = pq_file.stem
+        abs_path = str(pq_file.resolve())
+        try:
+            conn.execute(f'DROP VIEW IF EXISTS "{view_name}"')
+            conn.execute(
+                f"CREATE VIEW \"{view_name}\" AS SELECT * FROM read_parquet('{abs_path}')"
+            )
+            count = conn.execute(f'SELECT count(*) FROM "{view_name}"').fetchone()[0]
+            total_rows += count
+        except Exception as e:
+            typer.echo(f"  Warning: could not create view for {view_name}: {e}", err=True)
+
+    conn.close()
+    return total_rows
+
+
+# ---------------------------------------------------------------------------
+# Helper: resolve instance name
+# ---------------------------------------------------------------------------
+
+def _get_instance_name(server_url: str, token: str) -> str:
+    """Retrieve instance name from /api/health, fall back to hostname."""
+    import httpx
+
+    server_url = server_url.rstrip("/")
+    headers = {"Authorization": f"Bearer {token}"}
+
+    try:
+        resp = httpx.get(f"{server_url}/api/health", headers=headers, timeout=10.0)
+        if resp.status_code == 200:
+            data = resp.json()
+            name = data.get("instance_name") or data.get("name")
+            if name:
+                return name
+    except Exception:
+        pass
+
+    # Fall back to hostname extracted from URL
+    parsed = urlparse(server_url)
+    return parsed.hostname or "AI Data Analyst"
+
+
+# ---------------------------------------------------------------------------
+# Helper: generate CLAUDE.md from template
+# ---------------------------------------------------------------------------
+
+def _generate_claude_md(
+    workspace: Path,
+    instance_name: str,
+    server_url: str,
+    sync_interval: str,
+) -> None:
+    """Write CLAUDE.md from the template; create CLAUDE.local.md if absent."""
+    # Locate template relative to this file (../../config/claude_md_template.txt)
+    here = Path(__file__).parent
+    template_path = here.parent.parent / "config" / "claude_md_template.txt"
+
+    if template_path.exists():
+        template = template_path.read_text(encoding="utf-8")
+    else:
+        # Fallback minimal template
+        template = (
+            "# {instance_name} — AI Data Analyst\n\n"
+            "This workspace is connected to {server_url}.\n\n"
+            "- Data on the server refreshes every {sync_interval}\n"
+        )
+
+    content = (
+        template
+        .replace("{instance_name}", instance_name)
+        .replace("{server_url}", server_url)
+        .replace("{sync_interval}", sync_interval)
+    )
+
+    (workspace / "CLAUDE.md").write_text(content, encoding="utf-8")
+
+    # .claude/CLAUDE.local.md — never overwrite if it already exists
+    local_md = workspace / ".claude" / "CLAUDE.local.md"
+    if not local_md.exists():
+        local_md.write_text(
+            "# My Notes\n\n"
+            "Personal notes for this workspace. Uploaded to the server on `da sync --upload-only`.\n",
+            encoding="utf-8",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helper: data freshness check (for returning-session detection)
+# ---------------------------------------------------------------------------
+
+def _check_data_freshness(workspace: Path) -> str:
+    """Return 'fresh', 'stale' (>24 h old), or 'missing'."""
+    last_sync_file = workspace / "data" / "metadata" / "last_sync.json"
+    if not last_sync_file.exists():
+        return "missing"
+
+    try:
+        data = json.loads(last_sync_file.read_text(encoding="utf-8"))
+        synced_at_str = data.get("synced_at", "")
+        if not synced_at_str:
+            return "missing"
+        synced_at = datetime.fromisoformat(synced_at_str)
+        age_hours = (datetime.now(timezone.utc) - synced_at).total_seconds() / 3600
+        return "stale" if age_hours > 24 else "fresh"
+    except Exception:
+        return "missing"
+
+
+# ---------------------------------------------------------------------------
+# Command: da analyst setup
+# ---------------------------------------------------------------------------
+
+@analyst_app.command()
+def setup(
+    server_url: str = typer.Option(..., "--server-url", help="URL of the AI Data Analyst server"),
+    force: bool = typer.Option(False, "--force", help="Re-initialise even if workspace already exists"),
+    sync_interval: str = typer.Option("1 hour", "--sync-interval", help="Data refresh interval shown in CLAUDE.md"),
+    workspace_dir: Optional[str] = typer.Option(None, "--workspace", help="Workspace directory (default: current dir)"),
+):
+    """Bootstrap a new analyst workspace from a remote server."""
+    workspace = Path(workspace_dir).resolve() if workspace_dir else Path.cwd()
+
+    # 1. Detect existing project
+    if _detect_existing_project(workspace) and not force:
+        typer.echo(
+            "Existing analyst workspace detected. Use --force to re-initialise.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    typer.echo(f"Setting up analyst workspace in: {workspace}")
+
+    # 2. Connect to instance
+    token = _connect_to_instance(server_url)
+
+    # 3. Create workspace directory structure
+    typer.echo("Creating workspace directories...")
+    _create_workspace(workspace)
+
+    # 4. Download metadata
+    typer.echo("Downloading metadata...")
+    _download_metadata(workspace, server_url, token)
+
+    # 5. Download data
+    typer.echo("Downloading data...")
+    n_downloaded = _download_data(workspace, server_url, token)
+
+    # 6. Initialise DuckDB
+    typer.echo("Initialising DuckDB views...")
+    total_rows = _initialize_duckdb(workspace)
+
+    # 7. Generate CLAUDE.md
+    typer.echo("Generating CLAUDE.md...")
+    instance_name = _get_instance_name(server_url, token)
+    _generate_claude_md(workspace, instance_name, server_url, sync_interval)
+
+    # 8. Summary
+    typer.echo("")
+    typer.echo("Setup complete!")
+    typer.echo(f"  Instance : {instance_name}")
+    typer.echo(f"  Server   : {server_url}")
+    typer.echo(f"  Tables   : {n_downloaded} downloaded, {total_rows} total rows")
+    typer.echo(f"  Workspace: {workspace}")
+    typer.echo("")
+    typer.echo("Next steps:")
+    typer.echo("  da sync          — refresh data")
+    typer.echo("  da metrics list  — explore available metrics")
+
+
+# ---------------------------------------------------------------------------
+# Command: da analyst status
+# ---------------------------------------------------------------------------
+
+@analyst_app.command()
+def status(
+    workspace_dir: Optional[str] = typer.Option(None, "--workspace", help="Workspace directory (default: current dir)"),
+    as_json: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Show workspace status and data freshness for returning sessions."""
+    workspace = Path(workspace_dir).resolve() if workspace_dir else Path.cwd()
+
+    exists = _detect_existing_project(workspace)
+    freshness = _check_data_freshness(workspace)
+
+    # Count parquet files
+    parquet_dir = workspace / "data" / "parquet"
+    parquet_count = len(list(parquet_dir.glob("*.parquet"))) if parquet_dir.exists() else 0
+
+    # Last sync timestamp
+    last_sync_file = workspace / "data" / "metadata" / "last_sync.json"
+    last_sync = "never"
+    if last_sync_file.exists():
+        try:
+            data = json.loads(last_sync_file.read_text(encoding="utf-8"))
+            last_sync = data.get("synced_at", "never")
+        except Exception:
+            pass
+
+    info = {
+        "workspace": str(workspace),
+        "initialized": exists,
+        "freshness": freshness,
+        "parquet_tables": parquet_count,
+        "last_sync": last_sync,
+    }
+
+    if as_json:
+        typer.echo(json.dumps(info, indent=2))
+        return
+
+    typer.echo(f"Workspace : {workspace}")
+    typer.echo(f"Initialized: {'yes' if exists else 'no'}")
+    typer.echo(f"Data freshness: {freshness}")
+    typer.echo(f"Parquet tables: {parquet_count}")
+    typer.echo(f"Last sync: {last_sync}")
+
+    if freshness == "stale":
+        typer.echo("")
+        typer.echo("Data is stale (>24 h). Run: da sync")
+    elif freshness == "missing":
+        typer.echo("")
+        typer.echo("No data found. Run: da analyst setup --server-url <url>")

--- a/cli/commands/analyst.py
+++ b/cli/commands/analyst.py
@@ -197,6 +197,8 @@ def _download_data(workspace: Path, server_url: str, token: str) -> int:
             typer.echo(f"  Downloaded {table_id}")
         except Exception as e:
             typer.echo(f"  Warning: could not download {table_id}: {e}", err=True)
+            if target.exists():
+                target.unlink()
 
     return downloaded
 
@@ -231,10 +233,11 @@ def _initialize_duckdb(workspace: Path) -> int:
             typer.echo(f"  Warning: Skipping {pq_file.name}: unsafe view name", err=True)
             continue
         abs_path = str(pq_resolved)
+        safe_path = abs_path.replace("'", "''")
         try:
             conn.execute(f'DROP VIEW IF EXISTS "{view_name}"')
             conn.execute(
-                f"CREATE VIEW \"{view_name}\" AS SELECT * FROM read_parquet('{abs_path}')"
+                f"CREATE VIEW \"{view_name}\" AS SELECT * FROM read_parquet('{safe_path}')"
             )
             count = conn.execute(f'SELECT count(*) FROM "{view_name}"').fetchone()[0]
             total_rows += count

--- a/cli/commands/analyst.py
+++ b/cli/commands/analyst.py
@@ -1,12 +1,15 @@
 """Analyst bootstrap commands — da analyst setup, da analyst status."""
 
 import json
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 from urllib.parse import urlparse
 
 import typer
+
+_SAFE_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,63}$")
 
 analyst_app = typer.Typer(help="Analyst workspace bootstrap and status")
 
@@ -59,6 +62,17 @@ def _connect_to_instance(server_url: str) -> str:
         )
         resp.raise_for_status()
         data = resp.json()
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 401:
+            typer.echo("Authentication failed: invalid credentials", err=True)
+        elif e.response.status_code == 403:
+            typer.echo("Authentication failed: account disabled or forbidden", err=True)
+        else:
+            typer.echo(f"Authentication failed: HTTP {e.response.status_code}", err=True)
+        raise typer.Exit(1)
+    except httpx.TimeoutException:
+        typer.echo(f"Authentication failed: connection timeout to {server_url}", err=True)
+        raise typer.Exit(1)
     except Exception as e:
         typer.echo(f"Authentication failed: {e}", err=True)
         raise typer.Exit(1)
@@ -199,9 +213,21 @@ def _initialize_duckdb(workspace: Path) -> int:
     conn = duckdb.connect(str(db_path))
     total_rows = 0
 
+    parquet_dir_resolved = parquet_dir.resolve()
     for pq_file in parquet_dir.glob("*.parquet"):
         view_name = pq_file.stem
-        abs_path = str(pq_file.resolve())
+        # Validate path is within the expected parquet directory (no path traversal)
+        try:
+            pq_resolved = pq_file.resolve()
+            pq_resolved.relative_to(parquet_dir_resolved)
+        except ValueError:
+            typer.echo(f"  Warning: Skipping {pq_file.name}: path traversal detected", err=True)
+            continue
+        # Validate view name is a safe SQL identifier
+        if not _SAFE_IDENTIFIER.match(view_name):
+            typer.echo(f"  Warning: Skipping {pq_file.name}: unsafe view name", err=True)
+            continue
+        abs_path = str(pq_resolved)
         try:
             conn.execute(f'DROP VIEW IF EXISTS "{view_name}"')
             conn.execute(
@@ -284,6 +310,11 @@ def _generate_claude_md(
             "Personal notes for this workspace. Uploaded to the server on `da sync --upload-only`.\n",
             encoding="utf-8",
         )
+
+    settings_path = workspace / ".claude" / "settings.json"
+    if not settings_path.exists():
+        settings = {"model": "sonnet", "permissions": {"allow": ["Read", "Bash", "Grep", "Glob"]}}
+        settings_path.write_text(json.dumps(settings, indent=2))
 
 
 # ---------------------------------------------------------------------------

--- a/cli/commands/analyst.py
+++ b/cli/commands/analyst.py
@@ -77,7 +77,10 @@ def _connect_to_instance(server_url: str) -> str:
         typer.echo(f"Authentication failed: {e}", err=True)
         raise typer.Exit(1)
 
-    token = data["access_token"]
+    token = data.get("access_token")
+    if not token:
+        typer.echo("Authentication failed: server response missing access_token", err=True)
+        raise typer.Exit(1)
     role = data.get("role", "analyst")
 
     save_config({"server": server_url})

--- a/cli/commands/metrics.py
+++ b/cli/commands/metrics.py
@@ -1,0 +1,169 @@
+"""Metrics commands — da metrics."""
+
+import json
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from cli.client import api_get
+
+metrics_app = typer.Typer(help="Metric definitions — list, show, import, export, validate")
+
+
+@metrics_app.command("list")
+def list_metrics(
+    category: Optional[str] = typer.Option(None, "--category", help="Filter by category"),
+    as_json: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """List metric definitions from the server."""
+    params = {}
+    if category:
+        params["category"] = category
+
+    resp = api_get("/api/metrics", params=params)
+    if resp.status_code != 200:
+        typer.echo(f"Failed: {resp.json().get('detail', resp.text)}", err=True)
+        raise typer.Exit(1)
+
+    data = resp.json()
+    metrics = data if isinstance(data, list) else data.get("metrics", [])
+
+    if as_json:
+        typer.echo(json.dumps(metrics, indent=2, default=str))
+        return
+
+    if not metrics:
+        typer.echo("No metrics found.")
+        return
+
+    # Group by category for display
+    by_category: dict = {}
+    for m in metrics:
+        cat = m.get("category", "uncategorized")
+        by_category.setdefault(cat, []).append(m)
+
+    for cat, items in sorted(by_category.items()):
+        typer.echo(f"\n[{cat}]")
+        for m in items:
+            name = m.get("name", m.get("id", "?"))
+            display = m.get("display_name", name)
+            unit = m.get("unit", "")
+            unit_str = f" ({unit})" if unit else ""
+            typer.echo(f"  {name:30s} {display}{unit_str}")
+
+
+@metrics_app.command("show")
+def show_metric(
+    metric_id: str = typer.Argument(..., help="Metric ID (e.g. revenue/mrr)"),
+    as_json: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Show details for a single metric."""
+    resp = api_get(f"/api/metrics/{metric_id}")
+    if resp.status_code == 404:
+        typer.echo(f"Metric not found: {metric_id}", err=True)
+        raise typer.Exit(1)
+    if resp.status_code != 200:
+        typer.echo(f"Failed: {resp.json().get('detail', resp.text)}", err=True)
+        raise typer.Exit(1)
+
+    m = resp.json()
+
+    if as_json:
+        typer.echo(json.dumps(m, indent=2, default=str))
+        return
+
+    typer.echo(f"ID:           {m.get('id', metric_id)}")
+    typer.echo(f"Name:         {m.get('name', '')}")
+    typer.echo(f"Display Name: {m.get('display_name', '')}")
+    typer.echo(f"Category:     {m.get('category', '')}")
+    typer.echo(f"Type:         {m.get('type', '')}")
+    if m.get("unit"):
+        typer.echo(f"Unit:         {m['unit']}")
+    if m.get("grain"):
+        typer.echo(f"Grain:        {m['grain']}")
+    if m.get("table_name"):
+        typer.echo(f"Table:        {m['table_name']}")
+    if m.get("description"):
+        typer.echo(f"Description:  {m['description']}")
+    if m.get("sql"):
+        typer.echo(f"SQL:\n  {m['sql']}")
+    if m.get("synonyms"):
+        typer.echo(f"Synonyms:     {', '.join(m['synonyms'])}")
+
+
+@metrics_app.command("import")
+def import_metrics(
+    path: str = typer.Argument(..., help="Path to a YAML file or directory of YAML files"),
+):
+    """Import metric definitions from YAML into DuckDB (direct, no API)."""
+    from src.db import get_system_db
+    from src.repositories.metrics import MetricRepository
+
+    import_path = Path(path)
+    if not import_path.exists():
+        typer.echo(f"Path not found: {path}", err=True)
+        raise typer.Exit(1)
+
+    conn = get_system_db()
+    try:
+        repo = MetricRepository(conn)
+        count = repo.import_from_yaml(import_path)
+        typer.echo(f"Imported {count} metric(s) from {path}")
+    finally:
+        conn.close()
+
+
+@metrics_app.command("export")
+def export_metrics(
+    output_dir: str = typer.Option("./export/", "--dir", help="Output directory for YAML files"),
+):
+    """Export metric definitions from DuckDB to YAML files (direct, no API)."""
+    from src.db import get_system_db
+    from src.repositories.metrics import MetricRepository
+
+    conn = get_system_db()
+    try:
+        repo = MetricRepository(conn)
+        count = repo.export_to_yaml(output_dir)
+        typer.echo(f"Exported {count} metric(s) to {output_dir}")
+    finally:
+        conn.close()
+
+
+@metrics_app.command("validate")
+def validate_metrics():
+    """Check each metric's table reference against registered tables (direct, no API)."""
+    from src.db import get_system_db
+    from src.repositories.metrics import MetricRepository
+    from src.repositories.table_registry import TableRegistryRepository
+
+    conn = get_system_db()
+    try:
+        metric_repo = MetricRepository(conn)
+        registry_repo = TableRegistryRepository(conn)
+
+        metrics = metric_repo.list()
+        registered_tables = {t["name"] for t in registry_repo.list_all()}
+
+        ok_count = 0
+        warn_count = 0
+
+        for m in metrics:
+            name = m.get("name", m.get("id", "?"))
+            table = m.get("table_name")
+            if not table:
+                typer.echo(f"  OK   {name:30s} (no table reference)")
+                ok_count += 1
+            elif table in registered_tables:
+                typer.echo(f"  OK   {name:30s} table={table}")
+                ok_count += 1
+            else:
+                typer.echo(f"  WARN {name:30s} table={table} (not registered)")
+                warn_count += 1
+
+        typer.echo(f"\nTotal: {len(metrics)} metric(s) — {ok_count} OK, {warn_count} WARN")
+        if warn_count > 0:
+            raise typer.Exit(1)
+    finally:
+        conn.close()

--- a/cli/config.py
+++ b/cli/config.py
@@ -58,3 +58,15 @@ def get_sync_state() -> dict:
 def save_sync_state(state: dict):
     state_file = _config_dir() / "sync_state.json"
     state_file.write_text(json.dumps(state, indent=2))
+
+
+def save_config(data: dict):
+    """Persist server URL and other config to config.yaml."""
+    import yaml
+
+    config_file = _config_dir() / "config.yaml"
+    existing = {}
+    if config_file.exists():
+        existing = yaml.safe_load(config_file.read_text()) or {}
+    existing.update(data)
+    config_file.write_text(yaml.dump(existing, default_flow_style=False))

--- a/cli/main.py
+++ b/cli/main.py
@@ -15,6 +15,7 @@ from cli.commands.skills import skills_app
 from cli.commands.setup import setup_app
 from cli.commands.server import server_app
 from cli.commands.explore import explore_app
+from cli.commands.metrics import metrics_app
 
 app = typer.Typer(
     name="da",
@@ -33,6 +34,7 @@ app.add_typer(skills_app, name="skills")
 app.add_typer(setup_app, name="setup")
 app.add_typer(server_app, name="server")
 app.add_typer(explore_app, name="explore")
+app.add_typer(metrics_app, name="metrics")
 
 
 if __name__ == "__main__":

--- a/cli/main.py
+++ b/cli/main.py
@@ -16,6 +16,7 @@ from cli.commands.setup import setup_app
 from cli.commands.server import server_app
 from cli.commands.explore import explore_app
 from cli.commands.metrics import metrics_app
+from cli.commands.analyst import analyst_app
 
 app = typer.Typer(
     name="da",
@@ -35,6 +36,7 @@ app.add_typer(setup_app, name="setup")
 app.add_typer(server_app, name="server")
 app.add_typer(explore_app, name="explore")
 app.add_typer(metrics_app, name="metrics")
+app.add_typer(analyst_app, name="analyst")
 
 
 if __name__ == "__main__":

--- a/config/claude_md_template.txt
+++ b/config/claude_md_template.txt
@@ -1,0 +1,32 @@
+# {instance_name} — AI Data Analyst
+
+This workspace is connected to {server_url}.
+
+## Rules
+- Before computing any business metric: run `da metrics show <category>/<name>`
+- For current schema: read `data/metadata/schema.json`
+- Do not use DESCRIBE/SHOW COLUMNS — read metadata files instead
+- Save work output to `user/artifacts/`
+- Sync data regularly with `da sync`
+
+## Metrics Workflow
+1. `da metrics list` — find the relevant metric
+2. `da metrics show revenue/mrr` — read SQL and business rules
+3. Use the canonical SQL from the metric definition, adapt to the question
+4. Never invent metric calculations — always check existing definitions first
+
+## Data Sync
+- `da sync` — download current data from server
+- `da sync --docs-only` — just metadata and metrics (fast refresh)
+- `da sync --upload-only` — upload sessions and local notes to server
+- Data on the server refreshes every {sync_interval}
+
+## Directory Structure
+- `data/` — read-only data downloaded from server
+  - `data/parquet/` — table data in Parquet format
+  - `data/duckdb/` — local analytics DuckDB database
+  - `data/metadata/` — profiles, schema, metrics cache
+- `user/` — your workspace (persistent across syncs)
+  - `user/artifacts/` — analysis outputs, reports, charts
+  - `user/sessions/` — Claude Code session logs
+- `.claude/CLAUDE.local.md` — your personal notes (never overwritten, uploaded on sync)

--- a/docs/metrics/metrics.yml
+++ b/docs/metrics/metrics.yml
@@ -1,0 +1,15 @@
+version: "2.0"
+description: "Business metrics starter pack. Import with: da metrics import docs/metrics/"
+categories:
+  - name: revenue
+    folder: revenue/
+    metrics: [total_revenue, mrr, arr, churn_rate]
+  - name: product_usage
+    folder: product_usage/
+    metrics: [active_users, feature_adoption]
+  - name: sales
+    folder: sales/
+    metrics: [new_customers, upsell_expansion, pipeline_value]
+  - name: operations
+    folder: operations/
+    metrics: [support_resolution_time, infrastructure_cost]

--- a/docs/metrics/operations/infrastructure_cost.yml
+++ b/docs/metrics/operations/infrastructure_cost.yml
@@ -1,0 +1,40 @@
+name: infrastructure_cost
+display_name: Infrastructure Cost
+category: operations
+type: sum
+unit: USD
+grain: monthly
+table: infra_costs
+expression: "SUM(cost_usd)"
+time_column: usage_date
+description: "Infrastructure Cost — total cloud infrastructure spend per month, broken down by provider, service, and environment."
+dimensions:
+  - provider
+  - service
+  - environment
+synonyms:
+  - cloud_cost
+  - infra_spend
+  - cloud_spend
+notes:
+  - "Includes compute, storage, networking, and managed services"
+  - "Production and staging costs should be tracked separately via environment dimension"
+  - "Compare month-over-month to detect unexpected cost spikes"
+  - "Calculate cost per MAU to normalize against growth"
+sql: |
+  SELECT
+      DATE_TRUNC('month', usage_date) AS month,
+      SUM(cost_usd) AS infrastructure_cost
+  FROM infra_costs
+  GROUP BY 1
+  ORDER BY 1
+sql_by_provider: |
+  SELECT
+      DATE_TRUNC('month', usage_date) AS month,
+      provider,
+      service,
+      environment,
+      SUM(cost_usd) AS cost
+  FROM infra_costs
+  GROUP BY 1, 2, 3, 4
+  ORDER BY 1, cost DESC

--- a/docs/metrics/operations/support_resolution_time.yml
+++ b/docs/metrics/operations/support_resolution_time.yml
@@ -1,0 +1,36 @@
+name: support_resolution_time
+display_name: Support Resolution Time
+category: operations
+type: avg
+unit: hours
+grain: monthly
+table: tickets
+expression: "AVG(resolution_hours)"
+time_column: created_at
+description: "Average Support Resolution Time — the mean time in hours from ticket creation to resolution. Key support quality and efficiency metric."
+dimensions:
+  - priority
+  - category
+synonyms:
+  - mean_resolution_time
+  - avg_resolution_time
+  - time_to_resolve
+  - ttr
+notes:
+  - "Resolution time = resolved_at - created_at, in hours"
+  - "Exclude tickets still open (no resolved_at)"
+  - "SLA targets vary by priority: Critical <4h, High <24h, Normal <72h"
+  - "Consider p50/p95 in addition to mean to detect outliers"
+sql: |
+  SELECT
+      DATE_TRUNC('month', created_at) AS month,
+      priority,
+      category,
+      COUNT(*) AS tickets_resolved,
+      ROUND(AVG(resolution_hours), 2) AS avg_resolution_hours,
+      ROUND(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY resolution_hours), 2) AS p50_hours,
+      ROUND(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY resolution_hours), 2) AS p95_hours
+  FROM tickets
+  WHERE resolved_at IS NOT NULL
+  GROUP BY 1, 2, 3
+  ORDER BY 1, priority, avg_resolution_hours DESC

--- a/docs/metrics/product_usage/active_users.yml
+++ b/docs/metrics/product_usage/active_users.yml
@@ -1,0 +1,29 @@
+name: active_users
+display_name: Monthly Active Users
+category: product_usage
+type: count
+unit: users
+grain: monthly
+table: user_events
+expression: "COUNT(DISTINCT user_id)"
+time_column: event_date
+description: "Monthly Active Users (MAU) — the count of unique users who performed at least one event in a given month."
+dimensions:
+  - feature
+  - plan_type
+synonyms:
+  - mau
+  - monthly_actives
+  - active_users_monthly
+notes:
+  - "A user counts as active if they trigger any tracked event within the month"
+  - "Distinguish from logins-only — prefer meaningful engagement events"
+  - "Filter internal/test accounts before aggregating"
+sql: |
+  SELECT
+      DATE_TRUNC('month', event_date) AS month,
+      COUNT(DISTINCT user_id) AS active_users
+  FROM user_events
+  WHERE event_type != 'internal'
+  GROUP BY 1
+  ORDER BY 1

--- a/docs/metrics/product_usage/feature_adoption.yml
+++ b/docs/metrics/product_usage/feature_adoption.yml
@@ -1,0 +1,48 @@
+name: feature_adoption
+display_name: Feature Adoption Rate
+category: product_usage
+type: ratio
+unit: percentage
+grain: monthly
+table: user_events
+expression: "COUNT(DISTINCT feature_users) / COUNT(DISTINCT total_users) * 100"
+time_column: event_date
+description: "Feature Adoption Rate — the percentage of active users who used a specific feature in a given month."
+dimensions:
+  - feature
+  - plan_type
+synonyms:
+  - feature_usage_rate
+  - adoption_rate
+notes:
+  - "Denominator is all MAU for the period, numerator is MAU who triggered the feature event"
+  - "Track each feature separately by filtering on feature_name or event_type"
+  - "Adoption >20% within 90 days of launch is a common success threshold"
+sql: |
+  WITH monthly_active AS (
+      SELECT
+          DATE_TRUNC('month', event_date) AS month,
+          COUNT(DISTINCT user_id) AS total_users
+      FROM user_events
+      WHERE event_type != 'internal'
+      GROUP BY 1
+  ),
+  feature_users AS (
+      SELECT
+          DATE_TRUNC('month', event_date) AS month,
+          feature_name,
+          COUNT(DISTINCT user_id) AS users_adopted
+      FROM user_events
+      WHERE event_type = 'feature_used'
+        AND event_type != 'internal'
+      GROUP BY 1, 2
+  )
+  SELECT
+      f.month,
+      f.feature_name,
+      f.users_adopted,
+      m.total_users,
+      ROUND(f.users_adopted * 100.0 / NULLIF(m.total_users, 0), 2) AS adoption_rate_pct
+  FROM feature_users f
+  JOIN monthly_active m ON f.month = m.month
+  ORDER BY f.month, adoption_rate_pct DESC

--- a/docs/metrics/revenue/arr.yml
+++ b/docs/metrics/revenue/arr.yml
@@ -1,0 +1,29 @@
+name: arr
+display_name: Annual Recurring Revenue
+category: revenue
+type: sum
+unit: USD
+grain: monthly
+table: subscriptions
+expression: "SUM(mrr_amount) * 12"
+time_column: billing_date
+description: "Annual Recurring Revenue — MRR annualized. Standard SaaS valuation metric used for board reporting and investor communications."
+dimensions:
+  - plan_type
+  - region
+synonyms:
+  - annual_revenue
+  - annualized_revenue
+  - annualized_mrr
+notes:
+  - "ARR = MRR * 12 — snapshot at end of period"
+  - "Not a trailing 12-month sum; it is the current MRR extrapolated to a year"
+  - "Excludes one-time and non-recurring revenue"
+sql: |
+  SELECT
+      DATE_TRUNC('month', billing_date) AS month,
+      SUM(mrr_amount) * 12 AS arr
+  FROM subscriptions
+  WHERE status = 'active'
+  GROUP BY 1
+  ORDER BY 1

--- a/docs/metrics/revenue/churn_rate.yml
+++ b/docs/metrics/revenue/churn_rate.yml
@@ -1,0 +1,48 @@
+name: churn_rate
+display_name: Monthly Churn Rate
+category: revenue
+type: ratio
+unit: percentage
+grain: monthly
+table: subscriptions
+expression: "churned_mrr / beginning_mrr * 100"
+time_column: billing_date
+description: "Monthly revenue churn rate — the percentage of MRR lost due to cancellations and downgrades in a given month."
+dimensions:
+  - plan_type
+  - region
+synonyms:
+  - mrr_churn
+  - revenue_churn
+  - monthly_churn
+notes:
+  - "Revenue churn differs from customer churn — one large customer churning can dominate"
+  - "Negative churn occurs when expansion revenue exceeds lost revenue"
+  - "Target: <2% monthly for healthy SaaS businesses"
+  - "Churned MRR includes full cancellations and partial downgrades"
+sql: |
+  WITH monthly_mrr AS (
+      SELECT
+          DATE_TRUNC('month', billing_date) AS month,
+          SUM(CASE WHEN status = 'active' THEN mrr_amount ELSE 0 END) AS active_mrr,
+          SUM(CASE WHEN status = 'churned'
+                   AND DATE_TRUNC('month', churned_at) = DATE_TRUNC('month', billing_date)
+                   THEN mrr_amount ELSE 0 END) AS churned_mrr
+      FROM subscriptions
+      GROUP BY 1
+  ),
+  lagged AS (
+      SELECT
+          month,
+          churned_mrr,
+          LAG(active_mrr) OVER (ORDER BY month) AS beginning_mrr
+      FROM monthly_mrr
+  )
+  SELECT
+      month,
+      churned_mrr,
+      beginning_mrr,
+      ROUND(churned_mrr / NULLIF(beginning_mrr, 0) * 100, 2) AS churn_rate_pct
+  FROM lagged
+  WHERE beginning_mrr IS NOT NULL
+  ORDER BY month

--- a/docs/metrics/revenue/mrr.yml
+++ b/docs/metrics/revenue/mrr.yml
@@ -1,0 +1,39 @@
+name: mrr
+display_name: Monthly Recurring Revenue
+category: revenue
+type: sum
+unit: USD
+grain: monthly
+table: subscriptions
+expression: "SUM(mrr_amount)"
+time_column: billing_date
+description: "Monthly Recurring Revenue — the predictable monthly revenue from active subscriptions. Core SaaS health metric."
+dimensions:
+  - plan_type
+  - region
+synonyms:
+  - monthly_revenue
+  - recurring_revenue
+  - subscription_revenue
+notes:
+  - "Excludes one-time fees, setup fees, and professional services"
+  - "Churned subscriptions are removed in the month they cancel"
+  - "Upgrades and downgrades are reflected in the month the change takes effect"
+  - "Use billing_date (not payment date) for recognition"
+sql: |
+  SELECT
+      DATE_TRUNC('month', billing_date) AS month,
+      SUM(mrr_amount) AS mrr
+  FROM subscriptions
+  WHERE status = 'active'
+  GROUP BY 1
+  ORDER BY 1
+sql_by_plan: |
+  SELECT
+      DATE_TRUNC('month', billing_date) AS month,
+      plan_type,
+      SUM(mrr_amount) AS mrr
+  FROM subscriptions
+  WHERE status = 'active'
+  GROUP BY 1, 2
+  ORDER BY 1, 3 DESC

--- a/docs/metrics/sales/new_customers.yml
+++ b/docs/metrics/sales/new_customers.yml
@@ -1,0 +1,36 @@
+name: new_customers
+display_name: New Customers
+category: sales
+type: count
+unit: customers
+grain: monthly
+table: orders
+expression: "COUNT(DISTINCT customer_id)"
+time_column: order_date
+description: "New Customers — the count of customers placing their first-ever order in a given month."
+dimensions:
+  - channel
+  - region
+synonyms:
+  - new_logos
+  - first_time_buyers
+  - customer_acquisition
+notes:
+  - "A customer is 'new' only if they have no prior orders in any historical period"
+  - "Exclude internal test accounts and employees from the count"
+  - "Use acquisition channel (UTM/referral) from first order for attribution"
+sql: |
+  WITH first_orders AS (
+      SELECT
+          customer_id,
+          MIN(order_date) AS first_order_date
+      FROM orders
+      WHERE status != 'cancelled'
+      GROUP BY customer_id
+  )
+  SELECT
+      DATE_TRUNC('month', first_order_date) AS month,
+      COUNT(DISTINCT customer_id) AS new_customers
+  FROM first_orders
+  GROUP BY 1
+  ORDER BY 1

--- a/docs/metrics/sales/pipeline_value.yml
+++ b/docs/metrics/sales/pipeline_value.yml
@@ -1,0 +1,34 @@
+name: pipeline_value
+display_name: Pipeline Value
+category: sales
+type: sum
+unit: USD
+grain: monthly
+table: opportunities
+expression: "SUM(deal_value * probability / 100)"
+time_column: created_at
+description: "Pipeline Value — the probability-weighted total value of open sales opportunities, used for revenue forecasting."
+dimensions:
+  - stage
+  - owner
+  - region
+synonyms:
+  - weighted_pipeline
+  - pipeline_forecast
+  - opportunity_value
+notes:
+  - "Weighted by close probability for each stage (e.g., 20% at Qualify, 80% at Proposal)"
+  - "Snapshot the pipeline at month-end for trend analysis"
+  - "Exclude closed-won and closed-lost opportunities"
+  - "Compare to quota to assess pipeline coverage ratio (target: 3-4x)"
+sql: |
+  SELECT
+      DATE_TRUNC('month', created_at) AS month,
+      stage,
+      COUNT(*) AS opportunity_count,
+      SUM(deal_value) AS total_deal_value,
+      SUM(deal_value * probability / 100.0) AS weighted_pipeline_value
+  FROM opportunities
+  WHERE status = 'open'
+  GROUP BY 1, 2
+  ORDER BY 1, weighted_pipeline_value DESC

--- a/docs/metrics/sales/upsell_expansion.yml
+++ b/docs/metrics/sales/upsell_expansion.yml
@@ -1,0 +1,30 @@
+name: upsell_expansion
+display_name: Upsell & Expansion Revenue
+category: sales
+type: sum
+unit: USD
+grain: monthly
+table: subscriptions
+expression: "SUM(delta_mrr)"
+time_column: billing_date
+description: "Upsell & Expansion MRR — incremental recurring revenue gained from existing customers upgrading or expanding their subscriptions."
+dimensions:
+  - plan_type
+  - region
+synonyms:
+  - expansion_mrr
+  - upsell_revenue
+  - expansion_revenue
+notes:
+  - "Only includes positive MRR changes (upgrades, seat additions, add-ons)"
+  - "Excludes new business — filter on customers with prior active subscriptions"
+  - "Negative expansion (downgrades) is tracked separately as contraction MRR"
+sql: |
+  SELECT
+      DATE_TRUNC('month', billing_date) AS month,
+      SUM(delta_mrr) AS expansion_mrr
+  FROM subscriptions
+  WHERE change_type IN ('upgrade', 'expansion', 'seat_add')
+    AND delta_mrr > 0
+  GROUP BY 1
+  ORDER BY 1

--- a/docs/superpowers/plans/2026-04-10-analyst-bootstrap.md
+++ b/docs/superpowers/plans/2026-04-10-analyst-bootstrap.md
@@ -1,0 +1,602 @@
+# Analyst Bootstrap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `da analyst setup` command that onboards analysts to a remote Agnes instance — connects, downloads data, initializes local DuckDB, generates CLAUDE.md.
+
+**Architecture:** New top-level Typer command `da analyst` with `setup` subcommand. Uses existing `cli/client.py` HTTP helpers. Generates CLAUDE.md from template with instance-specific placeholders.
+
+**Tech Stack:** Typer, httpx (via cli/client.py), DuckDB, Rich (progress bars), Jinja2-style string substitution
+
+**Spec:** `docs/superpowers/specs/2026-04-10-porting-internal-features-design.md` — Section 2
+
+**Depends on:** Business Metrics plan (Task 5 — metrics API must exist for Step 4)
+
+---
+
+### Task 1: CLAUDE.md Template
+
+**Files:**
+- Create: `config/claude_md_template.txt`
+
+- [ ] **Step 1: Create the template file**
+
+Create `config/claude_md_template.txt`:
+
+```
+# {instance_name} — AI Data Analyst
+
+This workspace is connected to {server_url}.
+
+## Rules
+- Before computing any business metric: run `da metrics show <category>/<name>`
+- For current schema: read `data/metadata/schema.json`
+- Do not use DESCRIBE/SHOW COLUMNS — read metadata files instead
+- Save work output to `user/artifacts/`
+- Sync data regularly with `da sync`
+
+## Metrics Workflow
+1. `da metrics list` — find the relevant metric
+2. `da metrics show revenue/mrr` — read SQL and business rules
+3. Use the canonical SQL from the metric definition, adapt to the question
+4. Never invent metric calculations — always check existing definitions first
+
+## Data Sync
+- `da sync` — download current data from server
+- `da sync --docs-only` — just metadata and metrics (fast refresh)
+- `da sync --upload-only` — upload sessions and local notes to server
+- Data on the server refreshes every {sync_interval}
+
+## Directory Structure
+- `data/` — read-only data downloaded from server
+  - `data/parquet/` — table data in Parquet format
+  - `data/duckdb/` — local analytics DuckDB database
+  - `data/metadata/` — profiles, schema, metrics cache
+- `user/` — your workspace (persistent across syncs)
+  - `user/artifacts/` — analysis outputs, reports, charts
+  - `user/sessions/` — Claude Code session logs
+- `.claude/CLAUDE.local.md` — your personal notes (never overwritten, uploaded on sync)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add config/claude_md_template.txt
+git commit -m "feat: add CLAUDE.md template for analyst bootstrap"
+```
+
+---
+
+### Task 2: `da analyst setup` — Core Command
+
+**Files:**
+- Create: `cli/commands/analyst.py`
+- Modify: `cli/main.py` (register analyst_app)
+- Test: `tests/test_cli.py` (help test)
+- Test: `tests/test_analyst_bootstrap.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `tests/test_cli.py` in `TestCLIHelp`:
+
+```python
+    def test_analyst_help(self):
+        result = runner.invoke(app, ["analyst", "--help"])
+        assert result.exit_code == 0
+        assert "setup" in result.output
+```
+
+Create `tests/test_analyst_bootstrap.py`:
+
+```python
+"""Tests for analyst bootstrap flow."""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+from typer.testing import CliRunner
+from cli.main import app
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def tmp_workspace(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("DA_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("DA_LOCAL_DIR", str(tmp_path / "local"))
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret")
+    (tmp_path / "data").mkdir()
+    (tmp_path / "config").mkdir()
+    (tmp_path / "local").mkdir()
+    monkeypatch.chdir(tmp_path / "workspace")
+    (tmp_path / "workspace").mkdir()
+    yield tmp_path / "workspace"
+
+
+class TestDetectExistingProject:
+    def test_detects_existing_claude_md(self, tmp_workspace):
+        (tmp_workspace / "CLAUDE.md").write_text("# Acme — AI Data Analyst\n")
+        result = runner.invoke(app, ["analyst", "setup", "--server-url", "http://localhost:8000"])
+        assert "already set up" in result.output.lower() or result.exit_code == 0
+
+    def test_no_detection_with_force(self, tmp_workspace):
+        (tmp_workspace / "CLAUDE.md").write_text("# Acme — AI Data Analyst\n")
+        with patch("cli.commands.analyst._connect_to_instance") as mock_connect:
+            mock_connect.side_effect = SystemExit(1)  # Will fail at connect step
+            result = runner.invoke(app, ["analyst", "setup", "--force",
+                                         "--server-url", "http://localhost:8000"])
+            # Should have passed detection and attempted connect
+            mock_connect.assert_called_once()
+
+
+class TestCreateWorkspace:
+    def test_creates_directory_structure(self, tmp_workspace):
+        from cli.commands.analyst import _create_workspace
+        _create_workspace(tmp_workspace)
+        assert (tmp_workspace / "data" / "parquet").is_dir()
+        assert (tmp_workspace / "data" / "duckdb").is_dir()
+        assert (tmp_workspace / "data" / "metadata").is_dir()
+        assert (tmp_workspace / "user" / "artifacts").is_dir()
+        assert (tmp_workspace / "user" / "sessions").is_dir()
+        assert (tmp_workspace / ".claude").is_dir()
+
+
+class TestGenerateClaudeMd:
+    def test_generates_from_template(self, tmp_workspace):
+        from cli.commands.analyst import _generate_claude_md
+        _generate_claude_md(
+            workspace=tmp_workspace,
+            instance_name="Acme Analytics",
+            server_url="https://data.acme.com",
+            sync_interval="15 minutes",
+        )
+        claude_md = tmp_workspace / "CLAUDE.md"
+        assert claude_md.exists()
+        content = claude_md.read_text()
+        assert "Acme Analytics" in content
+        assert "https://data.acme.com" in content
+        assert "15 minutes" in content
+
+    def test_creates_claude_local_md(self, tmp_workspace):
+        from cli.commands.analyst import _generate_claude_md
+        (tmp_workspace / ".claude").mkdir(parents=True, exist_ok=True)
+        _generate_claude_md(
+            workspace=tmp_workspace,
+            instance_name="Test",
+            server_url="http://localhost",
+            sync_interval="1 hour",
+        )
+        assert (tmp_workspace / ".claude" / "CLAUDE.local.md").exists()
+
+    def test_does_not_overwrite_existing_local_md(self, tmp_workspace):
+        (tmp_workspace / ".claude").mkdir(parents=True, exist_ok=True)
+        local_md = tmp_workspace / ".claude" / "CLAUDE.local.md"
+        local_md.write_text("my notes")
+        from cli.commands.analyst import _generate_claude_md
+        _generate_claude_md(
+            workspace=tmp_workspace,
+            instance_name="Test",
+            server_url="http://localhost",
+            sync_interval="1 hour",
+        )
+        assert local_md.read_text() == "my notes"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_analyst_bootstrap.py -v`
+Expected: FAIL — `No such command 'analyst'`
+
+- [ ] **Step 3: Implement `cli/commands/analyst.py`**
+
+Create `cli/commands/analyst.py`:
+
+```python
+"""Analyst commands — da analyst."""
+
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+logger = logging.getLogger(__name__)
+
+analyst_app = typer.Typer(help="Analyst workspace — setup, connect to a remote instance")
+
+AGNES_IDENTIFIER = "AI Data Analyst"
+
+
+@analyst_app.command("setup")
+def setup(
+    server_url: str = typer.Option(None, "--server-url", "-s", help="Agnes instance URL"),
+    force: bool = typer.Option(False, "--force", help="Re-run from scratch, clean partial state"),
+):
+    """Set up a local analyst workspace connected to a remote Agnes instance."""
+    workspace = Path.cwd()
+
+    # Step 1: Detect existing project
+    if not force:
+        claude_md = workspace / "CLAUDE.md"
+        if claude_md.exists() and AGNES_IDENTIFIER in claude_md.read_text():
+            typer.echo("Project already set up. Use 'da sync' to refresh data, or --force to re-setup.")
+            return
+
+    # Step 2: Connect
+    if not server_url:
+        server_url = typer.prompt("Agnes instance URL (e.g., https://data.acme.com)")
+
+    token = _connect_to_instance(server_url)
+
+    # Step 3: Create workspace
+    _create_workspace(workspace)
+
+    # Step 4: Download schema and metrics
+    _download_metadata(workspace, server_url, token)
+
+    # Step 5: Download data
+    table_count = _download_data(workspace, server_url, token)
+
+    # Step 6: Initialize DuckDB
+    row_count = _initialize_duckdb(workspace)
+
+    # Step 7: Generate CLAUDE.md
+    instance_name = _get_instance_name(server_url, token)
+    _generate_claude_md(
+        workspace=workspace,
+        instance_name=instance_name,
+        server_url=server_url,
+        sync_interval="15 minutes",
+    )
+
+    # Step 8: Verify
+    typer.echo(f"\nSetup complete. {table_count} tables, {row_count} total rows.")
+    typer.echo("Start analyzing with Claude Code, or run 'da sync' to refresh data.")
+
+
+def _connect_to_instance(server_url: str) -> str:
+    """Connect to Agnes instance, authenticate, return JWT token."""
+    import httpx
+
+    # Health check
+    try:
+        resp = httpx.get(f"{server_url}/api/health", timeout=10)
+        resp.raise_for_status()
+    except Exception as e:
+        typer.echo(f"Cannot reach {server_url}: {e}", err=True)
+        raise typer.Exit(1)
+
+    # Authenticate
+    email = typer.prompt("Email")
+    password = typer.prompt("Password", hide_input=True)
+
+    try:
+        resp = httpx.post(
+            f"{server_url}/auth/token",
+            data={"username": email, "password": password},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        token = resp.json().get("access_token")
+        if not token:
+            typer.echo("Authentication failed: no token in response", err=True)
+            raise typer.Exit(1)
+    except httpx.HTTPStatusError as e:
+        typer.echo(f"Authentication failed: {e.response.text}", err=True)
+        raise typer.Exit(1)
+
+    # Save credentials
+    from cli.config import save_config
+    save_config({"server_url": server_url, "token": token})
+    typer.echo(f"Connected to {server_url}")
+    return token
+
+
+def _create_workspace(workspace: Path) -> None:
+    """Create analyst directory structure."""
+    dirs = [
+        workspace / "data" / "parquet",
+        workspace / "data" / "duckdb",
+        workspace / "data" / "metadata",
+        workspace / "user" / "artifacts",
+        workspace / "user" / "sessions",
+        workspace / ".claude",
+    ]
+    for d in dirs:
+        d.mkdir(parents=True, exist_ok=True)
+
+
+def _download_metadata(workspace: Path, server_url: str, token: str) -> None:
+    """Download table list and metrics to local cache."""
+    import httpx
+
+    headers = {"Authorization": f"Bearer {token}"}
+    metadata_dir = workspace / "data" / "metadata"
+
+    # Tables
+    try:
+        resp = httpx.get(f"{server_url}/api/catalog/tables", headers=headers, timeout=30)
+        resp.raise_for_status()
+        (metadata_dir / "tables.json").write_text(json.dumps(resp.json(), indent=2))
+        typer.echo(f"Downloaded table catalog ({resp.json().get('count', '?')} tables)")
+    except Exception as e:
+        typer.echo(f"Warning: could not download table catalog: {e}", err=True)
+
+    # Metrics
+    try:
+        resp = httpx.get(f"{server_url}/api/metrics", headers=headers, timeout=30)
+        resp.raise_for_status()
+        (metadata_dir / "metrics.json").write_text(json.dumps(resp.json(), indent=2))
+        typer.echo(f"Downloaded metrics ({resp.json().get('count', '?')} metrics)")
+    except Exception as e:
+        typer.echo(f"Warning: could not download metrics: {e}", err=True)
+
+
+def _download_data(workspace: Path, server_url: str, token: str) -> int:
+    """Download parquet files for all accessible tables. Returns count."""
+    import httpx
+
+    metadata_dir = workspace / "data" / "metadata"
+    parquet_dir = workspace / "data" / "parquet"
+
+    tables_file = metadata_dir / "tables.json"
+    if not tables_file.exists():
+        return 0
+
+    tables_data = json.loads(tables_file.read_text())
+    tables = tables_data.get("tables", [])
+    count = 0
+
+    for table in tables:
+        tid = table["id"]
+        target = parquet_dir / f"{tid}.parquet"
+
+        # Resume: skip if already downloaded
+        if target.exists() and target.stat().st_size > 0:
+            count += 1
+            continue
+
+        try:
+            with httpx.Client(base_url=server_url, headers={"Authorization": f"Bearer {token}"},
+                              timeout=300) as client:
+                with client.stream("GET", f"/api/data/{tid}/download") as resp:
+                    if resp.status_code == 404:
+                        continue
+                    resp.raise_for_status()
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    with open(target, "wb") as f:
+                        for chunk in resp.iter_bytes(65536):
+                            f.write(chunk)
+            count += 1
+            typer.echo(f"  Downloaded {tid}")
+        except Exception as e:
+            typer.echo(f"  Failed {tid}: {e}", err=True)
+
+    typer.echo(f"Downloaded {count}/{len(tables)} tables")
+    return count
+
+
+def _initialize_duckdb(workspace: Path) -> int:
+    """Create local analytics.duckdb with views over downloaded parquets. Returns total rows."""
+    import duckdb
+
+    parquet_dir = workspace / "data" / "parquet"
+    db_path = workspace / "data" / "duckdb" / "analytics.duckdb"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    conn = duckdb.connect(str(db_path))
+    total_rows = 0
+
+    for pq in sorted(parquet_dir.glob("*.parquet")):
+        view_name = pq.stem
+        try:
+            conn.execute(f"CREATE OR REPLACE VIEW \"{view_name}\" AS SELECT * FROM read_parquet('{pq}')")
+            row_count = conn.execute(f"SELECT count(*) FROM \"{view_name}\"").fetchone()[0]
+            total_rows += row_count
+        except Exception as e:
+            logger.warning("Could not create view for %s: %s", pq.name, e)
+
+    conn.close()
+    typer.echo(f"Initialized DuckDB with {len(list(parquet_dir.glob('*.parquet')))} views")
+    return total_rows
+
+
+def _get_instance_name(server_url: str, token: str) -> str:
+    """Get instance name from server, fallback to URL hostname."""
+    import httpx
+    try:
+        resp = httpx.get(f"{server_url}/api/health", headers={"Authorization": f"Bearer {token}"}, timeout=10)
+        data = resp.json()
+        return data.get("instance_name", server_url.split("//")[-1].split("/")[0])
+    except Exception:
+        return server_url.split("//")[-1].split("/")[0]
+
+
+def _generate_claude_md(
+    workspace: Path,
+    instance_name: str,
+    server_url: str,
+    sync_interval: str,
+) -> None:
+    """Generate CLAUDE.md from template."""
+    template_path = Path(__file__).parent.parent.parent / "config" / "claude_md_template.txt"
+    if template_path.exists():
+        template = template_path.read_text()
+    else:
+        # Inline fallback
+        template = "# {instance_name} — AI Data Analyst\n\nConnected to {server_url}.\n"
+
+    content = template.replace("{instance_name}", instance_name)
+    content = content.replace("{server_url}", server_url)
+    content = content.replace("{sync_interval}", sync_interval)
+
+    (workspace / "CLAUDE.md").write_text(content)
+
+    # Create CLAUDE.local.md if it doesn't exist
+    local_md = workspace / ".claude" / "CLAUDE.local.md"
+    local_md.parent.mkdir(parents=True, exist_ok=True)
+    if not local_md.exists():
+        local_md.write_text("# Personal Notes\n\nAdd your learnings and insights here.\n")
+```
+
+Register in `cli/main.py`:
+
+```python
+from cli.commands.analyst import analyst_app
+# ...
+app.add_typer(analyst_app, name="analyst")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_analyst_bootstrap.py -v && pytest tests/test_cli.py::TestCLIHelp::test_analyst_help -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/commands/analyst.py cli/main.py config/claude_md_template.txt tests/test_analyst_bootstrap.py tests/test_cli.py
+git commit -m "feat: add da analyst setup command with bootstrap flow"
+```
+
+---
+
+### Task 3: Returning-Session Detection
+
+**Files:**
+- Modify: `cli/commands/analyst.py` (add `da analyst status` command)
+- Test: `tests/test_analyst_bootstrap.py`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `tests/test_analyst_bootstrap.py`:
+
+```python
+import time
+
+class TestReturningSession:
+    def test_stale_data_warning(self, tmp_workspace):
+        from cli.commands.analyst import _check_data_freshness
+        metadata_dir = tmp_workspace / "data" / "metadata"
+        metadata_dir.mkdir(parents=True, exist_ok=True)
+        # Write last_sync.json with old timestamp
+        import json
+        from datetime import datetime, timezone, timedelta
+        old_time = (datetime.now(timezone.utc) - timedelta(hours=25)).isoformat()
+        (metadata_dir / "last_sync.json").write_text(json.dumps({"last_sync": old_time}))
+        result = _check_data_freshness(tmp_workspace)
+        assert result == "stale"
+
+    def test_fresh_data_ok(self, tmp_workspace):
+        from cli.commands.analyst import _check_data_freshness
+        metadata_dir = tmp_workspace / "data" / "metadata"
+        metadata_dir.mkdir(parents=True, exist_ok=True)
+        import json
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc).isoformat()
+        (metadata_dir / "last_sync.json").write_text(json.dumps({"last_sync": now}))
+        result = _check_data_freshness(tmp_workspace)
+        assert result == "fresh"
+
+    def test_no_data_returns_missing(self, tmp_workspace):
+        from cli.commands.analyst import _check_data_freshness
+        result = _check_data_freshness(tmp_workspace)
+        assert result == "missing"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_analyst_bootstrap.py::TestReturningSession -v`
+Expected: FAIL — `_check_data_freshness` not found
+
+- [ ] **Step 3: Implement freshness check and status command**
+
+Add to `cli/commands/analyst.py`:
+
+```python
+@analyst_app.command("status")
+def status():
+    """Check workspace status and data freshness."""
+    workspace = Path.cwd()
+
+    claude_md = workspace / "CLAUDE.md"
+    if not claude_md.exists() or AGNES_IDENTIFIER not in claude_md.read_text():
+        typer.echo("No analyst workspace detected. Run 'da analyst setup' first.")
+        raise typer.Exit(1)
+
+    freshness = _check_data_freshness(workspace)
+    if freshness == "stale":
+        typer.echo("Data is stale (>24h old). Run 'da sync' to refresh.")
+    elif freshness == "missing":
+        typer.echo("No data found. Run 'da analyst setup' to download data.")
+    else:
+        typer.echo("Data is fresh.")
+
+
+def _check_data_freshness(workspace: Path) -> str:
+    """Check data freshness. Returns 'fresh', 'stale', or 'missing'."""
+    last_sync_file = workspace / "data" / "metadata" / "last_sync.json"
+    if not last_sync_file.exists():
+        return "missing"
+
+    try:
+        data = json.loads(last_sync_file.read_text())
+        last_sync_str = data.get("last_sync")
+        if not last_sync_str:
+            return "missing"
+
+        from datetime import datetime, timezone, timedelta
+        last_sync = datetime.fromisoformat(last_sync_str)
+        if last_sync.tzinfo is None:
+            last_sync = last_sync.replace(tzinfo=timezone.utc)
+        age = datetime.now(timezone.utc) - last_sync
+        if age > timedelta(hours=24):
+            return "stale"
+        return "fresh"
+    except Exception:
+        return "missing"
+```
+
+Also update `_download_metadata` to write `last_sync.json`:
+
+At the end of the `_download_metadata` function, add:
+
+```python
+    # Record sync timestamp
+    from datetime import datetime, timezone
+    sync_record = {"last_sync": datetime.now(timezone.utc).isoformat(), "server_url": server_url}
+    (metadata_dir / "last_sync.json").write_text(json.dumps(sync_record))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_analyst_bootstrap.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/commands/analyst.py tests/test_analyst_bootstrap.py
+git commit -m "feat: add da analyst status and returning-session freshness check"
+```
+
+---
+
+### Task 4: Final Integration
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `pytest tests/ -v --timeout=60`
+Expected: ALL PASS
+
+- [ ] **Step 2: Commit if any fixes needed**
+
+```bash
+git add -A
+git commit -m "fix: address analyst bootstrap integration issues"
+```

--- a/docs/superpowers/plans/2026-04-10-business-metrics.md
+++ b/docs/superpowers/plans/2026-04-10-business-metrics.md
@@ -1,0 +1,1808 @@
+# Business Metrics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add DuckDB-backed business metrics framework with YAML import/export, CLI, API, profiler integration, and a 10-metric starter pack.
+
+**Architecture:** New `metric_definitions` table in system.duckdb (schema v4). Repository pattern matching `table_registry.py`. CLI commands via Typer, API via FastAPI router. Profiler refactored to read metrics from DuckDB instead of YAML.
+
+**Tech Stack:** DuckDB, FastAPI, Typer, PyYAML, pytest
+
+**Spec:** `docs/superpowers/specs/2026-04-10-porting-internal-features-design.md` — Section 1
+
+---
+
+### Task 1: Schema Migration v3→v4
+
+**Files:**
+- Modify: `src/db.py:19` (SCHEMA_VERSION), `src/db.py:258-302` (migrations + _ensure_schema)
+- Test: `tests/test_db.py`
+
+- [ ] **Step 1: Write failing test for v4 schema**
+
+In `tests/test_db.py`, add:
+
+```python
+class TestSchemaV4:
+    def test_metric_definitions_table_exists(self, tmp_path, monkeypatch):
+        _setup_data_dir(tmp_path, monkeypatch)
+        from src.db import get_system_db
+
+        conn = get_system_db()
+        try:
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
+                ).fetchall()
+            }
+            assert "metric_definitions" in tables
+            assert "column_metadata" in tables
+        finally:
+            conn.close()
+
+    def test_metric_definitions_columns(self, tmp_path, monkeypatch):
+        _setup_data_dir(tmp_path, monkeypatch)
+        from src.db import get_system_db
+
+        conn = get_system_db()
+        try:
+            cols = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT column_name FROM information_schema.columns "
+                    "WHERE table_name = 'metric_definitions'"
+                ).fetchall()
+            }
+            expected = {
+                "id", "name", "display_name", "category", "description",
+                "type", "unit", "grain", "table_name", "tables", "expression",
+                "time_column", "dimensions", "filters", "synonyms", "notes",
+                "sql", "sql_variants", "validation", "source",
+                "created_at", "updated_at",
+            }
+            assert expected.issubset(cols), f"Missing: {expected - cols}"
+        finally:
+            conn.close()
+
+    def test_column_metadata_table_exists(self, tmp_path, monkeypatch):
+        _setup_data_dir(tmp_path, monkeypatch)
+        from src.db import get_system_db
+
+        conn = get_system_db()
+        try:
+            cols = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT column_name FROM information_schema.columns "
+                    "WHERE table_name = 'column_metadata'"
+                ).fetchall()
+            }
+            expected = {"table_id", "column_name", "basetype", "description", "confidence", "source", "updated_at"}
+            assert expected.issubset(cols), f"Missing: {expected - cols}"
+        finally:
+            conn.close()
+
+    def test_v3_to_v4_migration(self, tmp_path, monkeypatch):
+        """Simulate a v3 database and verify migration to v4."""
+        _setup_data_dir(tmp_path, monkeypatch)
+        import duckdb
+        from src.db import _SYSTEM_SCHEMA
+
+        db_path = tmp_path / "state" / "system.duckdb"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = duckdb.connect(str(db_path))
+        conn.execute(_SYSTEM_SCHEMA)
+        conn.execute("INSERT INTO schema_version (version) VALUES (3)")
+        conn.close()
+
+        from src.db import get_system_db
+        conn = get_system_db()
+        try:
+            version = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()[0]
+            assert version == 4
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
+                ).fetchall()
+            }
+            assert "metric_definitions" in tables
+            assert "column_metadata" in tables
+        finally:
+            conn.close()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_db.py::TestSchemaV4 -v`
+Expected: FAIL — `metric_definitions` table does not exist
+
+- [ ] **Step 3: Implement schema v4 migration**
+
+In `src/db.py`, change line 19:
+
+```python
+SCHEMA_VERSION = 4
+```
+
+After `_V2_TO_V3_MIGRATIONS` (line ~260), add:
+
+```python
+_V3_TO_V4_MIGRATIONS = [
+    """CREATE TABLE IF NOT EXISTS metric_definitions (
+        id              VARCHAR PRIMARY KEY,
+        name            VARCHAR NOT NULL,
+        display_name    VARCHAR NOT NULL,
+        category        VARCHAR NOT NULL,
+        description     TEXT,
+        type            VARCHAR DEFAULT 'sum',
+        unit            VARCHAR,
+        grain           VARCHAR DEFAULT 'monthly',
+        table_name      VARCHAR,
+        tables          VARCHAR[],
+        expression      VARCHAR,
+        time_column     VARCHAR,
+        dimensions      VARCHAR[],
+        filters         VARCHAR[],
+        synonyms        VARCHAR[],
+        notes           VARCHAR[],
+        sql             TEXT NOT NULL,
+        sql_variants    JSON,
+        validation      JSON,
+        source          VARCHAR DEFAULT 'manual',
+        created_at      TIMESTAMP DEFAULT current_timestamp,
+        updated_at      TIMESTAMP DEFAULT current_timestamp
+    )""",
+    """CREATE TABLE IF NOT EXISTS column_metadata (
+        table_id        VARCHAR NOT NULL,
+        column_name     VARCHAR NOT NULL,
+        basetype        VARCHAR,
+        description     VARCHAR,
+        confidence      VARCHAR DEFAULT 'manual',
+        source          VARCHAR DEFAULT 'manual',
+        updated_at      TIMESTAMP DEFAULT current_timestamp,
+        PRIMARY KEY (table_id, column_name)
+    )""",
+]
+```
+
+In `_ensure_schema()`, after the `if current < 3:` block (line ~298), add:
+
+```python
+            if current < 4:
+                for sql in _V3_TO_V4_MIGRATIONS:
+                    conn.execute(sql)
+```
+
+Also update the `test_creates_all_tables` test's `expected` set to include `"metric_definitions"` and `"column_metadata"`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_db.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/db.py tests/test_db.py
+git commit -m "feat: add schema v4 with metric_definitions and column_metadata tables"
+```
+
+---
+
+### Task 2: MetricRepository — CRUD
+
+**Files:**
+- Create: `src/repositories/metrics.py`
+- Test: `tests/test_metrics.py`
+
+- [ ] **Step 1: Write failing tests for MetricRepository CRUD**
+
+Create `tests/test_metrics.py`:
+
+```python
+"""Tests for MetricRepository."""
+
+import os
+import pytest
+import duckdb
+
+
+@pytest.fixture
+def db_conn(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    from src.db import get_system_db
+    conn = get_system_db()
+    yield conn
+    conn.close()
+
+
+SAMPLE_METRIC = {
+    "id": "revenue/mrr",
+    "name": "mrr",
+    "display_name": "Monthly Recurring Revenue",
+    "category": "revenue",
+    "description": "Total MRR from all subscriptions",
+    "type": "sum",
+    "unit": "USD",
+    "grain": "monthly",
+    "table_name": "subscriptions",
+    "expression": "SUM(mrr_amount)",
+    "time_column": "billing_date",
+    "dimensions": ["plan_type", "region"],
+    "synonyms": ["monthly_revenue", "recurring_revenue"],
+    "notes": ["Excludes one-time fees"],
+    "sql": "SELECT DATE_TRUNC('month', billing_date) AS month, SUM(mrr_amount) AS mrr FROM subscriptions GROUP BY 1",
+}
+
+
+class TestMetricRepositoryCreate:
+    def test_create_metric(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        result = repo.create(**SAMPLE_METRIC)
+        assert result["id"] == "revenue/mrr"
+        assert result["name"] == "mrr"
+
+    def test_create_duplicate_upserts(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        repo.create(**SAMPLE_METRIC)
+        updated = {**SAMPLE_METRIC, "display_name": "Updated MRR"}
+        result = repo.create(**updated)
+        assert result["display_name"] == "Updated MRR"
+        assert len(repo.list()) == 1
+
+
+class TestMetricRepositoryRead:
+    def test_get_existing(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        repo.create(**SAMPLE_METRIC)
+        result = repo.get("revenue/mrr")
+        assert result is not None
+        assert result["name"] == "mrr"
+        assert result["dimensions"] == ["plan_type", "region"]
+
+    def test_get_missing(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        assert repo.get("nonexistent/metric") is None
+
+    def test_list_all(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        repo.create(**SAMPLE_METRIC)
+        repo.create(
+            id="revenue/arr", name="arr", display_name="ARR",
+            category="revenue", sql="SELECT 1",
+        )
+        results = repo.list()
+        assert len(results) == 2
+
+    def test_list_by_category(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        repo.create(**SAMPLE_METRIC)
+        repo.create(
+            id="ops/resolution_time", name="resolution_time",
+            display_name="Resolution Time", category="ops",
+            sql="SELECT 1",
+        )
+        results = repo.list(category="revenue")
+        assert len(results) == 1
+        assert results[0]["name"] == "mrr"
+
+
+class TestMetricRepositoryUpdate:
+    def test_update_fields(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        repo.create(**SAMPLE_METRIC)
+        result = repo.update("revenue/mrr", display_name="Gross MRR", unit="EUR")
+        assert result["display_name"] == "Gross MRR"
+        assert result["unit"] == "EUR"
+        assert result["name"] == "mrr"  # unchanged
+
+    def test_update_missing_returns_none(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        assert repo.update("nonexistent/x", name="y") is None
+
+
+class TestMetricRepositoryDelete:
+    def test_delete_existing(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        repo.create(**SAMPLE_METRIC)
+        assert repo.delete("revenue/mrr") is True
+        assert repo.get("revenue/mrr") is None
+
+    def test_delete_missing(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        assert repo.delete("nonexistent/x") is False
+
+
+class TestMetricRepositorySearch:
+    def test_find_by_table(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        repo.create(**SAMPLE_METRIC)
+        repo.create(
+            id="revenue/arr", name="arr", display_name="ARR",
+            category="revenue", table_name="subscriptions",
+            sql="SELECT 1",
+        )
+        repo.create(
+            id="ops/tickets", name="tickets", display_name="Tickets",
+            category="ops", table_name="tickets",
+            sql="SELECT 1",
+        )
+        results = repo.find_by_table("subscriptions")
+        assert len(results) == 2
+        names = {r["name"] for r in results}
+        assert names == {"mrr", "arr"}
+
+    def test_find_by_synonym(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        repo.create(**SAMPLE_METRIC)
+        results = repo.find_by_synonym("recurring_revenue")
+        assert len(results) == 1
+        assert results[0]["name"] == "mrr"
+
+    def test_get_table_map(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        repo.create(**SAMPLE_METRIC)
+        repo.create(
+            id="ops/tickets", name="tickets", display_name="Tickets",
+            category="ops", table_name="tickets",
+            sql="SELECT 1",
+        )
+        table_map = repo.get_table_map()
+        assert table_map == {"subscriptions": ["mrr"], "tickets": ["tickets"]}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_metrics.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'src.repositories.metrics'`
+
+- [ ] **Step 3: Implement MetricRepository**
+
+Create `src/repositories/metrics.py`:
+
+```python
+"""Repository for metric definitions."""
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+import duckdb
+
+
+class MetricRepository:
+    def __init__(self, conn: duckdb.DuckDBPyConnection):
+        self.conn = conn
+
+    def create(self, id: str, name: str, display_name: str, category: str,
+               sql: str, description: Optional[str] = None,
+               type: str = "sum", unit: Optional[str] = None,
+               grain: str = "monthly", table_name: Optional[str] = None,
+               tables: Optional[List[str]] = None, expression: Optional[str] = None,
+               time_column: Optional[str] = None, dimensions: Optional[List[str]] = None,
+               filters: Optional[List[str]] = None, synonyms: Optional[List[str]] = None,
+               notes: Optional[List[str]] = None, sql_variants: Optional[dict] = None,
+               validation: Optional[dict] = None, source: str = "manual",
+               **kwargs) -> Dict[str, Any]:
+        now = datetime.now(timezone.utc)
+        self.conn.execute(
+            """INSERT INTO metric_definitions (
+                id, name, display_name, category, description, type, unit, grain,
+                table_name, tables, expression, time_column, dimensions, filters,
+                synonyms, notes, sql, sql_variants, validation, source,
+                created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT (id) DO UPDATE SET
+                name = excluded.name, display_name = excluded.display_name,
+                category = excluded.category, description = excluded.description,
+                type = excluded.type, unit = excluded.unit, grain = excluded.grain,
+                table_name = excluded.table_name, tables = excluded.tables,
+                expression = excluded.expression, time_column = excluded.time_column,
+                dimensions = excluded.dimensions, filters = excluded.filters,
+                synonyms = excluded.synonyms, notes = excluded.notes,
+                sql = excluded.sql, sql_variants = excluded.sql_variants,
+                validation = excluded.validation, source = excluded.source,
+                updated_at = excluded.updated_at""",
+            [id, name, display_name, category, description, type, unit, grain,
+             table_name, tables, expression, time_column, dimensions, filters,
+             synonyms, notes, sql,
+             json_dumps(sql_variants), json_dumps(validation),
+             source, now, now],
+        )
+        return self.get(id)
+
+    def get(self, metric_id: str) -> Optional[Dict[str, Any]]:
+        result = self.conn.execute(
+            "SELECT * FROM metric_definitions WHERE id = ?", [metric_id]
+        ).fetchone()
+        if not result:
+            return None
+        columns = [desc[0] for desc in self.conn.description]
+        return dict(zip(columns, result))
+
+    def list(self, category: Optional[str] = None) -> List[Dict[str, Any]]:
+        if category:
+            results = self.conn.execute(
+                "SELECT * FROM metric_definitions WHERE category = ? ORDER BY name",
+                [category],
+            ).fetchall()
+        else:
+            results = self.conn.execute(
+                "SELECT * FROM metric_definitions ORDER BY category, name"
+            ).fetchall()
+        if not results:
+            return []
+        columns = [desc[0] for desc in self.conn.description]
+        return [dict(zip(columns, row)) for row in results]
+
+    def update(self, metric_id: str, **kwargs) -> Optional[Dict[str, Any]]:
+        existing = self.get(metric_id)
+        if not existing:
+            return None
+        kwargs["updated_at"] = datetime.now(timezone.utc)
+        # Convert JSON fields
+        for json_field in ("sql_variants", "validation"):
+            if json_field in kwargs and kwargs[json_field] is not None:
+                kwargs[json_field] = json_dumps(kwargs[json_field])
+        set_clauses = ", ".join(f"{k} = ?" for k in kwargs)
+        values = list(kwargs.values()) + [metric_id]
+        self.conn.execute(
+            f"UPDATE metric_definitions SET {set_clauses} WHERE id = ?",
+            values,
+        )
+        return self.get(metric_id)
+
+    def delete(self, metric_id: str) -> bool:
+        existing = self.get(metric_id)
+        if not existing:
+            return False
+        self.conn.execute("DELETE FROM metric_definitions WHERE id = ?", [metric_id])
+        return True
+
+    def find_by_table(self, table_name: str) -> List[Dict[str, Any]]:
+        results = self.conn.execute(
+            "SELECT * FROM metric_definitions WHERE table_name = ? ORDER BY name",
+            [table_name],
+        ).fetchall()
+        if not results:
+            return []
+        columns = [desc[0] for desc in self.conn.description]
+        return [dict(zip(columns, row)) for row in results]
+
+    def find_by_synonym(self, term: str) -> List[Dict[str, Any]]:
+        results = self.conn.execute(
+            "SELECT * FROM metric_definitions WHERE list_contains(synonyms, ?) ORDER BY name",
+            [term],
+        ).fetchall()
+        if not results:
+            return []
+        columns = [desc[0] for desc in self.conn.description]
+        return [dict(zip(columns, row)) for row in results]
+
+    def get_table_map(self) -> Dict[str, List[str]]:
+        """Return {table_name: [metric_name, ...]} for profiler integration."""
+        results = self.conn.execute(
+            "SELECT table_name, name FROM metric_definitions WHERE table_name IS NOT NULL ORDER BY table_name"
+        ).fetchall()
+        table_map: Dict[str, List[str]] = {}
+        for table_name, metric_name in results:
+            table_map.setdefault(table_name, []).append(metric_name)
+        return table_map
+
+
+def json_dumps(obj) -> Optional[str]:
+    """Serialize to JSON string for DuckDB JSON columns, or None."""
+    if obj is None:
+        return None
+    import json
+    return json.dumps(obj)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_metrics.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/repositories/metrics.py tests/test_metrics.py
+git commit -m "feat: add MetricRepository with CRUD, search, and table map"
+```
+
+---
+
+### Task 3: YAML Import/Export
+
+**Files:**
+- Modify: `src/repositories/metrics.py` (add import_from_yaml, export_to_yaml)
+- Test: `tests/test_metrics.py` (add import/export tests)
+
+- [ ] **Step 1: Write failing tests for YAML import/export**
+
+Add to `tests/test_metrics.py`:
+
+```python
+import yaml
+from pathlib import Path
+
+
+@pytest.fixture
+def metrics_dir(tmp_path):
+    """Create a sample metrics directory with YAML files."""
+    revenue_dir = tmp_path / "metrics" / "revenue"
+    revenue_dir.mkdir(parents=True)
+    ops_dir = tmp_path / "metrics" / "operations"
+    ops_dir.mkdir(parents=True)
+
+    # total_revenue.yml — uses 'table' key (YAML format)
+    (revenue_dir / "total_revenue.yml").write_text(yaml.dump({
+        "name": "total_revenue",
+        "display_name": "Total Revenue",
+        "category": "revenue",
+        "type": "sum",
+        "unit": "USD",
+        "grain": "monthly",
+        "table": "orders",
+        "expression": "SUM(total_amount)",
+        "time_column": "order_date",
+        "dimensions": ["channel", "region"],
+        "synonyms": ["gross_revenue"],
+        "sql": "SELECT SUM(total_amount) FROM orders",
+        "sql_by_channel": "SELECT channel, SUM(total_amount) FROM orders GROUP BY 1",
+    }))
+
+    # resolution_time.yml
+    (ops_dir / "resolution_time.yml").write_text(yaml.dump({
+        "name": "resolution_time",
+        "display_name": "Support Resolution Time",
+        "category": "operations",
+        "type": "avg",
+        "unit": "hours",
+        "table": "tickets",
+        "sql": "SELECT AVG(resolution_hours) FROM tickets",
+    }))
+
+    return tmp_path / "metrics"
+
+
+class TestMetricRepositoryImport:
+    def test_import_from_directory(self, db_conn, metrics_dir):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        count = repo.import_from_yaml(metrics_dir)
+        assert count == 2
+        assert repo.get("revenue/total_revenue") is not None
+        assert repo.get("operations/resolution_time") is not None
+
+    def test_import_maps_table_to_table_name(self, db_conn, metrics_dir):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        repo.import_from_yaml(metrics_dir)
+        metric = repo.get("revenue/total_revenue")
+        assert metric["table_name"] == "orders"
+
+    def test_import_collects_sql_variants(self, db_conn, metrics_dir):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        repo.import_from_yaml(metrics_dir)
+        metric = repo.get("revenue/total_revenue")
+        variants = metric["sql_variants"]
+        # DuckDB returns JSON as string or dict depending on version
+        if isinstance(variants, str):
+            import json
+            variants = json.loads(variants)
+        assert "by_channel" in variants
+
+    def test_import_single_file(self, db_conn, metrics_dir):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        count = repo.import_from_yaml(metrics_dir / "revenue" / "total_revenue.yml")
+        assert count == 1
+
+    def test_import_idempotent(self, db_conn, metrics_dir):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        repo.import_from_yaml(metrics_dir)
+        repo.import_from_yaml(metrics_dir)
+        assert len(repo.list()) == 2
+
+
+class TestMetricRepositoryExport:
+    def test_export_to_yaml(self, db_conn, metrics_dir, tmp_path):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        repo.import_from_yaml(metrics_dir)
+
+        export_dir = tmp_path / "export"
+        count = repo.export_to_yaml(export_dir)
+        assert count == 2
+
+        # Check directory structure
+        assert (export_dir / "revenue" / "total_revenue.yml").exists()
+        assert (export_dir / "operations" / "resolution_time.yml").exists()
+
+        # Check content
+        data = yaml.safe_load((export_dir / "revenue" / "total_revenue.yml").read_text())
+        assert data["name"] == "total_revenue"
+        assert data["table"] == "orders"  # exported as 'table', not 'table_name'
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_metrics.py::TestMetricRepositoryImport -v`
+Expected: FAIL — `AttributeError: 'MetricRepository' object has no attribute 'import_from_yaml'`
+
+- [ ] **Step 3: Implement import_from_yaml and export_to_yaml**
+
+Add to `MetricRepository` class in `src/repositories/metrics.py`:
+
+```python
+    def import_from_yaml(self, path) -> int:
+        """Import metrics from YAML file(s). Returns count imported.
+
+        Args:
+            path: Path to a single YAML file or directory containing category/metric.yml files.
+        """
+        from pathlib import Path
+        import yaml
+
+        path = Path(path)
+        count = 0
+
+        if path.is_file():
+            yml_files = [path]
+        elif path.is_dir():
+            yml_files = sorted(path.glob("*/*.yml"))
+        else:
+            return 0
+
+        for yml_file in yml_files:
+            try:
+                with open(yml_file) as f:
+                    data = yaml.safe_load(f)
+            except (yaml.YAMLError, OSError):
+                continue
+
+            if not data:
+                continue
+
+            # Handle list-wrapped metrics (internal repo format)
+            metric_list = data if isinstance(data, list) else [data]
+            for metric in metric_list:
+                if not isinstance(metric, dict) or "name" not in metric:
+                    continue
+
+                # Infer category from directory name
+                category = metric.get("category", yml_file.parent.name)
+                name = metric["name"]
+                metric_id = f"{category}/{name}"
+
+                # Map YAML 'table' → DuckDB 'table_name'
+                table_name = metric.pop("table", None)
+
+                # Collect sql_by_* variants
+                sql_variants = {}
+                keys_to_remove = []
+                for key in list(metric.keys()):
+                    if key.startswith("sql_by_"):
+                        variant_name = key[4:]  # "sql_by_channel" → "by_channel"
+                        sql_variants[variant_name] = metric[key]
+                        keys_to_remove.append(key)
+                for key in keys_to_remove:
+                    del metric[key]
+
+                self.create(
+                    id=metric_id,
+                    name=name,
+                    display_name=metric.get("display_name", name),
+                    category=category,
+                    description=metric.get("description"),
+                    type=metric.get("type", "sum"),
+                    unit=metric.get("unit"),
+                    grain=metric.get("grain", "monthly"),
+                    table_name=table_name or metric.get("table_name"),
+                    tables=metric.get("tables"),
+                    expression=metric.get("expression"),
+                    time_column=metric.get("time_column"),
+                    dimensions=metric.get("dimensions"),
+                    filters=metric.get("filters"),
+                    synonyms=metric.get("synonyms"),
+                    notes=metric.get("notes"),
+                    sql=metric.get("sql", ""),
+                    sql_variants=sql_variants if sql_variants else None,
+                    validation=metric.get("validation"),
+                    source="yaml_import",
+                )
+                count += 1
+
+        return count
+
+    def export_to_yaml(self, output_dir) -> int:
+        """Export all metrics to YAML files. Returns count exported."""
+        from pathlib import Path
+        import yaml
+        import json
+
+        output_dir = Path(output_dir)
+        count = 0
+
+        for metric in self.list():
+            category = metric["category"]
+            name = metric["name"]
+            cat_dir = output_dir / category
+            cat_dir.mkdir(parents=True, exist_ok=True)
+
+            # Build YAML-compatible dict
+            data = {
+                "name": name,
+                "display_name": metric["display_name"],
+                "category": category,
+            }
+
+            # Map DuckDB 'table_name' back to YAML 'table'
+            if metric.get("table_name"):
+                data["table"] = metric["table_name"]
+
+            for field in ("description", "type", "unit", "grain", "tables",
+                          "expression", "time_column", "dimensions", "filters",
+                          "synonyms", "notes"):
+                if metric.get(field) is not None:
+                    data[field] = metric[field]
+
+            if metric.get("sql"):
+                data["sql"] = metric["sql"]
+
+            # Expand sql_variants back to sql_by_* keys
+            variants = metric.get("sql_variants")
+            if variants:
+                if isinstance(variants, str):
+                    variants = json.loads(variants)
+                for key, val in variants.items():
+                    data[f"sql_{key}"] = val
+
+            if metric.get("validation"):
+                val = metric["validation"]
+                if isinstance(val, str):
+                    val = json.loads(val)
+                data["validation"] = val
+
+            yml_path = cat_dir / f"{name}.yml"
+            yml_path.write_text(yaml.dump(data, default_flow_style=False, allow_unicode=True, sort_keys=False))
+            count += 1
+
+        return count
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_metrics.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/repositories/metrics.py tests/test_metrics.py
+git commit -m "feat: add YAML import/export to MetricRepository"
+```
+
+---
+
+### Task 4: CLI `da metrics`
+
+**Files:**
+- Create: `cli/commands/metrics.py`
+- Modify: `cli/main.py` (register metrics_app)
+- Test: `tests/test_cli.py` (add metrics help test)
+
+- [ ] **Step 1: Write failing test for CLI registration**
+
+Add to `tests/test_cli.py` in `TestCLIHelp`:
+
+```python
+    def test_metrics_help(self):
+        result = runner.invoke(app, ["metrics", "--help"])
+        assert result.exit_code == 0
+        assert "list" in result.output
+        assert "show" in result.output
+        assert "import" in result.output
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_cli.py::TestCLIHelp::test_metrics_help -v`
+Expected: FAIL — `No such command 'metrics'`
+
+- [ ] **Step 3: Implement CLI commands**
+
+Create `cli/commands/metrics.py`:
+
+```python
+"""Metrics commands — da metrics."""
+
+import json
+from pathlib import Path
+
+import typer
+
+from cli.client import api_get
+
+metrics_app = typer.Typer(help="Business metrics — list, show, import, export, validate")
+
+
+@metrics_app.command("list")
+def list_metrics(
+    category: str = typer.Option(None, "--category", "-c", help="Filter by category"),
+    as_json: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """List all metrics."""
+    params = {}
+    if category:
+        params["category"] = category
+    resp = api_get("/api/metrics", params=params)
+    if resp.status_code != 200:
+        typer.echo(f"Failed: {resp.json().get('detail', resp.text)}", err=True)
+        raise typer.Exit(1)
+
+    data = resp.json()
+    metrics = data.get("metrics", [])
+
+    if as_json:
+        typer.echo(json.dumps(metrics, indent=2))
+    else:
+        if not metrics:
+            typer.echo("No metrics found. Import with: da metrics import docs/metrics/")
+            return
+        current_cat = None
+        for m in metrics:
+            if m["category"] != current_cat:
+                current_cat = m["category"]
+                typer.echo(f"\n  {current_cat.upper()}")
+            typer.echo(f"    {m['id']:40s} {m.get('display_name', m['name'])}")
+        typer.echo(f"\nTotal: {len(metrics)} metrics")
+
+
+@metrics_app.command("show")
+def show_metric(
+    metric_id: str = typer.Argument(..., help="Metric ID (e.g., revenue/mrr)"),
+    as_json: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Show detail for a metric."""
+    resp = api_get(f"/api/metrics/{metric_id}")
+    if resp.status_code == 404:
+        typer.echo(f"Metric not found: {metric_id}", err=True)
+        raise typer.Exit(1)
+    if resp.status_code != 200:
+        typer.echo(f"Failed: {resp.json().get('detail', resp.text)}", err=True)
+        raise typer.Exit(1)
+
+    m = resp.json()
+    if as_json:
+        typer.echo(json.dumps(m, indent=2))
+    else:
+        typer.echo(f"  {m['display_name']}  ({m['id']})")
+        typer.echo(f"  Type: {m.get('type', 'sum')}  |  Unit: {m.get('unit', '-')}  |  Grain: {m.get('grain', '-')}")
+        if m.get("description"):
+            typer.echo(f"\n  {m['description']}")
+        if m.get("table_name"):
+            typer.echo(f"\n  Table: {m['table_name']}")
+        if m.get("dimensions"):
+            typer.echo(f"  Dimensions: {', '.join(m['dimensions'])}")
+        if m.get("notes"):
+            typer.echo("\n  Notes:")
+            for note in m["notes"]:
+                typer.echo(f"    - {note}")
+        if m.get("sql"):
+            typer.echo(f"\n  SQL:\n    {m['sql']}")
+
+
+@metrics_app.command("import")
+def import_metrics(
+    path: str = typer.Argument(..., help="Path to YAML file or directory"),
+):
+    """Import metrics from YAML into DuckDB."""
+    from src.db import get_system_db
+    from src.repositories.metrics import MetricRepository
+
+    source = Path(path)
+    if not source.exists():
+        typer.echo(f"Path not found: {path}", err=True)
+        raise typer.Exit(1)
+
+    conn = get_system_db()
+    try:
+        repo = MetricRepository(conn)
+        count = repo.import_from_yaml(source)
+        typer.echo(f"Imported {count} metrics into DuckDB")
+    finally:
+        conn.close()
+
+
+@metrics_app.command("export")
+def export_metrics(
+    output_dir: str = typer.Option("./metrics_export", "--dir", "-d", help="Output directory"),
+):
+    """Export metrics from DuckDB to YAML files."""
+    from src.db import get_system_db
+    from src.repositories.metrics import MetricRepository
+
+    conn = get_system_db()
+    try:
+        repo = MetricRepository(conn)
+        count = repo.export_to_yaml(output_dir)
+        typer.echo(f"Exported {count} metrics to {output_dir}/")
+    finally:
+        conn.close()
+
+
+@metrics_app.command("validate")
+def validate_metrics():
+    """Validate metrics — check that referenced tables exist in analytics DB."""
+    from src.db import get_system_db
+    from src.repositories.metrics import MetricRepository
+    from src.repositories.table_registry import TableRegistryRepository
+
+    conn = get_system_db()
+    try:
+        metrics_repo = MetricRepository(conn)
+        tables_repo = TableRegistryRepository(conn)
+        all_tables = {t["id"] for t in tables_repo.list_all()}
+        metrics = metrics_repo.list()
+
+        ok = 0
+        warnings = 0
+        for m in metrics:
+            if m.get("table_name") and m["table_name"] not in all_tables:
+                typer.echo(f"  WARN  {m['id']}: table '{m['table_name']}' not in registry")
+                warnings += 1
+            else:
+                ok += 1
+
+        typer.echo(f"\nValidated {len(metrics)} metrics: {ok} OK, {warnings} warnings")
+    finally:
+        conn.close()
+```
+
+Register in `cli/main.py` — add import and registration:
+
+```python
+from cli.commands.metrics import metrics_app
+# ...
+app.add_typer(metrics_app, name="metrics")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_cli.py::TestCLIHelp::test_metrics_help -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/commands/metrics.py cli/main.py tests/test_cli.py
+git commit -m "feat: add da metrics CLI commands (list, show, import, export, validate)"
+```
+
+---
+
+### Task 5: API Endpoints
+
+**Files:**
+- Create: `app/api/metrics.py`
+- Modify: `app/main.py` (register router)
+- Modify: `app/api/catalog.py` (deprecation redirect)
+- Test: `tests/test_api.py` (add metrics API tests)
+
+- [ ] **Step 1: Write failing tests for metrics API**
+
+Add to `tests/test_api.py`:
+
+```python
+class TestMetricsAPI:
+    def test_list_metrics_empty(self, seeded_client):
+        client, admin_token, _ = seeded_client
+        resp = client.get("/api/metrics", headers={"Authorization": f"Bearer {admin_token}"})
+        assert resp.status_code == 200
+        assert resp.json()["metrics"] == []
+
+    def test_create_and_list_metric(self, seeded_client):
+        client, admin_token, _ = seeded_client
+        metric = {
+            "id": "revenue/mrr",
+            "name": "mrr",
+            "display_name": "MRR",
+            "category": "revenue",
+            "sql": "SELECT SUM(amount) FROM subscriptions",
+        }
+        resp = client.post(
+            "/api/admin/metrics",
+            json=metric,
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert resp.status_code == 201
+
+        resp = client.get("/api/metrics", headers={"Authorization": f"Bearer {admin_token}"})
+        assert resp.status_code == 200
+        assert len(resp.json()["metrics"]) == 1
+
+    def test_get_metric_detail(self, seeded_client):
+        client, admin_token, _ = seeded_client
+        client.post(
+            "/api/admin/metrics",
+            json={"id": "revenue/mrr", "name": "mrr", "display_name": "MRR",
+                  "category": "revenue", "sql": "SELECT 1"},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        resp = client.get("/api/metrics/revenue/mrr", headers={"Authorization": f"Bearer {admin_token}"})
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "mrr"
+
+    def test_get_metric_not_found(self, seeded_client):
+        client, admin_token, _ = seeded_client
+        resp = client.get("/api/metrics/nonexistent/x", headers={"Authorization": f"Bearer {admin_token}"})
+        assert resp.status_code == 404
+
+    def test_delete_metric(self, seeded_client):
+        client, admin_token, _ = seeded_client
+        client.post(
+            "/api/admin/metrics",
+            json={"id": "revenue/mrr", "name": "mrr", "display_name": "MRR",
+                  "category": "revenue", "sql": "SELECT 1"},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        resp = client.delete("/api/admin/metrics/revenue/mrr",
+                             headers={"Authorization": f"Bearer {admin_token}"})
+        assert resp.status_code == 200
+
+    def test_analyst_cannot_create_metric(self, seeded_client):
+        client, _, analyst_token = seeded_client
+        resp = client.post(
+            "/api/admin/metrics",
+            json={"id": "revenue/mrr", "name": "mrr", "display_name": "MRR",
+                  "category": "revenue", "sql": "SELECT 1"},
+            headers={"Authorization": f"Bearer {analyst_token}"},
+        )
+        assert resp.status_code == 403
+
+    def test_list_metrics_filter_by_category(self, seeded_client):
+        client, admin_token, _ = seeded_client
+        for m in [
+            {"id": "revenue/mrr", "name": "mrr", "display_name": "MRR", "category": "revenue", "sql": "SELECT 1"},
+            {"id": "ops/tickets", "name": "tickets", "display_name": "Tickets", "category": "ops", "sql": "SELECT 1"},
+        ]:
+            client.post("/api/admin/metrics", json=m, headers={"Authorization": f"Bearer {admin_token}"})
+        resp = client.get("/api/metrics?category=revenue", headers={"Authorization": f"Bearer {admin_token}"})
+        assert len(resp.json()["metrics"]) == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_api.py::TestMetricsAPI -v`
+Expected: FAIL — 404 on `/api/metrics`
+
+- [ ] **Step 3: Implement API router**
+
+Create `app/api/metrics.py`:
+
+```python
+"""Metrics API endpoints."""
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+import duckdb
+
+from app.auth.dependencies import get_current_user, require_admin, _get_db
+from src.repositories.metrics import MetricRepository
+
+router = APIRouter(tags=["metrics"])
+
+
+class MetricCreate(BaseModel):
+    id: str
+    name: str
+    display_name: str
+    category: str
+    sql: str
+    description: Optional[str] = None
+    type: str = "sum"
+    unit: Optional[str] = None
+    grain: str = "monthly"
+    table_name: Optional[str] = None
+    tables: Optional[list] = None
+    expression: Optional[str] = None
+    time_column: Optional[str] = None
+    dimensions: Optional[list] = None
+    filters: Optional[list] = None
+    synonyms: Optional[list] = None
+    notes: Optional[list] = None
+    sql_variants: Optional[dict] = None
+    validation: Optional[dict] = None
+
+
+@router.get("/api/metrics")
+async def list_metrics(
+    category: Optional[str] = Query(None),
+    user: dict = Depends(get_current_user),
+    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
+):
+    repo = MetricRepository(conn)
+    metrics = repo.list(category=category)
+    return {"metrics": metrics, "count": len(metrics)}
+
+
+@router.get("/api/metrics/{metric_id:path}")
+async def get_metric(
+    metric_id: str,
+    user: dict = Depends(get_current_user),
+    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
+):
+    repo = MetricRepository(conn)
+    metric = repo.get(metric_id)
+    if not metric:
+        raise HTTPException(status_code=404, detail=f"Metric not found: {metric_id}")
+    return metric
+
+
+@router.post("/api/admin/metrics", status_code=201)
+async def create_metric(
+    body: MetricCreate,
+    user: dict = Depends(require_admin),
+    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
+):
+    repo = MetricRepository(conn)
+    return repo.create(**body.model_dump())
+
+
+@router.delete("/api/admin/metrics/{metric_id:path}")
+async def delete_metric(
+    metric_id: str,
+    user: dict = Depends(require_admin),
+    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
+):
+    repo = MetricRepository(conn)
+    if not repo.delete(metric_id):
+        raise HTTPException(status_code=404, detail=f"Metric not found: {metric_id}")
+    return {"status": "deleted", "id": metric_id}
+```
+
+Register in `app/main.py` — add import and include:
+
+```python
+from app.api.metrics import router as metrics_router
+# ... (add near other router imports at top of file)
+
+# In create_app(), add before web_router:
+app.include_router(metrics_router)
+```
+
+Deprecate old endpoint in `app/api/catalog.py` — replace the `get_metric` function:
+
+```python
+@router.get("/metrics/{metric_path:path}", deprecated=True)
+async def get_metric(
+    metric_path: str,
+    user: dict = Depends(get_current_user),
+):
+    """Deprecated: Use GET /api/metrics/{metric_id} instead."""
+    from fastapi.responses import RedirectResponse
+    # Strip .yml extension for the new endpoint
+    metric_id = metric_path.replace(".yml", "")
+    return RedirectResponse(url=f"/api/metrics/{metric_id}", status_code=301)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_api.py::TestMetricsAPI -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/metrics.py app/main.py app/api/catalog.py tests/test_api.py
+git commit -m "feat: add metrics API endpoints with admin CRUD"
+```
+
+---
+
+### Task 6: Starter Pack Metrics
+
+**Files:**
+- Create: `docs/metrics/metrics.yml` (index)
+- Create: `docs/metrics/revenue/mrr.yml`
+- Create: `docs/metrics/revenue/arr.yml`
+- Create: `docs/metrics/revenue/churn_rate.yml`
+- Create: `docs/metrics/product_usage/active_users.yml`
+- Create: `docs/metrics/product_usage/feature_adoption.yml`
+- Create: `docs/metrics/sales/new_customers.yml`
+- Create: `docs/metrics/sales/upsell_expansion.yml`
+- Create: `docs/metrics/sales/pipeline_value.yml`
+- Create: `docs/metrics/operations/support_resolution_time.yml`
+- Create: `docs/metrics/operations/infrastructure_cost.yml`
+- Existing: `docs/metrics/revenue/total_revenue.yml` (already exists, no change)
+
+- [ ] **Step 1: Create metrics index**
+
+Create `docs/metrics/metrics.yml`:
+
+```yaml
+version: "2.0"
+description: "Business metrics starter pack. Import with: da metrics import docs/metrics/"
+categories:
+  - name: revenue
+    folder: revenue/
+    metrics: [total_revenue, mrr, arr, churn_rate]
+  - name: product_usage
+    folder: product_usage/
+    metrics: [active_users, feature_adoption]
+  - name: sales
+    folder: sales/
+    metrics: [new_customers, upsell_expansion, pipeline_value]
+  - name: operations
+    folder: operations/
+    metrics: [support_resolution_time, infrastructure_cost]
+```
+
+- [ ] **Step 2: Create revenue metrics**
+
+Create `docs/metrics/revenue/mrr.yml`:
+
+```yaml
+- name: mrr
+  display_name: Monthly Recurring Revenue
+  category: revenue
+  type: sum
+  unit: USD
+  grain: monthly
+  table: subscriptions
+  expression: "SUM(mrr_amount)"
+  time_column: billing_date
+  dimensions:
+    - plan_type
+    - region
+  notes:
+    - "Aggregated at company level, not per-contract"
+    - "Excludes one-time setup fees and overages"
+  synonyms:
+    - monthly_revenue
+    - recurring_revenue
+  sql: |
+    SELECT
+        DATE_TRUNC('month', billing_date) AS month,
+        SUM(mrr_amount) AS mrr
+    FROM subscriptions
+    WHERE status = 'active'
+    GROUP BY 1
+    ORDER BY 1
+  sql_by_plan: |
+    SELECT
+        DATE_TRUNC('month', billing_date) AS month,
+        plan_type,
+        SUM(mrr_amount) AS mrr
+    FROM subscriptions
+    WHERE status = 'active'
+    GROUP BY 1, 2
+    ORDER BY 1, 3 DESC
+```
+
+Create `docs/metrics/revenue/arr.yml`:
+
+```yaml
+- name: arr
+  display_name: Annual Recurring Revenue
+  category: revenue
+  type: sum
+  unit: USD
+  grain: monthly
+  table: subscriptions
+  expression: "SUM(mrr_amount) * 12"
+  time_column: billing_date
+  notes:
+    - "ARR = MRR × 12 (annualized current MRR)"
+    - "Point-in-time snapshot, not forward-looking"
+  synonyms:
+    - annual_revenue
+    - annualized_revenue
+  sql: |
+    SELECT
+        DATE_TRUNC('month', billing_date) AS month,
+        SUM(mrr_amount) * 12 AS arr
+    FROM subscriptions
+    WHERE status = 'active'
+    GROUP BY 1
+    ORDER BY 1
+```
+
+Create `docs/metrics/revenue/churn_rate.yml`:
+
+```yaml
+- name: churn_rate
+  display_name: Monthly Churn Rate
+  category: revenue
+  type: ratio
+  unit: percentage
+  grain: monthly
+  table: subscriptions
+  expression: "churned_mrr / beginning_mrr * 100"
+  time_column: billing_date
+  notes:
+    - "Gross revenue churn — does not net out expansion"
+    - "Beginning MRR is MRR at start of month"
+  synonyms:
+    - revenue_churn
+    - mrr_churn
+  sql: |
+    WITH monthly AS (
+        SELECT
+            DATE_TRUNC('month', cancelled_at) AS month,
+            SUM(mrr_amount) AS churned_mrr
+        FROM subscriptions
+        WHERE status = 'cancelled'
+        GROUP BY 1
+    ),
+    beginning AS (
+        SELECT
+            DATE_TRUNC('month', billing_date) AS month,
+            SUM(mrr_amount) AS beginning_mrr
+        FROM subscriptions
+        WHERE status = 'active'
+        GROUP BY 1
+    )
+    SELECT
+        b.month,
+        COALESCE(m.churned_mrr, 0) / NULLIF(b.beginning_mrr, 0) * 100 AS churn_rate
+    FROM beginning b
+    LEFT JOIN monthly m ON b.month = m.month
+    ORDER BY 1
+```
+
+- [ ] **Step 3: Create product_usage metrics**
+
+Create `docs/metrics/product_usage/active_users.yml`:
+
+```yaml
+- name: active_users
+  display_name: Monthly Active Users
+  category: product_usage
+  type: count
+  unit: count
+  grain: monthly
+  table: user_events
+  expression: "COUNT(DISTINCT user_id)"
+  time_column: event_date
+  dimensions:
+    - feature
+    - plan_type
+  synonyms:
+    - mau
+    - monthly_active
+  sql: |
+    SELECT
+        DATE_TRUNC('month', event_date) AS month,
+        COUNT(DISTINCT user_id) AS active_users
+    FROM user_events
+    GROUP BY 1
+    ORDER BY 1
+```
+
+Create `docs/metrics/product_usage/feature_adoption.yml`:
+
+```yaml
+- name: feature_adoption
+  display_name: Feature Adoption Rate
+  category: product_usage
+  type: ratio
+  unit: percentage
+  grain: monthly
+  table: user_events
+  expression: "users_using_feature / total_active_users * 100"
+  time_column: event_date
+  dimensions:
+    - feature
+  synonyms:
+    - adoption_rate
+    - feature_usage
+  sql: |
+    WITH feature_users AS (
+        SELECT
+            DATE_TRUNC('month', event_date) AS month,
+            feature,
+            COUNT(DISTINCT user_id) AS users_using
+        FROM user_events
+        GROUP BY 1, 2
+    ),
+    total AS (
+        SELECT
+            DATE_TRUNC('month', event_date) AS month,
+            COUNT(DISTINCT user_id) AS total_users
+        FROM user_events
+        GROUP BY 1
+    )
+    SELECT
+        f.month, f.feature,
+        f.users_using * 100.0 / NULLIF(t.total_users, 0) AS adoption_pct
+    FROM feature_users f
+    JOIN total t ON f.month = t.month
+    ORDER BY 1, 3 DESC
+```
+
+- [ ] **Step 4: Create sales metrics**
+
+Create `docs/metrics/sales/new_customers.yml`:
+
+```yaml
+- name: new_customers
+  display_name: New Customers
+  category: sales
+  type: count
+  unit: count
+  grain: monthly
+  table: orders
+  expression: "COUNT(DISTINCT customer_id)"
+  time_column: order_date
+  dimensions:
+    - channel
+    - region
+  synonyms:
+    - customer_acquisition
+    - new_logos
+  sql: |
+    SELECT
+        DATE_TRUNC('month', first_order_date) AS month,
+        COUNT(DISTINCT customer_id) AS new_customers
+    FROM (
+        SELECT customer_id, MIN(order_date) AS first_order_date
+        FROM orders
+        WHERE status = 'completed'
+        GROUP BY 1
+    )
+    GROUP BY 1
+    ORDER BY 1
+```
+
+Create `docs/metrics/sales/upsell_expansion.yml`:
+
+```yaml
+- name: upsell_expansion
+  display_name: Upsell & Expansion Revenue
+  category: sales
+  type: sum
+  unit: USD
+  grain: monthly
+  table: subscriptions
+  expression: "SUM(CASE WHEN change_type IN ('upgrade','expansion') THEN delta_mrr END)"
+  time_column: change_date
+  synonyms:
+    - expansion_revenue
+    - upsell
+  sql: |
+    SELECT
+        DATE_TRUNC('month', change_date) AS month,
+        SUM(delta_mrr) AS expansion_mrr
+    FROM subscription_changes
+    WHERE change_type IN ('upgrade', 'expansion')
+    GROUP BY 1
+    ORDER BY 1
+```
+
+Create `docs/metrics/sales/pipeline_value.yml`:
+
+```yaml
+- name: pipeline_value
+  display_name: Pipeline Value
+  category: sales
+  type: sum
+  unit: USD
+  grain: monthly
+  table: opportunities
+  expression: "SUM(deal_value * probability / 100)"
+  time_column: expected_close_date
+  dimensions:
+    - stage
+    - owner
+  synonyms:
+    - weighted_pipeline
+    - deal_pipeline
+  sql: |
+    SELECT
+        DATE_TRUNC('month', expected_close_date) AS month,
+        SUM(deal_value * probability / 100) AS weighted_pipeline
+    FROM opportunities
+    WHERE stage NOT IN ('closed_won', 'closed_lost')
+    GROUP BY 1
+    ORDER BY 1
+```
+
+- [ ] **Step 5: Create operations metrics**
+
+Create `docs/metrics/operations/support_resolution_time.yml`:
+
+```yaml
+- name: support_resolution_time
+  display_name: Support Resolution Time
+  category: operations
+  type: avg
+  unit: hours
+  grain: monthly
+  table: tickets
+  expression: "AVG(resolution_hours)"
+  time_column: created_at
+  dimensions:
+    - priority
+    - category
+  synonyms:
+    - resolution_time
+    - mttr
+    - mean_time_to_resolve
+  sql: |
+    SELECT
+        DATE_TRUNC('month', created_at) AS month,
+        AVG(resolution_hours) AS avg_resolution_hours,
+        PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY resolution_hours) AS median_hours
+    FROM tickets
+    WHERE status = 'resolved'
+    GROUP BY 1
+    ORDER BY 1
+```
+
+Create `docs/metrics/operations/infrastructure_cost.yml`:
+
+```yaml
+- name: infrastructure_cost
+  display_name: Infrastructure Cost
+  category: operations
+  type: sum
+  unit: USD
+  grain: monthly
+  table: infra_costs
+  expression: "SUM(cost_usd)"
+  time_column: billing_month
+  dimensions:
+    - provider
+    - service
+    - environment
+  synonyms:
+    - cloud_cost
+    - hosting_cost
+    - infra_spend
+  sql: |
+    SELECT
+        billing_month AS month,
+        SUM(cost_usd) AS total_cost
+    FROM infra_costs
+    GROUP BY 1
+    ORDER BY 1
+  sql_by_provider: |
+    SELECT
+        billing_month AS month,
+        provider,
+        SUM(cost_usd) AS cost
+    FROM infra_costs
+    GROUP BY 1, 2
+    ORDER BY 1, 3 DESC
+```
+
+- [ ] **Step 6: Write import test for starter pack**
+
+Add to `tests/test_metrics.py`:
+
+```python
+class TestStarterPack:
+    def test_import_starter_pack(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        starter_dir = Path(__file__).parent.parent / "docs" / "metrics"
+        if not starter_dir.exists():
+            pytest.skip("Starter pack not found")
+        count = repo.import_from_yaml(starter_dir)
+        assert count >= 11  # 11 metrics (total_revenue + 10 new)
+        assert repo.get("revenue/total_revenue") is not None
+        assert repo.get("revenue/mrr") is not None
+        assert repo.get("operations/infrastructure_cost") is not None
+```
+
+- [ ] **Step 7: Run tests**
+
+Run: `pytest tests/test_metrics.py::TestStarterPack -v`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add docs/metrics/ tests/test_metrics.py
+git commit -m "feat: add 10 starter pack metrics (revenue, usage, sales, operations)"
+```
+
+---
+
+### Task 7: Profiler Integration
+
+**Files:**
+- Modify: `src/profiler.py:1154,1248` (replace load_metrics calls)
+- Test: manual verification (profiler is integration-heavy)
+
+- [ ] **Step 1: Add get_table_map fallback to profiler**
+
+In `src/profiler.py`, find the two call sites where `load_metrics()` is called (lines ~1154 and ~1248). In each location, replace:
+
+```python
+    metrics_map = load_metrics(METRICS_YML_PATH)
+```
+
+with:
+
+```python
+    # Try DuckDB-backed metrics first, fall back to YAML scan
+    metrics_map = _load_metrics_from_db()
+    if not metrics_map:
+        metrics_map = load_metrics(METRICS_YML_PATH)
+```
+
+Add this helper function near the top of the file (after the imports):
+
+```python
+def _load_metrics_from_db() -> Dict[str, List[str]]:
+    """Load metrics table map from DuckDB. Returns empty dict on failure."""
+    try:
+        from src.db import get_system_db
+        from src.repositories.metrics import MetricRepository
+        conn = get_system_db()
+        repo = MetricRepository(conn)
+        table_map = repo.get_table_map()
+        conn.close()
+        return table_map
+    except Exception as exc:
+        logger.debug("Could not load metrics from DuckDB: %s", exc)
+        return {}
+```
+
+- [ ] **Step 2: Run existing profiler tests**
+
+Run: `pytest tests/ -k profiler -v`
+Expected: ALL PASS (existing tests should not break)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/profiler.py
+git commit -m "feat: profiler reads metrics from DuckDB with YAML fallback"
+```
+
+---
+
+### Task 8: CLAUDE.md Update
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Add metrics workflow section to CLAUDE.md**
+
+After the "## Development" section, add:
+
+```markdown
+## Business Metrics
+
+Standardized metric definitions live in DuckDB (`metric_definitions` table). Import starter pack:
+
+```bash
+da metrics import docs/metrics/
+```
+
+### For AI agents analyzing data:
+Before computing any business metric, look up the canonical definition:
+1. `da metrics list` — find the relevant metric
+2. `da metrics show revenue/mrr` — read the SQL and business rules
+3. Use the SQL from the metric definition, adapt to the specific question
+
+Never invent metric calculations — always use the canonical definitions.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: add metrics workflow instructions to CLAUDE.md"
+```
+
+---
+
+### Task 9: Migration Script
+
+**Files:**
+- Create: `scripts/migrate_metrics_to_duckdb.py`
+
+- [ ] **Step 1: Create standalone migration script**
+
+Create `scripts/migrate_metrics_to_duckdb.py`:
+
+```python
+"""Migrate metric YAML files to DuckDB metric_definitions table.
+
+Usage:
+    python scripts/migrate_metrics_to_duckdb.py [--metrics-dir docs/metrics]
+
+Idempotent — safe to run repeatedly. Uses UPSERT (ON CONFLICT DO UPDATE).
+"""
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Migrate metric YAMLs to DuckDB")
+    parser.add_argument("--metrics-dir", default="docs/metrics", help="Path to metrics directory")
+    args = parser.parse_args()
+
+    metrics_dir = Path(args.metrics_dir)
+    if not metrics_dir.is_dir():
+        logger.error("Metrics directory not found: %s", metrics_dir)
+        sys.exit(1)
+
+    from src.db import get_system_db
+    from src.repositories.metrics import MetricRepository
+
+    conn = get_system_db()
+    try:
+        repo = MetricRepository(conn)
+        count = repo.import_from_yaml(metrics_dir)
+        logger.info("Imported %d metrics from %s", count, metrics_dir)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Run it manually to verify**
+
+Run: `python scripts/migrate_metrics_to_duckdb.py --metrics-dir docs/metrics`
+Expected: `Imported N metrics from docs/metrics`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/migrate_metrics_to_duckdb.py
+git commit -m "feat: add standalone metric YAML → DuckDB migration script"
+```
+
+---
+
+### Task 10: Final Integration Test
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `pytest tests/ -v --timeout=60`
+Expected: ALL PASS (no regressions)
+
+- [ ] **Step 2: Run OpenAPI snapshot test (if exists)**
+
+Run: `pytest tests/ -k openapi -v`
+Expected: May need snapshot update if endpoint list changed. If it fails, regenerate with `python scripts/generate_openapi.py`
+
+- [ ] **Step 3: Final commit if any fixes needed**
+
+```bash
+git add -A
+git commit -m "fix: address integration test issues"
+```

--- a/docs/superpowers/plans/2026-04-10-metadata-writer.md
+++ b/docs/superpowers/plans/2026-04-10-metadata-writer.md
@@ -1,0 +1,567 @@
+# Metadata Writer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add column metadata management — discover basetypes/descriptions, store in DuckDB, push back to Keboola Storage API.
+
+**Architecture:** `column_metadata` table (created in schema v4 by the metrics plan). New `ColumnMetadataRepository` following `table_registry.py` pattern. CLI subcommands under `da admin metadata`. API endpoints under `/api/admin/metadata/`. Keboola push uses Storage API v2.
+
+**Tech Stack:** DuckDB, FastAPI, Typer, httpx (for Keboola API push), PyArrow (for schema introspection)
+
+**Spec:** `docs/superpowers/specs/2026-04-10-porting-internal-features-design.md` — Section 3
+
+**Depends on:** Business Metrics plan (Task 1 — schema v4 creates `column_metadata` table)
+
+---
+
+### Task 1: ColumnMetadataRepository
+
+**Files:**
+- Create: `src/repositories/column_metadata.py`
+- Test: `tests/test_column_metadata.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_column_metadata.py`:
+
+```python
+"""Tests for ColumnMetadataRepository."""
+
+import os
+import json
+from pathlib import Path
+
+import pytest
+import duckdb
+
+
+@pytest.fixture
+def db_conn(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    from src.db import get_system_db
+    conn = get_system_db()
+    yield conn
+    conn.close()
+
+
+class TestColumnMetadataCreate:
+    def test_save_single_column(self, db_conn):
+        from src.repositories.column_metadata import ColumnMetadataRepository
+        repo = ColumnMetadataRepository(db_conn)
+        repo.save("orders", "total_amount", basetype="NUMERIC", description="Order total in USD")
+        result = repo.get("orders", "total_amount")
+        assert result is not None
+        assert result["basetype"] == "NUMERIC"
+        assert result["description"] == "Order total in USD"
+        assert result["confidence"] == "manual"
+
+    def test_upsert_overwrites(self, db_conn):
+        from src.repositories.column_metadata import ColumnMetadataRepository
+        repo = ColumnMetadataRepository(db_conn)
+        repo.save("orders", "total_amount", basetype="NUMERIC", description="v1")
+        repo.save("orders", "total_amount", basetype="FLOAT", description="v2")
+        result = repo.get("orders", "total_amount")
+        assert result["basetype"] == "FLOAT"
+        assert result["description"] == "v2"
+
+
+class TestColumnMetadataRead:
+    def test_list_for_table(self, db_conn):
+        from src.repositories.column_metadata import ColumnMetadataRepository
+        repo = ColumnMetadataRepository(db_conn)
+        repo.save("orders", "id", basetype="STRING")
+        repo.save("orders", "total", basetype="NUMERIC")
+        repo.save("users", "email", basetype="STRING")
+        results = repo.list_for_table("orders")
+        assert len(results) == 2
+        names = {r["column_name"] for r in results}
+        assert names == {"id", "total"}
+
+    def test_get_missing(self, db_conn):
+        from src.repositories.column_metadata import ColumnMetadataRepository
+        repo = ColumnMetadataRepository(db_conn)
+        assert repo.get("x", "y") is None
+
+
+class TestColumnMetadataDelete:
+    def test_delete_column(self, db_conn):
+        from src.repositories.column_metadata import ColumnMetadataRepository
+        repo = ColumnMetadataRepository(db_conn)
+        repo.save("orders", "total", basetype="NUMERIC")
+        assert repo.delete("orders", "total") is True
+        assert repo.get("orders", "total") is None
+
+    def test_delete_missing(self, db_conn):
+        from src.repositories.column_metadata import ColumnMetadataRepository
+        repo = ColumnMetadataRepository(db_conn)
+        assert repo.delete("x", "y") is False
+
+
+class TestColumnMetadataProposal:
+    def test_import_proposal(self, db_conn, tmp_path):
+        from src.repositories.column_metadata import ColumnMetadataRepository
+        repo = ColumnMetadataRepository(db_conn)
+
+        proposal = {
+            "project": {"name": "sales"},
+            "generated_at": "2026-04-10T12:00:00",
+            "tables": {
+                "orders": {
+                    "columns": {
+                        "id": {"basetype": "STRING", "description": "Order ID", "confidence": "high"},
+                        "total": {"basetype": "NUMERIC", "description": "Total amount", "confidence": "medium"},
+                    }
+                }
+            },
+        }
+        proposal_path = tmp_path / "proposal.json"
+        proposal_path.write_text(json.dumps(proposal))
+
+        count = repo.import_proposal(proposal_path)
+        assert count == 2
+        assert repo.get("orders", "id")["basetype"] == "STRING"
+        assert repo.get("orders", "total")["confidence"] == "medium"
+
+    def test_import_proposal_sets_source(self, db_conn, tmp_path):
+        from src.repositories.column_metadata import ColumnMetadataRepository
+        repo = ColumnMetadataRepository(db_conn)
+
+        proposal = {
+            "tables": {
+                "orders": {
+                    "columns": {
+                        "id": {"basetype": "STRING", "description": "test", "confidence": "high"},
+                    }
+                }
+            },
+        }
+        (tmp_path / "p.json").write_text(json.dumps(proposal))
+        repo.import_proposal(tmp_path / "p.json")
+        assert repo.get("orders", "id")["source"] == "ai_enrichment"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_column_metadata.py -v`
+Expected: FAIL — `ModuleNotFoundError`
+
+- [ ] **Step 3: Implement ColumnMetadataRepository**
+
+Create `src/repositories/column_metadata.py`:
+
+```python
+"""Repository for column metadata (descriptions, basetypes)."""
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import duckdb
+
+logger = logging.getLogger(__name__)
+
+
+class ColumnMetadataRepository:
+    def __init__(self, conn: duckdb.DuckDBPyConnection):
+        self.conn = conn
+
+    def save(self, table_id: str, column_name: str,
+             basetype: Optional[str] = None,
+             description: Optional[str] = None,
+             confidence: str = "manual",
+             source: str = "manual") -> Dict[str, Any]:
+        now = datetime.now(timezone.utc)
+        self.conn.execute(
+            """INSERT INTO column_metadata (table_id, column_name, basetype, description, confidence, source, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT (table_id, column_name) DO UPDATE SET
+                basetype = excluded.basetype,
+                description = excluded.description,
+                confidence = excluded.confidence,
+                source = excluded.source,
+                updated_at = excluded.updated_at""",
+            [table_id, column_name, basetype, description, confidence, source, now],
+        )
+        return self.get(table_id, column_name)
+
+    def get(self, table_id: str, column_name: str) -> Optional[Dict[str, Any]]:
+        result = self.conn.execute(
+            "SELECT * FROM column_metadata WHERE table_id = ? AND column_name = ?",
+            [table_id, column_name],
+        ).fetchone()
+        if not result:
+            return None
+        columns = [desc[0] for desc in self.conn.description]
+        return dict(zip(columns, result))
+
+    def list_for_table(self, table_id: str) -> List[Dict[str, Any]]:
+        results = self.conn.execute(
+            "SELECT * FROM column_metadata WHERE table_id = ? ORDER BY column_name",
+            [table_id],
+        ).fetchall()
+        if not results:
+            return []
+        columns = [desc[0] for desc in self.conn.description]
+        return [dict(zip(columns, row)) for row in results]
+
+    def delete(self, table_id: str, column_name: str) -> bool:
+        existing = self.get(table_id, column_name)
+        if not existing:
+            return False
+        self.conn.execute(
+            "DELETE FROM column_metadata WHERE table_id = ? AND column_name = ?",
+            [table_id, column_name],
+        )
+        return True
+
+    def import_proposal(self, proposal_path) -> int:
+        """Import a metadata proposal JSON file. Returns count of columns imported."""
+        path = Path(proposal_path)
+        data = json.loads(path.read_text())
+        count = 0
+
+        tables = data.get("tables", {})
+        for table_id, table_data in tables.items():
+            columns = table_data.get("columns", {})
+            for col_name, col_data in columns.items():
+                self.save(
+                    table_id=table_id,
+                    column_name=col_name,
+                    basetype=col_data.get("basetype"),
+                    description=col_data.get("description"),
+                    confidence=col_data.get("confidence", "medium"),
+                    source="ai_enrichment",
+                )
+                count += 1
+
+        return count
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_column_metadata.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/repositories/column_metadata.py tests/test_column_metadata.py
+git commit -m "feat: add ColumnMetadataRepository with CRUD and proposal import"
+```
+
+---
+
+### Task 2: CLI Subcommands `da admin metadata`
+
+**Files:**
+- Modify: `cli/commands/admin.py` (add metadata subcommands)
+- Test: `tests/test_cli.py`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `tests/test_cli.py` in `TestCLIHelp`:
+
+```python
+    def test_admin_metadata_help(self):
+        result = runner.invoke(app, ["admin", "metadata-show", "--help"])
+        assert result.exit_code == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_cli.py::TestCLIHelp::test_admin_metadata_help -v`
+Expected: FAIL — `No such command 'metadata-show'`
+
+- [ ] **Step 3: Add metadata commands to admin.py**
+
+Add to `cli/commands/admin.py`:
+
+```python
+@admin_app.command("metadata-show")
+def metadata_show(
+    table_id: str = typer.Argument(..., help="Table ID"),
+    as_json: bool = typer.Option(False, "--json"),
+):
+    """Show column metadata for a table."""
+    resp = api_get(f"/api/admin/metadata/{table_id}")
+    if resp.status_code != 200:
+        typer.echo(f"Failed: {resp.json().get('detail', resp.text)}", err=True)
+        raise typer.Exit(1)
+
+    columns = resp.json().get("columns", [])
+    if as_json:
+        typer.echo(json.dumps(columns, indent=2))
+    else:
+        if not columns:
+            typer.echo(f"No metadata for table '{table_id}'")
+            return
+        typer.echo(f"\n  Metadata for {table_id}:")
+        for c in columns:
+            desc = c.get("description", "-")
+            typer.echo(f"    {c['column_name']:30s} {c.get('basetype', '?'):12s} {desc}")
+
+
+@admin_app.command("metadata-apply")
+def metadata_apply(
+    proposal_path: str = typer.Argument(..., help="Path to proposal JSON file"),
+    push_to_source: bool = typer.Option(False, "--push-to-source", help="Push to Keboola Storage API"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Show changes without applying"),
+):
+    """Apply a metadata proposal (JSON) to DuckDB and optionally push to source."""
+    from pathlib import Path
+
+    path = Path(proposal_path)
+    if not path.exists():
+        typer.echo(f"File not found: {proposal_path}", err=True)
+        raise typer.Exit(1)
+
+    import json as json_mod
+    data = json_mod.loads(path.read_text())
+    tables = data.get("tables", {})
+
+    if dry_run:
+        for table_id, td in tables.items():
+            for col, cd in td.get("columns", {}).items():
+                typer.echo(f"  {table_id}.{col}: {cd.get('basetype', '?')} — {cd.get('description', '-')}")
+        typer.echo(f"\nDry run: {sum(len(td.get('columns', {})) for td in tables.values())} columns would be applied")
+        return
+
+    from src.db import get_system_db
+    from src.repositories.column_metadata import ColumnMetadataRepository
+
+    conn = get_system_db()
+    try:
+        repo = ColumnMetadataRepository(conn)
+        count = repo.import_proposal(path)
+        typer.echo(f"Applied {count} column metadata entries to DuckDB")
+    finally:
+        conn.close()
+
+    if push_to_source:
+        resp = api_post(f"/api/admin/metadata/push", json={"proposal_path": str(path)})
+        if resp.status_code == 200:
+            typer.echo("Pushed metadata to source system")
+        else:
+            typer.echo(f"Push failed: {resp.json().get('detail', resp.text)}", err=True)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_cli.py::TestCLIHelp::test_admin_metadata_help -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/commands/admin.py tests/test_cli.py
+git commit -m "feat: add da admin metadata-show and metadata-apply commands"
+```
+
+---
+
+### Task 3: API Endpoints
+
+**Files:**
+- Create: `app/api/metadata.py`
+- Modify: `app/main.py` (register router)
+- Test: `tests/test_api.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `tests/test_api.py`:
+
+```python
+class TestMetadataAPI:
+    def test_get_metadata_empty(self, seeded_client):
+        client, admin_token, _ = seeded_client
+        resp = client.get("/api/admin/metadata/orders",
+                          headers={"Authorization": f"Bearer {admin_token}"})
+        assert resp.status_code == 200
+        assert resp.json()["columns"] == []
+
+    def test_save_and_get_metadata(self, seeded_client):
+        client, admin_token, _ = seeded_client
+        resp = client.post(
+            "/api/admin/metadata/orders",
+            json={"columns": [
+                {"column_name": "id", "basetype": "STRING", "description": "Order ID"},
+                {"column_name": "total", "basetype": "NUMERIC", "description": "Total amount"},
+            ]},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["count"] == 2
+
+        resp = client.get("/api/admin/metadata/orders",
+                          headers={"Authorization": f"Bearer {admin_token}"})
+        assert len(resp.json()["columns"]) == 2
+
+    def test_analyst_cannot_save_metadata(self, seeded_client):
+        client, _, analyst_token = seeded_client
+        resp = client.post(
+            "/api/admin/metadata/orders",
+            json={"columns": [{"column_name": "id", "basetype": "STRING"}]},
+            headers={"Authorization": f"Bearer {analyst_token}"},
+        )
+        assert resp.status_code == 403
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_api.py::TestMetadataAPI -v`
+Expected: FAIL — 404 on `/api/admin/metadata/orders`
+
+- [ ] **Step 3: Implement API router**
+
+Create `app/api/metadata.py`:
+
+```python
+"""Column metadata API endpoints."""
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+import duckdb
+
+from app.auth.dependencies import get_current_user, require_admin, _get_db
+from src.repositories.column_metadata import ColumnMetadataRepository
+
+router = APIRouter(tags=["metadata"])
+
+
+class ColumnMetadataItem(BaseModel):
+    column_name: str
+    basetype: Optional[str] = None
+    description: Optional[str] = None
+    confidence: str = "manual"
+
+
+class ColumnMetadataSave(BaseModel):
+    columns: List[ColumnMetadataItem]
+
+
+@router.get("/api/admin/metadata/{table_id}")
+async def get_table_metadata(
+    table_id: str,
+    user: dict = Depends(get_current_user),
+    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
+):
+    repo = ColumnMetadataRepository(conn)
+    columns = repo.list_for_table(table_id)
+    return {"table_id": table_id, "columns": columns}
+
+
+@router.post("/api/admin/metadata/{table_id}")
+async def save_table_metadata(
+    table_id: str,
+    body: ColumnMetadataSave,
+    user: dict = Depends(require_admin),
+    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
+):
+    repo = ColumnMetadataRepository(conn)
+    for col in body.columns:
+        repo.save(
+            table_id=table_id,
+            column_name=col.column_name,
+            basetype=col.basetype,
+            description=col.description,
+            confidence=col.confidence,
+            source="api",
+        )
+    return {"status": "ok", "table_id": table_id, "count": len(body.columns)}
+
+
+@router.post("/api/admin/metadata/{table_id}/push")
+async def push_metadata_to_source(
+    table_id: str,
+    user: dict = Depends(require_admin),
+    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
+):
+    """Push column metadata to the source system (Keboola only)."""
+    from src.repositories.table_registry import TableRegistryRepository
+    table_repo = TableRegistryRepository(conn)
+    table = table_repo.get(table_id)
+
+    if not table:
+        raise HTTPException(status_code=404, detail=f"Table not found: {table_id}")
+    if table.get("source_type") != "keboola":
+        raise HTTPException(status_code=400, detail="Push only supported for Keboola source tables")
+
+    meta_repo = ColumnMetadataRepository(conn)
+    columns = meta_repo.list_for_table(table_id)
+    if not columns:
+        raise HTTPException(status_code=400, detail="No metadata to push")
+
+    # Build Keboola API payload
+    import os
+    import httpx
+
+    stack_url = os.environ.get("KBC_STACK_URL", "")
+    token = os.environ.get("KBC_STORAGE_TOKEN", "")
+    if not stack_url or not token:
+        raise HTTPException(status_code=400, detail="KBC_STACK_URL and KBC_STORAGE_TOKEN must be set")
+
+    source_table = table.get("source_table", table_id)
+    columns_metadata = {}
+    for col in columns:
+        entries = []
+        if col.get("basetype"):
+            entries.append({"key": "KBC.datatype.basetype", "value": col["basetype"]})
+        if col.get("description"):
+            entries.append({"key": "KBC.description", "value": col["description"]})
+        if entries:
+            columns_metadata[col["column_name"]] = entries
+
+    try:
+        resp = httpx.post(
+            f"{stack_url}/v2/storage/tables/{source_table}/metadata",
+            headers={"X-StorageApi-Token": token},
+            json={"provider": "ai-metadata-enrichment", "columnsMetadata": columns_metadata},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        return {"status": "pushed", "table_id": table_id, "columns": len(columns_metadata)}
+    except httpx.HTTPStatusError as e:
+        raise HTTPException(status_code=502, detail=f"Keboola API error: {e.response.text}")
+```
+
+Register in `app/main.py`:
+
+```python
+from app.api.metadata import router as metadata_router
+# ... (add near other router imports)
+
+# In create_app(), add before web_router:
+app.include_router(metadata_router)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_api.py::TestMetadataAPI -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/metadata.py app/main.py tests/test_api.py
+git commit -m "feat: add column metadata API with Keboola push support"
+```
+
+---
+
+### Task 4: Final Integration
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `pytest tests/ -v --timeout=60`
+Expected: ALL PASS
+
+- [ ] **Step 2: Commit if any fixes needed**
+
+```bash
+git add -A
+git commit -m "fix: address metadata writer integration issues"
+```

--- a/docs/superpowers/specs/2026-04-10-porting-internal-features-design.md
+++ b/docs/superpowers/specs/2026-04-10-porting-internal-features-design.md
@@ -58,7 +58,13 @@ CREATE TABLE metric_definitions (
 
 ### 1.2 Schema Versioning
 
-Added to `src/db.py` as `SCHEMA_VERSION = 4` migration (v3→v4). Migration creates both `metric_definitions` and `column_metadata` tables. Existing data untouched.
+Bump `SCHEMA_VERSION` from 3 to 4 in `src/db.py`. Implementation requires:
+
+1. Define `_V3_TO_V4_MIGRATIONS` list with CREATE TABLE statements for `metric_definitions` and `column_metadata`
+2. Extend the `_ensure_schema()` function's `if current < N` chain with `if current < 4: _apply(_V3_TO_V4_MIGRATIONS)`
+3. After table creation, auto-import YAML metrics if `docs/metrics/*/*.yml` files exist
+
+Follows the established pattern of `_V1_TO_V2_MIGRATIONS` and `_V2_TO_V3_MIGRATIONS`.
 
 ### 1.3 Repository (`src/repositories/metrics.py`)
 
@@ -87,12 +93,24 @@ Format remains compatible with the internal repo (same fields as `total_revenue.
 ### 1.5 Migration Script (`scripts/migrate_metrics_to_duckdb.py`)
 
 1. Scans `docs/metrics/*/*.yml` via glob
-2. Parses YAML, maps fields to DuckDB columns
-3. `sql_by_*` variants → `sql_variants` JSON
-4. INSERT OR REPLACE into `metric_definitions`
-5. Idempotent — safe to run repeatedly
+2. Parses YAML, maps fields to DuckDB columns using this mapping:
 
-Auto-runs during schema migration v3→v4 if YAML files exist.
+   | YAML field | DuckDB column | Notes |
+   |---|---|---|
+   | `name` | `name` | direct |
+   | `display_name` | `display_name` | direct |
+   | `category` | `category` | direct |
+   | `table` | `table_name` | **renamed** — YAML uses `table`, DuckDB uses `table_name` |
+   | `tables` | `tables` | direct (for JOIN metrics) |
+   | `sql_by_*` | `sql_variants` | all `sql_by_X` keys collected into JSON dict `{"by_X": "..."}` |
+   | all other fields | same name | direct mapping |
+
+   The `id` is computed as `"{category}/{name}"`.
+
+3. INSERT OR REPLACE into `metric_definitions`
+4. Idempotent — safe to run repeatedly
+
+Auto-runs during schema migration v3→v4 if YAML files exist. Also callable standalone: `python scripts/migrate_metrics_to_duckdb.py`
 
 ### 1.6 Metrics Index (`docs/metrics/metrics.yml`)
 
@@ -133,25 +151,34 @@ SQL queries are **generic templates** referencing typical tables (`orders`, `sub
 ```
 da metrics list [--category revenue]     # list from DuckDB
 da metrics show revenue/mrr              # detail
-da metrics import docs/metrics/          # YAML → DuckDB
+da metrics import docs/metrics/          # YAML → DuckDB (single file or directory)
 da metrics export [--dir ./export/]      # DuckDB → YAML
 da metrics validate                      # verify consistency (tables exist?)
-da metrics add                           # interactive wizard
 ```
+
+Note: `da metrics add --file metric.yml` imports a single YAML file. Interactive wizard deferred to a future iteration.
 
 ### 1.9 API Endpoints
 
 ```
-GET  /api/metrics                        → list categories and metrics
-GET  /api/metrics/{category}/{name}      → metric detail
-POST /api/admin/metrics                  → create/update metric
-DELETE /api/admin/metrics/{id}           → delete metric
-POST /api/admin/metrics/import           → YAML upload → DuckDB
+GET  /api/metrics                              → list categories and metrics
+GET  /api/metrics/{metric_id:path}             → metric detail (path param to handle slashes in ID)
+POST /api/admin/metrics                        → create/update metric
+DELETE /api/admin/metrics/{metric_id:path}     → delete metric
+POST /api/admin/metrics/import                 → YAML upload → DuckDB
 ```
+
+**Deprecation:** The existing `GET /api/catalog/metrics/{metric_path:path}` endpoint (serves raw YAML) will be deprecated. After migration, it redirects to the new DuckDB-backed `GET /api/metrics/{metric_id:path}` endpoint. Remove the old endpoint after one release cycle.
 
 ### 1.10 Profiler Integration
 
-`src/profiler.py` already has `load_metrics()` logic. Wire new `src/repositories/metrics.py` into profiler so `profiles.json` includes metrics assigned to tables. Read from DuckDB instead of scanning YAML.
+`src/profiler.py` has `load_metrics()` (line ~343) that reads YAML files directly. This must be refactored to read from DuckDB instead.
+
+**Specific changes required:**
+1. `load_metrics(metrics_yml_path)` at profiler lines ~1154 and ~1248 must be replaced with calls to `MetricRepository(conn).find_by_table()` or a new `get_table_map()` method
+2. The DuckDB connection must be threaded through to `run_profiler()` and `profile_single_table()` entry points
+3. The `metrics_map` dict structure (`{table_name: [metric_name, ...]}`) must remain the same for compatibility with the rest of the profiler
+4. If DuckDB has no metrics yet (empty table), fall back gracefully to empty map (no error)
 
 ### 1.11 CLAUDE.md Instructions
 
@@ -176,13 +203,16 @@ Add section to CLAUDE.md:
 
 ### 2.2 Flow: `da analyst setup`
 
-New command (subcommand of `da setup` or standalone `da analyst`):
+New top-level Typer command `da analyst` registered in `cli/main.py` (follows same pattern as existing `da sync`, `da admin`, etc.). Implemented in `cli/commands/analyst.py`.
+
+Use `--force` flag to re-run from scratch (cleans up partial state).
 
 ```
 Step 1: detect_existing_project
-  → looks for ./CLAUDE.md with Agnes identifier
+  → looks for ./CLAUDE.md with Agnes identifier string
   → if found: "Project already set up. Want to resync? (da sync)"
   → if not: continue
+  → if --force: skip detection, clean up and re-run
 
 Step 2: connect_to_instance
   → asks for instance URL (https://data.acme.com)
@@ -198,16 +228,19 @@ Step 3: create_workspace
     ./data/metadata/         ← profiles, schema
     ./user/artifacts/        ← analyst work output
     ./user/sessions/         ← Claude Code session logs
+    ./.claude/               ← Claude Code config
 
 Step 4: download_schema_and_metrics
-  → GET /api/data/tables → list of available tables
+  → GET /api/catalog/tables → list of available tables
   → GET /api/metrics → all metrics
-  → saves as local JSON/YAML cache
+  → saves as local JSON/YAML cache in data/metadata/
 
 Step 5: download_data
   → for each table the user has access to:
-    GET /api/data/table/{id}/download → parquet
+    GET /api/data/{table_id}/download → parquet
   → Rich progress bar
+  → on failure: logs which tables failed, continues with remaining
+  → partial state is resumable (re-run skips already-downloaded parquets by checking file existence + size)
 
 Step 6: initialize_duckdb
   → creates local analytics.duckdb
@@ -216,7 +249,7 @@ Step 6: initialize_duckdb
 
 Step 7: generate_claude_md
   → generates CLAUDE.md from template (see 2.3)
-  → creates empty CLAUDE.local.md
+  → creates empty .claude/CLAUDE.local.md (matches existing sync.py _upload() path)
   → writes .claude/settings.json
 
 Step 8: verify
@@ -249,7 +282,7 @@ Generated template for analysts, adapted from internal repo:
 ## Directory Structure
 - `data/` — read-only (downloaded from server)
 - `user/` — your workspace
-- `CLAUDE.local.md` — your personal notes (never overwritten)
+- `.claude/CLAUDE.local.md` — your personal notes (never overwritten, uploaded on sync)
 ```
 
 Placeholders `{instance_name}`, `{sync_interval}` substituted at generation time from instance config.
@@ -261,14 +294,13 @@ On every `da` CLI invocation:
 - If >24h: suggest `da sync`
 - If CLAUDE.md missing: suggest `da analyst setup`
 
-### 2.5 Sync Command Extensions
+### 2.5 Sync Command — Existing Capabilities
 
-Extensions to existing `da sync`:
-```
-da sync                    # download updated data from server
-da sync --docs-only        # just metadata and metrics (fast)
-da sync --upload-local     # upload CLAUDE.local.md to server (corporate memory)
-```
+The existing `da sync` already supports these flags (no changes needed):
+- `da sync --docs-only` — just metadata and metrics (already implemented)
+- `da sync --upload-only` — uploads sessions + `.claude/CLAUDE.local.md` to server (already implemented)
+
+No new flags required for the bootstrap flow.
 
 ---
 
@@ -299,7 +331,8 @@ da admin metadata discover [--table orders]
   → for each column without description:
     sample 500 rows → heuristics for basetype
     if Claude Code agent: generate descriptions
-  → saves as "proposal" JSON (same format as internal repo)
+  → saves as "proposal" JSON to ./data/metadata/proposals/ directory
+    (same format as internal repo: {project}_metadata_{YYYYMMDD_HHMMSS}.json)
 ```
 
 **Phase 2: Review** — user reviews proposals
@@ -349,7 +382,7 @@ POST /api/admin/metadata/{table_id}/push      → push to source system
 
 | Component | Files |
 |---|---|
-| **Metrics** | `src/repositories/metrics.py`, `src/metrics.py`, `cli/commands/metrics.py`, `app/api/metrics.py`, `scripts/migrate_metrics_to_duckdb.py`, 10-15 YAML in `docs/metrics/` |
+| **Metrics** | `src/repositories/metrics.py`, `cli/commands/metrics.py`, `app/api/metrics.py`, `scripts/migrate_metrics_to_duckdb.py`, 10-15 YAML in `docs/metrics/` |
 | **Bootstrap** | `cli/commands/analyst.py`, `config/claude_md_template.txt` |
 | **Metadata** | `src/repositories/column_metadata.py`, `app/api/metadata.py` (metadata commands added as subcommands of `da admin`) |
 
@@ -360,8 +393,9 @@ POST /api/admin/metadata/{table_id}/push      → push to source system
 | `src/db.py` | SCHEMA_VERSION=4, `metric_definitions` + `column_metadata` tables, v3→v4 migration |
 | `src/profiler.py` | Read metrics + column_metadata from DuckDB instead of YAML scan |
 | `app/main.py` | Register metrics + metadata routers |
-| `cli/main.py` | Register `metrics` + `analyst` commands |
-| `cli/commands/sync.py` | `--docs-only`, `--upload-local` flags |
+| `app/api/catalog.py` | Deprecate `GET /api/catalog/metrics/` → redirect to new metrics API |
+| `cli/main.py` | Register `metrics` + `analyst` top-level Typer commands |
+| `cli/commands/sync.py` | No changes needed (flags already exist) |
 | `CLAUDE.md` | Metrics workflow instructions |
 
 ### Schema Migration v3→v4

--- a/docs/superpowers/specs/2026-04-10-porting-internal-features-design.md
+++ b/docs/superpowers/specs/2026-04-10-porting-internal-features-design.md
@@ -1,0 +1,382 @@
+# Porting Internal Features to OSS — Design Spec
+
+**Date:** 2026-04-10
+**Status:** Approved
+**Approach:** Metric-First (A) — metriky → bootstrap → metadata writer
+
+## Context
+
+Comparison of `keboola/internal_ai_data_analyst` (private, Jan 2026) with the OSS version revealed three feature gaps worth porting. Many features initially thought missing (session collector, corporate memory, Jira SLA polling, CI/CD, telegram bot) already exist in OSS.
+
+**Primary user:** Local Claude Code agent analyzing data. Web UI is secondary.
+
+**What's being ported:**
+1. Business metrics layer (20+ YAML metrics → DuckDB-backed framework + starter pack)
+2. Analyst bootstrap flow (onboarding for analysts connecting to a remote instance)
+3. Metadata writer (column descriptions + basetype push back to Keboola Storage API)
+
+**What's NOT being ported:**
+- macOS desktop app (narrow use-case, WebSocket gateway covers most needs)
+- Linux user management (replaced by DuckDB RBAC)
+- rsync distribution (replaced by FastAPI API)
+- systemd services (replaced by Docker Compose)
+
+---
+
+## 1. Business Metrics in DuckDB
+
+### 1.1 DuckDB Schema — `metric_definitions` table
+
+New table in `system.duckdb`, added as part of schema migration v3→v4:
+
+```sql
+CREATE TABLE metric_definitions (
+    id              VARCHAR PRIMARY KEY,     -- 'revenue/mrr'
+    name            VARCHAR NOT NULL,        -- 'mrr'
+    display_name    VARCHAR NOT NULL,        -- 'Monthly Recurring Revenue'
+    category        VARCHAR NOT NULL,        -- 'revenue'
+    description     TEXT,
+    type            VARCHAR DEFAULT 'sum',   -- sum, count, ratio, comparison
+    unit            VARCHAR,                 -- 'USD', 'percentage', 'count'
+    grain           VARCHAR DEFAULT 'monthly', -- monthly, weekly, daily
+    table_name      VARCHAR,                 -- primary table
+    tables          VARCHAR[],               -- for JOIN metrics
+    expression      VARCHAR,                 -- 'SUM(total_amount)'
+    time_column     VARCHAR,                 -- 'order_date'
+    dimensions      VARCHAR[],              -- ['channel', 'region']
+    filters         VARCHAR[],              -- descriptive WHERE conditions
+    synonyms        VARCHAR[],              -- for NL matching
+    notes           VARCHAR[],              -- business rules
+    sql             TEXT NOT NULL,           -- canonical SQL query
+    sql_variants    JSON,                   -- {"by_channel": "SELECT ...", "by_region": "..."}
+    validation      JSON,                   -- {"method": "...", "result": "..."}
+    source          VARCHAR DEFAULT 'manual', -- 'yaml_import', 'manual', 'api'
+    created_at      TIMESTAMP DEFAULT now(),
+    updated_at      TIMESTAMP DEFAULT now()
+);
+```
+
+### 1.2 Schema Versioning
+
+Added to `src/db.py` as `SCHEMA_VERSION = 4` migration (v3→v4). Migration creates both `metric_definitions` and `column_metadata` tables. Existing data untouched.
+
+### 1.3 Repository (`src/repositories/metrics.py`)
+
+Follows existing pattern from `table_registry.py`:
+
+- `list(category=None)` → all metrics, optionally filtered
+- `get(metric_id)` → single metric or None
+- `create(**kwargs)` → insert metric
+- `update(metric_id, **kwargs)` → update fields
+- `delete(metric_id)` → remove metric
+- `find_by_table(table_name)` → metrics referencing a table
+- `find_by_synonym(term)` → NL matching for Claude Code agent
+- `import_from_yaml(yaml_path)` → parse YAML, upsert into DuckDB, return count
+- `export_to_yaml(output_dir)` → DuckDB → YAML files, return count
+
+### 1.4 YAML as Seed/Import Format
+
+YAML files in `docs/metrics/` serve as:
+- **Starter pack** — 10-15 generic SaaS metrics shipped with the project
+- **Import source** — `da metrics import docs/metrics/` loads into DuckDB
+- **Export target** — `da metrics export` dumps DuckDB → YAML (sharing, backup, version control)
+- **Migration** — on first run after upgrade: detect YAML without DuckDB records → auto-import
+
+Format remains compatible with the internal repo (same fields as `total_revenue.yml`).
+
+### 1.5 Migration Script (`scripts/migrate_metrics_to_duckdb.py`)
+
+1. Scans `docs/metrics/*/*.yml` via glob
+2. Parses YAML, maps fields to DuckDB columns
+3. `sql_by_*` variants → `sql_variants` JSON
+4. INSERT OR REPLACE into `metric_definitions`
+5. Idempotent — safe to run repeatedly
+
+Auto-runs during schema migration v3→v4 if YAML files exist.
+
+### 1.6 Metrics Index (`docs/metrics/metrics.yml`)
+
+Master index for the YAML starter pack. After `da metrics import`, DuckDB becomes the source of truth. The YAML index is only used during import to define categories and discover files — it is NOT read at runtime.
+
+```yaml
+version: "2.0"
+categories:
+  - name: revenue
+    folder: revenue/
+    metrics: [total_revenue, mrr, arr, churn_rate]
+  - name: product_usage
+    folder: product_usage/
+    metrics: [active_users, feature_adoption]
+  - name: sales
+    folder: sales/
+    metrics: [new_customers, upsell_expansion, pipeline_value]
+  - name: operations
+    folder: operations/
+    metrics: [support_resolution_time, infrastructure_cost]
+```
+
+### 1.7 Starter Pack Metrics (10-15 generic)
+
+Ported and generalized from internal repo, adapted for generic SaaS data:
+
+| Category | Metric | Internal source |
+|---|---|---|
+| **Revenue** | `total_revenue` (exists), `mrr`, `arr`, `churn_rate` | mrr.yml, new_arr.yml |
+| **Product Usage** | `active_users`, `feature_adoption`, `usage_vs_limit` | usage_value.yml, usage_vs_limit.yml |
+| **Sales** | `new_customers`, `upsell_expansion`, `pipeline_value` | upsell_expansion.yml, closed_won.yml |
+| **Operations** | `support_resolution_time`, `infrastructure_cost` | resolution_time.yml, infra_cost.yml |
+
+SQL queries are **generic templates** referencing typical tables (`orders`, `subscriptions`, `users`, `tickets`). Users adapt to their schema.
+
+### 1.8 CLI Command `da metrics`
+
+```
+da metrics list [--category revenue]     # list from DuckDB
+da metrics show revenue/mrr              # detail
+da metrics import docs/metrics/          # YAML → DuckDB
+da metrics export [--dir ./export/]      # DuckDB → YAML
+da metrics validate                      # verify consistency (tables exist?)
+da metrics add                           # interactive wizard
+```
+
+### 1.9 API Endpoints
+
+```
+GET  /api/metrics                        → list categories and metrics
+GET  /api/metrics/{category}/{name}      → metric detail
+POST /api/admin/metrics                  → create/update metric
+DELETE /api/admin/metrics/{id}           → delete metric
+POST /api/admin/metrics/import           → YAML upload → DuckDB
+```
+
+### 1.10 Profiler Integration
+
+`src/profiler.py` already has `load_metrics()` logic. Wire new `src/repositories/metrics.py` into profiler so `profiles.json` includes metrics assigned to tables. Read from DuckDB instead of scanning YAML.
+
+### 1.11 CLAUDE.md Instructions
+
+Add section to CLAUDE.md:
+> Before computing any business metric: `da metrics show {category}/{name}`, read the SQL and business rules, use the canonical SQL from the metric definition.
+
+---
+
+## 2. Analyst Bootstrap Flow
+
+### 2.1 Two Bootstrap Modes
+
+**Server-side** (already exists in `da setup`):
+- `da setup init` → `bootstrap` → `test-connection` → `first-sync` → `verify`
+- Sets up instance (instance.yaml, .env, Docker)
+- No changes needed.
+
+**Analyst-side** (new — equivalent of internal `bootstrap.yaml`):
+- Analyst connects local Claude Code to a remote Agnes instance
+- Downloads data, initializes DuckDB, sets up CLAUDE.md
+- Uses API instead of SSH/rsync
+
+### 2.2 Flow: `da analyst setup`
+
+New command (subcommand of `da setup` or standalone `da analyst`):
+
+```
+Step 1: detect_existing_project
+  → looks for ./CLAUDE.md with Agnes identifier
+  → if found: "Project already set up. Want to resync? (da sync)"
+  → if not: continue
+
+Step 2: connect_to_instance
+  → asks for instance URL (https://data.acme.com)
+  → asks for credentials (email/password or OAuth token)
+  → GET /api/health → verify availability
+  → POST /auth/token → obtain JWT
+  → store token in .env or ~/.agnes/credentials
+
+Step 3: create_workspace
+  → creates directory structure:
+    ./data/parquet/          ← downloaded data
+    ./data/duckdb/           ← local analytics.duckdb
+    ./data/metadata/         ← profiles, schema
+    ./user/artifacts/        ← analyst work output
+    ./user/sessions/         ← Claude Code session logs
+
+Step 4: download_schema_and_metrics
+  → GET /api/data/tables → list of available tables
+  → GET /api/metrics → all metrics
+  → saves as local JSON/YAML cache
+
+Step 5: download_data
+  → for each table the user has access to:
+    GET /api/data/table/{id}/download → parquet
+  → Rich progress bar
+
+Step 6: initialize_duckdb
+  → creates local analytics.duckdb
+  → CREATE VIEW for each downloaded parquet
+  → verify: SELECT count(*) from a few tables
+
+Step 7: generate_claude_md
+  → generates CLAUDE.md from template (see 2.3)
+  → creates empty CLAUDE.local.md
+  → writes .claude/settings.json
+
+Step 8: verify
+  → runs test query
+  → prints: "Setup complete. X tables, Y metrics, Z rows."
+```
+
+### 2.3 CLAUDE.md Template (`config/claude_md_template.txt`)
+
+Generated template for analysts, adapted from internal repo:
+
+```markdown
+# {instance_name} — AI Data Analyst
+
+## Rules
+- Before computing any business metric: `da metrics show {category}/{name}`
+- For current schema: read `data/metadata/schema.json`
+- Do not use DESCRIBE/SHOW COLUMNS — read metadata files
+- Save work output to `user/artifacts/`
+
+## Metrics Workflow
+1. `da metrics list` → identify relevant metric
+2. `da metrics show revenue/mrr` → read SQL and rules
+3. Use the SQL from the metric, adapt to the question
+
+## Data Sync
+- `da sync` → download current data from server
+- Data refreshes every {sync_interval}
+
+## Directory Structure
+- `data/` — read-only (downloaded from server)
+- `user/` — your workspace
+- `CLAUDE.local.md` — your personal notes (never overwritten)
+```
+
+Placeholders `{instance_name}`, `{sync_interval}` substituted at generation time from instance config.
+
+### 2.4 Returning-Session Detection
+
+On every `da` CLI invocation:
+- Check data age (`data/metadata/last_sync.json`)
+- If >24h: suggest `da sync`
+- If CLAUDE.md missing: suggest `da analyst setup`
+
+### 2.5 Sync Command Extensions
+
+Extensions to existing `da sync`:
+```
+da sync                    # download updated data from server
+da sync --docs-only        # just metadata and metrics (fast)
+da sync --upload-local     # upload CLAUDE.local.md to server (corporate memory)
+```
+
+---
+
+## 3. Metadata Writer
+
+### 3.1 DuckDB Schema — `column_metadata` table
+
+New table in `system.duckdb` (part of v3→v4 migration alongside `metric_definitions`):
+
+```sql
+CREATE TABLE column_metadata (
+    table_id        VARCHAR NOT NULL,        -- FK → table_registry.id
+    column_name     VARCHAR NOT NULL,
+    basetype        VARCHAR,                 -- STRING, INTEGER, NUMERIC, FLOAT, BOOLEAN, DATE, TIMESTAMP
+    description     VARCHAR,
+    confidence      VARCHAR DEFAULT 'manual', -- high, medium, low, manual
+    source          VARCHAR DEFAULT 'manual', -- 'manual', 'ai_enrichment', 'keboola_import'
+    updated_at      TIMESTAMP DEFAULT now(),
+    PRIMARY KEY (table_id, column_name)
+);
+```
+
+### 3.2 Workflow (3 phases)
+
+**Phase 1: Discover** — profiler or AI agent analyzes columns
+```
+da admin metadata discover [--table orders]
+  → for each column without description:
+    sample 500 rows → heuristics for basetype
+    if Claude Code agent: generate descriptions
+  → saves as "proposal" JSON (same format as internal repo)
+```
+
+**Phase 2: Review** — user reviews proposals
+```
+da admin metadata review proposals/sales_metadata_20260410.json
+  → prints table: column | basetype | description | confidence
+  → user can edit or confirm
+```
+
+**Phase 3: Apply** — write to DuckDB + optional push to Keboola
+```
+da admin metadata apply proposals/sales_metadata_20260410.json
+  → INSERT/UPDATE into column_metadata in DuckDB
+  → --push-to-source: if source_type=keboola, POST to Keboola Storage API
+  → --dry-run: just show what would change
+```
+
+### 3.3 Push to Keboola Storage API
+
+Ported from `apply_metadata.py`:
+- Provider: `"ai-metadata-enrichment"`
+- Keys: `KBC.datatype.basetype`, `KBC.description`
+- Endpoint: `POST {stack_url}/v2/storage/tables/{table_id}/metadata`
+- Token and stack_url from `config/instance.yaml` / env vars (not hardcoded JSON)
+
+Only works for tables with `source_type = 'keboola'` in `table_registry`. For BigQuery/CSV/Jira, metadata is stored locally in DuckDB only.
+
+### 3.4 API Endpoints
+
+```
+GET  /api/admin/metadata/{table_id}           → column metadata for table
+POST /api/admin/metadata/{table_id}           → save metadata (JSON body)
+POST /api/admin/metadata/{table_id}/push      → push to source system
+```
+
+### 3.5 Integration
+
+- **Profiler**: `src/profiler.py` enriches `profiles.json` with `column_metadata` from DuckDB
+- **Catalog API**: `GET /api/catalog` returns metadata alongside profiles
+- **Claude Code agent**: reads metadata via `da admin metadata show {table}` or from `profiles.json`
+
+---
+
+## Implementation Summary
+
+### New Files
+
+| Component | Files |
+|---|---|
+| **Metrics** | `src/repositories/metrics.py`, `src/metrics.py`, `cli/commands/metrics.py`, `app/api/metrics.py`, `scripts/migrate_metrics_to_duckdb.py`, 10-15 YAML in `docs/metrics/` |
+| **Bootstrap** | `cli/commands/analyst.py`, `config/claude_md_template.txt` |
+| **Metadata** | `src/repositories/column_metadata.py`, `app/api/metadata.py` (metadata commands added as subcommands of `da admin`) |
+
+### Modified Files
+
+| File | Changes |
+|---|---|
+| `src/db.py` | SCHEMA_VERSION=4, `metric_definitions` + `column_metadata` tables, v3→v4 migration |
+| `src/profiler.py` | Read metrics + column_metadata from DuckDB instead of YAML scan |
+| `app/main.py` | Register metrics + metadata routers |
+| `cli/main.py` | Register `metrics` + `analyst` commands |
+| `cli/commands/sync.py` | `--docs-only`, `--upload-local` flags |
+| `CLAUDE.md` | Metrics workflow instructions |
+
+### Schema Migration v3→v4
+
+Single migration creating both tables. Auto-imports existing YAML metrics if found. Idempotent.
+
+### Implementation Order
+
+1. Schema v4 + metrics (framework + starter pack + CLI + API)
+2. Bootstrap flow (analyst setup + CLAUDE.md template)
+3. Metadata writer (discover + apply + Keboola push)
+
+### Test Coverage
+
+Each component gets its own test file following existing patterns:
+- `tests/test_metrics.py` — repository CRUD, YAML import/export, API endpoints
+- `tests/test_analyst_bootstrap.py` — setup flow (mocked API calls)
+- `tests/test_column_metadata.py` — repository CRUD, proposal format, Keboola push (mocked)

--- a/scripts/migrate_metrics_to_duckdb.py
+++ b/scripts/migrate_metrics_to_duckdb.py
@@ -1,0 +1,38 @@
+"""Migrate metric YAML files to DuckDB metric_definitions table.
+
+Usage:
+    python scripts/migrate_metrics_to_duckdb.py [--metrics-dir docs/metrics]
+"""
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Migrate metric YAMLs to DuckDB")
+    parser.add_argument("--metrics-dir", default="docs/metrics", help="Path to metrics directory")
+    args = parser.parse_args()
+
+    metrics_dir = Path(args.metrics_dir)
+    if not metrics_dir.is_dir():
+        logger.error("Metrics directory not found: %s", metrics_dir)
+        sys.exit(1)
+
+    from src.db import get_system_db
+    from src.repositories.metrics import MetricRepository
+    conn = get_system_db()
+    try:
+        repo = MetricRepository(conn)
+        count = repo.import_from_yaml(metrics_dir)
+        logger.info("Imported %d metrics from %s", count, metrics_dir)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/db.py
+++ b/src/db.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 _SAFE_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,63}$")
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 _SYSTEM_SCHEMA = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -168,6 +168,42 @@ CREATE TABLE IF NOT EXISTS access_requests (
     reviewed_at TIMESTAMP,
     created_at TIMESTAMP DEFAULT current_timestamp
 );
+
+CREATE TABLE IF NOT EXISTS metric_definitions (
+    id              VARCHAR PRIMARY KEY,
+    name            VARCHAR NOT NULL,
+    display_name    VARCHAR NOT NULL,
+    category        VARCHAR NOT NULL,
+    description     TEXT,
+    type            VARCHAR DEFAULT 'sum',
+    unit            VARCHAR,
+    grain           VARCHAR DEFAULT 'monthly',
+    table_name      VARCHAR,
+    tables          VARCHAR[],
+    expression      VARCHAR,
+    time_column     VARCHAR,
+    dimensions      VARCHAR[],
+    filters         VARCHAR[],
+    synonyms        VARCHAR[],
+    notes           VARCHAR[],
+    sql             TEXT NOT NULL,
+    sql_variants    JSON,
+    validation      JSON,
+    source          VARCHAR DEFAULT 'manual',
+    created_at      TIMESTAMP DEFAULT current_timestamp,
+    updated_at      TIMESTAMP DEFAULT current_timestamp
+);
+
+CREATE TABLE IF NOT EXISTS column_metadata (
+    table_id        VARCHAR NOT NULL,
+    column_name     VARCHAR NOT NULL,
+    basetype        VARCHAR,
+    description     VARCHAR,
+    confidence      VARCHAR DEFAULT 'manual',
+    source          VARCHAR DEFAULT 'manual',
+    updated_at      TIMESTAMP DEFAULT current_timestamp,
+    PRIMARY KEY (table_id, column_name)
+);
 """
 
 
@@ -259,6 +295,47 @@ _V2_TO_V3_MIGRATIONS = [
     "ALTER TABLE table_registry ADD COLUMN IF NOT EXISTS is_public BOOLEAN DEFAULT true",
 ]
 
+_V3_TO_V4_MIGRATIONS = [
+    """
+    CREATE TABLE IF NOT EXISTS metric_definitions (
+        id              VARCHAR PRIMARY KEY,
+        name            VARCHAR NOT NULL,
+        display_name    VARCHAR NOT NULL,
+        category        VARCHAR NOT NULL,
+        description     TEXT,
+        type            VARCHAR DEFAULT 'sum',
+        unit            VARCHAR,
+        grain           VARCHAR DEFAULT 'monthly',
+        table_name      VARCHAR,
+        tables          VARCHAR[],
+        expression      VARCHAR,
+        time_column     VARCHAR,
+        dimensions      VARCHAR[],
+        filters         VARCHAR[],
+        synonyms        VARCHAR[],
+        notes           VARCHAR[],
+        sql             TEXT NOT NULL,
+        sql_variants    JSON,
+        validation      JSON,
+        source          VARCHAR DEFAULT 'manual',
+        created_at      TIMESTAMP DEFAULT current_timestamp,
+        updated_at      TIMESTAMP DEFAULT current_timestamp
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS column_metadata (
+        table_id        VARCHAR NOT NULL,
+        column_name     VARCHAR NOT NULL,
+        basetype        VARCHAR,
+        description     VARCHAR,
+        confidence      VARCHAR DEFAULT 'manual',
+        source          VARCHAR DEFAULT 'manual',
+        updated_at      TIMESTAMP DEFAULT current_timestamp,
+        PRIMARY KEY (table_id, column_name)
+    )
+    """,
+]
+
 
 def _ensure_schema(conn: duckdb.DuckDBPyConnection) -> None:
     """Create tables if they don't exist. Apply migrations if schema version changed."""
@@ -295,6 +372,9 @@ def _ensure_schema(conn: duckdb.DuckDBPyConnection) -> None:
                     conn.execute(sql)
             if current < 3:
                 for sql in _V2_TO_V3_MIGRATIONS:
+                    conn.execute(sql)
+            if current < 4:
+                for sql in _V3_TO_V4_MIGRATIONS:
                     conn.execute(sql)
             conn.execute(
                 "UPDATE schema_version SET version = ?, applied_at = current_timestamp",

--- a/src/profiler.py
+++ b/src/profiler.py
@@ -94,6 +94,21 @@ METRICS_YML_PATH = DOCS_DIR / "metrics.yml"
 METRICS_DIR = DOCS_DIR / "metrics"
 DATA_DESCRIPTION_PATH = DOCS_DIR / "data_description.md"
 
+def _load_metrics_from_db() -> Dict[str, List[str]]:
+    """Load metrics table map from DuckDB. Returns empty dict on failure."""
+    try:
+        from src.db import get_system_db
+        from src.repositories.metrics import MetricRepository
+        conn = get_system_db()
+        repo = MetricRepository(conn)
+        table_map = repo.get_table_map()
+        conn.close()
+        return table_map
+    except Exception as exc:
+        logger.debug("Could not load metrics from DuckDB: %s", exc)
+        return {}
+
+
 # Jira tables - loaded dynamically if Jira connector is enabled
 # The Jira connector stores partitioned parquet files in PARQUET_DIR/jira/
 def _load_jira_tables() -> tuple:
@@ -1151,7 +1166,10 @@ def profile_changed_tables(table_names: list[str]) -> dict:
 
     # Load sync state and metrics
     sync_state = load_sync_state(SYNC_STATE_PATH)
-    metrics_map = load_metrics(METRICS_YML_PATH)
+    # Try DuckDB-backed metrics first, fall back to YAML scan
+    metrics_map = _load_metrics_from_db()
+    if not metrics_map:
+        metrics_map = load_metrics(METRICS_YML_PATH)
     metric_file_map = load_metric_file_map(METRICS_YML_PATH)
 
     # Load existing profiles.json to preserve untouched tables
@@ -1245,7 +1263,10 @@ def main() -> None:
     sync_state = load_sync_state(SYNC_STATE_PATH)
 
     # Load metrics
-    metrics_map = load_metrics(METRICS_YML_PATH)
+    # Try DuckDB-backed metrics first, fall back to YAML scan
+    metrics_map = _load_metrics_from_db()
+    if not metrics_map:
+        metrics_map = load_metrics(METRICS_YML_PATH)
     metric_file_map = load_metric_file_map(METRICS_YML_PATH)
 
     # Load existing profiles for fallback (preserve data for tables that fail)

--- a/src/repositories/column_metadata.py
+++ b/src/repositories/column_metadata.py
@@ -1,0 +1,107 @@
+"""Repository for column metadata."""
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Optional, List, Dict
+
+import duckdb
+
+
+class ColumnMetadataRepository:
+    def __init__(self, conn: duckdb.DuckDBPyConnection):
+        self.conn = conn
+
+    def save(
+        self,
+        table_id: str,
+        column_name: str,
+        basetype: Optional[str] = None,
+        description: Optional[str] = None,
+        confidence: str = "manual",
+        source: str = "manual",
+    ) -> dict:
+        """Insert or update column metadata. Returns the saved record."""
+        now = datetime.now(timezone.utc)
+        self.conn.execute(
+            """INSERT INTO column_metadata (table_id, column_name, basetype, description, confidence, source, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT (table_id, column_name) DO UPDATE SET
+                basetype = excluded.basetype,
+                description = excluded.description,
+                confidence = excluded.confidence,
+                source = excluded.source,
+                updated_at = excluded.updated_at""",
+            [table_id, column_name, basetype, description, confidence, source, now],
+        )
+        return self.get(table_id, column_name)
+
+    def get(self, table_id: str, column_name: str) -> Optional[Dict[str, Any]]:
+        """Select by composite PK. Returns None if not found."""
+        result = self.conn.execute(
+            "SELECT * FROM column_metadata WHERE table_id = ? AND column_name = ?",
+            [table_id, column_name],
+        ).fetchone()
+        if not result:
+            return None
+        columns = [desc[0] for desc in self.conn.description]
+        return dict(zip(columns, result))
+
+    def list_for_table(self, table_id: str) -> List[Dict[str, Any]]:
+        """Select all columns for a table, ordered by column_name."""
+        results = self.conn.execute(
+            "SELECT * FROM column_metadata WHERE table_id = ? ORDER BY column_name",
+            [table_id],
+        ).fetchall()
+        if not results:
+            return []
+        columns = [desc[0] for desc in self.conn.description]
+        return [dict(zip(columns, row)) for row in results]
+
+    def delete(self, table_id: str, column_name: str) -> bool:
+        """Delete column metadata. Returns True if a row was deleted."""
+        before = self.conn.execute(
+            "SELECT COUNT(*) FROM column_metadata WHERE table_id = ? AND column_name = ?",
+            [table_id, column_name],
+        ).fetchone()[0]
+        if before == 0:
+            return False
+        self.conn.execute(
+            "DELETE FROM column_metadata WHERE table_id = ? AND column_name = ?",
+            [table_id, column_name],
+        )
+        return True
+
+    def import_proposal(self, proposal_path: str) -> int:
+        """Import a proposal JSON file.
+
+        Format:
+            {
+                "tables": {
+                    "orders": {
+                        "columns": {
+                            "id": {"basetype": "STRING", "description": "...", "confidence": "high"}
+                        }
+                    }
+                }
+            }
+
+        Sets source="ai_enrichment". Returns count of columns imported.
+        """
+        with open(proposal_path, "r", encoding="utf-8") as f:
+            proposal = json.load(f)
+
+        count = 0
+        tables = proposal.get("tables", {})
+        for table_id, table_data in tables.items():
+            columns = table_data.get("columns", {})
+            for column_name, col_data in columns.items():
+                self.save(
+                    table_id=table_id,
+                    column_name=column_name,
+                    basetype=col_data.get("basetype"),
+                    description=col_data.get("description"),
+                    confidence=col_data.get("confidence", "high"),
+                    source="ai_enrichment",
+                )
+                count += 1
+        return count

--- a/src/repositories/metrics.py
+++ b/src/repositories/metrics.py
@@ -156,8 +156,8 @@ class MetricRepository:
 
     def find_by_table(self, table_name: str) -> List[Dict[str, Any]]:
         rows = self.conn.execute(
-            "SELECT * FROM metric_definitions WHERE table_name = ? ORDER BY name",
-            [table_name],
+            "SELECT * FROM metric_definitions WHERE table_name = ? OR list_contains(tables, ?) ORDER BY name",
+            [table_name, table_name],
         ).fetchall()
         return self._rows_to_dicts(rows)
 
@@ -176,6 +176,12 @@ class MetricRepository:
         result: Dict[str, List[str]] = {}
         for table_name, metric_name in rows:
             result.setdefault(table_name, []).append(metric_name)
+        # Also include metrics that reference tables via the 'tables' array
+        results2 = self.conn.execute(
+            "SELECT unnest(tables) AS tbl, name FROM metric_definitions WHERE tables IS NOT NULL"
+        ).fetchall()
+        for tbl, metric_name in results2:
+            result.setdefault(tbl, []).append(metric_name)
         return result
 
     def import_from_yaml(self, path: Union[str, Path]) -> int:

--- a/src/repositories/metrics.py
+++ b/src/repositories/metrics.py
@@ -2,9 +2,11 @@
 
 import json
 from datetime import datetime, timezone
-from typing import Any, Optional, List, Dict
+from pathlib import Path
+from typing import Any, Optional, List, Dict, Union
 
 import duckdb
+import yaml
 
 
 def json_dumps(obj) -> Optional[str]:
@@ -175,3 +177,169 @@ class MetricRepository:
         for table_name, metric_name in rows:
             result.setdefault(table_name, []).append(metric_name)
         return result
+
+    def import_from_yaml(self, path: Union[str, Path]) -> int:
+        """Import metrics from a YAML file or directory of YAML files.
+
+        Args:
+            path: Path to a single .yml file or a directory containing */*.yml files.
+
+        Returns:
+            Number of metrics imported.
+        """
+        path = Path(path)
+        files: List[Path] = []
+
+        if path.is_file():
+            files = [path]
+        elif path.is_dir():
+            files = sorted(path.glob("*/*.yml"))
+
+        count = 0
+        for file_path in files:
+            # Infer category from parent directory name
+            category_from_dir = file_path.parent.name
+
+            with open(file_path, "r") as f:
+                raw = yaml.safe_load(f)
+
+            # Support both list-wrapped [{...}] and plain {...} formats
+            if isinstance(raw, list):
+                metrics_data = raw
+            elif isinstance(raw, dict):
+                metrics_data = [raw]
+            else:
+                continue
+
+            for data in metrics_data:
+                if not isinstance(data, dict):
+                    continue
+
+                name = data.get("name")
+                if not name:
+                    continue
+
+                category = data.get("category") or category_from_dir
+
+                # Build id as "category/name"
+                metric_id = f"{category}/{name}"
+
+                # Map YAML 'table' -> DB 'table_name'
+                table_name = data.get("table") or data.get("table_name")
+
+                # Collect sql_by_* keys into sql_variants dict
+                # e.g. sql_by_channel → {"by_channel": "..."}
+                sql_variants: Dict[str, str] = {}
+                for key, value in data.items():
+                    if key.startswith("sql_by_"):
+                        variant_key = key[len("sql_"):]  # strip 'sql_' prefix → 'by_channel'
+                        sql_variants[variant_key] = value
+
+                self.create(
+                    id=metric_id,
+                    name=name,
+                    display_name=data.get("display_name", name),
+                    category=category,
+                    sql=data.get("sql", ""),
+                    description=data.get("description"),
+                    type=data.get("type", "sum"),
+                    unit=data.get("unit"),
+                    grain=data.get("grain", "monthly"),
+                    table_name=table_name,
+                    tables=data.get("tables"),
+                    expression=data.get("expression"),
+                    time_column=data.get("time_column"),
+                    dimensions=data.get("dimensions"),
+                    filters=data.get("filters"),
+                    synonyms=data.get("synonyms"),
+                    notes=data.get("notes"),
+                    sql_variants=sql_variants if sql_variants else None,
+                    validation=data.get("validation"),
+                    source="yaml_import",
+                )
+                count += 1
+
+        return count
+
+    def export_to_yaml(self, output_dir: Union[str, Path]) -> int:
+        """Export all metrics to YAML files under output_dir/{category}/{name}.yml.
+
+        Args:
+            output_dir: Root directory for the exported YAML files.
+
+        Returns:
+            Number of metrics exported.
+        """
+        output_dir = Path(output_dir)
+        metrics = self.list()
+        count = 0
+
+        for metric in metrics:
+            category = metric.get("category") or "uncategorized"
+            name = metric.get("name") or metric["id"].split("/")[-1]
+
+            category_dir = output_dir / category
+            category_dir.mkdir(parents=True, exist_ok=True)
+
+            # Build the YAML dict — map table_name back to table
+            data: Dict[str, Any] = {"name": name}
+            if metric.get("display_name"):
+                data["display_name"] = metric["display_name"]
+            data["category"] = category
+            if metric.get("type"):
+                data["type"] = metric["type"]
+            if metric.get("unit"):
+                data["unit"] = metric["unit"]
+            if metric.get("grain"):
+                data["grain"] = metric["grain"]
+            if metric.get("time_column"):
+                data["time_column"] = metric["time_column"]
+            # Use 'table' (not 'table_name') in YAML output
+            if metric.get("table_name"):
+                data["table"] = metric["table_name"]
+            if metric.get("expression"):
+                data["expression"] = metric["expression"]
+            if metric.get("description"):
+                data["description"] = metric["description"]
+            if metric.get("dimensions"):
+                data["dimensions"] = metric["dimensions"]
+            if metric.get("filters"):
+                data["filters"] = metric["filters"]
+            if metric.get("synonyms"):
+                data["synonyms"] = metric["synonyms"]
+            if metric.get("notes"):
+                data["notes"] = metric["notes"]
+            if metric.get("sql"):
+                data["sql"] = metric["sql"]
+
+            # Expand sql_variants back to sql_by_* keys
+            sql_variants = metric.get("sql_variants")
+            if sql_variants:
+                if isinstance(sql_variants, str):
+                    try:
+                        sql_variants = json.loads(sql_variants)
+                    except (json.JSONDecodeError, ValueError):
+                        sql_variants = {}
+                if isinstance(sql_variants, dict):
+                    for variant_key, variant_sql in sql_variants.items():
+                        # variant_key is e.g. 'by_channel' → YAML key 'sql_by_channel'
+                        data[f"sql_{variant_key}"] = variant_sql
+
+            # Handle validation JSON
+            validation = metric.get("validation")
+            if validation:
+                if isinstance(validation, str):
+                    try:
+                        validation = json.loads(validation)
+                    except (json.JSONDecodeError, ValueError):
+                        validation = None
+                if validation:
+                    data["validation"] = validation
+
+            out_file = category_dir / f"{name}.yml"
+            with open(out_file, "w") as f:
+                yaml.dump(data, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+
+            count += 1
+
+        return count

--- a/src/repositories/metrics.py
+++ b/src/repositories/metrics.py
@@ -1,0 +1,177 @@
+"""Repository for metric definitions."""
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Optional, List, Dict
+
+import duckdb
+
+
+def json_dumps(obj) -> Optional[str]:
+    """Serialize obj to JSON string, or None if obj is None."""
+    if obj is None:
+        return None
+    return json.dumps(obj)
+
+
+class MetricRepository:
+    def __init__(self, conn: duckdb.DuckDBPyConnection):
+        self.conn = conn
+
+    def _row_to_dict(self, row) -> Optional[Dict[str, Any]]:
+        if not row:
+            return None
+        columns = [desc[0] for desc in self.conn.description]
+        return dict(zip(columns, row))
+
+    def _rows_to_dicts(self, rows) -> List[Dict[str, Any]]:
+        if not rows:
+            return []
+        columns = [desc[0] for desc in self.conn.description]
+        return [dict(zip(columns, row)) for row in rows]
+
+    def create(
+        self,
+        id: str,
+        name: str,
+        display_name: str,
+        category: str,
+        sql: str,
+        description: Optional[str] = None,
+        type: str = "sum",
+        unit: Optional[str] = None,
+        grain: str = "monthly",
+        table_name: Optional[str] = None,
+        tables: Optional[List[str]] = None,
+        expression: Optional[str] = None,
+        time_column: Optional[str] = None,
+        dimensions: Optional[List[str]] = None,
+        filters: Optional[List[str]] = None,
+        synonyms: Optional[List[str]] = None,
+        notes: Optional[List[str]] = None,
+        sql_variants: Optional[Dict[str, Any]] = None,
+        validation: Optional[Dict[str, Any]] = None,
+        source: str = "manual",
+        **kwargs,
+    ) -> Dict[str, Any]:
+        now = datetime.now(timezone.utc)
+        self.conn.execute(
+            """INSERT INTO metric_definitions (
+                id, name, display_name, category, description, type, unit, grain,
+                table_name, tables, expression, time_column, dimensions, filters,
+                synonyms, notes, sql, sql_variants, validation, source,
+                created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT (id) DO UPDATE SET
+                name = excluded.name,
+                display_name = excluded.display_name,
+                category = excluded.category,
+                description = excluded.description,
+                type = excluded.type,
+                unit = excluded.unit,
+                grain = excluded.grain,
+                table_name = excluded.table_name,
+                tables = excluded.tables,
+                expression = excluded.expression,
+                time_column = excluded.time_column,
+                dimensions = excluded.dimensions,
+                filters = excluded.filters,
+                synonyms = excluded.synonyms,
+                notes = excluded.notes,
+                sql = excluded.sql,
+                sql_variants = excluded.sql_variants,
+                validation = excluded.validation,
+                source = excluded.source,
+                updated_at = excluded.updated_at""",
+            [
+                id, name, display_name, category, description, type, unit, grain,
+                table_name, tables, expression, time_column, dimensions, filters,
+                synonyms, notes, sql,
+                json_dumps(sql_variants), json_dumps(validation), source,
+                now, now,
+            ],
+        )
+        return self.get(id)
+
+    def get(self, metric_id: str) -> Optional[Dict[str, Any]]:
+        result = self.conn.execute(
+            "SELECT * FROM metric_definitions WHERE id = ?", [metric_id]
+        ).fetchone()
+        return self._row_to_dict(result)
+
+    def list(self, category: Optional[str] = None) -> List[Dict[str, Any]]:
+        if category is not None:
+            rows = self.conn.execute(
+                "SELECT * FROM metric_definitions WHERE category = ? ORDER BY name",
+                [category],
+            ).fetchall()
+        else:
+            rows = self.conn.execute(
+                "SELECT * FROM metric_definitions ORDER BY name"
+            ).fetchall()
+        return self._rows_to_dicts(rows)
+
+    def update(self, metric_id: str, **kwargs) -> Optional[Dict[str, Any]]:
+        # Check existence first
+        existing = self.get(metric_id)
+        if existing is None:
+            return None
+
+        allowed = {
+            "name", "display_name", "category", "description", "type", "unit",
+            "grain", "table_name", "tables", "expression", "time_column",
+            "dimensions", "filters", "synonyms", "notes", "sql",
+            "sql_variants", "validation", "source",
+        }
+        # JSON fields that need serialization
+        json_fields = {"sql_variants", "validation"}
+
+        updates = {}
+        for k, v in kwargs.items():
+            if k in allowed:
+                if k in json_fields:
+                    updates[k] = json_dumps(v)
+                else:
+                    updates[k] = v
+
+        if not updates:
+            return existing
+
+        updates["updated_at"] = datetime.now(timezone.utc)
+        set_clause = ", ".join(f"{k} = ?" for k in updates)
+        values = list(updates.values()) + [metric_id]
+        self.conn.execute(
+            f"UPDATE metric_definitions SET {set_clause} WHERE id = ?", values
+        )
+        return self.get(metric_id)
+
+    def delete(self, metric_id: str) -> bool:
+        existing = self.get(metric_id)
+        if existing is None:
+            return False
+        self.conn.execute("DELETE FROM metric_definitions WHERE id = ?", [metric_id])
+        return True
+
+    def find_by_table(self, table_name: str) -> List[Dict[str, Any]]:
+        rows = self.conn.execute(
+            "SELECT * FROM metric_definitions WHERE table_name = ? ORDER BY name",
+            [table_name],
+        ).fetchall()
+        return self._rows_to_dicts(rows)
+
+    def find_by_synonym(self, term: str) -> List[Dict[str, Any]]:
+        rows = self.conn.execute(
+            "SELECT * FROM metric_definitions WHERE list_contains(synonyms, ?) ORDER BY name",
+            [term],
+        ).fetchall()
+        return self._rows_to_dicts(rows)
+
+    def get_table_map(self) -> Dict[str, List[str]]:
+        """Return {table_name: [metric_name, ...]} for profiler use."""
+        rows = self.conn.execute(
+            "SELECT table_name, name FROM metric_definitions WHERE table_name IS NOT NULL ORDER BY table_name, name"
+        ).fetchall()
+        result: Dict[str, List[str]] = {}
+        for table_name, metric_name in rows:
+            result.setdefault(table_name, []).append(metric_name)
+        return result

--- a/tests/test_analyst_bootstrap.py
+++ b/tests/test_analyst_bootstrap.py
@@ -1,0 +1,250 @@
+"""Tests for analyst bootstrap flow."""
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from cli.main import app
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def tmp_workspace(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("DA_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("DA_LOCAL_DIR", str(tmp_path / "local"))
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret")
+    (tmp_path / "data").mkdir()
+    (tmp_path / "config").mkdir()
+    (tmp_path / "local").mkdir()
+    ws = tmp_path / "workspace"
+    ws.mkdir()
+    monkeypatch.chdir(ws)
+    yield ws
+
+
+# ---------------------------------------------------------------------------
+# TestDetectExistingProject
+# ---------------------------------------------------------------------------
+
+class TestDetectExistingProject:
+    def test_no_claude_md_returns_false(self, tmp_workspace):
+        from cli.commands.analyst import _detect_existing_project
+
+        assert _detect_existing_project(tmp_workspace) is False
+
+    def test_claude_md_with_marker_returns_true(self, tmp_workspace):
+        from cli.commands.analyst import _detect_existing_project
+
+        (tmp_workspace / "CLAUDE.md").write_text(
+            "# Acme — AI Data Analyst\n\nThis workspace is connected to http://localhost:8000.\n",
+            encoding="utf-8",
+        )
+        assert _detect_existing_project(tmp_workspace) is True
+
+    def test_claude_md_without_marker_returns_false(self, tmp_workspace):
+        from cli.commands.analyst import _detect_existing_project
+
+        (tmp_workspace / "CLAUDE.md").write_text(
+            "# Some Other Project\n\nNot an analyst workspace.\n",
+            encoding="utf-8",
+        )
+        assert _detect_existing_project(tmp_workspace) is False
+
+    def test_setup_blocked_when_existing_without_force(self, tmp_workspace):
+        """Setup must exit(1) when workspace exists and --force not supplied."""
+        (tmp_workspace / "CLAUDE.md").write_text(
+            "# Acme — AI Data Analyst\nThis workspace is connected to http://localhost:8000.\n",
+            encoding="utf-8",
+        )
+        result = runner.invoke(app, ["analyst", "setup", "--server-url", "http://localhost:8000"])
+        assert result.exit_code == 1
+        assert "force" in result.output.lower() or "force" in (result.stderr or "").lower()
+
+    def test_setup_proceeds_with_force(self, tmp_workspace):
+        """--force bypasses existing-project detection."""
+        (tmp_workspace / "CLAUDE.md").write_text(
+            "# Acme — AI Data Analyst\nThis workspace is connected to http://localhost:8000.\n",
+            encoding="utf-8",
+        )
+
+        with patch("cli.commands.analyst._connect_to_instance", return_value="tok"), \
+             patch("cli.commands.analyst._download_metadata"), \
+             patch("cli.commands.analyst._download_data", return_value=0), \
+             patch("cli.commands.analyst._initialize_duckdb", return_value=0), \
+             patch("cli.commands.analyst._get_instance_name", return_value="Acme"), \
+             patch("cli.commands.analyst._generate_claude_md"):
+            result = runner.invoke(
+                app,
+                ["analyst", "setup", "--server-url", "http://localhost:8000", "--force"],
+            )
+        assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# TestCreateWorkspace
+# ---------------------------------------------------------------------------
+
+class TestCreateWorkspace:
+    def test_creates_all_directories(self, tmp_workspace):
+        from cli.commands.analyst import _create_workspace
+
+        _create_workspace(tmp_workspace)
+
+        expected = [
+            tmp_workspace / "data" / "parquet",
+            tmp_workspace / "data" / "duckdb",
+            tmp_workspace / "data" / "metadata",
+            tmp_workspace / "user" / "artifacts",
+            tmp_workspace / "user" / "sessions",
+            tmp_workspace / ".claude",
+        ]
+        for d in expected:
+            assert d.is_dir(), f"Expected directory missing: {d}"
+
+    def test_idempotent(self, tmp_workspace):
+        """Calling _create_workspace twice should not raise."""
+        from cli.commands.analyst import _create_workspace
+
+        _create_workspace(tmp_workspace)
+        _create_workspace(tmp_workspace)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# TestGenerateClaudeMd
+# ---------------------------------------------------------------------------
+
+class TestGenerateClaudeMd:
+    def test_template_substitution(self, tmp_workspace):
+        from cli.commands.analyst import _create_workspace, _generate_claude_md
+
+        _create_workspace(tmp_workspace)
+        _generate_claude_md(
+            tmp_workspace,
+            instance_name="Acme Corp",
+            server_url="https://data.acme.com",
+            sync_interval="2 hours",
+        )
+
+        content = (tmp_workspace / "CLAUDE.md").read_text(encoding="utf-8")
+        assert "Acme Corp" in content
+        assert "https://data.acme.com" in content
+        assert "2 hours" in content
+
+    def test_creates_claude_local_md_when_absent(self, tmp_workspace):
+        from cli.commands.analyst import _create_workspace, _generate_claude_md
+
+        _create_workspace(tmp_workspace)
+        _generate_claude_md(
+            tmp_workspace,
+            instance_name="Acme",
+            server_url="http://localhost:8000",
+            sync_interval="1 hour",
+        )
+
+        local_md = tmp_workspace / ".claude" / "CLAUDE.local.md"
+        assert local_md.exists()
+        assert local_md.read_text(encoding="utf-8").strip() != ""
+
+    def test_does_not_overwrite_existing_local_md(self, tmp_workspace):
+        from cli.commands.analyst import _create_workspace, _generate_claude_md
+
+        _create_workspace(tmp_workspace)
+        local_md = tmp_workspace / ".claude" / "CLAUDE.local.md"
+        original_content = "# My custom notes\n\nDo not overwrite me.\n"
+        local_md.write_text(original_content, encoding="utf-8")
+
+        _generate_claude_md(
+            tmp_workspace,
+            instance_name="Acme",
+            server_url="http://localhost:8000",
+            sync_interval="1 hour",
+        )
+
+        assert local_md.read_text(encoding="utf-8") == original_content
+
+    def test_uses_template_file_if_available(self, tmp_workspace):
+        """Smoke-test that the real template file is found and substituted."""
+        from cli.commands.analyst import _create_workspace, _generate_claude_md
+
+        _create_workspace(tmp_workspace)
+        _generate_claude_md(
+            tmp_workspace,
+            instance_name="TestCo",
+            server_url="https://test.example.com",
+            sync_interval="30 minutes",
+        )
+
+        content = (tmp_workspace / "CLAUDE.md").read_text(encoding="utf-8")
+        # Template contains these literals after substitution
+        assert "TestCo" in content
+        assert "https://test.example.com" in content
+        assert "30 minutes" in content
+        # Ensure placeholders are gone
+        assert "{instance_name}" not in content
+        assert "{server_url}" not in content
+        assert "{sync_interval}" not in content
+
+
+# ---------------------------------------------------------------------------
+# TestReturningSession
+# ---------------------------------------------------------------------------
+
+class TestReturningSession:
+    def test_missing_when_no_last_sync_file(self, tmp_workspace):
+        from cli.commands.analyst import _check_data_freshness
+
+        assert _check_data_freshness(tmp_workspace) == "missing"
+
+    def test_fresh_when_recent_sync(self, tmp_workspace):
+        from cli.commands.analyst import _create_workspace, _check_data_freshness
+
+        _create_workspace(tmp_workspace)
+        synced_at = datetime.now(timezone.utc).isoformat()
+        (tmp_workspace / "data" / "metadata" / "last_sync.json").write_text(
+            json.dumps({"synced_at": synced_at}), encoding="utf-8"
+        )
+        assert _check_data_freshness(tmp_workspace) == "fresh"
+
+    def test_stale_when_old_sync(self, tmp_workspace):
+        from cli.commands.analyst import _create_workspace, _check_data_freshness
+
+        _create_workspace(tmp_workspace)
+        old_time = (datetime.now(timezone.utc) - timedelta(hours=25)).isoformat()
+        (tmp_workspace / "data" / "metadata" / "last_sync.json").write_text(
+            json.dumps({"synced_at": old_time}), encoding="utf-8"
+        )
+        assert _check_data_freshness(tmp_workspace) == "stale"
+
+    def test_status_command_output(self, tmp_workspace):
+        result = runner.invoke(app, ["analyst", "status"])
+        assert result.exit_code == 0
+        assert "freshness" in result.output.lower() or "Data freshness" in result.output
+
+    def test_status_command_json(self, tmp_workspace):
+        result = runner.invoke(app, ["analyst", "status", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "freshness" in data
+        assert data["freshness"] == "missing"
+        assert "parquet_tables" in data
+
+    def test_status_fresh_after_setup_metadata(self, tmp_workspace):
+        from cli.commands.analyst import _create_workspace
+
+        _create_workspace(tmp_workspace)
+        synced_at = datetime.now(timezone.utc).isoformat()
+        (tmp_workspace / "data" / "metadata" / "last_sync.json").write_text(
+            json.dumps({"synced_at": synced_at}), encoding="utf-8"
+        )
+
+        result = runner.invoke(app, ["analyst", "status", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["freshness"] == "fresh"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -375,3 +375,79 @@ class TestMetadataAPI:
             headers={"Authorization": f"Bearer {analyst_token}"},
         )
         assert resp.status_code == 403
+
+    def test_push_non_keboola_table_fails(self, seeded_client):
+        client, admin_token, _ = seeded_client
+        resp = client.post(
+            "/api/admin/metadata/orders/push",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        # 'orders' is not in table_registry — expect 404 or 400
+        assert resp.status_code in (400, 404)
+
+    def test_push_keboola_table(self, seeded_client, monkeypatch):
+        client, admin_token, _ = seeded_client
+
+        # 1. Register a keboola table
+        from src.db import get_system_db
+        from src.repositories.table_registry import TableRegistryRepository
+
+        conn = get_system_db()
+        TableRegistryRepository(conn).register(
+            id="kbc_orders",
+            name="Orders",
+            source_type="keboola",
+            source_table="in.c-main.orders",
+        )
+        conn.close()
+
+        # 2. Save column metadata
+        client.post(
+            "/api/admin/metadata/kbc_orders",
+            json={"columns": [
+                {"column_name": "id", "basetype": "STRING", "description": "Order ID"},
+            ]},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+        # 3. Set required env vars
+        monkeypatch.setenv("KBC_STACK_URL", "https://connection.keboola.com")
+        monkeypatch.setenv("KBC_STORAGE_TOKEN", "test-token")
+
+        # 4. Mock httpx.AsyncClient so no real HTTP call is made
+        import httpx as _httpx
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        mock_response = _httpx.Response(200, json={"ok": True})
+        mock_post = AsyncMock(return_value=mock_response)
+
+        # AsyncClient is used as "async with httpx.AsyncClient() as client: await client.post(...)"
+        # We patch the class so the context-manager instance has our mock_post.
+        mock_async_client_instance = MagicMock()
+        mock_async_client_instance.post = mock_post
+        mock_async_client_instance.__aenter__ = AsyncMock(return_value=mock_async_client_instance)
+        mock_async_client_instance.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("httpx.AsyncClient", return_value=mock_async_client_instance):
+            resp = client.post(
+                "/api/admin/metadata/kbc_orders/push",
+                headers={"Authorization": f"Bearer {admin_token}"},
+            )
+
+        # 5. Assertions
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data.get("pushed") == 1
+
+        mock_post.assert_called_once()
+        call_args = mock_post.call_args
+        # Verify URL contains the source table name
+        called_url = call_args[0][0] if call_args[0] else call_args.kwargs.get("url", "")
+        assert "in.c-main.orders" in called_url
+        # Verify auth header
+        called_headers = call_args.kwargs.get("headers", {})
+        assert called_headers.get("X-StorageApi-Token") == "test-token"
+        # Verify payload structure
+        called_json = call_args.kwargs.get("json", {})
+        assert called_json.get("provider") == "ai-metadata-enrichment"
+        assert isinstance(called_json.get("metadata"), list)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -330,6 +330,17 @@ class TestMetricsAPI:
         assert data["count"] == 1
         assert data["metrics"][0]["category"] == "finance"
 
+    def test_import_metrics_yaml(self, seeded_client):
+        client, admin_token, _ = seeded_client
+        yaml_content = b"- name: test_metric\n  display_name: Test\n  category: test\n  sql: SELECT 1\n"
+        resp = client.post(
+            "/api/admin/metrics/import",
+            files={"file": ("test.yml", yaml_content, "application/x-yaml")},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["count"] == 1
+
 
 class TestMetadataAPI:
     def test_get_metadata_empty(self, seeded_client):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -329,3 +329,38 @@ class TestMetricsAPI:
         data = resp.json()
         assert data["count"] == 1
         assert data["metrics"][0]["category"] == "finance"
+
+
+class TestMetadataAPI:
+    def test_get_metadata_empty(self, seeded_client):
+        client, admin_token, _ = seeded_client
+        resp = client.get("/api/admin/metadata/orders", headers={"Authorization": f"Bearer {admin_token}"})
+        assert resp.status_code == 200
+        assert resp.json()["columns"] == []
+
+    def test_save_and_get_metadata(self, seeded_client):
+        client, admin_token, _ = seeded_client
+        resp = client.post(
+            "/api/admin/metadata/orders",
+            json={"columns": [
+                {"column_name": "id", "basetype": "STRING", "description": "Order ID"},
+                {"column_name": "total", "basetype": "NUMERIC", "description": "Total"},
+            ]},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+        assert resp.json()["count"] == 2
+
+        resp = client.get("/api/admin/metadata/orders", headers={"Authorization": f"Bearer {admin_token}"})
+        assert resp.status_code == 200
+        assert len(resp.json()["columns"]) == 2
+
+    def test_analyst_cannot_save_metadata(self, seeded_client):
+        client, _, analyst_token = seeded_client
+        resp = client.post(
+            "/api/admin/metadata/orders",
+            json={"columns": [{"column_name": "id", "basetype": "STRING"}]},
+            headers={"Authorization": f"Bearer {analyst_token}"},
+        )
+        assert resp.status_code == 403

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -233,3 +233,99 @@ class TestUpload:
         )
         assert resp.status_code == 200
         assert resp.json()["user"] == "analyst@acme.com"
+
+
+# ---- Metrics API ----
+
+SAMPLE_METRIC = {
+    "id": "finance/mrr",
+    "name": "mrr",
+    "display_name": "Monthly Recurring Revenue",
+    "category": "finance",
+    "sql": "SELECT SUM(amount) FROM subscriptions WHERE active = true",
+}
+
+
+class TestMetricsAPI:
+    def test_list_metrics_empty(self, seeded_client):
+        client, admin_token, _ = seeded_client
+        headers = {"Authorization": f"Bearer {admin_token}"}
+        resp = client.get("/api/metrics", headers=headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] == 0
+        assert data["metrics"] == []
+
+    def test_create_and_list_metric(self, seeded_client):
+        client, admin_token, _ = seeded_client
+        headers = {"Authorization": f"Bearer {admin_token}"}
+
+        resp = client.post("/api/admin/metrics", json=SAMPLE_METRIC, headers=headers)
+        assert resp.status_code == 201
+
+        resp = client.get("/api/metrics", headers=headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] == 1
+        assert data["metrics"][0]["id"] == "finance/mrr"
+
+    def test_get_metric_detail(self, seeded_client):
+        client, admin_token, _ = seeded_client
+        headers = {"Authorization": f"Bearer {admin_token}"}
+
+        client.post("/api/admin/metrics", json=SAMPLE_METRIC, headers=headers)
+
+        resp = client.get("/api/metrics/finance/mrr", headers=headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["id"] == "finance/mrr"
+        assert data["display_name"] == "Monthly Recurring Revenue"
+        assert data["category"] == "finance"
+
+    def test_get_metric_not_found(self, seeded_client):
+        client, admin_token, _ = seeded_client
+        headers = {"Authorization": f"Bearer {admin_token}"}
+
+        resp = client.get("/api/metrics/nonexistent/metric", headers=headers)
+        assert resp.status_code == 404
+
+    def test_delete_metric(self, seeded_client):
+        client, admin_token, _ = seeded_client
+        headers = {"Authorization": f"Bearer {admin_token}"}
+
+        client.post("/api/admin/metrics", json=SAMPLE_METRIC, headers=headers)
+
+        resp = client.delete("/api/admin/metrics/finance/mrr", headers=headers)
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "deleted"
+
+        resp = client.get("/api/metrics/finance/mrr", headers=headers)
+        assert resp.status_code == 404
+
+    def test_analyst_cannot_create_metric(self, seeded_client):
+        client, _, analyst_token = seeded_client
+        headers = {"Authorization": f"Bearer {analyst_token}"}
+
+        resp = client.post("/api/admin/metrics", json=SAMPLE_METRIC, headers=headers)
+        assert resp.status_code == 403
+
+    def test_list_metrics_filter_by_category(self, seeded_client):
+        client, admin_token, _ = seeded_client
+        headers = {"Authorization": f"Bearer {admin_token}"}
+
+        finance_metric = {**SAMPLE_METRIC}
+        support_metric = {
+            "id": "support/tickets",
+            "name": "tickets",
+            "display_name": "Open Tickets",
+            "category": "support",
+            "sql": "SELECT COUNT(*) FROM tickets WHERE status = 'open'",
+        }
+        client.post("/api/admin/metrics", json=finance_metric, headers=headers)
+        client.post("/api/admin/metrics", json=support_metric, headers=headers)
+
+        resp = client.get("/api/metrics?category=finance", headers=headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] == 1
+        assert data["metrics"][0]["category"] == "finance"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -245,3 +245,8 @@ class TestMetricsHelp:
         assert "list" in result.output
         assert "show" in result.output
         assert "import" in result.output
+
+    def test_analyst_help(self):
+        result = runner.invoke(app, ["analyst", "--help"])
+        assert result.exit_code == 0
+        assert "setup" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -232,3 +232,12 @@ class TestAdminCommands:
         with patch("cli.commands.admin.api_get", return_value=mock_resp):
             result = runner.invoke(app, ["admin", "list-tables"])
             assert result.exit_code == 1
+
+
+class TestMetricsHelp:
+    def test_metrics_help(self):
+        result = runner.invoke(app, ["metrics", "--help"])
+        assert result.exit_code == 0
+        assert "list" in result.output
+        assert "show" in result.output
+        assert "import" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,6 +46,10 @@ class TestCLIHelp:
         result = runner.invoke(app, ["admin", "--help"])
         assert result.exit_code == 0
 
+    def test_admin_metadata_help(self):
+        result = runner.invoke(app, ["admin", "metadata-show", "--help"])
+        assert result.exit_code == 0
+
     def test_diagnose_help(self):
         result = runner.invoke(app, ["diagnose", "--help"])
         assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -250,3 +250,8 @@ class TestMetricsHelp:
         result = runner.invoke(app, ["analyst", "--help"])
         assert result.exit_code == 0
         assert "setup" in result.output
+
+    def test_analyst_status_help(self):
+        result = runner.invoke(app, ["analyst", "status", "--help"])
+        assert result.exit_code == 0
+        assert "freshness" in result.output.lower() or "workspace" in result.output.lower()

--- a/tests/test_column_metadata.py
+++ b/tests/test_column_metadata.py
@@ -1,0 +1,144 @@
+"""Tests for ColumnMetadataRepository."""
+
+import json
+import pytest
+
+
+@pytest.fixture
+def db_conn(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    from src.db import get_system_db
+    conn = get_system_db()
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def repo(db_conn):
+    from src.repositories.column_metadata import ColumnMetadataRepository
+    return ColumnMetadataRepository(db_conn)
+
+
+class TestColumnMetadataCreate:
+    def test_save_single_column(self, repo):
+        result = repo.save("orders", "id", basetype="STRING", description="Order ID")
+        assert result["table_id"] == "orders"
+        assert result["column_name"] == "id"
+        assert result["basetype"] == "STRING"
+        assert result["description"] == "Order ID"
+        assert result["confidence"] == "manual"
+        assert result["source"] == "manual"
+
+    def test_upsert_overwrites(self, repo):
+        repo.save("orders", "id", basetype="STRING", description="Old")
+        result = repo.save("orders", "id", basetype="INTEGER", description="New", confidence="high")
+        assert result["basetype"] == "INTEGER"
+        assert result["description"] == "New"
+        assert result["confidence"] == "high"
+        # Should still be only one row
+        rows = repo.list_for_table("orders")
+        assert len(rows) == 1
+
+
+class TestColumnMetadataRead:
+    def test_list_for_table_filters_by_table(self, repo):
+        repo.save("orders", "id", basetype="STRING")
+        repo.save("orders", "total", basetype="NUMERIC")
+        repo.save("orders", "status", basetype="STRING")
+        repo.save("customers", "email", basetype="STRING")
+
+        orders_cols = repo.list_for_table("orders")
+        assert len(orders_cols) == 3
+        assert all(c["table_id"] == "orders" for c in orders_cols)
+
+        customer_cols = repo.list_for_table("customers")
+        assert len(customer_cols) == 1
+        assert customer_cols[0]["column_name"] == "email"
+
+    def test_list_for_table_ordered_by_column_name(self, repo):
+        repo.save("orders", "total", basetype="NUMERIC")
+        repo.save("orders", "id", basetype="STRING")
+        repo.save("orders", "status", basetype="STRING")
+
+        cols = repo.list_for_table("orders")
+        names = [c["column_name"] for c in cols]
+        assert names == sorted(names)
+
+    def test_get_missing_returns_none(self, repo):
+        result = repo.get("orders", "nonexistent")
+        assert result is None
+
+
+class TestColumnMetadataDelete:
+    def test_delete_column(self, repo):
+        repo.save("orders", "id", basetype="STRING")
+        deleted = repo.delete("orders", "id")
+        assert deleted is True
+        assert repo.get("orders", "id") is None
+
+    def test_delete_missing_returns_false(self, repo):
+        result = repo.delete("orders", "does_not_exist")
+        assert result is False
+
+
+class TestColumnMetadataProposal:
+    def test_import_proposal_count(self, repo, tmp_path):
+        proposal = {
+            "tables": {
+                "orders": {
+                    "columns": {
+                        "id": {"basetype": "STRING", "description": "Order ID", "confidence": "high"},
+                        "total": {"basetype": "NUMERIC", "description": "Total amount"},
+                    }
+                },
+                "customers": {
+                    "columns": {
+                        "email": {"basetype": "STRING", "description": "Customer email", "confidence": "medium"},
+                    }
+                },
+            }
+        }
+        path = tmp_path / "proposal.json"
+        path.write_text(json.dumps(proposal))
+
+        count = repo.import_proposal(str(path))
+        assert count == 3
+
+    def test_import_proposal_data(self, repo, tmp_path):
+        proposal = {
+            "tables": {
+                "orders": {
+                    "columns": {
+                        "id": {"basetype": "STRING", "description": "Order ID", "confidence": "high"},
+                    }
+                }
+            }
+        }
+        path = tmp_path / "proposal.json"
+        path.write_text(json.dumps(proposal))
+
+        repo.import_proposal(str(path))
+
+        result = repo.get("orders", "id")
+        assert result is not None
+        assert result["basetype"] == "STRING"
+        assert result["description"] == "Order ID"
+        assert result["confidence"] == "high"
+
+    def test_import_sets_source_ai_enrichment(self, repo, tmp_path):
+        proposal = {
+            "tables": {
+                "orders": {
+                    "columns": {
+                        "id": {"basetype": "STRING"},
+                    }
+                }
+            }
+        }
+        path = tmp_path / "proposal.json"
+        path.write_text(json.dumps(proposal))
+
+        repo.import_proposal(str(path))
+
+        result = repo.get("orders", "id")
+        assert result["source"] == "ai_enrichment"

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -28,7 +28,7 @@ class TestGetSystemDb:
                 "user_sync_settings", "knowledge_items", "knowledge_votes",
                 "audit_log", "telegram_links", "pending_codes",
                 "script_registry", "table_registry", "table_profiles",
-                "dataset_permissions",
+                "dataset_permissions", "metric_definitions", "column_metadata",
             }
             assert expected.issubset(tables), f"Missing: {expected - tables}"
         finally:
@@ -55,11 +55,11 @@ class TestGetSystemDb:
 class TestGetSchemaVersion:
     def test_returns_version(self, tmp_path, monkeypatch):
         _setup_data_dir(tmp_path, monkeypatch)
-        from src.db import get_schema_version, get_system_db
+        from src.db import get_schema_version, get_system_db, SCHEMA_VERSION
 
         conn = get_system_db()
         try:
-            assert get_schema_version(conn) == 3
+            assert get_schema_version(conn) == SCHEMA_VERSION
         finally:
             conn.close()
 
@@ -113,7 +113,8 @@ class TestV1ToV2Migration:
         from src.db import get_system_db, get_schema_version
         conn2 = get_system_db()
         try:
-            assert get_schema_version(conn2) == 3
+            from src.db import SCHEMA_VERSION
+            assert get_schema_version(conn2) == SCHEMA_VERSION
             # Verify old data preserved
             row = conn2.execute("SELECT name, folder FROM table_registry WHERE id='t1'").fetchone()
             assert row[0] == "Test"
@@ -198,10 +199,10 @@ class TestMigrationSafety:
             conn.close()
 
     def test_v2_to_v3_migration(self, tmp_path, monkeypatch):
-        """v2 DB migrated to v3: schema_version=3 and is_public column added."""
+        """v2 DB migrated to current schema: is_public column added."""
         monkeypatch.setenv("DATA_DIR", str(tmp_path))
         import duckdb as _duckdb
-        from src.db import _ensure_schema, get_schema_version
+        from src.db import _ensure_schema, get_schema_version, SCHEMA_VERSION
 
         db_path = tmp_path / "state" / "system.duckdb"
         self._create_v2_db(db_path)
@@ -209,7 +210,7 @@ class TestMigrationSafety:
         conn = _duckdb.connect(str(db_path))
         try:
             _ensure_schema(conn)
-            assert get_schema_version(conn) == 3
+            assert get_schema_version(conn) == SCHEMA_VERSION
             cols = {
                 r[0]
                 for r in conn.execute(
@@ -285,7 +286,8 @@ class TestMigrationSafety:
 
             _ensure_schema(conn)
 
-            assert get_schema_version(conn) == 3
+            from src.db import SCHEMA_VERSION
+            assert get_schema_version(conn) == SCHEMA_VERSION
             row = conn.execute(
                 "SELECT name, description FROM table_registry WHERE id='row1'"
             ).fetchone()
@@ -341,6 +343,123 @@ class TestMigrationSafety:
             assert get_schema_version(conn) == 99
         finally:
             conn.close()
+
+
+class TestSchemaV4:
+    """Tests for v4 schema additions: metric_definitions and column_metadata tables."""
+
+    def test_metric_definitions_table_exists(self, tmp_path, monkeypatch):
+        """metric_definitions and column_metadata tables exist after get_system_db()."""
+        _setup_data_dir(tmp_path, monkeypatch)
+        from src.db import get_system_db
+
+        conn = get_system_db()
+        try:
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
+                ).fetchall()
+            }
+            assert "metric_definitions" in tables, "metric_definitions table missing"
+            assert "column_metadata" in tables, "column_metadata table missing"
+        finally:
+            conn.close()
+
+    def test_metric_definitions_columns(self, tmp_path, monkeypatch):
+        """metric_definitions table has all expected columns."""
+        _setup_data_dir(tmp_path, monkeypatch)
+        from src.db import get_system_db
+
+        conn = get_system_db()
+        try:
+            cols = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT column_name FROM information_schema.columns WHERE table_name = 'metric_definitions'"
+                ).fetchall()
+            }
+            expected = {
+                "id", "name", "display_name", "category", "description",
+                "type", "unit", "grain", "table_name", "tables",
+                "expression", "time_column", "dimensions", "filters",
+                "synonyms", "notes", "sql", "sql_variants", "validation",
+                "source", "created_at", "updated_at",
+            }
+            assert expected.issubset(cols), f"Missing columns: {expected - cols}"
+        finally:
+            conn.close()
+
+    def test_column_metadata_table_exists(self, tmp_path, monkeypatch):
+        """column_metadata table has all expected columns."""
+        _setup_data_dir(tmp_path, monkeypatch)
+        from src.db import get_system_db
+
+        conn = get_system_db()
+        try:
+            cols = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT column_name FROM information_schema.columns WHERE table_name = 'column_metadata'"
+                ).fetchall()
+            }
+            expected = {
+                "table_id", "column_name", "basetype", "description",
+                "confidence", "source", "updated_at",
+            }
+            assert expected.issubset(cols), f"Missing columns: {expected - cols}"
+        finally:
+            conn.close()
+
+    def test_v3_to_v4_migration(self, tmp_path, monkeypatch):
+        """Simulate a v3 database, call get_system_db(), verify it migrates to v4."""
+        monkeypatch.setenv("DATA_DIR", str(tmp_path))
+        import duckdb as _duckdb
+        from src.db import get_system_db, get_schema_version
+
+        # Build a minimal v3 database manually
+        db_path = tmp_path / "state" / "system.duckdb"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = _duckdb.connect(str(db_path))
+        try:
+            conn.execute(
+                "CREATE TABLE schema_version (version INTEGER, applied_at TIMESTAMP DEFAULT current_timestamp);"
+                "INSERT INTO schema_version (version) VALUES (3);"
+            )
+            # Create the tables that exist in v3 (minimal stubs)
+            conn.execute("CREATE TABLE IF NOT EXISTS table_registry (id VARCHAR PRIMARY KEY, name VARCHAR NOT NULL, is_public BOOLEAN DEFAULT true)")
+            for ddl in [
+                "CREATE TABLE IF NOT EXISTS users (id VARCHAR PRIMARY KEY, email VARCHAR)",
+                "CREATE TABLE IF NOT EXISTS sync_state (table_id VARCHAR PRIMARY KEY)",
+                "CREATE TABLE IF NOT EXISTS sync_history (id VARCHAR PRIMARY KEY, table_id VARCHAR)",
+                "CREATE TABLE IF NOT EXISTS user_sync_settings (user_id VARCHAR, dataset VARCHAR, PRIMARY KEY(user_id, dataset))",
+                "CREATE TABLE IF NOT EXISTS knowledge_items (id VARCHAR PRIMARY KEY, title VARCHAR)",
+                "CREATE TABLE IF NOT EXISTS knowledge_votes (item_id VARCHAR, user_id VARCHAR, PRIMARY KEY(item_id, user_id))",
+                "CREATE TABLE IF NOT EXISTS audit_log (id VARCHAR PRIMARY KEY, action VARCHAR)",
+                "CREATE TABLE IF NOT EXISTS telegram_links (user_id VARCHAR PRIMARY KEY, chat_id BIGINT)",
+                "CREATE TABLE IF NOT EXISTS pending_codes (code VARCHAR PRIMARY KEY, chat_id BIGINT)",
+                "CREATE TABLE IF NOT EXISTS script_registry (id VARCHAR PRIMARY KEY, name VARCHAR, source TEXT)",
+                "CREATE TABLE IF NOT EXISTS table_profiles (table_id VARCHAR PRIMARY KEY, profile JSON)",
+                "CREATE TABLE IF NOT EXISTS dataset_permissions (user_id VARCHAR, dataset VARCHAR, PRIMARY KEY(user_id, dataset))",
+                "CREATE TABLE IF NOT EXISTS access_requests (id VARCHAR PRIMARY KEY, user_id VARCHAR, user_email VARCHAR, table_id VARCHAR)",
+            ]:
+                conn.execute(ddl)
+        finally:
+            conn.close()
+
+        conn2 = get_system_db()
+        try:
+            assert get_schema_version(conn2) == 4, f"Expected version 4, got {get_schema_version(conn2)}"
+            tables = {
+                row[0]
+                for row in conn2.execute(
+                    "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
+                ).fetchall()
+            }
+            assert "metric_definitions" in tables, "metric_definitions table missing after migration"
+            assert "column_metadata" in tables, "column_metadata table missing after migration"
+        finally:
+            conn2.close()
 
 
 class TestGetAnalyticsDbReadonly:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -415,7 +415,7 @@ class TestSchemaV4:
         """Simulate a v3 database, call get_system_db(), verify it migrates to v4."""
         monkeypatch.setenv("DATA_DIR", str(tmp_path))
         import duckdb as _duckdb
-        from src.db import get_system_db, get_schema_version
+        from src.db import get_system_db, get_schema_version, SCHEMA_VERSION
 
         # Build a minimal v3 database manually
         db_path = tmp_path / "state" / "system.duckdb"
@@ -449,7 +449,7 @@ class TestSchemaV4:
 
         conn2 = get_system_db()
         try:
-            assert get_schema_version(conn2) == 4, f"Expected version 4, got {get_schema_version(conn2)}"
+            assert get_schema_version(conn2) == SCHEMA_VERSION, f"Expected version {SCHEMA_VERSION}, got {get_schema_version(conn2)}"
             tables = {
                 row[0]
                 for row in conn2.execute(

--- a/tests/test_e2e_extract.py
+++ b/tests/test_e2e_extract.py
@@ -260,10 +260,10 @@ class TestSchemaMigration:
         conn.close()
 
         # Open via get_system_db -> triggers migration
-        from src.db import get_system_db, get_schema_version
+        from src.db import get_system_db, get_schema_version, SCHEMA_VERSION
         conn2 = get_system_db()
 
-        assert get_schema_version(conn2) == 3
+        assert get_schema_version(conn2) == SCHEMA_VERSION
 
         # Old data preserved
         old = conn2.execute("SELECT name, folder FROM table_registry WHERE id='old_table'").fetchone()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -304,3 +304,118 @@ class TestMetricRepositorySearch:
         table_map = repo.get_table_map()
         assert "None" not in table_map
         assert None not in table_map
+
+
+@pytest.fixture
+def metrics_dir(tmp_path):
+    revenue_dir = tmp_path / "metrics" / "revenue"
+    revenue_dir.mkdir(parents=True)
+    ops_dir = tmp_path / "metrics" / "operations"
+    ops_dir.mkdir(parents=True)
+
+    # total_revenue.yml — list-wrapped format with table key and sql_by_channel variant
+    (revenue_dir / "total_revenue.yml").write_text(
+        "- name: total_revenue\n"
+        "  display_name: Total Revenue\n"
+        "  category: revenue\n"
+        "  type: sum\n"
+        "  unit: USD\n"
+        "  grain: monthly\n"
+        "  table: orders\n"
+        "  sql: |\n"
+        "    SELECT DATE_TRUNC('month', order_date) AS month, SUM(total_amount) AS revenue FROM orders GROUP BY 1\n"
+        "  sql_by_channel: |\n"
+        "    SELECT channel, SUM(total_amount) AS revenue FROM orders GROUP BY 1\n"
+    )
+
+    # resolution_time.yml — plain dict format (no list wrapper)
+    (ops_dir / "resolution_time.yml").write_text(
+        "name: resolution_time\n"
+        "display_name: Resolution Time\n"
+        "type: avg\n"
+        "unit: hours\n"
+        "grain: weekly\n"
+        "table: tickets\n"
+        "sql: |\n"
+        "  SELECT AVG(resolution_hours) FROM tickets\n"
+    )
+
+    return tmp_path / "metrics"
+
+
+class TestMetricRepositoryImport:
+    def test_import_from_directory(self, db_conn, metrics_dir):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        count = repo.import_from_yaml(metrics_dir)
+        assert count == 2
+        all_metrics = repo.list()
+        assert len(all_metrics) == 2
+        ids = {m["id"] for m in all_metrics}
+        assert "revenue/total_revenue" in ids
+        assert "operations/resolution_time" in ids
+
+    def test_import_maps_table_to_table_name(self, db_conn, metrics_dir):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        repo.import_from_yaml(metrics_dir)
+        metric = repo.get("revenue/total_revenue")
+        assert metric is not None
+        assert metric["table_name"] == "orders"
+
+    def test_import_collects_sql_variants(self, db_conn, metrics_dir):
+        from src.repositories.metrics import MetricRepository
+        import json
+        repo = MetricRepository(db_conn)
+        repo.import_from_yaml(metrics_dir)
+        metric = repo.get("revenue/total_revenue")
+        assert metric is not None
+        sql_variants = metric["sql_variants"]
+        # DuckDB may return as a string — parse if so
+        if isinstance(sql_variants, str):
+            sql_variants = json.loads(sql_variants)
+        assert isinstance(sql_variants, dict)
+        assert "by_channel" in sql_variants
+        assert "channel" in sql_variants["by_channel"]
+
+    def test_import_single_file(self, db_conn, metrics_dir):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        single_file = metrics_dir / "revenue" / "total_revenue.yml"
+        count = repo.import_from_yaml(single_file)
+        assert count == 1
+        metric = repo.get("revenue/total_revenue")
+        assert metric is not None
+
+    def test_import_idempotent(self, db_conn, metrics_dir):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        repo.import_from_yaml(metrics_dir)
+        repo.import_from_yaml(metrics_dir)
+        all_metrics = repo.list()
+        assert len(all_metrics) == 2
+
+
+class TestMetricRepositoryExport:
+    def test_export_to_yaml(self, db_conn, metrics_dir, tmp_path):
+        from src.repositories.metrics import MetricRepository
+        import yaml
+        repo = MetricRepository(db_conn)
+        repo.import_from_yaml(metrics_dir)
+        output_dir = tmp_path / "exported"
+        count = repo.export_to_yaml(output_dir)
+        assert count == 2
+        # Check expected files exist
+        revenue_file = output_dir / "revenue" / "total_revenue.yml"
+        ops_file = output_dir / "operations" / "resolution_time.yml"
+        assert revenue_file.exists()
+        assert ops_file.exists()
+        # Verify content uses 'table' not 'table_name'
+        with open(revenue_file) as f:
+            data = yaml.safe_load(f)
+        assert "table" in data
+        assert "table_name" not in data
+        assert data["table"] == "orders"
+        # Verify sql_variants are expanded back to sql_by_* keys
+        assert "sql_by_channel" in data
+        assert "sql_variants" not in data

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -230,6 +230,15 @@ class TestMetricRepositorySearch:
             table_name="events",
             sql="SELECT COUNT(DISTINCT user_id) FROM events",
         )
+        # 1 metric using tables[] array (no table_name)
+        repo.create(
+            id="combined/multi",
+            name="multi",
+            display_name="Multi Table Metric",
+            category="combined",
+            tables=["a", "b"],
+            sql="SELECT 1",
+        )
         sub_metrics = repo.find_by_table("subscriptions")
         assert len(sub_metrics) == 2
         ids = {m["id"] for m in sub_metrics}
@@ -239,6 +248,16 @@ class TestMetricRepositorySearch:
         event_metrics = repo.find_by_table("events")
         assert len(event_metrics) == 1
         assert event_metrics[0]["id"] == "engagement/dau"
+
+        # Metric referencing 'a' via tables[] array should be found
+        a_metrics = repo.find_by_table("a")
+        assert len(a_metrics) == 1
+        assert a_metrics[0]["id"] == "combined/multi"
+
+        # Metric referencing 'b' via tables[] array should also be found
+        b_metrics = repo.find_by_table("b")
+        assert len(b_metrics) == 1
+        assert b_metrics[0]["id"] == "combined/multi"
 
     def test_find_by_synonym(self, db_conn):
         from src.repositories.metrics import MetricRepository
@@ -283,12 +302,26 @@ class TestMetricRepositorySearch:
             table_name="events",
             sql="SELECT COUNT(DISTINCT user_id) FROM events",
         )
+        # Metric using tables[] array
+        repo.create(
+            id="combined/multi",
+            name="multi",
+            display_name="Multi Table Metric",
+            category="combined",
+            tables=["subscriptions", "events"],
+            sql="SELECT 1",
+        )
         table_map = repo.get_table_map()
         assert isinstance(table_map, dict)
         assert "subscriptions" in table_map
         assert "events" in table_map
-        assert set(table_map["subscriptions"]) == {"mrr", "arr"}
-        assert table_map["events"] == ["dau"]
+        # 'subscriptions' should include mrr, arr (table_name) plus multi (tables[])
+        assert "mrr" in table_map["subscriptions"]
+        assert "arr" in table_map["subscriptions"]
+        assert "multi" in table_map["subscriptions"]
+        # 'events' should include dau (table_name) plus multi (tables[])
+        assert "dau" in table_map["events"]
+        assert "multi" in table_map["events"]
 
     def test_get_table_map_excludes_null_table(self, db_conn):
         from src.repositories.metrics import MetricRepository

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,306 @@
+"""Tests for MetricRepository (metric_definitions table)."""
+
+import pytest
+
+
+@pytest.fixture
+def db_conn(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    from src.db import get_system_db
+    conn = get_system_db()
+    yield conn
+    conn.close()
+
+
+SAMPLE_METRIC = {
+    "id": "revenue/mrr",
+    "name": "mrr",
+    "display_name": "Monthly Recurring Revenue",
+    "category": "revenue",
+    "description": "Total MRR from all subscriptions",
+    "type": "sum",
+    "unit": "USD",
+    "grain": "monthly",
+    "table_name": "subscriptions",
+    "expression": "SUM(mrr_amount)",
+    "time_column": "billing_date",
+    "dimensions": ["plan_type", "region"],
+    "synonyms": ["monthly_revenue", "recurring_revenue"],
+    "notes": ["Excludes one-time fees"],
+    "sql": "SELECT DATE_TRUNC('month', billing_date) AS month, SUM(mrr_amount) AS mrr FROM subscriptions GROUP BY 1",
+}
+
+
+class TestMetricRepositoryCreate:
+    def test_create_metric(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        result = repo.create(**SAMPLE_METRIC)
+        assert result is not None
+        assert result["id"] == "revenue/mrr"
+        assert result["name"] == "mrr"
+        assert result["display_name"] == "Monthly Recurring Revenue"
+        assert result["category"] == "revenue"
+        assert result["description"] == "Total MRR from all subscriptions"
+        assert result["type"] == "sum"
+        assert result["unit"] == "USD"
+        assert result["grain"] == "monthly"
+        assert result["table_name"] == "subscriptions"
+        assert result["expression"] == "SUM(mrr_amount)"
+        assert result["time_column"] == "billing_date"
+        assert result["dimensions"] == ["plan_type", "region"]
+        assert result["synonyms"] == ["monthly_revenue", "recurring_revenue"]
+        assert result["notes"] == ["Excludes one-time fees"]
+        assert "SELECT" in result["sql"]
+        assert result["source"] == "manual"
+
+    def test_create_duplicate_upserts(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        repo.create(**SAMPLE_METRIC)
+        # Create again with different display_name
+        updated = {**SAMPLE_METRIC, "display_name": "MRR (Updated)"}
+        repo.create(**updated)
+        # Should only have one record
+        all_metrics = repo.list()
+        assert len(all_metrics) == 1
+        assert all_metrics[0]["display_name"] == "MRR (Updated)"
+
+    def test_create_with_defaults(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        result = repo.create(
+            id="test/metric",
+            name="test_metric",
+            display_name="Test Metric",
+            category="test",
+            sql="SELECT 1",
+        )
+        assert result["type"] == "sum"
+        assert result["grain"] == "monthly"
+        assert result["source"] == "manual"
+
+    def test_create_with_json_fields(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        result = repo.create(
+            **SAMPLE_METRIC,
+            sql_variants={"weekly": "SELECT DATE_TRUNC('week', billing_date), SUM(mrr) FROM subscriptions GROUP BY 1"},
+            validation={"min": 0, "max": 1000000},
+        )
+        assert result is not None
+        assert result["id"] == "revenue/mrr"
+
+
+class TestMetricRepositoryRead:
+    def test_get_existing(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        repo.create(**SAMPLE_METRIC)
+        metric = repo.get("revenue/mrr")
+        assert metric is not None
+        assert metric["name"] == "mrr"
+        assert metric["category"] == "revenue"
+
+    def test_get_missing(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        result = repo.get("nonexistent/metric")
+        assert result is None
+
+    def test_list_all(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        repo.create(**SAMPLE_METRIC)
+        repo.create(
+            id="engagement/dau",
+            name="dau",
+            display_name="Daily Active Users",
+            category="engagement",
+            sql="SELECT COUNT(DISTINCT user_id) FROM events WHERE DATE(created_at) = CURRENT_DATE",
+        )
+        all_metrics = repo.list()
+        assert len(all_metrics) == 2
+        ids = {m["id"] for m in all_metrics}
+        assert "revenue/mrr" in ids
+        assert "engagement/dau" in ids
+
+    def test_list_by_category(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        repo.create(**SAMPLE_METRIC)
+        repo.create(
+            id="engagement/dau",
+            name="dau",
+            display_name="Daily Active Users",
+            category="engagement",
+            sql="SELECT COUNT(DISTINCT user_id) FROM events",
+        )
+        revenue_metrics = repo.list(category="revenue")
+        assert len(revenue_metrics) == 1
+        assert revenue_metrics[0]["id"] == "revenue/mrr"
+
+        engagement_metrics = repo.list(category="engagement")
+        assert len(engagement_metrics) == 1
+        assert engagement_metrics[0]["id"] == "engagement/dau"
+
+
+class TestMetricRepositoryUpdate:
+    def test_update_fields(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        repo.create(**SAMPLE_METRIC)
+        updated = repo.update("revenue/mrr", display_name="MRR (New)", unit="EUR")
+        assert updated is not None
+        assert updated["display_name"] == "MRR (New)"
+        assert updated["unit"] == "EUR"
+        # Unchanged fields should persist
+        assert updated["name"] == "mrr"
+        assert updated["category"] == "revenue"
+        assert updated["description"] == "Total MRR from all subscriptions"
+
+    def test_update_missing_returns_none(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        result = repo.update("nonexistent/metric", display_name="Doesn't matter")
+        assert result is None
+
+    def test_update_persists_to_db(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        repo.create(**SAMPLE_METRIC)
+        repo.update("revenue/mrr", unit="GBP")
+        # Re-fetch from DB to verify persistence
+        metric = repo.get("revenue/mrr")
+        assert metric["unit"] == "GBP"
+
+
+class TestMetricRepositoryDelete:
+    def test_delete_existing(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        repo.create(**SAMPLE_METRIC)
+        result = repo.delete("revenue/mrr")
+        assert result is True
+        assert repo.get("revenue/mrr") is None
+
+    def test_delete_missing(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        result = repo.delete("nonexistent/metric")
+        assert result is False
+
+    def test_delete_only_target(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        repo.create(**SAMPLE_METRIC)
+        repo.create(
+            id="engagement/dau",
+            name="dau",
+            display_name="Daily Active Users",
+            category="engagement",
+            sql="SELECT 1",
+        )
+        repo.delete("revenue/mrr")
+        all_metrics = repo.list()
+        assert len(all_metrics) == 1
+        assert all_metrics[0]["id"] == "engagement/dau"
+
+
+class TestMetricRepositorySearch:
+    def test_find_by_table(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        # 2 metrics with table_name='subscriptions'
+        repo.create(**SAMPLE_METRIC)
+        repo.create(
+            id="revenue/arr",
+            name="arr",
+            display_name="Annual Recurring Revenue",
+            category="revenue",
+            table_name="subscriptions",
+            sql="SELECT SUM(mrr_amount) * 12 AS arr FROM subscriptions",
+        )
+        # 1 metric with different table
+        repo.create(
+            id="engagement/dau",
+            name="dau",
+            display_name="Daily Active Users",
+            category="engagement",
+            table_name="events",
+            sql="SELECT COUNT(DISTINCT user_id) FROM events",
+        )
+        sub_metrics = repo.find_by_table("subscriptions")
+        assert len(sub_metrics) == 2
+        ids = {m["id"] for m in sub_metrics}
+        assert "revenue/mrr" in ids
+        assert "revenue/arr" in ids
+
+        event_metrics = repo.find_by_table("events")
+        assert len(event_metrics) == 1
+        assert event_metrics[0]["id"] == "engagement/dau"
+
+    def test_find_by_synonym(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        repo.create(**SAMPLE_METRIC)  # has synonyms: ["monthly_revenue", "recurring_revenue"]
+        repo.create(
+            id="engagement/dau",
+            name="dau",
+            display_name="Daily Active Users",
+            category="engagement",
+            synonyms=["active_users", "daily_users"],
+            sql="SELECT COUNT(DISTINCT user_id) FROM events",
+        )
+        results = repo.find_by_synonym("monthly_revenue")
+        assert len(results) == 1
+        assert results[0]["id"] == "revenue/mrr"
+
+        results2 = repo.find_by_synonym("active_users")
+        assert len(results2) == 1
+        assert results2[0]["id"] == "engagement/dau"
+
+        results3 = repo.find_by_synonym("nonexistent_synonym")
+        assert len(results3) == 0
+
+    def test_get_table_map(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        repo.create(**SAMPLE_METRIC)  # table_name='subscriptions'
+        repo.create(
+            id="revenue/arr",
+            name="arr",
+            display_name="Annual Recurring Revenue",
+            category="revenue",
+            table_name="subscriptions",
+            sql="SELECT SUM(mrr_amount) * 12 FROM subscriptions",
+        )
+        repo.create(
+            id="engagement/dau",
+            name="dau",
+            display_name="Daily Active Users",
+            category="engagement",
+            table_name="events",
+            sql="SELECT COUNT(DISTINCT user_id) FROM events",
+        )
+        table_map = repo.get_table_map()
+        assert isinstance(table_map, dict)
+        assert "subscriptions" in table_map
+        assert "events" in table_map
+        assert set(table_map["subscriptions"]) == {"mrr", "arr"}
+        assert table_map["events"] == ["dau"]
+
+    def test_get_table_map_excludes_null_table(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        repo = MetricRepository(db_conn)
+        # Metric without table_name
+        repo.create(
+            id="test/no_table",
+            name="no_table",
+            display_name="No Table Metric",
+            category="test",
+            sql="SELECT 1",
+        )
+        table_map = repo.get_table_map()
+        assert "None" not in table_map
+        assert None not in table_map

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -396,6 +396,21 @@ class TestMetricRepositoryImport:
         assert len(all_metrics) == 2
 
 
+class TestStarterPack:
+    def test_import_starter_pack(self, db_conn):
+        from src.repositories.metrics import MetricRepository
+        from pathlib import Path
+        repo = MetricRepository(db_conn)
+        starter_dir = Path(__file__).parent.parent / "docs" / "metrics"
+        if not starter_dir.exists():
+            pytest.skip("Starter pack not found")
+        count = repo.import_from_yaml(starter_dir)
+        assert count >= 11  # total_revenue + 10 new
+        assert repo.get("revenue/total_revenue") is not None
+        assert repo.get("revenue/mrr") is not None
+        assert repo.get("operations/infrastructure_cost") is not None
+
+
 class TestMetricRepositoryExport:
     def test_export_to_yaml(self, db_conn, metrics_dir, tmp_path):
         from src.repositories.metrics import MetricRepository


### PR DESCRIPTION
## Summary

Ports three feature gaps identified by comparing with `keboola/internal_ai_data_analyst`:

- **Business Metrics in DuckDB** — `metric_definitions` table (schema v4), `MetricRepository` with YAML import/export, `da metrics` CLI, REST API (`/api/metrics`), 11 starter pack metrics across 4 categories, profiler integration
- **Analyst Bootstrap Flow** — `da analyst setup` command for onboarding analysts to a remote instance (connect, download data, init local DuckDB, generate CLAUDE.md from template), `da analyst status` for freshness check
- **Metadata Writer** — `column_metadata` table, `ColumnMetadataRepository` with proposal import, `da admin metadata-show/apply` CLI, REST API with Keboola Storage API push support

### Key details

- Schema migration v3→v4 (idempotent, with pre-migration snapshot)
- 35 files changed (22 new, 13 modified), +3189 lines
- **734 tests pass** (was 700 before), +34 new tests
- Security: path injection protection in DuckDB view creation, parameterized SQL throughout, admin-only write endpoints
- Code review findings addressed: multi-table search in `find_by_table()`, YAML import API endpoint, specific auth error messages

### New CLI commands
```
da metrics list [--category] [--json]
da metrics show <id> [--json]
da metrics import <path>
da metrics export [--dir]
da metrics validate
da analyst setup [--server-url] [--force]
da analyst status [--json]
da admin metadata-show <table_id>
da admin metadata-apply <proposal.json> [--dry-run] [--push-to-source]
```

### New API endpoints
```
GET    /api/metrics
GET    /api/metrics/{metric_id:path}
POST   /api/admin/metrics
DELETE /api/admin/metrics/{metric_id:path}
POST   /api/admin/metrics/import
GET    /api/admin/metadata/{table_id}
POST   /api/admin/metadata/{table_id}
POST   /api/admin/metadata/{table_id}/push
```

## Test plan

- [x] Full test suite passes (734 tests, 0 failures)
- [x] Schema migration tested: fresh install + v3→v4 upgrade path
- [x] MetricRepository CRUD + YAML round-trip tested
- [x] API auth verified (analyst gets 403 on admin endpoints)
- [x] Starter pack imports correctly (11 metrics)
- [x] Profiler DuckDB fallback works (YAML fallback when DB empty)
- [x] Analyst bootstrap workspace creation + template generation tested
- [x] Column metadata CRUD + proposal import tested
- [x] Path injection protection verified in DuckDB view creation
- [ ] Manual: `docker compose up` + `da metrics import docs/metrics/` + `da metrics list`
- [ ] Manual: `da analyst setup --server-url http://localhost:8000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/2" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
