### PR TITLE
feat(auth): Cloudflare Access as a third auth provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ See `config/instance.yaml.example` for all available options.
 
 - [Hackathon TL;DR](docs/HACKATHON.md) — condensed deploy + dev playbooks (for both humans and AI agents)
 - [Onboarding Guide](docs/ONBOARDING.md) — end-to-end Terraform deployment into a GCP project (recommended for production)
+- [Cloudflare Access Auth](docs/auth-cloudflare.md) — SSO via Cloudflare Zero Trust tunnel
 - [Deployment Guide](docs/DEPLOYMENT.md) — chooses between Terraform and Docker Compose; covers OSS self-host
 - [Configuration Reference](docs/CONFIGURATION.md) — `instance.yaml`, env vars, per-instance options
 - [Architecture](docs/architecture.md) — orchestrator, extractors, DB layout

--- a/app/auth/middleware.py
+++ b/app/auth/middleware.py
@@ -19,6 +19,7 @@ login flows on deployments that enable CF as *one of several* auth methods.
 """
 
 import logging
+import os
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
@@ -31,6 +32,28 @@ logger = logging.getLogger(__name__)
 CF_HEADER = "Cf-Access-Jwt-Assertion"
 COOKIE_NAME = "access_token"
 COOKIE_MAX_AGE = 86400  # 24h — matches ACCESS_TOKEN_EXPIRE_HOURS in app/auth/jwt.py
+
+
+def _inject_cookie(request: Request, name: str, value: str) -> None:
+    """Append/replace a cookie on the inbound request's headers in place.
+
+    Starlette's `Request.cookies` is parsed from the raw `cookie` header on
+    `request.scope["headers"]`. To make a freshly-minted token visible to
+    downstream dependencies on the SAME request (before `call_next`), we
+    mutate that header.
+    """
+    raw_headers = list(request.scope.get("headers", []))
+    existing = b""
+    filtered = []
+    for k, v in raw_headers:
+        if k == b"cookie":
+            existing = v
+        else:
+            filtered.append((k, v))
+    new_entry = f"{name}={value}".encode("ascii")
+    new_cookie = (existing + b"; " + new_entry) if existing else new_entry
+    filtered.append((b"cookie", new_cookie))
+    request.scope["headers"] = filtered
 
 
 class CloudflareAccessMiddleware(BaseHTTPMiddleware):
@@ -74,8 +97,17 @@ class CloudflareAccessMiddleware(BaseHTTPMiddleware):
             role=user["role"],
         )
 
+        # Inject our JWT into the request's Cookie header BEFORE call_next so
+        # the handler's auth dependencies find an `access_token` on this same
+        # request — makes the first CF-authenticated request succeed without
+        # a client-side redirect round-trip.
+        _inject_cookie(request, COOKIE_NAME, app_jwt)
+        # Also stash on request.state for handlers that prefer it.
+        request.state.cf_user = user
+
         response = await call_next(request)
-        import os
+
+        # Persist for subsequent requests (the injected cookie is request-scoped).
         use_secure = os.environ.get("TESTING", "").lower() not in ("1", "true")
         response.set_cookie(
             key=COOKIE_NAME,
@@ -85,9 +117,4 @@ class CloudflareAccessMiddleware(BaseHTTPMiddleware):
             samesite="lax",
             secure=use_secure,
         )
-        # Stash on request.state so this-request handlers can see the identity.
-        # (Not strictly needed — the next request will use the cookie — but it
-        # makes the first CF-authenticated request behave identically to a
-        # cookie-authenticated one.)
-        request.state.cf_user = user
         return response

--- a/app/auth/middleware.py
+++ b/app/auth/middleware.py
@@ -1,0 +1,93 @@
+"""Starlette middleware that transparently exchanges a verified Cloudflare Access
+JWT for our standard `access_token` session cookie.
+
+Runs before route handlers. On every request:
+
+1. If the CF provider is not configured, pass through untouched.
+2. If the request carries an `Authorization: Bearer` header (API/CLI/PAT
+   client), pass through — those clients don't need a cookie, and setting
+   one could leak into subsequent requests from shared clients.
+3. If the request already has an `access_token` cookie, pass through
+   (don't overwrite an active session — user may have logged in manually).
+4. If a `Cf-Access-Jwt-Assertion` header is present and verifies, provision
+   the user, mint our JWT, set the cookie, continue.
+5. On any verification failure, pass through — the route handler will
+   apply its normal auth logic (cookie/Bearer/redirect).
+
+Never returns 401 from the middleware itself — that would break password/Google
+login flows on deployments that enable CF as *one of several* auth methods.
+"""
+
+import logging
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+from app.auth.providers import cloudflare as cf
+
+logger = logging.getLogger(__name__)
+
+CF_HEADER = "Cf-Access-Jwt-Assertion"
+COOKIE_NAME = "access_token"
+COOKIE_MAX_AGE = 86400  # 24h — matches ACCESS_TOKEN_EXPIRE_HOURS in app/auth/jwt.py
+
+
+class CloudflareAccessMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next) -> Response:
+        if not cf.is_available():
+            return await call_next(request)
+        # Bearer clients (PATs, API scripts) manage their own auth — don't set a cookie on them.
+        auth_header = request.headers.get("authorization", "")
+        if auth_header.lower().startswith("bearer "):
+            return await call_next(request)
+        if request.cookies.get(COOKIE_NAME):
+            return await call_next(request)
+        token = request.headers.get(CF_HEADER)
+        if not token:
+            return await call_next(request)
+
+        claims = cf.verify_cf_jwt(token)
+        if claims is None:
+            return await call_next(request)
+
+        # Import inside dispatch to avoid circular imports at module load time
+        from src.db import get_system_db
+        from app.auth.jwt import create_access_token
+
+        email = claims.get("email", "")
+        name = claims.get("name", "")
+        conn = get_system_db()
+        try:
+            user = cf.get_or_create_user_from_cf(email=email, name=name, conn=conn)
+        finally:
+            conn.close()
+
+        if user is None:
+            # Email outside allowlist or deactivated — pass through so the
+            # normal 401 → /login redirect tells the user why.
+            return await call_next(request)
+
+        app_jwt = create_access_token(
+            user_id=user["id"],
+            email=user["email"],
+            role=user["role"],
+        )
+
+        response = await call_next(request)
+        import os
+        use_secure = os.environ.get("TESTING", "").lower() not in ("1", "true")
+        response.set_cookie(
+            key=COOKIE_NAME,
+            value=app_jwt,
+            httponly=True,
+            max_age=COOKIE_MAX_AGE,
+            samesite="lax",
+            secure=use_secure,
+        )
+        # Stash on request.state so this-request handlers can see the identity.
+        # (Not strictly needed — the next request will use the cookie — but it
+        # makes the first CF-authenticated request behave identically to a
+        # cookie-authenticated one.)
+        request.state.cf_user = user
+        return response

--- a/app/auth/providers/cloudflare.py
+++ b/app/auth/providers/cloudflare.py
@@ -12,8 +12,15 @@ This module exposes pure functions; the request-interception logic lives in
 
 import logging
 import os
+from typing import Optional
+
+import jwt as pyjwt
+from jwt import PyJWKClient
 
 logger = logging.getLogger(__name__)
+
+_JWKS_CLIENT: Optional[PyJWKClient] = None
+_JWKS_TEAM: Optional[str] = None  # team string the cached client was built for
 
 
 def _team() -> str:
@@ -25,13 +32,56 @@ def _aud() -> str:
 
 
 def is_available() -> bool:
-    """Provider is active only when BOTH team and aud are configured.
-
-    The two-env-var gate prevents header spoofing on deployments that don't
-    sit behind Cloudflare — an attacker could otherwise forge
-    `Cf-Access-Jwt-Assertion` and bypass auth.
-
-    Env vars are read at call time (not cached at import) so tests and
-    runtime env changes behave predictably.
-    """
+    """Provider is active only when BOTH team and aud are configured."""
     return bool(_team() and _aud())
+
+
+def _jwks_url() -> str:
+    return f"https://{_team()}.cloudflareaccess.com/cdn-cgi/access/certs"
+
+
+def _issuer() -> str:
+    return f"https://{_team()}.cloudflareaccess.com"
+
+
+def _get_jwks_client() -> PyJWKClient:
+    """Lazy-init JWKS client. PyJWKClient caches keys with 5-min TTL by default.
+
+    If `CF_ACCESS_TEAM` changes (e.g. between tests), rebuild the client.
+    """
+    global _JWKS_CLIENT, _JWKS_TEAM
+    current_team = _team()
+    if _JWKS_CLIENT is None or _JWKS_TEAM != current_team:
+        _JWKS_CLIENT = PyJWKClient(_jwks_url(), cache_jwk_set=True, lifespan=300)
+        _JWKS_TEAM = current_team
+    return _JWKS_CLIENT
+
+
+def verify_cf_jwt(token: str) -> Optional[dict]:
+    """Verify a Cloudflare Access JWT. Returns claims dict on success, None on any failure.
+
+    Never raises — all exceptions are logged at debug and mapped to None so the
+    middleware can treat them as "pass through to normal auth."
+    """
+    if not is_available():
+        return None
+    if not token:
+        return None
+    try:
+        signing_key = _get_jwks_client().get_signing_key_from_jwt(token)
+        claims = pyjwt.decode(
+            token,
+            signing_key.key,
+            algorithms=["RS256"],
+            audience=_aud(),
+            issuer=_issuer(),
+            options={"require": ["exp", "iat", "iss", "aud"]},
+        )
+        return claims
+    except pyjwt.InvalidTokenError as e:
+        logger.debug("CF Access JWT invalid: %s", e)
+        return None
+    except Exception as e:
+        # JWKS fetch failure, network error, etc. — never propagate
+        logger.warning("CF Access JWT verification error: %s", e)
+        return None

--- a/app/auth/providers/cloudflare.py
+++ b/app/auth/providers/cloudflare.py
@@ -12,10 +12,14 @@ This module exposes pure functions; the request-interception logic lives in
 
 import logging
 import os
-from typing import Optional
+import uuid
+from typing import Any, Optional
 
+import duckdb
 import jwt as pyjwt
 from jwt import PyJWKClient
+
+from src.repositories.users import UserRepository
 
 logger = logging.getLogger(__name__)
 
@@ -85,14 +89,6 @@ def verify_cf_jwt(token: str) -> Optional[dict]:
         # JWKS fetch failure, network error, etc. — never propagate
         logger.warning("CF Access JWT verification error: %s", e)
         return None
-
-
-import uuid
-from typing import Any
-
-import duckdb
-
-from src.repositories.users import UserRepository
 
 
 def _allowed_domains() -> list[str]:

--- a/app/auth/providers/cloudflare.py
+++ b/app/auth/providers/cloudflare.py
@@ -85,3 +85,66 @@ def verify_cf_jwt(token: str) -> Optional[dict]:
         # JWKS fetch failure, network error, etc. — never propagate
         logger.warning("CF Access JWT verification error: %s", e)
         return None
+
+
+import uuid
+from typing import Any
+
+import duckdb
+
+from src.repositories.users import UserRepository
+
+
+def _allowed_domains() -> list[str]:
+    """Domain allowlist — CF_ACCESS_DOMAIN_ALLOW env wins, else instance.yaml."""
+    env = os.environ.get("CF_ACCESS_DOMAIN_ALLOW", "").strip()
+    if env:
+        return [d.strip().lower() for d in env.split(",") if d.strip()]
+    try:
+        from app.instance_config import get_allowed_domains
+        return [d.lower() for d in (get_allowed_domains() or [])]
+    except Exception:
+        return []
+
+
+def get_or_create_user_from_cf(
+    email: str,
+    name: str,
+    conn: duckdb.DuckDBPyConnection,
+) -> Optional[dict[str, Any]]:
+    """Look up or provision a user from a verified CF Access identity.
+
+    Returns the user dict on success; returns None when:
+    - email domain is outside the allowlist
+    - user exists but is deactivated
+
+    New users default to `analyst` role (same default as Google OAuth).
+    """
+    if not email or not isinstance(email, str):
+        return None
+
+    allow = _allowed_domains()
+    if allow:
+        domain = email.split("@")[-1].lower()
+        if domain not in allow:
+            logger.info("CF Access: rejecting email outside allowlist: %s", email)
+            return None
+
+    repo = UserRepository(conn)
+    user = repo.get_by_email(email)
+    if user is None:
+        user_id = str(uuid.uuid4())
+        repo.create(
+            id=user_id,
+            email=email,
+            name=name or email.split("@")[0],
+            role="analyst",
+        )
+        user = repo.get_by_email(email)
+        logger.info("CF Access: provisioned new user %s", email)
+
+    if not bool(user.get("active", True)):
+        logger.info("CF Access: rejecting deactivated user %s", email)
+        return None
+
+    return user

--- a/app/auth/providers/cloudflare.py
+++ b/app/auth/providers/cloudflare.py
@@ -1,0 +1,37 @@
+"""Cloudflare Access auth provider — verifies edge JWT from Cloudflare Zero Trust.
+
+Unlike password/google/email providers, Cloudflare Access is NOT a clickable
+login button. Cloudflare's edge gate injects a signed JWT in the
+`Cf-Access-Jwt-Assertion` header on every request. The app trusts that JWT
+(after verifying signature + audience) and auto-provisions the user, issuing
+our standard `access_token` cookie so downstream route handlers work unchanged.
+
+This module exposes pure functions; the request-interception logic lives in
+`app/auth/middleware.py`.
+"""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def _team() -> str:
+    return os.environ.get("CF_ACCESS_TEAM", "")
+
+
+def _aud() -> str:
+    return os.environ.get("CF_ACCESS_AUD", "")
+
+
+def is_available() -> bool:
+    """Provider is active only when BOTH team and aud are configured.
+
+    The two-env-var gate prevents header spoofing on deployments that don't
+    sit behind Cloudflare — an attacker could otherwise forge
+    `Cf-Access-Jwt-Assertion` and bypass auth.
+
+    Env vars are read at call time (not cached at import) so tests and
+    runtime env changes behave predictably.
+    """
+    return bool(_team() and _aud())

--- a/app/main.py
+++ b/app/main.py
@@ -121,6 +121,12 @@ def create_app() -> FastAPI:
         allow_headers=["*"],
     )
 
+    # Cloudflare Access middleware — runs before route handlers to exchange
+    # a verified CF edge JWT for our session cookie. Inert unless
+    # CF_ACCESS_TEAM + CF_ACCESS_AUD are both set.
+    from app.auth.middleware import CloudflareAccessMiddleware
+    app.add_middleware(CloudflareAccessMiddleware)
+
     # Load .env_overlay (persisted by /api/admin/configure)
     _overlay = Path(os.environ.get("DATA_DIR", "./data")) / "state" / ".env_overlay"
     if _overlay.exists():

--- a/app/web/router.py
+++ b/app/web/router.py
@@ -258,7 +258,17 @@ async def login_page(request: Request):
                 _url += f"?next={quote(next_path, safe='')}"
             login_buttons.append({"url": _url, "text": "Sign in with Email Link", "css_class": "btn-secondary", "icon_html": ""})
 
-    ctx = _build_context(request, providers=providers, login_buttons=login_buttons, next_path=next_path)
+    cf_available = False
+    try:
+        from app.auth.providers.cloudflare import is_available as cf_is_available
+        cf_available = cf_is_available()
+    except Exception:
+        pass
+
+    ctx = _build_context(
+        request, providers=providers, login_buttons=login_buttons,
+        next_path=next_path, cf_available=cf_available,
+    )
     return templates.TemplateResponse(request, "login.html", ctx)
 
 

--- a/app/web/templates/login.html
+++ b/app/web/templates/login.html
@@ -114,6 +114,13 @@
                 {% endif %}
                 {% endfor %}
 
+                {% if cf_available %}
+                <p class="login-note" style="margin-top: 16px; font-size: 12px; opacity: 0.8;">
+                    This deployment is protected by Cloudflare Access. If you expected to be
+                    signed in automatically, please access via your configured Cloudflare URL.
+                </p>
+                {% endif %}
+
                 {% if not login_buttons %}
                 <p class="login-note">
                     No authentication providers are configured. Please set up at least one provider.

--- a/docs/auth-cloudflare.md
+++ b/docs/auth-cloudflare.md
@@ -66,6 +66,10 @@ and issue a session cookie.
   `Authorization: Bearer <token>` header bypass the middleware entirely —
   no cookie is set. This preserves the clean stateless contract for
   CLI tools, CI, and scripts.
+- **Use a distinct AUD per deployment**: two Agnes deployments sharing the
+  same `CF_ACCESS_AUD` would accept each other's tokens. Always create a
+  separate Cloudflare Access Application (and therefore a separate AUD tag)
+  for each environment — `agnes-dev`, `agnes-prod`, per-customer deployments.
 
 ## Logout Semantics
 

--- a/docs/auth-cloudflare.md
+++ b/docs/auth-cloudflare.md
@@ -1,0 +1,108 @@
+# Cloudflare Access Authentication
+
+Agnes can be deployed behind a Cloudflare Zero Trust tunnel with Access
+protecting it as an SSO gate. When configured, users who pass CF's
+identity check are automatically signed into Agnes — no second login.
+
+This works **alongside** the built-in password and Google OAuth flows:
+direct connections (e.g. local dev, CLI with PAT) still use those. Only
+the CF-gated path auto-logs-in.
+
+## Prerequisites
+
+- A Cloudflare Zero Trust team (Free tier works for up to 50 users)
+- A domain routed to Agnes via Cloudflare Tunnel (`cloudflared`) or CF proxy
+- An Access Application configured in front of that domain
+
+## Configure the Access Application
+
+1. In the Cloudflare Zero Trust dashboard → **Access** → **Applications**
+   → **Add an application** → **Self-hosted**
+2. Application domain: the hostname routed to your Agnes instance
+   (e.g. `agnes.yourco.com`)
+3. Identity providers: enable your IdP (Google Workspace, Okta, etc.)
+4. Policies: add at least one Allow policy (e.g. email ending in `@yourco.com`)
+5. After creation, open the app → **Overview** tab and copy the **Application
+   Audience (AUD) Tag**
+
+## Configure Agnes
+
+Set two environment variables in your deployment (`.env` or Secret Manager):
+
+~~~bash
+CF_ACCESS_TEAM=yourteam          # from https://yourteam.cloudflareaccess.com
+CF_ACCESS_AUD=abc123...          # AUD Tag from the Application → Overview page
+~~~
+
+Optionally restrict which email domains can auto-provision:
+
+~~~bash
+CF_ACCESS_DOMAIN_ALLOW=yourco.com,partner.com
+~~~
+
+If unset, falls back to `allowed_domains` in `config/instance.yaml` (same
+allowlist used by the Google OAuth provider).
+
+Restart Agnes. That's it — requests arriving with a valid
+`Cf-Access-Jwt-Assertion` header will auto-provision a new `analyst` user
+and issue a session cookie.
+
+## Security Model
+
+- **Both env vars required**: if either `CF_ACCESS_TEAM` or `CF_ACCESS_AUD`
+  is unset, the middleware is completely inert and the header is ignored.
+  This prevents header spoofing on deployments that don't actually sit
+  behind Cloudflare.
+- **JWT verification**: signature checked against the team's JWKS
+  (`https://<team>.cloudflareaccess.com/cdn-cgi/access/certs`, cached 5 min);
+  `aud` and `iss` both validated; expired tokens rejected.
+- **Never overwrites an existing session**: if the user already has an
+  `access_token` cookie, the middleware passes through — you can always
+  sign in explicitly with password/Google on a CF-protected deployment.
+- **Never 401s from middleware**: if verification fails for any reason, the
+  request continues to the normal auth layer — users see the normal login
+  page rather than a confusing middleware error.
+- **PAT/API (Bearer) clients are skipped**: requests carrying an
+  `Authorization: Bearer <token>` header bypass the middleware entirely —
+  no cookie is set. This preserves the clean stateless contract for
+  CLI tools, CI, and scripts.
+
+## Logout Semantics
+
+Clicking "log out" in Agnes clears the local `access_token` cookie.
+**However, if the user is still behind Cloudflare Access**, the next
+request will carry a fresh `Cf-Access-Jwt-Assertion` header and the
+middleware will immediately re-issue a session cookie — logout appears
+to have no effect.
+
+To fully sign out on a CF-gated deployment, the user must also sign out
+of their Cloudflare Access session by visiting:
+
+~~~
+https://<your-agnes-domain>/cdn-cgi/access/logout
+~~~
+
+Consider linking to this URL from Agnes's logout UI on CF-gated
+deployments, or document it in your internal user guide.
+
+## Troubleshooting
+
+**Auto-login doesn't happen:**
+- Check `CF_ACCESS_TEAM` matches the exact subdomain (no protocol, no path):
+  `keboola`, not `https://keboola.cloudflareaccess.com`
+- Check `CF_ACCESS_AUD` is the **Application AUD Tag**, not the Access
+  Team ID
+- Verify the request actually has the header:
+  `curl -I https://agnes.yourco.com/dashboard` behind CF should show
+  `Cf-Access-Jwt-Assertion` in the request (use `cloudflared access curl`
+  or browser dev tools)
+- Check Agnes logs for `CF Access JWT invalid: ...` or
+  `CF Access JWT verification error: ...`
+
+**"User deactivated" redirect:**
+- Someone deactivated this user in Agnes's admin panel. CF Access passes
+  identity, but Agnes enforces the `active` flag.
+
+**New users arrive with `analyst` role — how do I get admin access?**
+- Same as Google OAuth: bootstrap the first admin manually
+  (`POST /auth/bootstrap`) or have an existing admin promote via the web UI.

--- a/tests/test_cloudflare_auth.py
+++ b/tests/test_cloudflare_auth.py
@@ -178,3 +178,66 @@ class TestCloudflareProviderAvailability:
         from app.auth.providers import cloudflare as cf_mod
         importlib.reload(cf_mod)
         assert cf_mod.is_available() is True
+
+
+class TestVerifyCfJwt:
+    def test_valid_token_returns_claims(self, monkeypatch, patch_jwks, make_cf_jwt):
+        monkeypatch.setenv("CF_ACCESS_TEAM", "testteam")
+        monkeypatch.setenv("CF_ACCESS_AUD", "test-aud-123")
+        import importlib
+        from app.auth.providers import cloudflare as cf_mod
+        importlib.reload(cf_mod)
+
+        token = make_cf_jwt(email="alice@example.com")
+        claims = cf_mod.verify_cf_jwt(token)
+        assert claims is not None
+        assert claims["email"] == "alice@example.com"
+
+    def test_wrong_audience_rejected(self, monkeypatch, patch_jwks, make_cf_jwt):
+        monkeypatch.setenv("CF_ACCESS_TEAM", "testteam")
+        monkeypatch.setenv("CF_ACCESS_AUD", "test-aud-123")
+        import importlib
+        from app.auth.providers import cloudflare as cf_mod
+        importlib.reload(cf_mod)
+
+        token = make_cf_jwt(aud="wrong-aud")
+        assert cf_mod.verify_cf_jwt(token) is None
+
+    def test_wrong_issuer_rejected(self, monkeypatch, patch_jwks, make_cf_jwt):
+        monkeypatch.setenv("CF_ACCESS_TEAM", "testteam")
+        monkeypatch.setenv("CF_ACCESS_AUD", "test-aud-123")
+        import importlib
+        from app.auth.providers import cloudflare as cf_mod
+        importlib.reload(cf_mod)
+
+        token = make_cf_jwt(iss="https://evil.example.com")
+        assert cf_mod.verify_cf_jwt(token) is None
+
+    def test_expired_token_rejected(self, monkeypatch, patch_jwks, make_cf_jwt):
+        monkeypatch.setenv("CF_ACCESS_TEAM", "testteam")
+        monkeypatch.setenv("CF_ACCESS_AUD", "test-aud-123")
+        import importlib
+        from app.auth.providers import cloudflare as cf_mod
+        importlib.reload(cf_mod)
+
+        token = make_cf_jwt(exp_offset=-60)  # expired 60s ago
+        assert cf_mod.verify_cf_jwt(token) is None
+
+    def test_malformed_token_rejected(self, monkeypatch, patch_jwks):
+        monkeypatch.setenv("CF_ACCESS_TEAM", "testteam")
+        monkeypatch.setenv("CF_ACCESS_AUD", "test-aud-123")
+        import importlib
+        from app.auth.providers import cloudflare as cf_mod
+        importlib.reload(cf_mod)
+
+        assert cf_mod.verify_cf_jwt("not-a-jwt") is None
+        assert cf_mod.verify_cf_jwt("") is None
+
+    def test_verify_returns_none_when_unavailable(self, monkeypatch):
+        monkeypatch.delenv("CF_ACCESS_TEAM", raising=False)
+        monkeypatch.delenv("CF_ACCESS_AUD", raising=False)
+        import importlib
+        from app.auth.providers import cloudflare as cf_mod
+        importlib.reload(cf_mod)
+
+        assert cf_mod.verify_cf_jwt("anything") is None

--- a/tests/test_cloudflare_auth.py
+++ b/tests/test_cloudflare_auth.py
@@ -404,3 +404,103 @@ class TestMiddlewarePassthrough:
         # No cookie set, normal redirect to login
         assert resp.status_code == 302
         assert "access_token" not in resp.cookies
+
+
+class TestMiddlewareAutoLogin:
+    def test_valid_cf_header_auto_logs_in(self, cf_client, make_cf_jwt):
+        """Valid CF JWT on /dashboard request → middleware sets cookie → 200 (not 302)."""
+        token = make_cf_jwt(email="alice@example.com", name="Alice")
+        resp = cf_client.get(
+            "/dashboard",
+            headers={"Cf-Access-Jwt-Assertion": token},
+            follow_redirects=False,
+        )
+        # Middleware provisioned Alice + set cookie → dashboard renders
+        assert resp.status_code == 200, (
+            f"Expected 200, got {resp.status_code}: {resp.text[:300]}"
+        )
+        # Cookie was set on the response
+        assert "access_token" in resp.cookies
+        # User now exists
+        from src.db import get_system_db
+        from src.repositories.users import UserRepository
+        conn = get_system_db()
+        try:
+            user = UserRepository(conn).get_by_email("alice@example.com")
+            assert user is not None
+            assert user["role"] == "analyst"
+        finally:
+            conn.close()
+
+    def test_bearer_pat_passes_through_without_cookie(self, cf_client, make_cf_jwt):
+        """A Bearer-authenticated client (PAT/API) must NOT get a cookie set,
+        even if a CF header is also present."""
+        from app.auth.jwt import create_access_token
+        from src.db import get_system_db
+        from src.repositories.users import UserRepository
+        import uuid as _uuid
+
+        conn = get_system_db()
+        try:
+            uid = str(_uuid.uuid4())
+            UserRepository(conn).create(
+                id=uid, email="pat@example.com", name="PAT User", role="analyst",
+            )
+            bearer = create_access_token(uid, "pat@example.com", "analyst")
+        finally:
+            conn.close()
+
+        cf_token = make_cf_jwt(email="spoofed@example.com")
+        resp = cf_client.get(
+            "/dashboard",
+            headers={
+                "Authorization": f"Bearer {bearer}",
+                "Cf-Access-Jwt-Assertion": cf_token,
+            },
+            follow_redirects=False,
+        )
+        # Bearer auth succeeds, middleware skipped → no cookie leaked
+        assert resp.status_code == 200
+        assert "access_token" not in resp.cookies
+        # Spoofed email must not have been provisioned
+        from src.db import get_system_db as _gdb
+        conn2 = _gdb()
+        try:
+            spoofed = UserRepository(conn2).get_by_email("spoofed@example.com")
+            assert spoofed is None
+        finally:
+            conn2.close()
+
+    def test_existing_cookie_wins_over_cf_header(self, cf_client, make_cf_jwt):
+        """If the user already has an access_token cookie, middleware must not overwrite it."""
+        from app.auth.jwt import create_access_token
+        from src.db import get_system_db
+        from src.repositories.users import UserRepository
+        import uuid as _uuid
+
+        conn = get_system_db()
+        try:
+            uid = str(_uuid.uuid4())
+            UserRepository(conn).create(
+                id=uid, email="bob@example.com", name="Bob", role="admin",
+            )
+            existing_token = create_access_token(uid, "bob@example.com", "admin")
+        finally:
+            conn.close()
+
+        cf_client.cookies.set("access_token", existing_token)
+        cf_token = make_cf_jwt(email="carol@example.com", name="Carol")
+        resp = cf_client.get(
+            "/dashboard",
+            headers={"Cf-Access-Jwt-Assertion": cf_token},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 200
+        # Carol must NOT have been provisioned — existing cookie session wins
+        from src.db import get_system_db as _gdb
+        conn2 = _gdb()
+        try:
+            carol = UserRepository(conn2).get_by_email("carol@example.com")
+            assert carol is None
+        finally:
+            conn2.close()

--- a/tests/test_cloudflare_auth.py
+++ b/tests/test_cloudflare_auth.py
@@ -373,3 +373,34 @@ class TestGetOrCreateUserFromCf:
             assert cf_mod.get_or_create_user_from_cf(email=123, name="x", conn=conn) is None
         finally:
             conn.close()
+
+
+class TestMiddlewarePassthrough:
+    def test_no_header_no_cookie_redirects_to_login(self, cf_client):
+        """Dashboard without any auth → normal 302 to /login (middleware must not interfere)."""
+        resp = cf_client.get("/dashboard", follow_redirects=False)
+        assert resp.status_code == 302
+        assert "/login" in resp.headers.get("location", "")
+
+    def test_invalid_cf_header_passes_through(self, cf_client):
+        """Garbage CF header → middleware ignores it → normal 302 to login."""
+        resp = cf_client.get(
+            "/dashboard",
+            headers={"Cf-Access-Jwt-Assertion": "not-a-valid-jwt"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert "/login" in resp.headers.get("location", "")
+
+    def test_middleware_unavailable_when_env_missing(self, no_cf_client, make_cf_jwt):
+        """Without CF_ACCESS_* env, middleware must be inert even if header is present."""
+        # Note: make_cf_jwt still produces a token but middleware should ignore it.
+        token = make_cf_jwt()
+        resp = no_cf_client.get(
+            "/dashboard",
+            headers={"Cf-Access-Jwt-Assertion": token},
+            follow_redirects=False,
+        )
+        # No cookie set, normal redirect to login
+        assert resp.status_code == 302
+        assert "access_token" not in resp.cookies

--- a/tests/test_cloudflare_auth.py
+++ b/tests/test_cloudflare_auth.py
@@ -355,3 +355,21 @@ class TestGetOrCreateUserFromCf:
             assert user["email"] == "ok@partner.com"
         finally:
             conn.close()
+
+    def test_empty_or_none_email_rejected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("TESTING", "1")
+        monkeypatch.setenv("CF_ACCESS_TEAM", "testteam")
+        monkeypatch.setenv("CF_ACCESS_AUD", "test-aud-123")
+        import importlib
+        from app.auth.providers import cloudflare as cf_mod
+        importlib.reload(cf_mod)
+
+        from src.db import get_system_db
+        conn = get_system_db()
+        try:
+            assert cf_mod.get_or_create_user_from_cf(email="", name="x", conn=conn) is None
+            assert cf_mod.get_or_create_user_from_cf(email=None, name="x", conn=conn) is None
+            assert cf_mod.get_or_create_user_from_cf(email=123, name="x", conn=conn) is None
+        finally:
+            conn.close()

--- a/tests/test_cloudflare_auth.py
+++ b/tests/test_cloudflare_auth.py
@@ -143,3 +143,38 @@ def no_cf_client(tmp_path, monkeypatch):
 
     app = create_app()
     return TestClient(app)
+
+
+class TestCloudflareProviderAvailability:
+    def test_unavailable_without_env(self, monkeypatch):
+        monkeypatch.delenv("CF_ACCESS_TEAM", raising=False)
+        monkeypatch.delenv("CF_ACCESS_AUD", raising=False)
+        # Force re-import so module-level env reads are fresh
+        import importlib
+        from app.auth.providers import cloudflare as cf_mod
+        importlib.reload(cf_mod)
+        assert cf_mod.is_available() is False
+
+    def test_unavailable_with_only_team(self, monkeypatch):
+        monkeypatch.setenv("CF_ACCESS_TEAM", "testteam")
+        monkeypatch.delenv("CF_ACCESS_AUD", raising=False)
+        import importlib
+        from app.auth.providers import cloudflare as cf_mod
+        importlib.reload(cf_mod)
+        assert cf_mod.is_available() is False
+
+    def test_unavailable_with_only_aud(self, monkeypatch):
+        monkeypatch.delenv("CF_ACCESS_TEAM", raising=False)
+        monkeypatch.setenv("CF_ACCESS_AUD", "test-aud-123")
+        import importlib
+        from app.auth.providers import cloudflare as cf_mod
+        importlib.reload(cf_mod)
+        assert cf_mod.is_available() is False
+
+    def test_available_with_both_env(self, monkeypatch):
+        monkeypatch.setenv("CF_ACCESS_TEAM", "testteam")
+        monkeypatch.setenv("CF_ACCESS_AUD", "test-aud-123")
+        import importlib
+        from app.auth.providers import cloudflare as cf_mod
+        importlib.reload(cf_mod)
+        assert cf_mod.is_available() is True

--- a/tests/test_cloudflare_auth.py
+++ b/tests/test_cloudflare_auth.py
@@ -241,3 +241,117 @@ class TestVerifyCfJwt:
         importlib.reload(cf_mod)
 
         assert cf_mod.verify_cf_jwt("anything") is None
+
+
+class TestGetOrCreateUserFromCf:
+    def test_creates_new_user(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("TESTING", "1")
+        monkeypatch.setenv("CF_ACCESS_TEAM", "testteam")
+        monkeypatch.setenv("CF_ACCESS_AUD", "test-aud-123")
+        import importlib
+        from app.auth.providers import cloudflare as cf_mod
+        importlib.reload(cf_mod)
+
+        from src.db import get_system_db
+        conn = get_system_db()
+        try:
+            user = cf_mod.get_or_create_user_from_cf(
+                email="new@example.com", name="New User", conn=conn,
+            )
+            assert user is not None
+            assert user["email"] == "new@example.com"
+            assert user["role"] == "analyst"
+        finally:
+            conn.close()
+
+    def test_returns_existing_user(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("TESTING", "1")
+        monkeypatch.setenv("CF_ACCESS_TEAM", "testteam")
+        monkeypatch.setenv("CF_ACCESS_AUD", "test-aud-123")
+        import importlib
+        from app.auth.providers import cloudflare as cf_mod
+        importlib.reload(cf_mod)
+
+        from src.db import get_system_db
+        from src.repositories.users import UserRepository
+        conn = get_system_db()
+        try:
+            UserRepository(conn).create(
+                id="existing-id", email="existing@example.com",
+                name="Existing", role="admin",
+            )
+            user = cf_mod.get_or_create_user_from_cf(
+                email="existing@example.com", name="Existing", conn=conn,
+            )
+            assert user["id"] == "existing-id"
+            assert user["role"] == "admin"  # role preserved
+        finally:
+            conn.close()
+
+    def test_deactivated_user_rejected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("TESTING", "1")
+        monkeypatch.setenv("CF_ACCESS_TEAM", "testteam")
+        monkeypatch.setenv("CF_ACCESS_AUD", "test-aud-123")
+        import importlib
+        from app.auth.providers import cloudflare as cf_mod
+        importlib.reload(cf_mod)
+
+        from src.db import get_system_db
+        from src.repositories.users import UserRepository
+        conn = get_system_db()
+        try:
+            UserRepository(conn).create(
+                id="deact-id", email="deact@example.com",
+                name="Deact", role="analyst",
+            )
+            UserRepository(conn).update(id="deact-id", active=False)
+            user = cf_mod.get_or_create_user_from_cf(
+                email="deact@example.com", name="Deact", conn=conn,
+            )
+            assert user is None
+        finally:
+            conn.close()
+
+    def test_domain_allowlist_rejects_outsider(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("TESTING", "1")
+        monkeypatch.setenv("CF_ACCESS_TEAM", "testteam")
+        monkeypatch.setenv("CF_ACCESS_AUD", "test-aud-123")
+        monkeypatch.setenv("CF_ACCESS_DOMAIN_ALLOW", "example.com")
+        import importlib
+        from app.auth.providers import cloudflare as cf_mod
+        importlib.reload(cf_mod)
+
+        from src.db import get_system_db
+        conn = get_system_db()
+        try:
+            user = cf_mod.get_or_create_user_from_cf(
+                email="outsider@evil.com", name="Outsider", conn=conn,
+            )
+            assert user is None
+        finally:
+            conn.close()
+
+    def test_domain_allowlist_accepts_insider(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("TESTING", "1")
+        monkeypatch.setenv("CF_ACCESS_TEAM", "testteam")
+        monkeypatch.setenv("CF_ACCESS_AUD", "test-aud-123")
+        monkeypatch.setenv("CF_ACCESS_DOMAIN_ALLOW", "example.com,partner.com")
+        import importlib
+        from app.auth.providers import cloudflare as cf_mod
+        importlib.reload(cf_mod)
+
+        from src.db import get_system_db
+        conn = get_system_db()
+        try:
+            user = cf_mod.get_or_create_user_from_cf(
+                email="ok@partner.com", name="Partner", conn=conn,
+            )
+            assert user is not None
+            assert user["email"] == "ok@partner.com"
+        finally:
+            conn.close()

--- a/tests/test_cloudflare_auth.py
+++ b/tests/test_cloudflare_auth.py
@@ -1,6 +1,5 @@
 """Tests for Cloudflare Access auth provider and middleware."""
 
-import json
 import time
 import uuid
 from base64 import urlsafe_b64encode

--- a/tests/test_cloudflare_auth.py
+++ b/tests/test_cloudflare_auth.py
@@ -504,3 +504,17 @@ class TestMiddlewareAutoLogin:
             assert carol is None
         finally:
             conn2.close()
+
+
+class TestLoginPageCfHint:
+    def test_login_page_shows_cf_hint_when_available(self, cf_client):
+        """When CF provider is available, login page shows an informational hint."""
+        resp = cf_client.get("/login")
+        assert resp.status_code == 200
+        assert "Cloudflare Access" in resp.text
+
+    def test_login_page_no_cf_hint_when_unavailable(self, no_cf_client):
+        """Without CF env, no hint on login page."""
+        resp = no_cf_client.get("/login")
+        assert resp.status_code == 200
+        assert "Cloudflare Access" not in resp.text

--- a/tests/test_cloudflare_auth.py
+++ b/tests/test_cloudflare_auth.py
@@ -1,0 +1,146 @@
+"""Tests for Cloudflare Access auth provider and middleware."""
+
+import json
+import time
+import uuid
+from base64 import urlsafe_b64encode
+from typing import Callable
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import serialization
+import jwt as pyjwt
+
+
+def _b64url_uint(n: int) -> str:
+    """Encode an integer as base64url per RFC 7518 §6.3.1."""
+    byte_length = (n.bit_length() + 7) // 8
+    return urlsafe_b64encode(n.to_bytes(byte_length, "big")).rstrip(b"=").decode()
+
+
+@pytest.fixture
+def cf_keypair():
+    """Generate an RSA keypair for signing test CF Access JWTs."""
+    priv = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pub = priv.public_key()
+    pub_numbers = pub.public_numbers()
+    kid = "test-kid-1"
+    jwks = {
+        "keys": [
+            {
+                "kty": "RSA",
+                "kid": kid,
+                "use": "sig",
+                "alg": "RS256",
+                "n": _b64url_uint(pub_numbers.n),
+                "e": _b64url_uint(pub_numbers.e),
+            }
+        ]
+    }
+    priv_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return {"kid": kid, "jwks": jwks, "private_pem": priv_pem}
+
+
+@pytest.fixture
+def make_cf_jwt(cf_keypair) -> Callable[..., str]:
+    """Factory: build a signed CF Access JWT with overridable claims."""
+    def _make(
+        email: str = "user@example.com",
+        aud: str = "test-aud-123",
+        iss: str = "https://testteam.cloudflareaccess.com",
+        exp_offset: int = 3600,
+        name: str = "Test User",
+        extra_claims: dict | None = None,
+    ) -> str:
+        now = int(time.time())
+        claims = {
+            "email": email,
+            "name": name,
+            "aud": aud,
+            "iss": iss,
+            "iat": now,
+            "exp": now + exp_offset,
+            "sub": str(uuid.uuid4()),
+        }
+        if extra_claims:
+            claims.update(extra_claims)
+        return pyjwt.encode(
+            claims,
+            cf_keypair["private_pem"],
+            algorithm="RS256",
+            headers={"kid": cf_keypair["kid"]},
+        )
+    return _make
+
+
+@pytest.fixture(autouse=True)
+def _reset_cf_jwks_cache(monkeypatch):
+    """Reset the module-level JWKS client so each test starts fresh.
+
+    Without this, a client built from a previous test's team/URL would persist.
+    """
+    import sys
+    mod = sys.modules.get("app.auth.providers.cloudflare")
+    if mod is not None:
+        monkeypatch.setattr(mod, "_JWKS_CLIENT", None, raising=False)
+        monkeypatch.setattr(mod, "_JWKS_TEAM", None, raising=False)
+
+
+@pytest.fixture
+def patch_jwks(monkeypatch, cf_keypair):
+    """Patch PyJWKClient so verify_cf_jwt reads our test key instead of hitting the network."""
+    from cryptography.hazmat.primitives import serialization as _ser
+    # Build a PyJWK-compatible signing key object from the public key
+    pub_pem = _ser.load_pem_private_key(cf_keypair["private_pem"], password=None).public_key().public_bytes(
+        encoding=_ser.Encoding.PEM,
+        format=_ser.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    class _FakeSigningKey:
+        def __init__(self, key_bytes: bytes):
+            from cryptography.hazmat.primitives.serialization import load_pem_public_key
+            self.key = load_pem_public_key(key_bytes)
+
+    def _fake_get_signing_key_from_jwt(self, token):
+        return _FakeSigningKey(pub_pem)
+
+    monkeypatch.setattr(
+        "jwt.PyJWKClient.get_signing_key_from_jwt",
+        _fake_get_signing_key_from_jwt,
+    )
+
+
+@pytest.fixture
+def cf_client(tmp_path, monkeypatch, patch_jwks):
+    """TestClient with CF_ACCESS_* env vars set so the provider is available."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-32chars-minimum!!!!!")
+    monkeypatch.setenv("TESTING", "1")
+    monkeypatch.setenv("CF_ACCESS_TEAM", "testteam")
+    monkeypatch.setenv("CF_ACCESS_AUD", "test-aud-123")
+
+    from fastapi.testclient import TestClient
+    from app.main import create_app
+
+    app = create_app()
+    return TestClient(app)
+
+
+@pytest.fixture
+def no_cf_client(tmp_path, monkeypatch):
+    """TestClient WITHOUT CF_ACCESS_* env — provider should be unavailable."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-32chars-minimum!!!!!")
+    monkeypatch.setenv("TESTING", "1")
+    monkeypatch.delenv("CF_ACCESS_TEAM", raising=False)
+    monkeypatch.delenv("CF_ACCESS_AUD", raising=False)
+
+    from fastapi.testclient import TestClient
+    from app.main import create_app
+
+    app = create_app()
+    return TestClient(app)


### PR DESCRIPTION
## Summary

Adds **Cloudflare Access** as a third authentication method alongside existing password and Google OAuth. When a deployment sits behind a Cloudflare Zero Trust tunnel, CF injects a signed JWT in the \`Cf-Access-Jwt-Assertion\` header; a starlette middleware verifies it and auto-provisions the user, setting the standard \`access_token\` cookie so downstream handlers work unchanged.

All existing flows are preserved — the middleware is **inert** unless \`CF_ACCESS_TEAM\` + \`CF_ACCESS_AUD\` are both set, passes through on \`Authorization: Bearer\` (PAT/CLI), and never overwrites an existing session cookie.

## Base branch

Targets \`fix/web-auth-redirect-to-login\` (PR #28) because this work depends on schema v7 (\`users.active\` column). GitHub will auto-retarget to \`main\` once PR #28 merges.

## What's new

- \`app/auth/providers/cloudflare.py\` — \`is_available()\` + \`verify_cf_jwt()\` (RS256 + JWKS + aud + iss + exp) + \`get_or_create_user_from_cf()\` (domain allowlist, deactivation check)
- \`app/auth/middleware.py\` — \`CloudflareAccessMiddleware\` with 5-gate pass-through + same-request auth injection via \`request.scope[\"headers\"]\` mutation (so the first CF request succeeds without a client redirect)
- \`app/main.py\` — one-line middleware registration (LIFO: runs outermost on inbound)
- \`app/web/router.py\` + \`app/web/templates/login.html\` — optional CF hint on the login page
- \`docs/auth-cloudflare.md\` — setup, security model, logout semantics, troubleshooting
- \`tests/test_cloudflare_auth.py\` — 24 tests across 7 classes (availability, JWT verify, user provisioning, middleware passthrough, auto-login, login-page hint)

## Security Model

- **Two-env-var inert gate** prevents header spoofing on non-CF deployments
- **RS256 only** — blocks \`alg=none\` / HS256 confusion
- **\`aud\` + \`iss\` required** via \`options={\"require\": [...]}\`
- **JWKS cached 5 min**, rebuilt if team env changes
- **Never 401s from middleware** — verification failures fall through to normal auth
- **Distinct AUD per deployment** — documented in \`docs/auth-cloudflare.md\`

## Test plan

- [x] \`pytest tests/ -v --timeout=60\` → 1244 passed
- [x] Manual smoke: app starts without CF env (password/Google unchanged, login shows no CF hint)
- [x] Manual smoke: app starts with CF env (hint rendered, \`/dashboard\` still 302 when no JWT)
- [x] Manual smoke: spoofed \`Cf-Access-Jwt-Assertion\` header is ignored when env unset (302)
- [ ] Post-merge: configure \`CF_ACCESS_TEAM\` + \`CF_ACCESS_AUD\` on a staging deployment + verify auto-login via a real CF tunnel

## Plan

Full implementation plan and spec lives in \`docs/superpowers/plans/2026-04-22-cloudflare-access-auth.md\` (part of PR #28's scope).

## Follow-ups (optional)

- Add a logout link to \`/cdn-cgi/access/logout\` in the UI when \`cf_available\`
- Drop the unused \`_b64url_uint\` helper in test fixtures (dead code since \`patch_jwks\` uses a different path)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/30" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
