### PR TITLE
feat(cli): durable sync + server gzip + auto-update check

### DIFF
--- a/app/api/cli_artifacts.py
+++ b/app/api/cli_artifacts.py
@@ -39,6 +39,29 @@ def _find_wheel() -> Path | None:
     return wheels[-1] if wheels else None
 
 
+@router.get("/cli/latest")
+async def cli_latest():
+    """Metadata for the currently-shipped CLI wheel.
+
+    Consumed by `da` CLI's auto-update check so it can warn when a newer
+    version is on the server. Public + cacheable — no secrets here.
+    Returns `version=None` when the server has no wheel yet (dev image that
+    didn't run `uv build`).
+    """
+    wheel = _find_wheel()
+    if not wheel:
+        return {"version": None, "wheel_filename": None, "download_url_path": None}
+    # PEP 427 wheel filename: {name}-{version}(-{build})?-{py}-{abi}-{plat}.whl
+    # The version is the second `-`-separated token.
+    parts = wheel.stem.split("-")
+    version = parts[1] if len(parts) >= 2 else None
+    return {
+        "version": version,
+        "wheel_filename": wheel.name,
+        "download_url_path": f"/cli/wheel/{wheel.name}",
+    }
+
+
 @router.get("/cli/download")
 async def cli_download():
     wheel = _find_wheel()

--- a/app/main.py
+++ b/app/main.py
@@ -14,6 +14,31 @@ from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.gzip import GZipMiddleware
 from starlette.middleware.sessions import SessionMiddleware
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+class _SelectiveGZipMiddleware:
+    """GZipMiddleware wrapper that skips a set of path prefixes.
+
+    Parquet-serving endpoints send responses that are already columnar-
+    compressed (parquet's internal codec) and — for /api/data — can reach
+    hundreds of MB. Gzipping them on the way out costs CPU and latency with
+    no meaningful size reduction. Skip those paths; every other endpoint
+    (JSON manifests, HTML previews, install.sh) still gets compressed.
+    """
+
+    def __init__(self, app: ASGIApp, minimum_size: int = 1024, skip_prefixes: tuple[str, ...] = ()) -> None:
+        self._raw = app
+        self._gzip = GZipMiddleware(app, minimum_size=minimum_size)
+        self._skip_prefixes = skip_prefixes
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope.get("type") == "http":
+            path = scope.get("path", "")
+            if any(path.startswith(p) for p in self._skip_prefixes):
+                await self._raw(scope, receive, send)
+                return
+        await self._gzip(scope, receive, send)
 
 from app.auth.router import router as auth_router
 from app.api.health import router as health_router
@@ -56,11 +81,15 @@ def create_app() -> FastAPI:
         lifespan=lifespan,
     )
 
-    # Compress JSON / HTML responses on the wire. Parquet FileResponse bodies
-    # are already columnar-compressed so gzip gives little there, but manifest
-    # endpoints, /install HTML, and other JSON routes benefit noticeably.
-    # minimum_size=1024 avoids CPU cost on tiny responses.
-    app.add_middleware(GZipMiddleware, minimum_size=1024)
+    # Compress JSON / HTML responses on the wire. Parquet downloads are
+    # excluded — they're already columnar-compressed and re-gzipping them
+    # just burns CPU with no size win. minimum_size=1024 keeps tiny
+    # responses uncompressed too (cheaper than the header overhead).
+    app.add_middleware(
+        _SelectiveGZipMiddleware,
+        minimum_size=1024,
+        skip_prefixes=("/api/data/", "/cli/wheel/", "/cli/download"),
+    )
 
     # Session middleware (required for OAuth state)
     from app.secrets import get_session_secret

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.middleware.gzip import GZipMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
 from app.auth.router import router as auth_router
@@ -54,6 +55,12 @@ def create_app() -> FastAPI:
         version="2.0.0",
         lifespan=lifespan,
     )
+
+    # Compress JSON / HTML responses on the wire. Parquet FileResponse bodies
+    # are already columnar-compressed so gzip gives little there, but manifest
+    # endpoints, /install HTML, and other JSON routes benefit noticeably.
+    # minimum_size=1024 avoids CPU cost on tiny responses.
+    app.add_middleware(GZipMiddleware, minimum_size=1024)
 
     # Session middleware (required for OAuth state)
     from app.secrets import get_session_secret

--- a/cli/client.py
+++ b/cli/client.py
@@ -1,10 +1,19 @@
 """HTTP client wrapper for CLI — handles auth, retries, streaming."""
 
+import os
+import time
+from pathlib import Path
 from typing import Optional
 
 import httpx
 
 from cli.config import get_server_url, get_token
+
+# Retry policy for transient failures during stream downloads. Scoped to
+# network issues and 5xx — 4xx (auth, 404, 400) is NOT retried. Tunable via
+# env for tests; defaults sit in the "one flaky network blip" window.
+_RETRY_ATTEMPTS = int(os.environ.get("DA_STREAM_RETRIES", "3"))
+_RETRY_BACKOFFS_S = (0.3, 1.0, 3.0)  # seconds before attempt 2, 3, 4
 
 
 def get_client(timeout: float = 30.0) -> httpx.Client:
@@ -40,16 +49,51 @@ def api_patch(path: str, **kwargs) -> httpx.Response:
         return client.patch(path, **kwargs)
 
 
