### PR TITLE
ci(release): push dev-<user-prefix>-latest alias for <user>/* branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,24 @@ jobs:
             BRANCH_SLUG=$(echo "$BRANCH_NAME" | sed 's|^feature/||' | sed 's|[^a-zA-Z0-9-]|-|g' | tr '[:upper:]' '[:lower:]' | cut -c1-50)
             echo "branch_slug=${BRANCH_SLUG}" >> "$GITHUB_OUTPUT"
             echo "Branch slug: ${BRANCH_SLUG}"
+
+            # User prefix for <prefix>/<whatever> branches — powers the
+            # dev-<prefix>-latest alias tag so each developer's personal VM
+            # can pin to their prefix and auto-pull the latest push. Common
+            # Git Flow prefixes are skipped so `feature/x`, `fix/y` etc.
+            # don't create noisy -latest tags.
+            if [[ "$BRANCH_NAME" == *"/"* ]]; then
+              USER_PREFIX=$(echo "$BRANCH_NAME" | cut -d/ -f1 | sed 's|[^a-zA-Z0-9-]|-|g' | tr '[:upper:]' '[:lower:]')
+              case "$USER_PREFIX" in
+                feature|fix|hotfix|bugfix|docs|chore|test|ci|ops|refactor|perf|style|build)
+                  echo "Branch prefix '$USER_PREFIX' is a Git Flow convention — skipping dev-*-latest alias"
+                  ;;
+                *)
+                  echo "user_prefix=${USER_PREFIX}" >> "$GITHUB_OUTPUT"
+                  echo "User prefix: ${USER_PREFIX} (will push dev-${USER_PREFIX}-latest alias)"
+                  ;;
+              esac
+            fi
           fi
 
           echo "Channel: ${CHANNEL}"
@@ -123,6 +141,7 @@ jobs:
             ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.versioned_tag }}
             ghcr.io/${{ github.repository }}:sha-${{ steps.meta.outputs.short_sha }}
             ${{ steps.meta.outputs.channel == 'dev' && format('ghcr.io/{0}:dev-{1}', github.repository, steps.meta.outputs.branch_slug) || '' }}
+            ${{ steps.meta.outputs.channel == 'dev' && steps.meta.outputs.user_prefix != '' && format('ghcr.io/{0}:dev-{1}-latest', github.repository, steps.meta.outputs.user_prefix) || '' }}
 
   smoke-test:
     needs: build-and-push


### PR DESCRIPTION
## Summary

Adds a second tag to dev-channel image builds. When a branch is in the form `<prefix>/<whatever>`, the image is pushed with **both**:

- `dev-<prefix>-<branch_slug>` (existing — exact branch pinning)
- `dev-<prefix>-latest` (new — floating alias, overwritten on every push by the same user)

The `*-latest` alias enables **per-developer dev VMs that auto-deploy**: each VM pins its `.env` to `AGNES_TAG=dev-<prefix>-latest`, and the existing `agnes-auto-upgrade` cron (5 min tick, digest-diff) picks up the newly-pushed image on the next run. Developer just `git push` — VM catches up within ~10 min.

## Scope

One-file change: `.github/workflows/release.yml` (+19 lines).

## What it does

Current behavior (unchanged):
- Push to `main` → channel `stable` → tags `stable`, `stable-YYYY.MM.N`, `sha-<short>`
- Push to any other branch → channel `dev` → tags `dev`, `dev-YYYY.MM.N`, `sha-<short>`, `dev-<branch_slug>`

New behavior (additive):
- Push to `<prefix>/<whatever>` → **also** tag as `dev-<prefix>-latest`

Common Git Flow prefixes are **deliberately skipped** so noisy `dev-feature-latest` / `dev-fix-latest` don't get created. Skipped list (case-insensitive):

    feature, fix, hotfix, bugfix, docs, chore, test, ci, ops, refactor, perf, style, build

## Verified locally

Logic run against several branch names:

| Branch                 | Result                             |
|---                     |---                                 |
| `zs/my-feature`        | `dev-zs-latest`                    |
| `zs/other-edit`        | `dev-zs-latest` (overwrites)       |
| `vr/foo`               | `dev-vr-latest`                    |
| `pc/bar-baz`           | `dev-pc-latest`                    |
| `ma/FIX-ABC.123`       | `dev-ma-latest`                    |
| `feature/xyz`          | (skipped, Git Flow)                |
| `fix/bug`              | (skipped, Git Flow)                |
| `hotfix/critical`      | (skipped, Git Flow)                |
| `main`                 | (no-op, stable channel)            |
| `test-no-slash`        | (no-op, no slash in name)          |

## Companion rollout

GRPN side (`FoundryAI/agnes-the-ai-analyst-infra`): per-user VMs from #4 (`foundryai-dev-zsrotyr`, `-vrysanek`, etc.) each ship an `.env` with the matching pin:

```
# foundryai-dev-zsrotyr
AGNES_TAG=dev-zs-latest
```

No Terraform change needed for the MVP — operator scps each VM's `.env` once at provisioning time. The alias tag this PR introduces is the missing piece to make that wiring auto-deploy.

## Test plan

- [x] `yaml.safe_load` parses the modified workflow
- [x] Logic verified locally against 10+ branch names (see table above)
- [ ] First push to a `<prefix>/*` branch after merge produces both `dev-<prefix>-<slug>` and `dev-<prefix>-latest` tags in GHCR
- [ ] Subsequent push to a different `<prefix>/*` branch by the same user updates `dev-<prefix>-latest` (not leak across users)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/31" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
