### PR TITLE
fix(cli): versioned wheel URL in setup instructions; drop broken /cli/agnes.whl alias

### DIFF
--- a/app/api/cli_artifacts.py
+++ b/app/api/cli_artifacts.py
@@ -6,7 +6,7 @@ import shlex
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Request
-from fastapi.responses import FileResponse, PlainTextResponse
+from fastapi.responses import FileResponse, PlainTextResponse, RedirectResponse
 
 # Strict allowlists for values interpolated into the generated install.sh.
 # The endpoint is unauthenticated and users `curl | bash` it, so any shell
@@ -62,11 +62,12 @@ async def cli_download():
 async def cli_wheel_stable():
     """Stable `.whl` URL alias so `uv tool install <server>/cli/agnes.whl` works.
 
-    `uv tool install` inspects the URL path to decide how to treat the resource
-    and only accepts it as a wheel when the path ends in `.whl`. The existing
-    `/cli/download` path does not, which forces users through a multi-step
-    curl + tmpfile + install + rm dance. This alias collapses that into a
-    single `uv tool install` invocation.
+    `uv tool install` inspects the *URL path* to decide whether the resource is
+    a wheel — Content-Disposition is ignored at that stage — and also requires
+    the filename in the URL to be PEP 427-compliant (name + version, e.g.
+    `agnes-1.0-py3-none-any.whl`). A path that ends in `agnes.whl` fails with
+    "Must have a version". Redirect to the real versioned filename so `uv`
+    sees the PEP 427 form after following the redirect.
     """
     wheel = _find_wheel()
     if not wheel:
@@ -77,6 +78,20 @@ async def cli_wheel_stable():
                 "or run the official docker image (which builds on image-build)."
             ),
         )
+    return RedirectResponse(url=f"/cli/wheel/{wheel.name}", status_code=302)
+
+
+@router.get("/cli/wheel/{wheel_name}")
+async def cli_wheel_versioned(wheel_name: str):
+    """Serve the currently-present wheel at a PEP 427-compliant URL.
+
+    Only the exact filename of the current wheel is honoured; any other
+    `wheel_name` returns 404. No filesystem lookup is done from user input —
+    the path param is only compared against `_find_wheel().name`.
+    """
+    wheel = _find_wheel()
+    if not wheel or wheel.name != wheel_name:
+        raise HTTPException(status_code=404, detail="Wheel not found")
     return FileResponse(
         path=str(wheel),
         filename=wheel.name,

--- a/app/api/cli_artifacts.py
+++ b/app/api/cli_artifacts.py
@@ -6,7 +6,7 @@ import shlex
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Request
-from fastapi.responses import FileResponse, PlainTextResponse, RedirectResponse
+from fastapi.responses import FileResponse, PlainTextResponse
 
 # Strict allowlists for values interpolated into the generated install.sh.
 # The endpoint is unauthenticated and users `curl | bash` it, so any shell
@@ -56,29 +56,6 @@ async def cli_download():
         media_type="application/octet-stream",
         headers={"Content-Disposition": f'attachment; filename="{wheel.name}"'},
     )
-
-
-@router.get("/cli/agnes.whl")
-async def cli_wheel_stable():
-    """Stable `.whl` URL alias so `uv tool install <server>/cli/agnes.whl` works.
-
-    `uv tool install` inspects the *URL path* to decide whether the resource is
-    a wheel — Content-Disposition is ignored at that stage — and also requires
-    the filename in the URL to be PEP 427-compliant (name + version, e.g.
-    `agnes-1.0-py3-none-any.whl`). A path that ends in `agnes.whl` fails with
-    "Must have a version". Redirect to the real versioned filename so `uv`
-    sees the PEP 427 form after following the redirect.
-    """
-    wheel = _find_wheel()
-    if not wheel:
-        raise HTTPException(
-            status_code=404,
-            detail=(
-                "CLI wheel not found in dist dir. Build it with `uv build --wheel` "
-                "or run the official docker image (which builds on image-build)."
-            ),
-        )
-    return RedirectResponse(url=f"/cli/wheel/{wheel.name}", status_code=302)
 
 
 @router.get("/cli/wheel/{wheel_name}")