+def _is_transient(exc: Exception) -> bool:
+    """Worth retrying? Network blip or 5xx — yes. Auth / 4xx — no."""
+    if isinstance(exc, (httpx.ConnectError, httpx.ReadError, httpx.WriteError,
+                        httpx.RemoteProtocolError, httpx.TimeoutException)):
+        return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        return 500 <= exc.response.status_code < 600
+    return False
+
+
 def stream_download(path: str, target_path: str, progress_callback=None) -> int:
-    """Stream download a file from the API. Returns bytes written."""
-    with get_client(timeout=300.0) as client:
-        with client.stream("GET", path) as response:
-            response.raise_for_status()
-            total = 0
-            with open(target_path, "wb") as f:
-                for chunk in response.iter_bytes(chunk_size=65536):
-                    f.write(chunk)
-                    total += len(chunk)
-                    if progress_callback:
-                        progress_callback(len(chunk))
+    """Stream a file to `target_path` atomically and with retries.
+
+    Durability properties:
+    - Writes to `target_path + ".tmp"`, then `os.replace` on success. The
+      real target file never exists in a half-written state.
+    - Retries up to `_RETRY_ATTEMPTS` times on transient errors (network
+      blip, 5xx); 4xx (auth/404) is raised immediately.
+    - No hash check here — that's done in the sync command against the
+      manifest hash, because only the caller knows the expected value.
+    """
+    tmp_path = Path(f"{target_path}.tmp")
+    last_exc: Optional[Exception] = None
+    for attempt in range(_RETRY_ATTEMPTS + 1):
+        try:
+            tmp_path.unlink(missing_ok=True)
+            with get_client(timeout=300.0) as client:
+                with client.stream("GET", path) as response:
+                    response.raise_for_status()
+                    total = 0
+                    with open(tmp_path, "wb") as f:
+                        for chunk in response.iter_bytes(chunk_size=65536):
+                            f.write(chunk)
+                            total += len(chunk)
+                            if progress_callback:
+                                progress_callback(len(chunk))
+            # os.replace is atomic on POSIX and Windows for same-filesystem moves.
+            os.replace(tmp_path, target_path)
             return total
+        except Exception as exc:
+            last_exc = exc
+            if attempt == _RETRY_ATTEMPTS or not _is_transient(exc):
+                break
+            time.sleep(_RETRY_BACKOFFS_S[min(attempt, len(_RETRY_BACKOFFS_S) - 1)])
+    # Clean up any leftover tmp, then surface the last exception.
+    tmp_path.unlink(missing_ok=True)
+    assert last_exc is not None
+    raise last_exc

--- a/cli/commands/sync.py
+++ b/cli/commands/sync.py
@@ -1,5 +1,6 @@
 """Sync commands — da sync."""
 
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -99,10 +100,27 @@ def sync(
         for idx, tid in enumerate(to_download, start=1):
             progress.update(task, description=f"[{idx}/{total}] Downloading {tid}...")
             target = parquet_dir / f"{tid}.parquet"
+            expected_hash = server_tables[tid].get("hash", "")
             try:
                 stream_download(f"/api/data/{tid}/download", str(target))
+                # Integrity check against the manifest hash (server uses MD5
+                # over the parquet — see app/api/sync.py:_file_hash). A
+                # structural PAR1 check is kept as a fallback for when the
+                # manifest hash is empty (legacy snapshots).
+                if expected_hash:
+                    actual_hash = _md5_file(target)
+                    if actual_hash != expected_hash:
+                        target.unlink(missing_ok=True)
+                        raise ValueError(
+                            f"hash mismatch: expected {expected_hash[:12]}…, got {actual_hash[:12]}…"
+                        )
+                elif not _is_valid_parquet(target):
+                    target.unlink(missing_ok=True)
+                    raise ValueError(
+                        "downloaded file is not a valid parquet (missing PAR1 magic bytes)"
+                    )
                 local_tables[tid] = {
-                    "hash": server_tables[tid].get("hash", ""),
+                    "hash": expected_hash,
                     "rows": server_tables[tid].get("rows", 0),
                     "size_bytes": server_tables[tid].get("size_bytes", 0),
                 }
@@ -216,15 +234,62 @@ def _rebuild_duckdb_views(local_dir: Path, parquet_dir: Path):
     except Exception:
         pass
 
-    # Create views for each parquet file
+    # Create views for each parquet file. One broken file (corrupt download,
+    # partial write left over from a previous sync, …) must not abort the
+    # whole rebuild — skip it with a warning and keep going.
+    skipped_broken: list[str] = []
     for pq_file in parquet_dir.rglob("*.parquet"):
         view_name = pq_file.stem
         if view_name in existing_tables:
             continue  # don't shadow user tables
+        if not _is_valid_parquet(pq_file):
+            skipped_broken.append(view_name)
+            continue
         abs_path = str(pq_file.resolve())
-        conn.execute(f"CREATE VIEW \"{view_name}\" AS SELECT * FROM read_parquet('{abs_path}')")
+        try:
+            conn.execute(f"CREATE VIEW \"{view_name}\" AS SELECT * FROM read_parquet('{abs_path}')")
+        except duckdb.Error:
+            skipped_broken.append(view_name)
 
     conn.close()
+
+    if skipped_broken:
+        typer.echo(
+            f"Warning: skipped {len(skipped_broken)} broken parquet file(s) during view rebuild:",
+            err=True,
+        )
+        for name in skipped_broken:
+            typer.echo(f"  - {name}.parquet", err=True)
+
+
+def _md5_file(path: Path) -> str:
+    """MD5 of a file, same chunking as app/api/sync.py:_file_hash so the
+    client-side verification matches the manifest hash byte-for-byte."""
+    h = hashlib.md5()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _is_valid_parquet(path: Path) -> bool:
+    """Cheap structural check — parquet files begin and end with `PAR1`.
+
+    Used as a fallback when the manifest has no hash (legacy snapshots) and
+    during view rebuild to skip obviously-broken files. Does not guarantee
+    the footer is well-formed — that's DuckDB's job at CREATE VIEW time.
+    """
+    try:
+        size = path.stat().st_size
+        if size < 8:
+            return False
+        with open(path, "rb") as f:
+            head = f.read(4)
+            f.seek(-4, 2)
+            tail = f.read(4)
+        return head == b"PAR1" and tail == b"PAR1"
+    except OSError:
+        return False
 
 
 def _upload(as_json: bool, dry_run: bool = False):

--- a/cli/main.py
+++ b/cli/main.py
@@ -60,12 +60,27 @@ def _root(
         help="Show the CLI version and exit.",
     ),
 ) -> None:
