### PR TITLE
feat(cli): --version flag; sync --dry-run + progress indicator

### DIFF
--- a/cli/commands/sync.py
+++ b/cli/commands/sync.py
@@ -5,7 +5,14 @@ import os
 from pathlib import Path
 
 import typer
-from rich.progress import Progress, SpinnerColumn, TextColumn
+from rich.progress import (
+    BarColumn,
+    Progress,
+    SpinnerColumn,
+    TaskProgressColumn,
+    TextColumn,
+    TimeElapsedColumn,
+)
 
 from cli.client import api_get, api_post, stream_download
 from cli.config import get_sync_state, save_sync_state
@@ -23,14 +30,25 @@ def sync(
     upload_only: bool = typer.Option(False, "--upload-only", help="Only upload sessions/artifacts"),
     docs_only: bool = typer.Option(False, "--docs-only", help="Only sync documentation"),
     as_json: bool = typer.Option(False, "--json", help="Output as JSON"),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Show what would be synced without downloading, uploading, or writing local state.",
+    ),
 ):
     """Sync data between server and local machine."""
     if upload_only:
-        _upload(as_json)
+        _upload(as_json, dry_run=dry_run)
         return
 
-    with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}")) as progress:
-        # 1. Get manifest
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        TaskProgressColumn(),
+        TimeElapsedColumn(),
+    ) as progress:
+        # 1. Get manifest — indeterminate spinner (total unknown until manifest lands)
         task = progress.add_task("Fetching manifest...", total=None)
         try:
             resp = api_get("/api/sync/manifest")
