### PR TITLE
fix: redirect unauthenticated HTML routes to /login (#10)

### DIFF
--- a/app/auth/providers/password.py
+++ b/app/auth/providers/password.py
@@ -62,9 +62,10 @@ async def password_login(
 async def password_login_web(
     email: str = Form(...),
     password: str = Form(""),
+    next: str = Form(""),
     conn: duckdb.DuckDBPyConnection = Depends(_get_db),
 ):
-    """Web form login — sets cookie and redirects to dashboard."""
+    """Web form login — sets cookie and redirects to `next` (or /dashboard)."""
     repo = UserRepository(conn)
     user = repo.get_by_email(email)
     if not user or not user.get("password_hash"):
@@ -80,7 +81,10 @@ async def password_login_web(
     # Secure cookie only over HTTPS (detect via X-Forwarded-Proto or request scheme)
     # For dev/staging on plain HTTP, secure=False so the cookie is actually sent
     use_secure = os.environ.get("DOMAIN", "") != ""  # DOMAIN set = production with TLS
-    response = RedirectResponse(url="/dashboard", status_code=302)
+
+    # Sanitize `next`: must start with `/` and must not start with `//` (open-redirect guard)
+    target = next if (next.startswith("/") and not next.startswith("//")) else "/dashboard"
+    response = RedirectResponse(url=target, status_code=302)
     response.set_cookie(
         key="access_token", value=token,
         httponly=True, max_age=86400, samesite="lax",

--- a/app/main.py
+++ b/app/main.py
@@ -3,12 +3,15 @@
 import logging
 from contextlib import asynccontextmanager
 from pathlib import Path
+from urllib.parse import quote
 
 import os
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
+from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.sessions import SessionMiddleware
 
 from app.auth.router import router as auth_router
@@ -160,6 +163,25 @@ def create_app() -> FastAPI:
 
     # Web UI router (must be last — has catch-all routes)
     app.include_router(web_router)
+
+    @app.exception_handler(StarletteHTTPException)
+    async def _html_auth_redirect_handler(request, exc: StarletteHTTPException):
+        """Redirect unauthenticated HTML page loads (GET) to /login.
+
+        Only GET requests outside `/api/` are redirected — that targets browser
+        navigations to HTML pages. POSTs, `/api/*`, and non-401 errors fall
+        through to Starlette's default JSON response so API clients keep their
+        existing contract.
+        """
+        if (
+            exc.status_code == 401
+            and request.method == "GET"
+            and not request.url.path.startswith("/api/")
+        ):
+            next_param = quote(request.url.path, safe="")
+            return RedirectResponse(url=f"/login?next={next_param}", status_code=302)
+        from fastapi.exception_handlers import http_exception_handler
+        return await http_exception_handler(request, exc)
 
     return app
 

--- a/app/web/router.py
+++ b/app/web/router.py
@@ -192,6 +192,10 @@ async def setup_wizard(request: Request, conn: duckdb.DuckDBPyConnection = Depen
 
 @router.get("/login", response_class=HTMLResponse)
 async def login_page(request: Request):
+    next_path = request.query_params.get("next", "")
+    if not next_path.startswith("/") or next_path.startswith("//"):
+        next_path = ""
+
     providers = []
     try:
         from app.auth.providers.google import is_available as google_available
@@ -217,20 +221,23 @@ async def login_page(request: Request):
         elif p["name"] == "email":
             login_buttons.append({"url": "/login/email", "text": "Sign in with Email Link", "css_class": "btn-secondary", "icon_html": ""})
 
-    ctx = _build_context(request, providers=providers, login_buttons=login_buttons)
+    ctx = _build_context(request, providers=providers, login_buttons=login_buttons, next_path=next_path)
     return templates.TemplateResponse(request, "login.html", ctx)
 
 
 @router.get("/login/password", response_class=HTMLResponse)
 async def login_password_page(request: Request):
     """Password login form (email + password)."""
+    next_path = request.query_params.get("next", "")
+    if not next_path.startswith("/") or next_path.startswith("//"):
+        next_path = ""
     google_ok = False
     try:
         from app.auth.providers.google import is_available as google_available
         google_ok = google_available()
     except Exception:
         pass
-    ctx = _build_context(request, google_available=google_ok)
+    ctx = _build_context(request, google_available=google_ok, next_path=next_path)
     return templates.TemplateResponse(request, "login_email.html", ctx)
 
 

--- a/app/web/router.py
+++ b/app/web/router.py
@@ -8,6 +8,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
+from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, Request, HTTPException
 from fastapi.responses import HTMLResponse, RedirectResponse
@@ -217,9 +218,15 @@ async def login_page(request: Request):
         if p["name"] == "google":
             login_buttons.append({"url": "/auth/google/login", "text": "Sign in with Google", "css_class": "btn-primary", "icon_html": ""})
         elif p["name"] == "password":
-            login_buttons.append({"url": "/login/password", "text": "Sign in with Email & Password", "css_class": "btn-secondary", "icon_html": ""})
+            _url = "/login/password"
+            if next_path:
+                _url += f"?next={quote(next_path, safe='')}"
+            login_buttons.append({"url": _url, "text": "Sign in with Email & Password", "css_class": "btn-secondary", "icon_html": ""})
         elif p["name"] == "email":
-            login_buttons.append({"url": "/login/email", "text": "Sign in with Email Link", "css_class": "btn-secondary", "icon_html": ""})
+            _url = "/login/email"
+            if next_path:
+                _url += f"?next={quote(next_path, safe='')}"
+            login_buttons.append({"url": _url, "text": "Sign in with Email Link", "css_class": "btn-secondary", "icon_html": ""})
 
     ctx = _build_context(request, providers=providers, login_buttons=login_buttons, next_path=next_path)
     return templates.TemplateResponse(request, "login.html", ctx)

--- a/app/web/templates/login_email.html
+++ b/app/web/templates/login_email.html
@@ -19,6 +19,7 @@
         <!-- Sign In Tab -->
         <div id="signin-tab" class="auth-tab-content active">
             <form method="POST" action="/auth/password/login/web" class="login-form">
+                <input type="hidden" name="next" value="{{ next_path|default('', true) }}">
                 <div class="form-group">
                     <label for="email-signin">Email Address</label>
                     <input type="email"

--- a/tests/test_web_ui.py
+++ b/tests/test_web_ui.py
@@ -171,3 +171,46 @@ class TestUnauthenticatedHtmlRedirects:
         )
         assert resp.status_code == 302
         assert resp.headers["location"] == "/dashboard"
+
+    @pytest.mark.parametrize("hostile_next,expected_location", [
+        ("javascript:alert(1)", "/dashboard"),
+        ("http://evil.example/", "/dashboard"),
+        ("//evil.example/", "/dashboard"),
+        ("dashboard", "/dashboard"),           # missing leading slash
+        ("/foo?bar=baz", "/foo?bar=baz"),       # valid same-origin with query
+    ])
+    def test_password_login_sanitizes_next(self, web_client, tmp_path, hostile_next, expected_location):
+        from argon2 import PasswordHasher
+        from src.db import get_system_db
+        from src.repositories.users import UserRepository
+        import uuid
+        password = "TestPass1!"
+        uid = f"u-{uuid.uuid4().hex[:8]}"
+        conn = get_system_db()
+        UserRepository(conn).create(
+            id=uid, email=f"{uid}@test.com", name=uid, role="admin",
+            password_hash=PasswordHasher().hash(password),
+        )
+        conn.close()
+        resp = web_client.post(
+            "/auth/password/login/web",
+            data={"email": f"{uid}@test.com", "password": password, "next": hostile_next},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert resp.headers["location"] == expected_location
+
+    def test_non_api_post_still_returns_json_401(self, web_client):
+        # POST to a JSON auth endpoint that lives outside /api/ — must NOT be redirected.
+        resp = web_client.post("/auth/token", json={"email": "nope@x.com", "password": "wrong"},
+                               follow_redirects=False)
+        assert resp.status_code == 401
+        assert resp.headers["content-type"].startswith("application/json")
+
+    def test_login_page_propagates_next_to_password_button(self, web_client):
+        resp = web_client.get("/login?next=/catalog")
+        assert resp.status_code == 200
+        body = resp.text
+        # Password button URL should carry next.
+        assert "/login/password?next=%2Fcatalog" in body, \
+            f"Expected /login/password?next=%2Fcatalog in login page HTML; got snippet: {body[:500]}"

--- a/tests/test_web_ui.py
+++ b/tests/test_web_ui.py
@@ -113,3 +113,61 @@ class TestAdminRoleGuards:
     def test_analyst_cannot_access_corporate_memory_admin(self, web_client, admin_cookie, analyst_cookie):
         resp = web_client.get("/corporate-memory/admin", cookies=analyst_cookie)
         assert resp.status_code == 403
+
+
+class TestUnauthenticatedHtmlRedirects:
+    def test_dashboard_unauthenticated_redirects_to_login(self, web_client):
+        resp = web_client.get("/dashboard", follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers["location"].startswith("/login")
+        assert "next=%2Fdashboard" in resp.headers["location"]
+
+    def test_catalog_unauthenticated_redirects_to_login(self, web_client):
+        resp = web_client.get("/catalog", follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers["location"].startswith("/login")
+        assert "next=%2Fcatalog" in resp.headers["location"]
+
+    def test_api_route_still_returns_json_401(self, web_client):
+        # /api/sync/manifest requires auth; must keep JSON 401 (no redirect).
+        resp = web_client.get("/api/sync/manifest", follow_redirects=False)
+        assert resp.status_code == 401
+        assert resp.headers["content-type"].startswith("application/json")
+
+    def test_password_login_honors_next(self, web_client, tmp_path):
+        from argon2 import PasswordHasher
+        from src.db import get_system_db
+        from src.repositories.users import UserRepository
+        password = "TestPass1!"
+        conn = get_system_db()
+        UserRepository(conn).create(
+            id="u1", email="u1@test.com", name="U1", role="admin",
+            password_hash=PasswordHasher().hash(password),
+        )
+        conn.close()
+        resp = web_client.post(
+            "/auth/password/login/web",
+            data={"email": "u1@test.com", "password": password, "next": "/catalog"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/catalog"
+
+    def test_password_login_rejects_open_redirect(self, web_client, tmp_path):
+        from argon2 import PasswordHasher
+        from src.db import get_system_db
+        from src.repositories.users import UserRepository
+        password = "TestPass1!"
+        conn = get_system_db()
+        UserRepository(conn).create(
+            id="u2", email="u2@test.com", name="U2", role="admin",
+            password_hash=PasswordHasher().hash(password),
+        )
+        conn.close()
+        resp = web_client.post(
+            "/auth/password/login/web",
+            data={"email": "u2@test.com", "password": password, "next": "//evil.example/"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/dashboard"


### PR DESCRIPTION
## Summary

Unauthenticated access to HTML pages like `/dashboard` returned a raw JSON 401 body; they now redirect to `/login?next=<path>` and the password login flow carries `next` through the `/login` → `/login/password` hop and honors it on success.

Implementation: a single `StarletteHTTPException` handler registered on the FastAPI app. On `401` + `GET` + path not starting with `/api/`, return `302 /login?next=<path>`. Otherwise fall through to Starlette's default JSON response, so `/api/*` routes and non-GET JSON endpoints (e.g. `/auth/token`) keep their existing JSON 401 contract.

Closes #10.

## What this PR does

- `/dashboard`, `/catalog`, `/corporate-memory`, `/activity-center`, admin pages, etc. → 302 to `/login?next=<path>`
- `/api/*` and non-GET JSON auth endpoints unchanged — still return JSON 401
- `login_page` threads `next` into the Email & Password / Email Link button URLs so it survives the extra hop to `/login/password`
- Password web-login form carries `next` through as a hidden field and redirects there on success (sanitized: must start with `/`, must not start with `//`)

## Out of scope (follow-up)

Google OAuth still lands on `/dashboard` regardless of `next`. No regression vs. today.

## Supersedes

Replaces #25, which accumulated an unrelated doc commit from a parallel branch. This PR contains exclusively the two commits for issue #10.

## Test plan

- [x] `pytest tests/test_web_ui.py tests/test_auth_providers.py tests/test_access_control.py -v` → 73 passed
- [x] Sanitizer covered for `javascript:`, `http://evil/`, `//evil/`, `dashboard` (no leading slash), valid `/foo?bar=baz`
- [x] Non-GET non-`/api/` JSON endpoint (`/auth/token`) still returns JSON 401
- [x] `/login?next=/catalog` propagates `next` into the password button URL
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/27" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
