### PR TITLE
docs(quickstart): add Hackathon section (#14)

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -61,4 +61,8 @@ Open the project in Claude Code. The CLAUDE.md file will guide the AI assistant 
 1. Sync latest data: `bash server/scripts/sync_data.sh`
 2. Open Claude Code in your project directory
 3. Ask Claude to analyze your data using DuckDB
+
+## Hackathon
+
+Point the shared `agnes-dev` VM at your branch image with `scripts/switch-dev-vm.sh <branch-slug>`. See [`HACKATHON.md`](HACKATHON.md) for the full deploy-and-develop playbook.
 <!-- dryrun 2026-04-21T19:12:08Z -->


### PR DESCRIPTION
## Summary

Adds a short **Hackathon** section to `docs/QUICKSTART.md` pointing to `scripts/switch-dev-vm.sh` and `docs/HACKATHON.md`.

The `switch-dev-vm.sh` helper already landed via #20; this PR closes the only remaining acceptance criterion from #14 — a one-line usage note in QUICKSTART under a "Hackathon" section so participants can actually find the helper.

Closes #14.

## Test plan

- [x] `docs/QUICKSTART.md` renders cleanly (4-line addition, valid Markdown)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/23" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
