### PR TITLE
ci: propagate infra-v* tags to template repo + auto-merge rules

### DIFF
--- a/.github/workflows/propagate-infra-tag.yml
+++ b/.github/workflows/propagate-infra-tag.yml
@@ -1,0 +1,70 @@
+name: Propagate infra tag to template
+
+# On push of any infra-v* tag, open a PR in keboola/agnes-infra-template
+# that bumps the module ref in terraform/main.tf. Auto-merge rules in the
+# template repo (Renovate + CI validate) land it without manual work.
+#
+# Requires repository secret TEMPLATE_REPO_TOKEN: a fine-grained PAT or
+# GitHub App token with Contents:write + Pull requests:write on
+# keboola/agnes-infra-template.
+#
+# If the secret is missing the job is skipped (fail-soft) so manual
+# tag creation still works; Renovate on the template repo picks up
+# the new tag on its next cycle as a fallback.
+
+on:
+  push:
+    tags:
+      - 'infra-v*'
+
+permissions:
+  contents: read
+
+jobs:
+  propagate:
+    runs-on: ubuntu-latest
+    if: ${{ secrets.TEMPLATE_REPO_TOKEN != '' }}
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+    steps:
+      - name: Extract tag name
+        id: tag
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          echo "name=$TAG" >> $GITHUB_OUTPUT
+          echo "Propagating tag: $TAG"
+
+      - name: Checkout template repo
+        uses: actions/checkout@v5
+        with:
+          repository: keboola/agnes-infra-template
+          token: ${{ secrets.TEMPLATE_REPO_TOKEN }}
+          path: template
+
+      - name: Bump module ref in template
+        working-directory: template
+        env:
+          NEW_TAG: ${{ steps.tag.outputs.name }}
+        run: |
+          file=terraform/main.tf
+          # Replace any existing ref=infra-vX.Y.Z with the new tag
+          sed -i "s|ref=infra-v[0-9]\+\.[0-9]\+\.[0-9]\+\"|ref=$NEW_TAG\"|g" "$file"
+          echo "--- diff ---"
+          git diff "$file" || true
+
+      - name: Create PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          path: template
+          token: ${{ secrets.TEMPLATE_REPO_TOKEN }}
+          branch: bump-module-${{ steps.tag.outputs.name }}
+          title: "infra: bump module ref to ${{ steps.tag.outputs.name }}"
+          body: |
+            Automated bump triggered by release of [`${{ steps.tag.outputs.name }}`](https://github.com/keboola/agnes-the-ai-analyst/releases/tag/${{ steps.tag.outputs.name }}) in the upstream `keboola/agnes-the-ai-analyst` repo.
+
+            Auto-merge is enabled for patch/minor bumps (via Renovate config + this repo's `allow_auto_merge`). A `breaking` label on major bumps blocks auto-merge for human review.
+
+            If CI validate fails, fix the module upstream before retrying.
+          commit-message: "infra: bump module ref to ${{ steps.tag.outputs.name }}"
+          labels: renovate
+          delete-branch: true

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -261,6 +261,30 @@ gcloud alpha monitoring channels create \
 
 For Slack integrations, use type `slack` with a webhook URL.
 
+## Keeping the template up-to-date (maintainer note)
+
+New customers clone `keboola/agnes-infra-template` — so the template's `terraform/main.tf` must always point at the **latest stable** `infra-v*` tag. Two cooperating mechanisms keep it current:
+
+1. **Upstream release hook** (`.github/workflows/propagate-infra-tag.yml` in `keboola/agnes-the-ai-analyst`): on push of any `infra-v*` tag, opens a PR in the template repo that bumps the module ref. Requires a repository secret `TEMPLATE_REPO_TOKEN` (fine-grained PAT or GitHub App token with `Contents:write` + `Pull requests:write` on the template repo). Without the secret, the job is skipped — fail-soft.
+
+2. **Renovate on the template repo**: tracks `infra-v*` tags on polling cycles as a fallback when the release hook is unavailable. Config is already in `renovate.json`.
+
+For both to land automatically (no human clicks needed):
+
+- **`allow_auto_merge: true`** on the template repo (set via `gh api -X PATCH repos/keboola/agnes-infra-template -f allow_auto_merge=true`)
+- **`automerge: true`** in `renovate.json` for minor+patch (already configured)
+- **CI validate gate** (`.github/workflows/validate.yml` in the template repo — runs `terraform init -backend=false` + `terraform validate` on the PR). Renovate's `platformAutomerge` waits for this check to pass before merging.
+- **Major bumps stay manual** (labeled `breaking`, `automerge: false`).
+
+Customer-owned infra repos (e.g. `keboola/agnes-infra-keboola`) share the same Renovate config but typically leave patch/minor auto-merge **disabled** (because `terraform apply` touches live infrastructure; customers want a human to approve each bump). The template repo is different — it holds no state and doesn't touch GCP.
+
+### One-time setup checklist
+
+- [ ] Install Renovate GitHub App on `keboola/agnes-infra-template` and on each `keboola/agnes-infra-<customer>` repo
+- [ ] Create a fine-grained PAT with `Contents:write` + `Pull requests:write` on the template repo
+- [ ] Add it as `TEMPLATE_REPO_TOKEN` secret on `keboola/agnes-the-ai-analyst`
+- [ ] Verify: tag a test `infra-vX.Y.Z` in upstream → PR appears in template → CI validates → auto-merges
+
 ## Decommission
 
 ```bash

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -61,3 +61,4 @@ Open the project in Claude Code. The CLAUDE.md file will guide the AI assistant 
 1. Sync latest data: `bash server/scripts/sync_data.sh`
 2. Open Claude Code in your project directory
 3. Ask Claude to analyze your data using DuckDB
+<!-- dryrun 2026-04-21T19:12:08Z -->


### PR DESCRIPTION
## Summary
- New workflow `.github/workflows/propagate-infra-tag.yml` — on push of any `infra-v*` tag, opens PR in `keboola/agnes-infra-template` bumping the module ref.
- Template + keboola-infra repos now have Renovate `automerge: true` for patch/minor + GitHub native auto-merge enabled.
- New `validate.yml` workflow in both repos gates auto-merge with `terraform validate`.

## Why

Template needs to track latest `infra-v*` without manual editing, so fresh customers always clone a current version. Renovate alone has polling lag; the release hook closes the gap to within minutes.

## Requires (one-time setup)

1. **Repo secret `TEMPLATE_REPO_TOKEN`** — fine-grained PAT or GitHub App token with `Contents:write` + `Pull requests:write` on `keboola/agnes-infra-template`. Without it, the propagate job is skipped (fail-soft).
2. **Install Renovate GitHub App** on both private repos (to pick up new tags on polling cycle, auto-merge after CI passes).

See `docs/ONBOARDING.md` section "Keeping the template up-to-date" for the full story.

## Test plan
- [ ] Merge this PR
- [ ] Add `TEMPLATE_REPO_TOKEN` as repo secret
- [ ] Tag a test `infra-v1.5.3` in upstream → PR appears in template repo → CI validate passes → auto-merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