--- a/app/web/router.py
+++ b/app/web/router.py
@@ -155,7 +155,13 @@ def _build_context(request: Request, user: Optional[dict] = None, **extra) -> di
 
     # Lines + server_url for the "Setup a new Claude Code" preview/clipboard
     # partial; single source of truth lives in app/web/setup_instructions.py.
-    from app.web.setup_instructions import SETUP_INSTRUCTIONS_LINES
+    # Resolve the wheel filename server-side so the URL in the setup snippet
+    # is a PEP 427-compliant path — `uv tool install` rejects bare `agnes.whl`.
+    from app.web.setup_instructions import resolve_lines
+    from app.api.cli_artifacts import _find_wheel
+    _wheel = _find_wheel()
+    _wheel_filename = _wheel.name if _wheel else "agnes.whl"
+    setup_instructions_lines = resolve_lines(_wheel_filename)
     ctx_server_url = str(request.base_url).rstrip("/")
 
     ctx = {
@@ -168,7 +174,7 @@ def _build_context(request: Request, user: Optional[dict] = None, **extra) -> di
         "get_flashed_messages": lambda **kwargs: [],
         "url_for": lambda endpoint, **kw: _url_for_shim(endpoint, **kw),
         "session": _FlexDict({"user": user}) if user else _FlexDict(),
-        "setup_instructions_lines": SETUP_INSTRUCTIONS_LINES,
+        "setup_instructions_lines": setup_instructions_lines,
         "server_url": ctx_server_url,
     }
     # Flex all extra context values for template compatibility

--- a/app/web/setup_instructions.py
+++ b/app/web/setup_instructions.py
@@ -4,9 +4,11 @@ Both the JS-embedded clipboard renderer (`_claude_setup_instructions.jinja`)
 and the read-only HTML preview on the dashboard and /install pages consume
 these lines. Keep it in Python so there is exactly ONE place that edits.
 
-Placeholders `{server_url}` and `{token}` are substituted at render time.
-For the preview we substitute `{token}` with a user-visible placeholder
-string styled distinctly in the HTML preview.
+Placeholders `{server_url}`, `{token}`, and `{wheel_filename}` are substituted
+at render time. `{wheel_filename}` is pre-substituted server-side via
+`resolve_lines()` because `uv tool install` validates the PEP 427 filename
+*in the URL path* before fetching, so a stable alias like `agnes.whl` fails
+with "Must have a version" — we need the real versioned filename inlined.
 """
 
 from __future__ import annotations
@@ -21,7 +23,7 @@ SETUP_INSTRUCTIONS_LINES: list[str] = [
     "Run these, in order. If any step fails, paste the exact error back and stop.",
     "",
     "1) Install the CLI:",
-    "   uv tool install --force {server_url}/cli/agnes.whl",
+    "   uv tool install --force {server_url}/cli/wheel/{wheel_filename}",
     "",
     "   If uv is not installed yet:",
     "     curl -LsSf https://astral.sh/uv/install.sh | sh",
@@ -68,12 +70,26 @@ SETUP_INSTRUCTIONS_LINES: list[str] = [
 ]
 
 
-def render_setup_instructions(server_url: str, token: str) -> str:
+def resolve_lines(wheel_filename: str) -> list[str]:
+    """Return the template lines with `{wheel_filename}` pre-substituted.
+
+    Called by the web router before passing the lines to the Jinja partial
+    (both preview and JS modes). Keeps the client side from having to know
+    the wheel filename and keeps the two renderers byte-identical.
+
+    Fallback: callers pass `"agnes.whl"` when no wheel is present on disk.
+    The resulting URL will 404 at download time, but the instruction text
+    still renders — and `/cli/agnes.whl` also 404s with a helpful message.
+    """
+    return [line.replace("{wheel_filename}", wheel_filename) for line in SETUP_INSTRUCTIONS_LINES]
+
+
+def render_setup_instructions(server_url: str, token: str, wheel_filename: str = "agnes.whl") -> str:
     """Render the setup instructions as a single string.
 
     Used server-side for tests and any non-JS rendering path. The browser
     clipboard flow uses the JS renderer embedded in the Jinja partial; both