-    """Root callback — carries the --version option.
+    """Root callback — carries the --version option and fires the auto-update check.
 
-    Typer requires a callback for top-level options. The body is intentionally
-    empty; the heavy lifting happens in `_version_callback` (eager, so it
-    runs before any subcommand resolution).
+    Update check runs before subcommand dispatch but after the --version flag
+    (which exits early). It's best-effort: any failure is swallowed so a bad
+    network never blocks a working `da` command. Disable with
+    `DA_NO_UPDATE_CHECK=1`.
     """
+    _maybe_warn_outdated()
+
+
+def _maybe_warn_outdated() -> None:
+    """Hit /cli/latest on the configured server (cached 24h) and emit a
+    one-line stderr warning if the installed CLI is older. Never raises."""
+    try:
+        from cli.config import get_server_url
+        from cli.update_check import check, format_outdated_notice
+        info = check(get_server_url())
+        if info and info.is_outdated():
+            typer.echo(format_outdated_notice(info), err=True)
+    except Exception:
+        pass  # best-effort: never fail a command on the probe
 
 # Register subcommands
 app.add_typer(auth_app, name="auth")

--- a/cli/update_check.py
+++ b/cli/update_check.py
@@ -1,0 +1,138 @@
+"""Auto-check for a newer CLI version on the configured server.
+
+Runs in the root typer callback before subcommand dispatch. Failure is
+silent — we never block a working `da` command on a best-effort version
+probe. Result is cached in `$DA_CONFIG_DIR/update_check.json` for 24h so
+we don't hammer the server on every invocation.
+
+Disable with `DA_NO_UPDATE_CHECK=1`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from cli.config import _config_dir
+
+_CACHE_FILENAME = "update_check.json"
+_CACHE_TTL_SECONDS = 24 * 60 * 60  # 24h
+_REQUEST_TIMEOUT_SECONDS = 3.0  # keep startup snappy
+
+
+@dataclass(frozen=True)
+class UpdateInfo:
+    installed: str
+    latest: Optional[str]
+    download_url: Optional[str]
+
+    def is_outdated(self) -> bool:
+        if not self.latest or self.installed == "unknown":
+            return False
+        return self.latest != self.installed
+
+
+def is_disabled() -> bool:
+    return os.environ.get("DA_NO_UPDATE_CHECK", "").lower() in ("1", "true", "yes")
+
+
+def _installed_version() -> str:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _pkg_version
+    try:
+        return _pkg_version("agnes-the-ai-analyst")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def _cache_path() -> Path:
+    return _config_dir() / _CACHE_FILENAME
+
+
+def _read_cache() -> Optional[dict]:
+    p = _cache_path()
+    if not p.exists():
+        return None
+    try:
+        return json.loads(p.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _write_cache(entry: dict) -> None:
+    p = _cache_path()
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(entry))
+    except OSError:
+        pass  # best-effort — cache failure must not break the flow
+
+
+def _fetch_latest(server_url: str) -> Optional[dict]:
+    """Hit /cli/latest with a short timeout. Returns None on any failure."""
+    import httpx
+    try:
+        with httpx.Client(base_url=server_url, timeout=_REQUEST_TIMEOUT_SECONDS) as c:
+            resp = c.get("/cli/latest")
+            resp.raise_for_status()
+            return resp.json()
+    except Exception:
+        return None
+
+
+def check(server_url: Optional[str]) -> Optional[UpdateInfo]:
+    """Return UpdateInfo if a check ran (cached or fresh), else None.
+
+    Silent on every failure path: no server configured, CLI package not
+    installed, network down, malformed response, cache unreadable.
+    """
+    if is_disabled() or not server_url:
+        return None
+
+    installed = _installed_version()
+    if installed == "unknown":
+        return None  # can't compare without a known local version
+
+    cache = _read_cache()
+    now = time.time()
+    if (
+        cache
+        and cache.get("installed") == installed
+        and cache.get("server_url") == server_url
+        and isinstance(cache.get("checked_at"), (int, float))
+        and now - cache["checked_at"] < _CACHE_TTL_SECONDS
+    ):
+        return UpdateInfo(
+            installed=installed,
+            latest=cache.get("latest"),
+            download_url=cache.get("download_url"),
+        )
+
+    payload = _fetch_latest(server_url)
+    if not payload:
+        return None
+
+    latest = payload.get("version")
+    dl = payload.get("download_url_path")
+    download_url = f"{server_url.rstrip('/')}{dl}" if dl else None
+
+    _write_cache({
+        "installed": installed,
+        "server_url": server_url,
+        "latest": latest,
+        "download_url": download_url,
+        "checked_at": now,
+    })
+    return UpdateInfo(installed=installed, latest=latest, download_url=download_url)
+
+
+def format_outdated_notice(info: UpdateInfo) -> str:
+    """One-line stderr warning when the CLI is out of date."""
+    return (
+        f"[update] da {info.installed} is out of date — latest on this server is {info.latest}. "
+        f"Upgrade: uv tool install --force {info.download_url}"
+    )

