### PR TITLE
feat(dev): make local-dev targets for one-keystroke LOCAL_DEV_MODE startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,16 @@ docker:
 local-dev:
 	./scripts/run-local-dev.sh
 
-local-dev-down:
+# docker-compose.yml declares `env_file: .env` on several services; compose
+# validates those paths even for profiled services that never start. Create
+# the file on demand so down/logs work even if the user never ran local-dev.
+.env:
+	@touch $@
+
+local-dev-down: .env
 	docker compose $(LOCAL_DEV_COMPOSE) down
 
-local-dev-logs:
+local-dev-logs: .env
 	docker compose $(LOCAL_DEV_COMPOSE) logs -f
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,18 @@
 # Agnes AI Data Analyst — Development Makefile
 
-.PHONY: help test lint dev docker update-openapi-snapshot
+LOCAL_DEV_COMPOSE := -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.local-dev.yml
+
+.PHONY: help test lint dev docker local-dev local-dev-down local-dev-logs update-openapi-snapshot
 
 help:
 	@echo "Available targets:"
-	@echo "  make test     Run test suite"
-	@echo "  make dev      Start FastAPI dev server"
-	@echo "  make docker   Build and start Docker Compose"
-	@echo "  make lint     Run ruff linter (if installed)"
+	@echo "  make test            Run test suite"
+	@echo "  make dev             Start FastAPI dev server (native uvicorn)"
+	@echo "  make docker          Build and start Docker Compose"
+	@echo "  make local-dev       Start Agnes with LOCAL_DEV_MODE=1 (auth bypass, no .env needed)"
+	@echo "  make local-dev-down  Stop and remove the local-dev stack"
+	@echo "  make local-dev-logs  Tail logs from the local-dev stack"
+	@echo "  make lint            Run ruff linter (if installed)"
 
 test:
 	pytest tests/ -v --tb=short
@@ -17,6 +22,15 @@ dev:
 
 docker:
 	docker compose up --build
+
+local-dev:
+	./scripts/run-local-dev.sh
+
+local-dev-down:
+	docker compose $(LOCAL_DEV_COMPOSE) down
+
+local-dev-logs:
+	docker compose $(LOCAL_DEV_COMPOSE) logs -f
 
 lint:
 	@ruff check . 2>/dev/null || echo "ruff not installed: pip install ruff"


### PR DESCRIPTION
## Summary

Adds three Makefile targets that wrap \`scripts/run-local-dev.sh\` (introduced in #32):

- \`make local-dev\` — start the stack with LOCAL_DEV_MODE bypass
- \`make local-dev-down\` — stop + remove the stack
- \`make local-dev-logs\` — tail logs

Single compose-file list is defined once at the top of the Makefile.

## Test plan

- [x] \`make help\` lists the new targets
- [x] \`make -n local-dev\` prints \`./scripts/run-local-dev.sh\`
- [x] \`make -n local-dev-down\` and \`local-dev-logs\` expand to the same 3-file compose invocation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/33" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