-    must produce byte-identical output for a given (server_url, token).
+    must produce byte-identical output for a given (server_url, token, wheel).
     """
-    text = "\n".join(SETUP_INSTRUCTIONS_LINES)
+    text = "\n".join(resolve_lines(wheel_filename))
     return text.replace("{server_url}", server_url).replace("{token}", token)

--- a/app/web/setup_instructions.py
+++ b/app/web/setup_instructions.py
@@ -78,8 +78,9 @@ def resolve_lines(wheel_filename: str) -> list[str]:
     the wheel filename and keeps the two renderers byte-identical.
 
     Fallback: callers pass `"agnes.whl"` when no wheel is present on disk.
-    The resulting URL will 404 at download time, but the instruction text
-    still renders — and `/cli/agnes.whl` also 404s with a helpful message.
+    The resulting URL (`/cli/wheel/agnes.whl`) will 404 at download time, but
+    the instruction text still renders so operators can see the snippet shape
+    and diagnose the missing wheel on the server.
     """
     return [line.replace("{wheel_filename}", wheel_filename) for line in SETUP_INSTRUCTIONS_LINES]
 

--- a/tests/test_cli_artifacts.py
+++ b/tests/test_cli_artifacts.py
@@ -43,9 +43,8 @@ def test_cli_download_serves_wheel_when_present(monkeypatch, tmp_path):
     assert resp.content.startswith(b"PK")
 
 
-def test_cli_agnes_whl_alias_serves_same_bytes_as_download(monkeypatch, tmp_path):
-    """`/cli/agnes.whl` is a stable alias; after following the redirect to the
-    versioned path it must serve the same bytes as `/cli/download`."""
+def test_cli_wheel_versioned_serves_current_wheel(monkeypatch, tmp_path):
+    """`/cli/wheel/{filename}` serves the current wheel and matches `/cli/download` bytes."""
     wheel = tmp_path / "agnes_fake-1.0-py3-none-any.whl"
     wheel.write_bytes(b"PK\x03\x04fake-wheel-bytes-agnes")
     monkeypatch.setenv("AGNES_CLI_DIST_DIR", str(tmp_path))