--- a/cli/update_check.py
+++ b/cli/update_check.py
@@ -131,8 +131,14 @@ def check(server_url: Optional[str]) -> Optional[UpdateInfo]:
 
 
 def format_outdated_notice(info: UpdateInfo) -> str:
-    """One-line stderr warning when the CLI is out of date."""
-    return (
-        f"[update] da {info.installed} is out of date — latest on this server is {info.latest}. "
-        f"Upgrade: uv tool install --force {info.download_url}"
-    )
+    """One-line stderr warning when the CLI is out of date.
+
+    `download_url` may be absent (stale cache entry written by an older client,
+    or server returned a version without a download path). Don't emit the
+    literal string "None" into a copy-pasteable command — drop the upgrade
+    snippet in that case.
+    """
+    msg = f"[update] da {info.installed} is out of date — latest on this server is {info.latest}."
+    if info.download_url:
+        msg += f" Upgrade: uv tool install --force {info.download_url}"
+    return msg

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -1,5 +1,6 @@
 """Tests for da sync command."""
 
+import hashlib
 import json
 import pytest
 from unittest.mock import patch, MagicMock, call
@@ -27,19 +28,32 @@ def _resp(status_code=200, json_data=None):
     return r
 
 
+# Hash of the fake parquet payload below — matches what sync.py would compute.
+_FAKE_PARQUET_BYTES = b"PAR1" + b"\x00" * 32 + b"PAR1"
+_FAKE_PARQUET_MD5 = hashlib.md5(_FAKE_PARQUET_BYTES).hexdigest()
+
 MANIFEST = {
     "tables": {
-        "orders": {"hash": "abc123", "rows": 100, "size_bytes": 2048},
-        "customers": {"hash": "def456", "rows": 50, "size_bytes": 1024},
+        # Hashes match _FAKE_PARQUET_BYTES so happy-path tests pass the
+        # manifest-hash integrity check.
+        "orders": {"hash": _FAKE_PARQUET_MD5, "rows": 100, "size_bytes": 2048},
+        "customers": {"hash": _FAKE_PARQUET_MD5, "rows": 50, "size_bytes": 1024},
     }
 }
+
+
+def _fake_stream_download(path, target, *args, **kwargs):
+    """Drop-in replacement for cli.commands.sync.stream_download that writes
+    the well-known fake parquet to the target path."""
+    with open(target, "wb") as f:
+        f.write(_FAKE_PARQUET_BYTES)
 
 
 class TestSyncHappyPath:
     def test_sync_downloads_all_tables(self, tmp_config):
         """Sync with no local state downloads all tables."""
         with patch("cli.commands.sync.api_get", return_value=_resp(200, MANIFEST)):
-            with patch("cli.commands.sync.stream_download") as mock_dl:
+            with patch("cli.commands.sync.stream_download", side_effect=_fake_stream_download) as mock_dl:
                 with patch("cli.commands.sync._rebuild_duckdb_views"):
                     result = runner.invoke(app, ["sync"])
         assert result.exit_code == 0
@@ -49,7 +63,7 @@ class TestSyncHappyPath:
     def test_sync_specific_table(self, tmp_config):
         """--table flag limits download to one table."""
         with patch("cli.commands.sync.api_get", return_value=_resp(200, MANIFEST)):
-            with patch("cli.commands.sync.stream_download") as mock_dl:
+            with patch("cli.commands.sync.stream_download", side_effect=_fake_stream_download) as mock_dl:
                 with patch("cli.commands.sync._rebuild_duckdb_views"):
                     result = runner.invoke(app, ["sync", "--table", "orders"])
         assert result.exit_code == 0
@@ -60,7 +74,7 @@ class TestSyncHappyPath:
     def test_sync_json_output(self, tmp_config):
         """--json flag produces valid JSON output (rich spinner may precede JSON)."""
         with patch("cli.commands.sync.api_get", return_value=_resp(200, MANIFEST)):
-            with patch("cli.commands.sync.stream_download"):
+            with patch("cli.commands.sync.stream_download", side_effect=_fake_stream_download):
                 with patch("cli.commands.sync._rebuild_duckdb_views"):
                     result = runner.invoke(app, ["sync", "--json"])
         assert result.exit_code == 0
@@ -102,8 +116,8 @@ class TestSyncErrors:
         """Tables with matching hashes are not re-downloaded."""
         state = {
             "tables": {
-                "orders": {"hash": "abc123"},
-                "customers": {"hash": "def456"},
+                "orders": {"hash": _FAKE_PARQUET_MD5},
+                "customers": {"hash": _FAKE_PARQUET_MD5},
             }
         }
         with patch("cli.commands.sync.get_sync_state", return_value=state):
@@ -114,6 +128,163 @@ class TestSyncErrors:
         # Nothing to download — both hashes match
         assert mock_dl.call_count == 0
         assert "Downloaded: 0" in result.output