@@ -57,16 +75,29 @@ def sync(
             if server_hash != local_hash or tid not in local_tables or not server_hash:
                 to_download.append(tid)
 
-        progress.update(task, description=f"Found {len(to_download)} tables to sync")
+        # Switch the bar from indeterminate to "X/N" progress once we know the total.
+        progress.update(
+            task,
+            description=f"Found {len(to_download)} tables to sync",
+            total=len(to_download) or None,
+            completed=0,
+        )
 
-        # 3. Download parquets
+        # 3. Dry-run short-circuit — report what would happen, touch nothing on disk.
+        if dry_run:
+            progress.update(task, description="Dry run — nothing will be downloaded")
+            _print_dry_run_plan(to_download, server_tables, len(server_tables), as_json)
+            return
+
+        # 4. Download parquets
         local_dir = _local_data_dir()
         parquet_dir = local_dir / "server" / "parquet"
         parquet_dir.mkdir(parents=True, exist_ok=True)
 
         results = {"downloaded": [], "skipped": [], "errors": []}
-        for tid in to_download:
-            progress.update(task, description=f"Downloading {tid}...")
+        total = len(to_download)
+        for idx, tid in enumerate(to_download, start=1):
+            progress.update(task, description=f"[{idx}/{total}] Downloading {tid}...")
             target = parquet_dir / f"{tid}.parquet"
             try:
                 stream_download(f"/api/data/{tid}/download", str(target))
@@ -78,14 +109,15 @@ def sync(
                 results["downloaded"].append(tid)
             except Exception as e:
                 results["errors"].append({"table": tid, "error": str(e)})
+            progress.advance(task, 1)
 
-        # 4. Save local state
+        # 5. Save local state
         from datetime import datetime, timezone
         local_state["tables"] = local_tables
         local_state["last_sync"] = datetime.now(timezone.utc).isoformat()
         save_sync_state(local_state)
 
-        # 5. Rebuild DuckDB views
+        # 6. Rebuild DuckDB views
         if results["downloaded"]:
             progress.update(task, description="Rebuilding DuckDB views...")
             _rebuild_duckdb_views(local_dir, parquet_dir)
@@ -103,6 +135,58 @@ def sync(
             typer.echo(f"Errors: {len(results['errors'])}")
             for err in results["errors"]:
                 typer.echo(f"  {err['table']}: {err['error']}")
+
+
+def _print_dry_run_plan(
+    to_download: list[str],
+    server_tables: dict,
+    total_tables: int,
+    as_json: bool,
+) -> None:
+    """Render the dry-run plan for the download flow (no disk writes).
+
+    Pairs table IDs with their manifest `size_bytes` / `rows` so the operator
+    can judge cost before committing to the real sync.
+    """
+    total_bytes = sum(server_tables.get(tid, {}).get("size_bytes", 0) or 0 for tid in to_download)
+    plan = [
+        {
+            "table": tid,
+            "rows": server_tables.get(tid, {}).get("rows", 0) or 0,
+            "size_bytes": server_tables.get(tid, {}).get("size_bytes", 0) or 0,
+        }
+        for tid in to_download
+    ]
+    if as_json:
+        typer.echo(json.dumps(
+            {
+                "dry_run": True,
+                "would_download": plan,
+                "summary": {
+                    "tables_total": total_tables,
+                    "tables_to_download": len(to_download),
+                    "tables_skipped_unchanged": total_tables - len(to_download),
+                    "bytes_total": total_bytes,
+                },
+            },
+            indent=2,
+        ))
+        return
+
+    typer.echo(f"Dry run — would download {len(to_download)} tables ({_fmt_bytes(total_bytes)})")
+    typer.echo(f"Skipped (unchanged): {total_tables - len(to_download)}")
+    for row in plan:
+        typer.echo(f"  {row['table']}  rows={row['rows']}  size={_fmt_bytes(row['size_bytes'])}")
+
+
+def _fmt_bytes(n: int) -> str:
+    if n < 1024:
+        return f"{n} B"
+    for unit in ("KiB", "MiB", "GiB", "TiB"):
+        n /= 1024
+        if n < 1024:
+            return f"{n:.1f} {unit}"
+    return f"{n:.1f} PiB"
 
 
 def _rebuild_duckdb_views(local_dir: Path, parquet_dir: Path):
@@ -143,13 +227,44 @@ def _rebuild_duckdb_views(local_dir: Path, parquet_dir: Path):
     conn.close()
 
 
-def _upload(as_json: bool):
-    """Upload sessions and CLAUDE.local.md to server."""
+def _upload(as_json: bool, dry_run: bool = False):
+    """Upload sessions and CLAUDE.local.md to server.
+
+    When `dry_run=True`, enumerate what would be uploaded without hitting the
+    API or mutating anything on disk.
+    """
     local_dir = _local_data_dir()
+    sessions_dir = local_dir / "user" / "sessions"
+    local_md = local_dir / ".claude" / "CLAUDE.local.md"
+
+    if dry_run:
+        session_files = sorted(str(f) for f in sessions_dir.glob("*.jsonl")) if sessions_dir.exists() else []
+        plan = {
+            "dry_run": True,
+            "would_upload": {
+                "sessions": session_files,
+                "local_md": str(local_md) if local_md.exists() else None,
+            },
+            "summary": {
+                "sessions_count": len(session_files),
+                "local_md_present": local_md.exists(),
+            },
+        }
+        if as_json:
+            typer.echo(json.dumps(plan, indent=2))
+            return
+        typer.echo(f"Dry run — would upload {len(session_files)} session file(s)")
+        for f in session_files:
+            typer.echo(f"  {f}")
+        if local_md.exists():
+            typer.echo(f"Would upload CLAUDE.local.md  ({local_md})")
+        else:
+            typer.echo("No CLAUDE.local.md to upload")
+        return
+
     results = {"sessions": 0, "local_md": False}
 
     # Upload sessions
-    sessions_dir = local_dir / "user" / "sessions"
     if sessions_dir.exists():
         for f in sessions_dir.glob("*.jsonl"):
             try:
@@ -161,7 +276,6 @@ def _upload(as_json: bool):
                 pass
 
     # Upload CLAUDE.local.md
-    local_md = local_dir / ".claude" / "CLAUDE.local.md"
     if local_md.exists():
         content = local_md.read_text(encoding="utf-8")
         try:

--- a/cli/main.py
+++ b/cli/main.py
@@ -3,6 +3,9 @@
 Primary interface for AI agents. Install: uv tool install data-analyst
 """
 
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
 import typer
 
 from cli.commands.auth import auth_app
@@ -18,11 +21,51 @@ from cli.commands.explore import explore_app
 from cli.commands.metrics import metrics_app
 from cli.commands.analyst import analyst_app
 
+
+def _cli_version() -> str:
+    """Return the installed CLI version from package metadata.
+
+    Falls back to `"unknown"` when the package is not installed (e.g. running
+    from a source checkout without `uv pip install -e .`). Deliberately does
+    not read pyproject.toml at runtime — that file is not shipped with the
+    wheel and the metadata lookup is the canonical source.
+    """
+    try:
+        return _pkg_version("agnes-the-ai-analyst")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        typer.echo(f"da {_cli_version()}")
+        raise typer.Exit()
+
+
 app = typer.Typer(
     name="da",
     help="AI Data Analyst CLI — data sync, queries, and admin for AI agents",
     no_args_is_help=True,
 )
+
+
+@app.callback()
+def _root(
+    version: bool = typer.Option(
+        None,
+        "--version",
+        "-V",
+        callback=_version_callback,
+        is_eager=True,
+        help="Show the CLI version and exit.",
+    ),
+) -> None:
+    """Root callback — carries the --version option.
+
+    Typer requires a callback for top-level options. The body is intentionally
+    empty; the heavy lifting happens in `_version_callback` (eager, so it
+    runs before any subcommand resolution).
+    """
 
 # Register subcommands
 app.add_typer(auth_app, name="auth")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,6 +59,26 @@ class TestCLIHelp:
         assert result.exit_code == 0
 
 
+class TestCLIVersion:
+    def test_version_long_flag(self):
+        result = runner.invoke(app, ["--version"])
+        assert result.exit_code == 0
+        assert result.output.startswith("da ")
+        # Version string must be non-empty after the `da ` prefix.
+        assert result.output.strip() != "da"
+
+    def test_version_short_flag(self):
+        result = runner.invoke(app, ["-V"])
+        assert result.exit_code == 0
+        assert result.output.startswith("da ")
+
+    def test_version_exits_before_subcommand_resolution(self):
+        """Eager callback must run even when an unknown subcommand follows."""
+        result = runner.invoke(app, ["--version", "bogus-subcommand"])
+        assert result.exit_code == 0
+        assert "da " in result.output
+
+
 class TestSkills:
     def test_list_skills(self):
         result = runner.invoke(app, ["skills", "list"])

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -114,3 +114,56 @@ class TestSyncErrors:
         # Nothing to download — both hashes match
         assert mock_dl.call_count == 0
         assert "Downloaded: 0" in result.output
+
+
+class TestSyncDryRun:
+    def test_dry_run_skips_download_and_state_writes(self, tmp_config):
+        """--dry-run must not call stream_download, save_sync_state, or _rebuild_duckdb_views."""
+        with patch("cli.commands.sync.api_get", return_value=_resp(200, MANIFEST)):
+            with patch("cli.commands.sync.stream_download") as mock_dl:
+                with patch("cli.commands.sync.save_sync_state") as mock_save:
+                    with patch("cli.commands.sync._rebuild_duckdb_views") as mock_rebuild:
+                        result = runner.invoke(app, ["sync", "--dry-run"])
+        assert result.exit_code == 0
+        assert mock_dl.call_count == 0
+        assert mock_save.call_count == 0
+        assert mock_rebuild.call_count == 0
+        assert "Dry run" in result.output
+        # Table ids from the MANIFEST fixture must show up in the plan.
+        assert "orders" in result.output
+        assert "customers" in result.output
+
+    def test_dry_run_json_output_shape(self, tmp_config):
+        """--dry-run --json emits a parseable plan with dry_run=True and a summary."""
+        with patch("cli.commands.sync.api_get", return_value=_resp(200, MANIFEST)):
+            with patch("cli.commands.sync.stream_download"):
+                result = runner.invoke(app, ["sync", "--dry-run", "--json"])
+        assert result.exit_code == 0
+        json_start = result.output.find("{")
+        assert json_start >= 0
+        # Rich Progress may emit additional lines after the JSON block, so use
+        # raw_decode to stop at the object boundary.
+        data, _ = json.JSONDecoder().raw_decode(result.output[json_start:])
+        assert data["dry_run"] is True
+        assert data["summary"]["tables_to_download"] == 2
+        assert data["summary"]["bytes_total"] == 2048 + 1024
+        tables = [row["table"] for row in data["would_download"]]
+        assert set(tables) == {"orders", "customers"}
+
+    def test_dry_run_respects_table_filter(self, tmp_config):
+        """--dry-run --table X only lists that one table in the plan."""
+        with patch("cli.commands.sync.api_get", return_value=_resp(200, MANIFEST)):
+            with patch("cli.commands.sync.stream_download") as mock_dl:
+                result = runner.invoke(app, ["sync", "--dry-run", "--table", "orders"])
+        assert result.exit_code == 0
+        assert mock_dl.call_count == 0
+        assert "orders" in result.output
+        assert "customers" not in result.output
+
+    def test_dry_run_upload_only_does_not_hit_api(self, tmp_config):
+        """--upload-only --dry-run must not call api_post."""
+        with patch("cli.commands.sync.api_post") as mock_post:
+            result = runner.invoke(app, ["sync", "--upload-only", "--dry-run"])
+        assert result.exit_code == 0
+        assert mock_post.call_count == 0
+        assert "Dry run" in result.output or "would upload" in result.output.lower()


### PR DESCRIPTION
Two small CLI upgrades that share the same deployment flow.

## 1. \`da --version\` / \`-V\`

Prints the installed CLI version from \`importlib.metadata\`:

\`\`\`
$ da --version
da 2.0.0
\`\`\`

Eager typer callback, exits before subcommand resolution so it needs no config/auth. Falls back to \`unknown\` when the package is not installed (source checkout without \`uv pip install -e .\`) instead of crashing.

## 2. \`da sync --dry-run\`

Reports what would be downloaded/uploaded without hitting the API or writing local state:

\`\`\`
$ da sync --dry-run
Dry run — would download 3 tables (4.2 MiB)
Skipped (unchanged): 12
  orders  rows=100  size=2.0 KiB
  customers  rows=50  size=1.0 KiB
  ...
\`\`\`

- Respects \`--table\`, \`--docs-only\`, \`--upload-only\`, \`--json\`
- JSON shape: \`{"dry_run": true, "would_download": [...], "summary": {...}}\`
- \`--upload-only --dry-run\` enumerates session files + CLAUDE.local.md without calling \`api_post\`
- Skips \`stream_download\`, \`save_sync_state\`, and \`_rebuild_duckdb_views\` — tests pin those \`call_count == 0\`

## 3. \`da sync\` progress indicator

Replaces the bare spinner with \`SpinnerColumn + TextColumn + BarColumn + TaskProgressColumn + TimeElapsedColumn\`. Description becomes \`[X/N] Downloading <table>...\` so you can see how far a long sync is.

## Base branch

Targeting \`ps/wheel-name-fix\` to stay in the existing testing-instance deployment flow (same as #36).

## Tests

- \`tests/test_cli.py::TestCLIVersion\` — long/short flag, eager-before-subcommand
- \`tests/test_cli_sync.py::TestSyncDryRun\` — no-op asserts on \`stream_download\` / \`save_sync_state\` / \`_rebuild_duckdb_views\`, JSON shape, \`--table\` filter, \`--upload-only --dry-run\`