@@ -53,58 +52,40 @@ def test_cli_agnes_whl_alias_serves_same_bytes_as_download(monkeypatch, tmp_path
     from app.main import app
     client = TestClient(app)
 
-    # TestClient follows redirects by default — we get the file after the 302.
-    resp_alias = client.get("/cli/agnes.whl")
-    assert resp_alias.status_code == 200
-    assert resp_alias.headers["content-type"] == "application/octet-stream"
-    assert resp_alias.content == wheel.read_bytes()
+    resp = client.get("/cli/wheel/agnes_fake-1.0-py3-none-any.whl")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/octet-stream"
+    assert resp.content == wheel.read_bytes()
 
     resp_download = client.get("/cli/download")
     assert resp_download.status_code == 200
-    assert resp_alias.content == resp_download.content
+    assert resp.content == resp_download.content
 
 
-def test_cli_agnes_whl_alias_redirects_to_pep427_filename(monkeypatch, tmp_path):
-    """`uv tool install` looks at the URL path, not Content-Disposition, and
-    rejects a bare `agnes.whl` with `Must have a version`. The alias must 302
-    to a path that contains the real versioned filename so `uv` accepts it."""
+def test_cli_wheel_versioned_rejects_other_filenames(monkeypatch, tmp_path):
+    """Arbitrary `wheel_name` values must 404 — no filesystem lookup from user input."""
     wheel = tmp_path / "agnes_fake-1.0-py3-none-any.whl"
     wheel.write_bytes(b"PK\x03\x04")
     monkeypatch.setenv("AGNES_CLI_DIST_DIR", str(tmp_path))
     from fastapi.testclient import TestClient
     from app.main import app
     client = TestClient(app)
-
-    resp = client.get("/cli/agnes.whl", follow_redirects=False)
-    assert resp.status_code == 302
-    assert resp.headers["location"].endswith("/cli/wheel/agnes_fake-1.0-py3-none-any.whl")
-
-
-def test_cli_wheel_versioned_only_serves_current_wheel(monkeypatch, tmp_path):
-    """Versioned endpoint must not be usable to request arbitrary filenames —
-    it only serves whatever `_find_wheel()` currently returns."""
-    wheel = tmp_path / "agnes_fake-1.0-py3-none-any.whl"
-    wheel.write_bytes(b"PK\x03\x04")
-    monkeypatch.setenv("AGNES_CLI_DIST_DIR", str(tmp_path))
-    from fastapi.testclient import TestClient
-    from app.main import app
-    client = TestClient(app)
-
-    resp_ok = client.get("/cli/wheel/agnes_fake-1.0-py3-none-any.whl")
-    assert resp_ok.status_code == 200
-    assert resp_ok.content == wheel.read_bytes()
 
     resp_wrong = client.get("/cli/wheel/other-2.0-py3-none-any.whl")
     assert resp_wrong.status_code == 404
 
 
-def test_cli_agnes_whl_alias_404_when_no_wheel(monkeypatch, tmp_path):
-    """Alias returns 404 with a helpful message when no wheel is present."""
+def test_cli_agnes_whl_alias_is_gone(monkeypatch, tmp_path):
+    """The bareword alias was removed — it never worked with `uv tool install`
+    (uv validates the filename before fetching) and only confused users. The
+    only CLI wheel URL is now `/cli/wheel/{filename}`."""
+    wheel = tmp_path / "agnes_fake-1.0-py3-none-any.whl"
+    wheel.write_bytes(b"PK\x03\x04")
     monkeypatch.setenv("AGNES_CLI_DIST_DIR", str(tmp_path))
     from fastapi.testclient import TestClient
     from app.main import app
     client = TestClient(app)
-    resp = client.get("/cli/agnes.whl")
+    resp = client.get("/cli/agnes.whl", follow_redirects=False)
     assert resp.status_code == 404
 
 

--- a/tests/test_cli_artifacts.py
+++ b/tests/test_cli_artifacts.py
@@ -44,9 +44,8 @@ def test_cli_download_serves_wheel_when_present(monkeypatch, tmp_path):
 
 
 def test_cli_agnes_whl_alias_serves_same_bytes_as_download(monkeypatch, tmp_path):
-    """`/cli/agnes.whl` is a stable alias over `/cli/download` whose URL path
-    ends in `.whl`, which `uv tool install` requires to treat the resource as
-    a wheel. Both endpoints must serve identical bytes."""
+    """`/cli/agnes.whl` is a stable alias; after following the redirect to the
+    versioned path it must serve the same bytes as `/cli/download`."""
     wheel = tmp_path / "agnes_fake-1.0-py3-none-any.whl"
     wheel.write_bytes(b"PK\x03\x04fake-wheel-bytes-agnes")
     monkeypatch.setenv("AGNES_CLI_DIST_DIR", str(tmp_path))
@@ -54,6 +53,7 @@ def test_cli_agnes_whl_alias_serves_same_bytes_as_download(monkeypatch, tmp_path
     from app.main import app
     client = TestClient(app)
 
+    # TestClient follows redirects by default — we get the file after the 302.
     resp_alias = client.get("/cli/agnes.whl")
     assert resp_alias.status_code == 200
     assert resp_alias.headers["content-type"] == "application/octet-stream"
@@ -62,6 +62,40 @@ def test_cli_agnes_whl_alias_serves_same_bytes_as_download(monkeypatch, tmp_path
     resp_download = client.get("/cli/download")
     assert resp_download.status_code == 200
     assert resp_alias.content == resp_download.content
+
+
+def test_cli_agnes_whl_alias_redirects_to_pep427_filename(monkeypatch, tmp_path):
+    """`uv tool install` looks at the URL path, not Content-Disposition, and
+    rejects a bare `agnes.whl` with `Must have a version`. The alias must 302
+    to a path that contains the real versioned filename so `uv` accepts it."""
+    wheel = tmp_path / "agnes_fake-1.0-py3-none-any.whl"
+    wheel.write_bytes(b"PK\x03\x04")
+    monkeypatch.setenv("AGNES_CLI_DIST_DIR", str(tmp_path))
+    from fastapi.testclient import TestClient
+    from app.main import app
+    client = TestClient(app)
+
+    resp = client.get("/cli/agnes.whl", follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"].endswith("/cli/wheel/agnes_fake-1.0-py3-none-any.whl")
+
+
+def test_cli_wheel_versioned_only_serves_current_wheel(monkeypatch, tmp_path):
+    """Versioned endpoint must not be usable to request arbitrary filenames —
+    it only serves whatever `_find_wheel()` currently returns."""
+    wheel = tmp_path / "agnes_fake-1.0-py3-none-any.whl"
+    wheel.write_bytes(b"PK\x03\x04")
+    monkeypatch.setenv("AGNES_CLI_DIST_DIR", str(tmp_path))
+    from fastapi.testclient import TestClient
+    from app.main import app
+    client = TestClient(app)
+
+    resp_ok = client.get("/cli/wheel/agnes_fake-1.0-py3-none-any.whl")
+    assert resp_ok.status_code == 200
+    assert resp_ok.content == wheel.read_bytes()
+
+    resp_wrong = client.get("/cli/wheel/other-2.0-py3-none-any.whl")
+    assert resp_wrong.status_code == 404
 
 
 def test_cli_agnes_whl_alias_404_when_no_wheel(monkeypatch, tmp_path):

--- a/tests/test_setup_instructions.py
+++ b/tests/test_setup_instructions.py
@@ -1,0 +1,56 @@
+"""Tests for the setup-instructions template + resolver.
+
+`uv tool install` validates the PEP 427 filename in the URL path before
+fetching, so our setup snippet cannot use a stable alias like `agnes.whl`.
+These tests pin the wheel-filename substitution behavior.
+"""
+
+
+def test_resolve_lines_substitutes_wheel_filename():
+    from app.web.setup_instructions import resolve_lines
+
+    lines = resolve_lines("agnes_the_ai_analyst-2.0.0-py3-none-any.whl")
+    joined = "\n".join(lines)
+    assert "{wheel_filename}" not in joined
+    assert "/cli/wheel/agnes_the_ai_analyst-2.0.0-py3-none-any.whl" in joined
+
+
+def test_resolve_lines_fallback_filename_is_honoured():
+    """Callers pass `'agnes.whl'` when no wheel is on disk; substitution still works."""
+    from app.web.setup_instructions import resolve_lines
+
+    lines = resolve_lines("agnes.whl")
+    assert "{wheel_filename}" not in "\n".join(lines)
+    assert any("/cli/wheel/agnes.whl" in line for line in lines)
+
+
+def test_render_setup_instructions_wires_all_placeholders():
+    from app.web.setup_instructions import render_setup_instructions
+
+    out = render_setup_instructions(
+        server_url="https://agnes.example.com",
+        token="T-123",
+        wheel_filename="agnes_the_ai_analyst-2.0.0-py3-none-any.whl",
+    )
+    assert "{server_url}" not in out
+    assert "{token}" not in out
+    assert "{wheel_filename}" not in out
+    assert "https://agnes.example.com/cli/wheel/agnes_the_ai_analyst-2.0.0-py3-none-any.whl" in out
+    assert "T-123" in out
+
+
+def test_install_page_uses_versioned_wheel_url(monkeypatch, tmp_path):
+    """End-to-end: the /install preview must render the PEP 427 wheel URL,
+    so a user copy-pasting the snippet gets a URL `uv tool install` accepts."""
+    wheel = tmp_path / "agnes_the_ai_analyst-2.0.0-py3-none-any.whl"
+    wheel.write_bytes(b"PK\x03\x04")
+    monkeypatch.setenv("AGNES_CLI_DIST_DIR", str(tmp_path))
+
+    from fastapi.testclient import TestClient
+    from app.main import app
+    client = TestClient(app)
+    resp = client.get("/install", headers={"host": "agnes.test", "Accept": "text/html"})
+    assert resp.status_code == 200
+    assert "/cli/wheel/agnes_the_ai_analyst-2.0.0-py3-none-any.whl" in resp.text
+    # The bare alias must no longer appear in the rendered snippet.
+    assert "/cli/agnes.whl" not in resp.text

--- a/tests/test_web_ui.py
+++ b/tests/test_web_ui.py
@@ -160,8 +160,11 @@ class TestClaudeSetupPreview:
         assert "What Claude Code will receive" in body
         assert "&lt;will be generated on click&gt;" in body
         assert 'class="placeholder-token"' in body
-        # Setup payload text substituted with real server URL
-        assert "/cli/agnes.whl" in body
+        # Setup payload text substituted with real server URL. The wheel URL
+        # must be under /cli/wheel/ (uv tool install rejects a bare .whl alias
+        # because it validates the PEP 427 filename in the URL before fetch).
+        assert "/cli/wheel/" in body
+        assert "/cli/agnes.whl" not in body
         # New numbered headers + da diagnose step
         assert "1) Install the CLI" in body
         assert "4) Run diagnostics" in body


### PR DESCRIPTION
## Problem

From a fresh machine, the copy-pasted setup snippet failed at step 1:

\`\`\`
$ uv tool install --force http://34.77.94.14:8000/cli/agnes.whl
error: The wheel filename "agnes.whl" is invalid: Must have a version
\`\`\`

\`uv tool install\` parses the filename from the URL path and validates PEP 427 (name + version + python/abi/platform tags) **before** fetching. The server-side \`Content-Disposition\` header is never consulted at that stage. An HTTP redirect also does not rescue us — uv resolves the filename from the *initial* URL.

## Fix (two commits)

### 1. Inline the PEP 427 wheel filename into the setup snippet (\`cb42f79\`)

- **New endpoint:** \`GET /cli/wheel/{wheel_name}\` — serves the current wheel at a PEP 427 path. Only the exact filename currently on disk is honoured; any other \`wheel_name\` returns 404 (no filesystem lookup from user input).
- **Setup snippet:** template placeholder \`{wheel_filename}\` is substituted server-side in \`setup_instructions.resolve_lines()\` using \`_find_wheel()\` from \`app/api/cli_artifacts.py\`. Both the HTML preview (\`/install\`, \`/dashboard\`) and the JS clipboard renderer consume the same pre-substituted list, so both modes stay byte-identical for a given \`(server_url, token, wheel_filename)\`.

### 2. Drop the \`/cli/agnes.whl\` alias entirely (\`8bcae53\`)

The original plan left the bareword alias in place as a 302 redirect. That does not actually help \`uv tool install\` (uv validates before following redirects) and it makes the URL *visibly work* in browser / \`curl -L\` — which is exactly how the original bug was reported ("the URL loads, why doesn't install work?"). Remove it.

The only CLI wheel URL is now \`/cli/wheel/{filename}\` with the real PEP 427 filename.

## Verified locally

- \`uv tool install http://localhost:8000/cli/wheel/agnes_the_ai_analyst-2.0.0-py3-none-any.whl\` → succeeds, installs \`da\`
- \`curl http://localhost:8000/install\` → snippet contains the versioned URL, \`/cli/agnes.whl\` no longer appears
- \`GET /cli/agnes.whl\` → 404 (no longer routed)

## Tests

- \`tests/test_setup_instructions.py\` (new) — pins wheel-filename substitution, fallback behavior, and E2E that the \`/install\` page renders the PEP 427 URL
- \`tests/test_cli_artifacts.py\` — tests the versioned endpoint and that the old alias is gone
- \`tests/test_web_ui.py\` — flipped the install-preview assertion from \`"/cli/agnes.whl" in body\` to \`"/cli/wheel/" in body\` + \`"/cli/agnes.whl" not in body\`

## Rollout

On first deploy the wheel must be in \`AGNES_CLI_DIST_DIR\` (default \`/app/dist\`). If \`_find_wheel()\` returns \`None\` the snippet falls back to \`/cli/wheel/agnes.whl\` — which 404s at download time, giving the operator clear signal that the wheel is missing on the server.