+
+
+class TestSyncDurability:
+    """Durability & integrity layer: hash check, PAR1 fallback, broken-rebuild recovery."""
+
+    def _write(self, tmp_config, tid: str, body: bytes) -> None:
+        (tmp_config / "local" / "server" / "parquet").mkdir(parents=True, exist_ok=True)
+        (tmp_config / "local" / "server" / "parquet" / f"{tid}.parquet").write_bytes(body)
+
+    def test_hash_mismatch_recorded_as_error(self, tmp_config):
+        """If manifest hash is present and does not match the downloaded bytes,
+        the file must be discarded and the error recorded."""
+        def bad_stream(path, target, *a, **kw):
+            with open(target, "wb") as f:
+                f.write(b"PAR1" + b"\xaa" * 50 + b"PAR1")  # valid PAR1, wrong hash
+
+        with patch("cli.commands.sync.api_get", return_value=_resp(200, MANIFEST)):
+            with patch("cli.commands.sync.stream_download", side_effect=bad_stream):
+                with patch("cli.commands.sync._rebuild_duckdb_views") as mock_rebuild:
+                    result = runner.invoke(app, ["sync"])
+        assert result.exit_code == 0
+        assert "Downloaded: 0" in result.output
+        assert "Errors: 2" in result.output
+        assert "hash mismatch" in result.output
+        assert mock_rebuild.call_count == 0
+
+    def test_par1_fallback_when_manifest_hash_missing(self, tmp_config):
+        """Legacy manifests without `hash` must fall back to the PAR1 structural check."""
+        manifest_no_hash = {"tables": {"orders": {"hash": "", "rows": 10, "size_bytes": 16}}}
+
+        def html_stream(path, target, *a, **kw):
+            with open(target, "wb") as f:
+                f.write(b"<html>oops</html>")
+
+        with patch("cli.commands.sync.api_get", return_value=_resp(200, manifest_no_hash)):
+            with patch("cli.commands.sync.stream_download", side_effect=html_stream):
+                with patch("cli.commands.sync._rebuild_duckdb_views"):
+                    result = runner.invoke(app, ["sync"])
+        assert "PAR1" in result.output  # fallback message appears
+        assert "Downloaded: 0" in result.output
+
+    def test_rebuild_skips_broken_parquet_without_aborting(self, tmp_config):
+        """Pre-existing broken parquet must not kill the whole rebuild."""
+        self._write(tmp_config, "broken", b"not-parquet-at-all")
+        self._write(tmp_config, "also_bad", b"PAR1" + b"\x00" * 10 + b"PAR1")
+
+        from cli.commands.sync import _rebuild_duckdb_views
+        local_dir = tmp_config / "local"
+        parquet_dir = local_dir / "server" / "parquet"
+        # Must not raise — both files are garbage but the function recovers.
+        _rebuild_duckdb_views(local_dir, parquet_dir)
+
+
+class TestStreamDownloadAtomicAndRetry:
+    """stream_download: atomic tmp→rename, retries on transient errors, no retry on 4xx."""
+
+    def test_atomic_write_via_tmp_then_rename(self, tmp_path, monkeypatch):
+        """Target file must not exist before os.replace runs; writes go to .tmp first."""
+        monkeypatch.setenv("DA_CONFIG_DIR", str(tmp_path))
+        monkeypatch.setenv("DA_SERVER_URL", "http://localhost:9999")
+
+        target = tmp_path / "x.parquet"
+        observed_paths: list[str] = []
+
+        class FakeStream:
+            def __init__(self, chunks):
+                self._chunks = chunks
+            def raise_for_status(self): pass
+            def iter_bytes(self, chunk_size=65536):
+                # Observe target path at the moment of writing.
+                observed_paths.append(str(target) + " exists=" + str(target.exists()))
+                yield from self._chunks
+            def __enter__(self): return self
+            def __exit__(self, *a): pass
+
+        class FakeClient:
+            def __init__(self, *a, **kw): pass
+            def stream(self, method, path): return FakeStream([b"PAR1", b"\x00" * 10, b"PAR1"])
+            def __enter__(self): return self
+            def __exit__(self, *a): pass
+
+        import cli.client as client_mod
+        monkeypatch.setattr(client_mod, "get_client", lambda timeout=30.0: FakeClient())
+        client_mod.stream_download("/ignored", str(target))
+        assert target.exists()
+        assert not (tmp_path / "x.parquet.tmp").exists()
+        # The target did NOT exist while iter_bytes was pumping — only the .tmp did.
+        assert all("exists=False" in p for p in observed_paths)
+
+    def test_retries_on_transient_error(self, tmp_path, monkeypatch):
+        """Transient network errors (ConnectError) trigger retry; eventual success is transparent."""
+        monkeypatch.setenv("DA_CONFIG_DIR", str(tmp_path))
+        monkeypatch.setenv("DA_SERVER_URL", "http://localhost:9999")
+        monkeypatch.setenv("DA_STREAM_RETRIES", "3")
+
+        target = tmp_path / "x.parquet"
+        calls = {"n": 0}
+
+        import httpx
+        class FakeStream:
+            def raise_for_status(self): pass
+            def iter_bytes(self, chunk_size=65536):
+                yield b"PAR1" + b"\x00" * 4 + b"PAR1"
+            def __enter__(self): return self
+            def __exit__(self, *a): pass
+
+        class FakeClient:
+            def stream(self, method, path):
+                calls["n"] += 1
+                if calls["n"] < 3:
+                    raise httpx.ConnectError("flap")
+                return FakeStream()
+            def __enter__(self): return self
+            def __exit__(self, *a): pass
+
+        import cli.client as client_mod
+        monkeypatch.setattr(client_mod, "get_client", lambda timeout=30.0: FakeClient())
+        # Speed up test — drop sleep to zero.
+        monkeypatch.setattr(client_mod, "_RETRY_BACKOFFS_S", (0.0, 0.0, 0.0))
+
+        client_mod.stream_download("/ignored", str(target))
+        assert calls["n"] == 3  # 2 failures + 1 success
+        assert target.exists()
+
+    def test_no_retry_on_4xx(self, tmp_path, monkeypatch):
+        """4xx (auth, 404) must surface immediately — retries are for transient issues only."""
+        monkeypatch.setenv("DA_CONFIG_DIR", str(tmp_path))
+        monkeypatch.setenv("DA_SERVER_URL", "http://localhost:9999")
+
+        import httpx
+        calls = {"n": 0}
+
+        class FakeResponse:
+            status_code = 404
+            def raise_for_status(self):
+                raise httpx.HTTPStatusError(
+                    "404", request=MagicMock(), response=MagicMock(status_code=404)
+                )
+            def iter_bytes(self, chunk_size=65536):
+                return iter([])
+            def __enter__(self): return self
+            def __exit__(self, *a): pass
+
+        class FakeClient:
+            def stream(self, method, path):
+                calls["n"] += 1
+                return FakeResponse()
+            def __enter__(self): return self
+            def __exit__(self, *a): pass
+
+        import cli.client as client_mod
+        monkeypatch.setattr(client_mod, "get_client", lambda timeout=30.0: FakeClient())
+        monkeypatch.setattr(client_mod, "_RETRY_BACKOFFS_S", (0.0, 0.0, 0.0))
+
+        with pytest.raises(httpx.HTTPStatusError):
+            client_mod.stream_download("/ignored", str(tmp_path / "x.parquet"))
+        assert calls["n"] == 1  # no retry on 4xx
 
 
 class TestSyncDryRun:

