### PR TITLE
fix(sync): validate parquet magic bytes + skip broken files on rebuild

### DIFF
--- a/cli/commands/sync.py
+++ b/cli/commands/sync.py
@@ -101,6 +101,15 @@ def sync(
             target = parquet_dir / f"{tid}.parquet"
             try:
                 stream_download(f"/api/data/{tid}/download", str(target))
+                # HTTP 200 is not enough — the server can (and has) returned
+                # a truncated / empty body with a clean status code. Validate
+                # PAR1 magic bytes so we don't commit state for a broken file.
+                if not _is_valid_parquet(target):
+                    target.unlink(missing_ok=True)
+                    raise ValueError(
+                        "downloaded file is not a valid parquet (missing PAR1 magic bytes) — "
+                        "the server-side snapshot may be corrupt or the stream was truncated"
+                    )
                 local_tables[tid] = {
                     "hash": server_tables[tid].get("hash", ""),
                     "rows": server_tables[tid].get("rows", 0),
@@ -216,15 +225,52 @@ def _rebuild_duckdb_views(local_dir: Path, parquet_dir: Path):
     except Exception:
         pass
 
-    # Create views for each parquet file
+    # Create views for each parquet file. One broken file (corrupt download,
+    # leftover partial write from a previous sync) must not abort the whole
+    # rebuild — skip it and keep going so the rest of the catalog still works.
+    skipped_broken: list[str] = []
     for pq_file in parquet_dir.rglob("*.parquet"):
         view_name = pq_file.stem
         if view_name in existing_tables:
             continue  # don't shadow user tables
+        if not _is_valid_parquet(pq_file):
+            skipped_broken.append(view_name)
+            continue
         abs_path = str(pq_file.resolve())
-        conn.execute(f"CREATE VIEW \"{view_name}\" AS SELECT * FROM read_parquet('{abs_path}')")
+        try:
+            conn.execute(f"CREATE VIEW \"{view_name}\" AS SELECT * FROM read_parquet('{abs_path}')")
+        except duckdb.Error:
+            skipped_broken.append(view_name)
 
     conn.close()
+
+    if skipped_broken:
+        typer.echo(
+            f"Warning: skipped {len(skipped_broken)} broken parquet file(s) during view rebuild:",
+            err=True,
+        )
+        for name in skipped_broken:
+            typer.echo(f"  - {name}.parquet", err=True)
+
+
+def _is_valid_parquet(path: Path) -> bool:
+    """Cheap structural check — parquet files begin and end with `PAR1`.
+
+    Catches truncated downloads, 0-byte files, and HTML / JSON error bodies
+    that slipped through with HTTP 200. Does not guarantee the footer is
+    well-formed — that's DuckDB's job at CREATE VIEW time.
+    """
+    try:
+        size = path.stat().st_size
+        if size < 8:
+            return False
+        with open(path, "rb") as f:
+            head = f.read(4)
+            f.seek(-4, 2)
+            tail = f.read(4)
+        return head == b"PAR1" and tail == b"PAR1"
+    except OSError:
+        return False
 
 
 def _upload(as_json: bool, dry_run: bool = False):

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -35,11 +35,23 @@ MANIFEST = {
 }
 
 
+# Minimal byte-sequence that passes the PAR1 magic-byte check in cli.commands.sync.
+# Enough for tests to simulate a "well-formed" download without building a real parquet.
+_FAKE_PARQUET_BYTES = b"PAR1" + b"\x00" * 32 + b"PAR1"
+
+
+def _fake_stream_download(path, target, *args, **kwargs):
+    """Drop-in replacement for cli.commands.sync.stream_download that writes
+    a minimally valid parquet shell (PAR1 head + PAR1 tail) to the target."""
+    with open(target, "wb") as f:
+        f.write(_FAKE_PARQUET_BYTES)
+
+
 class TestSyncHappyPath:
     def test_sync_downloads_all_tables(self, tmp_config):
         """Sync with no local state downloads all tables."""
         with patch("cli.commands.sync.api_get", return_value=_resp(200, MANIFEST)):
-            with patch("cli.commands.sync.stream_download") as mock_dl:
+            with patch("cli.commands.sync.stream_download", side_effect=_fake_stream_download) as mock_dl:
                 with patch("cli.commands.sync._rebuild_duckdb_views"):
                     result = runner.invoke(app, ["sync"])
         assert result.exit_code == 0
@@ -49,7 +61,7 @@ class TestSyncHappyPath:
     def test_sync_specific_table(self, tmp_config):
         """--table flag limits download to one table."""
         with patch("cli.commands.sync.api_get", return_value=_resp(200, MANIFEST)):
-            with patch("cli.commands.sync.stream_download") as mock_dl:
+            with patch("cli.commands.sync.stream_download", side_effect=_fake_stream_download) as mock_dl:
                 with patch("cli.commands.sync._rebuild_duckdb_views"):
                     result = runner.invoke(app, ["sync", "--table", "orders"])
         assert result.exit_code == 0
@@ -60,7 +72,7 @@ class TestSyncHappyPath:
     def test_sync_json_output(self, tmp_config):
         """--json flag produces valid JSON output (rich spinner may precede JSON)."""
         with patch("cli.commands.sync.api_get", return_value=_resp(200, MANIFEST)):
-            with patch("cli.commands.sync.stream_download"):
+            with patch("cli.commands.sync.stream_download", side_effect=_fake_stream_download):
                 with patch("cli.commands.sync._rebuild_duckdb_views"):
                     result = runner.invoke(app, ["sync", "--json"])
         assert result.exit_code == 0
@@ -114,6 +126,63 @@ class TestSyncErrors:
         # Nothing to download — both hashes match
         assert mock_dl.call_count == 0
         assert "Downloaded: 0" in result.output
+
+
+class TestSyncParquetValidation:
+    """Two defensive hooks around the parquet pipeline:
+
+    1) After download, the file must have PAR1 magic bytes. A truncated /
+       empty body with HTTP 200 would otherwise be saved, committed into
+       sync_state, and then crash _rebuild_duckdb_views.
+    2) _rebuild_duckdb_views must skip individual broken parquets instead
+       of aborting the entire rebuild.
+    """
+
+    def _write(self, tmp_config, tid: str, body: bytes) -> None:
+        (tmp_config / "local" / "server" / "parquet").mkdir(parents=True, exist_ok=True)
+        (tmp_config / "local" / "server" / "parquet" / f"{tid}.parquet").write_bytes(body)
+
+    def test_download_producing_non_parquet_is_recorded_as_error(self, tmp_config):
+        """HTTP 200 with a truncated / HTML body must not commit state."""
+        def fake_stream(path, target, *a, **kw):
+            # Simulate a server that returned a 404 HTML page with 200 status
+            # (or a Caddy gateway error, or a truncated body).
+            with open(target, "wb") as f:
+                f.write(b"<html>oops</html>")
+
+        with patch("cli.commands.sync.api_get", return_value=_resp(200, MANIFEST)):
+            with patch("cli.commands.sync.stream_download", side_effect=fake_stream):
+                with patch("cli.commands.sync._rebuild_duckdb_views") as mock_rebuild:
+                    result = runner.invoke(app, ["sync"])
+
+        assert result.exit_code == 0
+        assert "Downloaded: 0" in result.output
+        assert "Errors: 2" in result.output
+        assert "PAR1" in result.output  # error message mentions the magic-byte reason
+        assert mock_rebuild.call_count == 0
+
+    def test_rebuild_skips_broken_parquet_without_aborting(self, tmp_config):
+        """Pre-existing broken parquet must not kill the whole rebuild."""
+        self._write(tmp_config, "broken", b"not-parquet-at-all")
+        self._write(tmp_config, "also_bad", b"PAR1" + b"\x00" * 10 + b"PAR1")
+
+        from cli.commands.sync import _rebuild_duckdb_views
+        local_dir = tmp_config / "local"
+        parquet_dir = local_dir / "server" / "parquet"
+        # Must not raise — both files are garbage but the function recovers.
+        _rebuild_duckdb_views(local_dir, parquet_dir)
+
+    def test_valid_parquet_magic_bytes_helper(self, tmp_config):
+        from cli.commands.sync import _is_valid_parquet
+        p = tmp_config / "x.parquet"
+        p.write_bytes(b"")
+        assert _is_valid_parquet(p) is False
+        p.write_bytes(b"PAR1")
+        assert _is_valid_parquet(p) is False  # too short
+        p.write_bytes(b"PAR1" + b"\x00" * 10 + b"PAR1")
+        assert _is_valid_parquet(p) is True
+        p.write_bytes(b"<html>err</html>")
+        assert _is_valid_parquet(p) is False
 
 
 class TestSyncDryRun:


### PR DESCRIPTION
## Problem

\`da sync\` crashed during view rebuild:

\`\`\`
InvalidInputException: No magic bytes found at end of file
'/…/server/parquet/activity_contact_20260227134402.parquet'
\`\`\`

Root cause: the download succeeded at the HTTP layer (status 200) but the body was either truncated, empty, or an HTML / JSON error page that slipped through with a clean status code. \`_rebuild_duckdb_views\` then ran \`CREATE VIEW\` over it without any guard, and **a single bad file aborted the entire rebuild**, so even the valid parquets were not registered.

## Fix — two defensive hooks

1. **After download, validate PAR1 magic bytes** (head + tail). On failure, delete the file, skip writing to \`sync_state\`, record an error. The \`Errors: N\` summary now surfaces the real reason.
2. **\`_rebuild_duckdb_views\` is tolerant.** Pre-check PAR1 and wrap \`CREATE VIEW\` in try/except — one bad parquet is skipped with a stderr warning instead of taking down the whole rebuild. Leftover broken files from a previous failed sync no longer block subsequent syncs.

## Tests

- \`TestSyncParquetValidation\` — 3 new cases:
  - HTML body with HTTP 200 → recorded as error, no state commit, rebuild not called
  - Broken parquets on disk do not abort rebuild
  - \`_is_valid_parquet\` helper covers empty, too-short, HTML, valid
- Existing \`TestSyncHappyPath\` tests updated — their stream-download mock now writes a PAR1 shell so they stay green

## Base

Targeting \`ps/wheel-name-fix\` to keep the testing-instance deployment flow intact.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/40" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