--- a/tests/test_cli_update_check.py
+++ b/tests/test_cli_update_check.py
@@ -1,0 +1,158 @@
+"""Tests for the CLI auto-update check (cli/update_check.py)."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from cli.main import app
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def tmp_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("DA_CONFIG_DIR", str(tmp_path))
+    # Point CLI at a fake server so get_server_url() returns something stable.
+    monkeypatch.setenv("DA_SERVER", "http://server.test:8000")
+    yield tmp_path
+
+
+def test_check_returns_none_when_disabled(tmp_config):
+    import os
+    os.environ["DA_NO_UPDATE_CHECK"] = "1"
+    try:
+        from cli import update_check
+        assert update_check.check("http://server.test:8000") is None
+    finally:
+        del os.environ["DA_NO_UPDATE_CHECK"]
+
+
+def test_check_returns_none_when_server_url_missing(tmp_config):
+    from cli import update_check
+    assert update_check.check("") is None
+    assert update_check.check(None) is None  # type: ignore[arg-type]
+
+
+def test_check_returns_none_when_installed_version_unknown(tmp_config):
+    from cli import update_check
+    with patch("cli.update_check._installed_version", return_value="unknown"):
+        assert update_check.check("http://server.test:8000") is None
+
+
+def test_check_fresh_fetch_and_cache_write(tmp_config):
+    from cli import update_check
+
+    payload = {
+        "version": "2.1.0",
+        "wheel_filename": "agnes_the_ai_analyst-2.1.0-py3-none-any.whl",
+        "download_url_path": "/cli/wheel/agnes_the_ai_analyst-2.1.0-py3-none-any.whl",
+    }
+    with patch("cli.update_check._installed_version", return_value="2.0.0"):
+        with patch("cli.update_check._fetch_latest", return_value=payload):
+            info = update_check.check("http://server.test:8000")
+
+    assert info is not None
+    assert info.installed == "2.0.0"
+    assert info.latest == "2.1.0"
+    assert info.download_url == (
+        "http://server.test:8000/cli/wheel/agnes_the_ai_analyst-2.1.0-py3-none-any.whl"
+    )
+    assert info.is_outdated() is True
+
+    # Cache file was written and re-reading it returns the same latest.
+    cache = json.loads((tmp_config / "update_check.json").read_text())
+    assert cache["installed"] == "2.0.0"
+    assert cache["latest"] == "2.1.0"
+
+
+def test_check_uses_cache_within_ttl(tmp_config):
+    """Cached entry within 24h skips the network fetch."""
+    from cli import update_check
+
+    # Seed a fresh cache entry.
+    (tmp_config / "update_check.json").write_text(json.dumps({
+        "installed": "2.0.0",
+        "server_url": "http://server.test:8000",
+        "latest": "2.0.5",
+        "download_url": "http://server.test:8000/cli/wheel/agnes_the_ai_analyst-2.0.5-py3-none-any.whl",
+        "checked_at": __import__("time").time(),  # now
+    }))
+
+    with patch("cli.update_check._installed_version", return_value="2.0.0"):
+        with patch("cli.update_check._fetch_latest") as mock_fetch:
+            info = update_check.check("http://server.test:8000")
+
+    assert mock_fetch.call_count == 0  # cache hit
+    assert info.latest == "2.0.5"
+    assert info.is_outdated() is True
+
+
+def test_check_invalidates_cache_when_installed_version_changed(tmp_config):
+    """User ran a fresh install after the cache was written — re-probe."""
+    from cli import update_check
+
+    # Seed cache claiming the installed version was 1.9.0.
+    (tmp_config / "update_check.json").write_text(json.dumps({
+        "installed": "1.9.0",
+        "server_url": "http://server.test:8000",
+        "latest": "2.0.0",
+        "download_url": "http://server.test:8000/cli/wheel/x.whl",
+        "checked_at": __import__("time").time(),
+    }))
+
+    payload = {"version": "2.1.0", "download_url_path": "/cli/wheel/y.whl"}
+    with patch("cli.update_check._installed_version", return_value="2.0.0"):
+        with patch("cli.update_check._fetch_latest", return_value=payload) as mock_fetch:
+            info = update_check.check("http://server.test:8000")
+
+    assert mock_fetch.call_count == 1  # cache was invalidated
+    assert info.latest == "2.1.0"
+
+
+def test_check_handles_network_failure_silently(tmp_config):
+    """A probe that errors out returns None; no exception leaks."""
+    from cli import update_check
+    with patch("cli.update_check._installed_version", return_value="2.0.0"):
+        with patch("cli.update_check._fetch_latest", return_value=None):
+            assert update_check.check("http://server.test:8000") is None
+
+
+def test_is_outdated_false_when_same_version(tmp_config):
+    from cli.update_check import UpdateInfo
+    info = UpdateInfo(installed="2.0.0", latest="2.0.0", download_url="…")
+    assert info.is_outdated() is False
+
+
+def test_is_outdated_false_when_latest_unknown(tmp_config):
+    from cli.update_check import UpdateInfo
+    info = UpdateInfo(installed="2.0.0", latest=None, download_url=None)
+    assert info.is_outdated() is False
+
+
+class TestRootCallbackIntegration:
+    """The root callback must not crash a command when the probe fails, and
+    must emit a stderr warning when the server advertises a newer version."""
+
+    def test_probe_failure_does_not_break_command(self, tmp_config):
+        with patch("cli.update_check.check", side_effect=RuntimeError("boom")):
+            result = runner.invoke(app, ["--help"])
+        assert result.exit_code == 0
+
+    def test_outdated_warning_is_emitted(self, tmp_config, capsys):
+        """Unit-test the warning hook directly: `--help` is eager and bypasses
+        the callback body, so we test `_maybe_warn_outdated` itself, which
+        is what every real subcommand dispatch triggers."""
+        from cli.main import _maybe_warn_outdated
+        from cli.update_check import UpdateInfo
+        info = UpdateInfo(
+            installed="2.0.0",
+            latest="2.1.0",
+            download_url="http://server.test:8000/cli/wheel/x.whl",
+        )
+        with patch("cli.update_check.check", return_value=info):
+            _maybe_warn_outdated()
+        captured = capsys.readouterr()
+        assert "[update]" in captured.err
+        assert "2.1.0" in captured.err

--- a/tests/test_cli_update_check.py
+++ b/tests/test_cli_update_check.py
@@ -131,6 +131,27 @@ def test_is_outdated_false_when_latest_unknown(tmp_config):
     assert info.is_outdated() is False
 
 
+def test_format_outdated_notice_drops_upgrade_line_when_no_download_url(tmp_config):
+    """`download_url=None` must NOT produce literal "None" in the copy-pasteable command."""
+    from cli.update_check import UpdateInfo, format_outdated_notice
+    info = UpdateInfo(installed="2.0.0", latest="2.1.0", download_url=None)
+    msg = format_outdated_notice(info)
+    assert "None" not in msg
+    assert "uv tool install" not in msg
+    assert "2.0.0" in msg and "2.1.0" in msg
+
+
+def test_format_outdated_notice_includes_upgrade_command_when_url_present(tmp_config):
+    from cli.update_check import UpdateInfo, format_outdated_notice
+    info = UpdateInfo(
+        installed="2.0.0",
+        latest="2.1.0",
+        download_url="http://s/cli/wheel/a-2.1.0-py3-none-any.whl",
+    )
+    msg = format_outdated_notice(info)
+    assert "uv tool install --force http://s/cli/wheel/a-2.1.0-py3-none-any.whl" in msg
+
+
 class TestRootCallbackIntegration:
     """The root callback must not crash a command when the probe fails, and
     must emit a stderr warning when the server advertises a newer version."""

--- a/tests/test_selective_gzip.py
+++ b/tests/test_selective_gzip.py
@@ -1,0 +1,87 @@
+"""Tests for the SelectiveGZipMiddleware path-skip logic in app/main.py.
+
+Key property: parquet-serving endpoints must not be gzipped on the wire,
+but JSON / HTML endpoints above the minimum-size threshold must be.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def isolated_client(tmp_path, monkeypatch):
+    """Fresh FastAPI app with its own tmp DATA_DIR so DuckDB locks don't
+    collide with a concurrently-running dev container."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("TESTING", "1")
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-min-32-characters!!")
+    (tmp_path / "state").mkdir()
+    (tmp_path / "analytics").mkdir()
+    (tmp_path / "extracts").mkdir()
+    from src.db import close_system_db
+    close_system_db()
+    from app.main import create_app
+    yield TestClient(create_app())
+    close_system_db()
+
+
+def test_parquet_path_is_not_gzipped(isolated_client, tmp_path, monkeypatch):
+    """/cli/wheel/... must return the raw bytes without Content-Encoding: gzip."""
+    wheel = tmp_path / "agnes_fake-1.0-py3-none-any.whl"
+    wheel.write_bytes(b"PK\x03\x04" + b"x" * 4096)
+    monkeypatch.setenv("AGNES_CLI_DIST_DIR", str(tmp_path))
+
+    resp = isolated_client.get(
+        f"/cli/wheel/{wheel.name}",
+        headers={"Accept-Encoding": "gzip"},
+    )
+    assert resp.status_code == 200
+    assert "gzip" not in resp.headers.get("content-encoding", "")
+    assert resp.content.startswith(b"PK")
+
+
+def test_install_page_is_gzipped(isolated_client):
+    """/install is HTML above the threshold — gzip should kick in when the
+    client advertises gzip support. TestClient may decompress transparently,
+    so we accept either the header or readable body as proof that the
+    middleware decided to handle the response (i.e. did not skip)."""
+    resp = isolated_client.get("/install", headers={"Accept-Encoding": "gzip"})
+    assert resp.status_code == 200
+    enc = resp.headers.get("content-encoding", "")
+    # Either we see the encoding on the wire OR TestClient auto-decoded it.
+    assert "gzip" in enc or "install" in resp.text.lower()
+
+
+def test_no_accept_encoding_means_no_gzip_anywhere(isolated_client):
+    """Client that doesn't advertise gzip gets uncompressed body."""
+    resp = isolated_client.get("/install", headers={"Accept-Encoding": "identity"})
+    assert resp.status_code == 200
+    assert "gzip" not in resp.headers.get("content-encoding", "")
+
+
+def test_selective_gzip_wrapper_dispatches_on_prefix():
+    """Direct unit test of the wrapper's path-based branch without standing up
+    the whole FastAPI app — verifies the skip list is honoured."""
+    from app.main import _SelectiveGZipMiddleware
+
+    calls = {"raw": 0, "gzip": 0}
+
+    async def raw_app(scope, receive, send):
+        calls["raw"] += 1
+
+    wrapper = _SelectiveGZipMiddleware(raw_app, minimum_size=10, skip_prefixes=("/api/data/",))
+    # Monkey-patch the gzip inner so we can count hits without running middleware.
+    async def stub_gzip(scope, receive, send):
+        calls["gzip"] += 1
+    wrapper._gzip = stub_gzip
+
+    import asyncio
+    # Path that matches the skip prefix → raw app
+    asyncio.run(wrapper({"type": "http", "path": "/api/data/orders/download"}, None, None))
+    assert calls == {"raw": 1, "gzip": 0}
+    # Path that does not → gzip app
+    asyncio.run(wrapper({"type": "http", "path": "/api/sync/manifest"}, None, None))
+    assert calls == {"raw": 1, "gzip": 1}
+    # Non-http scope (websocket, lifespan) → gzip app (it handles lifespan as pass-through)
+    asyncio.run(wrapper({"type": "lifespan"}, None, None))
+    assert calls == {"raw": 1, "gzip": 2}


### PR DESCRIPTION
Three independent upgrades, one PR so the whole durability story lands together on the testing instance. Three commits for clean per-feature review.

## 1. \`fix(sync): atomic writes + manifest hash verification + retry on transient errors\` (\`71ae2af\`)

Supersedes #40 (can be closed without merging).

- **Atomic writes**: \`stream_download\` writes to \`<target>.tmp\` and \`os.replace\`s on success. The real target never exists half-written.
- **Retry with backoff**: ConnectError / ReadError / RemoteProtocolError / Timeout / 5xx → up to 3 retries, backoffs 0.3/1/3s. 4xx (auth, 404) surfaces immediately.
- **Manifest-hash verify**: after download, MD5 the target (same 8KiB chunking as \`app/api/sync.py:_file_hash\`) and compare against \`server_tables[tid][\"hash\"]\`. Mismatch ⇒ unlink + record error + skip state commit. PAR1 structural check kept as fallback for legacy manifests without \`hash\`.
- \`_rebuild_duckdb_views\` is now tolerant — one broken parquet logs a warning and is skipped, doesn't kill the rebuild.

## 2. \`perf(server): enable GZipMiddleware for JSON / HTML responses\` (\`6bcadae\`)

\`GZipMiddleware(minimum_size=1024)\` applied globally. Parquet \`FileResponse\` bodies are already compressed so it's a no-op there, but manifest / version / \`/install\` preview and similar JSON/HTML endpoints noticeably benefit. httpx on the client decompresses transparently.

## 3. \`feat(cli): auto-check for newer CLI version on startup\` (\`6eac7bc\`)

- New \`GET /cli/latest\` on the server returns \`{version, wheel_filename, download_url_path}\` — read from \`_find_wheel()\`, public, cacheable.
- New \`cli/update_check.py\`: 3s timeout probe, 24h cache in \`$DA_CONFIG_DIR/update_check.json\`, invalidated when installed version changes.
- Root typer callback fires the probe before subcommand dispatch. Any failure is swallowed silently.
- Outdated → one-line stderr warning with \`uv tool install --force <url>\` ready to copy-paste.
- Disable with \`DA_NO_UPDATE_CHECK=1\`.

## Tests

Full breakdown by scope:

- \`TestSyncDurability\` — hash mismatch error, PAR1 fallback for empty manifest hash, broken-parquet tolerance
- \`TestStreamDownloadAtomicAndRetry\` — atomic \`.tmp\` + rename, retry on ConnectError, **no** retry on 4xx
- \`TestSyncHappyPath\` — existing happy-path tests updated to use hash-matching fake stream so the new integrity check stays green
- \`TestRootCallbackIntegration\` — probe failure doesn't crash command; outdated info emits stderr warning
- 8 unit tests for \`update_check.check\` covering disabled / no-server / unknown-version / fresh-fetch / cache-TTL-hit / cache-invalidation / network-failure / is_outdated edge cases

31/31 pytest cases passed locally.

## Base

Targeting \`ps/wheel-name-fix\` to stay in the existing testing-instance deployment flow. #40 becomes redundant after this PR lands (commit 1 here is a super-set of #40).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/41" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
