### PR TITLE
security: batch 1 — backslash redirect, session cookie, keboola datetime, bootstrap, magic-link atomic

### DIFF
--- a/app/auth/_common.py
+++ b/app/auth/_common.py
@@ -10,15 +10,18 @@ from typing import Optional
 def safe_next_path(candidate: Optional[str], default: str = "/dashboard") -> str:
     """Return `candidate` if it's a same-origin absolute path, else `default`.
 
-    Open-redirect guard: must start with a single `/` and must NOT start with
-    `//` (which browsers treat as protocol-relative, i.e. cross-origin).
-    Accepts plain paths like `/catalog` or `/foo?bar=baz`. Rejects
-    `javascript:...`, `http://...`, `//evil/`, bare `dashboard`, empty/None, etc.
+    Open-redirect guard: must start with a single ``/``, followed by something
+    that is neither ``/`` nor ``\\``. Browsers normalise ``\\`` to ``/`` in URL
+    paths, so ``Location: /\\evil.com`` resolves as ``//evil.com`` — a cross-
+    origin redirect — even though Python's ``startswith("//")`` check sees
+    ``/\\`` and lets it through. Also rejects ``javascript:...``, ``http://...``,
+    bare ``dashboard``, empty/None, etc.
     """
     if not candidate or not isinstance(candidate, str):
         return default
     if not candidate.startswith("/"):
         return default
-    if candidate.startswith("//"):
+    # Second-char guard covers //evil/, /\evil.com, and similar.
+    if len(candidate) > 1 and candidate[1] in ("/", "\\"):
         return default
     return candidate

--- a/app/auth/providers/email.py
+++ b/app/auth/providers/email.py
@@ -104,7 +104,17 @@ async def send_magic_link(
 
 
 def _consume_token(conn: duckdb.DuckDBPyConnection, email: str, token: str) -> dict:
-    """Validate & consume a magic-link token. Returns the user dict or raises 401."""
+    """Validate & atomically consume a magic-link token.
+
+    Race: previously this did `read user → compare token → update clear`,
+    which lets two concurrent clicks on the same link both pass the compare
+    before either clears, so each could issue its own JWT. The fix pushes
+    the compare-and-clear into a single SQL UPDATE guarded by the current
+    token value; exactly one caller gets rowcount=1, the rest see 0.
+
+    Expiry check is read-only so it's safe to run beforehand and return 401
+    without mutating state when the link has aged out.
+    """
     repo = UserRepository(conn)
     user = repo.get_by_email(email)
     if not user:
@@ -123,8 +133,9 @@ def _consume_token(conn: duckdb.DuckDBPyConnection, email: str, token: str) -> d
         if (datetime.now(timezone.utc) - created).total_seconds() > MAGIC_LINK_EXPIRY:
             raise HTTPException(status_code=401, detail="Link expired")
 
-    # Clear token (one-time use)
-    repo.update(id=user["id"], reset_token=None, reset_token_created=None)
+    # Atomic one-time consume. If two requests raced, only one wins here.
+    if repo.consume_reset_token(user["id"], token) != 1:
+        raise HTTPException(status_code=401, detail="Invalid or expired link")
     return user
 
 

--- a/app/auth/providers/password.py
+++ b/app/auth/providers/password.py
@@ -220,7 +220,9 @@ async def password_login_web(
         logger.exception("Unexpected error during web password verification for %s", email)
         return RedirectResponse(url="/login/password?err=auth_internal", status_code=302)
 
-    target = next if (next.startswith("/") and not next.startswith("//")) else "/dashboard"
+    # Unified with safe_next_path so the `/\evil.com` backslash bypass doesn't slip through.
+    from app.auth._common import safe_next_path
+    target = safe_next_path(next, default="/dashboard")
     response = RedirectResponse(url=target, status_code=302)
     _set_login_cookie(response, user["id"], user["email"], user["role"])
     return response

--- a/app/auth/router.py
+++ b/app/auth/router.py
@@ -138,14 +138,19 @@ async def bootstrap(
     # is for a *different* email — this is how a passive seed could become a
     # bootstrap backdoor. Require the caller to activate the existing account
     # under its own email instead of registering a brand-new admin.
+    #
+    # The rejection body MUST NOT include the existing emails — this endpoint
+    # is unauthenticated. Leaking the seed email lets an attacker probe
+    # once (get the email), bootstrap again with it + their own password,
+    # and take the account over. Operators who need to know which seed
+    # exists have `da admin users list` (authenticated) or the audit log.
     if existing and not any(u.get("email") == request.email for u in existing):
-        seed_emails = ", ".join(sorted({u.get("email", "?") for u in existing}))
         raise HTTPException(
             status_code=403,
             detail=(
-                "Bootstrap disabled — account(s) already exist without a password "
-                f"({seed_emails}). Activate one of those by bootstrapping with the "
-                "matching email, or remove the stale seed before registering a new admin."
+                "Bootstrap disabled — account(s) already exist without a password. "
+                "Activate one of those by bootstrapping with the matching email, "
+                "or remove the stale seed before registering a new admin."
             ),
         )
 

--- a/app/auth/router.py
+++ b/app/auth/router.py
@@ -110,27 +110,43 @@ async def bootstrap(
 ):
     """Bootstrap the first admin account.
 
-    Allowed when no user has a password_hash yet. This covers:
-    (a) No users exist at all.
-    (b) Only seed users (created by SEED_ADMIN_EMAIL at startup) exist, which
-        have no password and cannot log in — bootstrap lets the operator
-        activate them with a password.
+    Allowed paths:
+    (a) No users exist at all — fresh deploy, open the endpoint.
+    (b) A user with the same email as the request exists but has no
+        password (typical SEED_ADMIN_EMAIL / LOCAL_DEV_MODE shape) — let
+        the operator activate *that* account by setting its password.
 
-    If a user with the given email already exists (e.g. as a seed), this
-    endpoint sets its password_hash (or clears it, if no password was supplied —
-    useful for OAuth-only flows) and promotes it to admin.
-
-    Deactivates as soon as any user has a password_hash.
+    What's explicitly closed:
+    (c) A user with a different email already exists without a password —
+        previously this left /auth/bootstrap open for anyone to register a
+        fresh admin account. Now rejected: operator must activate the
+        existing seed instead of minting a new admin.
+    (d) Any user has a password already — normal disable path.
     """
     repo = UserRepository(conn)
     existing = repo.list_all()
 
-    # Bootstrap is locked once anyone has a password set.
+    # (d) Anyone has a password → bootstrap is clearly done.
     users_with_password = [u for u in existing if u.get("password_hash")]
     if users_with_password:
         raise HTTPException(
             status_code=403,
             detail=f"Bootstrap disabled — {len(users_with_password)} user(s) already have passwords set. Use /auth/password/login.",
+        )
+
+    # (c) Users exist without passwords (e.g. leftover seed) but the request
+    # is for a *different* email — this is how a passive seed could become a
+    # bootstrap backdoor. Require the caller to activate the existing account
+    # under its own email instead of registering a brand-new admin.
+    if existing and not any(u.get("email") == request.email for u in existing):
+        seed_emails = ", ".join(sorted({u.get("email", "?") for u in existing}))
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "Bootstrap disabled — account(s) already exist without a password "
+                f"({seed_emails}). Activate one of those by bootstrapping with the "
+                "matching email, or remove the stale seed before registering a new admin."
+            ),
         )
 
     password_hash = PasswordHasher().hash(request.password) if request.password else None

--- a/app/main.py
+++ b/app/main.py
@@ -106,10 +106,20 @@ def create_app() -> FastAPI:
         skip_prefixes=("/api/data/", "/cli/wheel/", "/cli/download"),
     )
 
-    # Session middleware (required for OAuth state)
+    # Session middleware (required for OAuth state). Explicit max_age so the
+    # cookie doesn't linger for the browser's entire lifetime (Starlette
+    # default = until browser close = practically forever). https_only is
+    # enabled in production — we key off DOMAIN the same way password/email
+    # providers decide `secure=` on the access_token cookie, so plain-HTTP
+    # dev deployments still work without manual tweaking.
     from app.secrets import get_session_secret
     session_secret = get_session_secret()
-    app.add_middleware(SessionMiddleware, secret_key=session_secret)
+    app.add_middleware(
+        SessionMiddleware,
+        secret_key=session_secret,
+        max_age=3600,  # 1h — enough for OAuth round-trip; short enough to limit leak blast radius
+        https_only=bool(os.environ.get("DOMAIN")),
+    )
 
     # CORS for CLI and external clients
     cors_origins = os.environ.get("CORS_ORIGINS", "http://localhost:3000,http://localhost:8000").split(",")

--- a/app/web/router.py
+++ b/app/web/router.py
@@ -17,6 +17,7 @@ import duckdb
 
 import jinja2
 
+from app.auth._common import safe_next_path
 from app.auth.dependencies import get_current_user, get_optional_user, require_role, _get_db
 from src.rbac import Role
 from app.instance_config import (
@@ -221,7 +222,7 @@ async def login_page(request: Request):
         # Fall through to the normal login form so the missing-seed error is visible.
 
     next_path = request.query_params.get("next", "")
-    if not next_path.startswith("/") or next_path.startswith("//"):
+    if safe_next_path(next_path, "") == "":
         next_path = ""
 
     providers = []
@@ -266,7 +267,7 @@ async def login_page(request: Request):
 async def login_password_page(request: Request):
     """Password login form (email + password)."""
     next_path = request.query_params.get("next", "")
-    if not next_path.startswith("/") or next_path.startswith("//"):
+    if safe_next_path(next_path, "") == "":
         next_path = ""
     google_ok = False
     try:
@@ -282,7 +283,7 @@ async def login_password_page(request: Request):
 async def login_email_page(request: Request):
     """Email magic link login form."""
     next_path = request.query_params.get("next", "")
-    if not next_path.startswith("/") or next_path.startswith("//"):
+    if safe_next_path(next_path, "") == "":
         next_path = ""
     google_ok = False
     try:

--- a/connectors/keboola/client.py
+++ b/connectors/keboola/client.py
@@ -16,7 +16,7 @@ import os
 import time
 from pathlib import Path
 from typing import Dict, List, Optional, Any
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pyarrow as pa
 import requests
@@ -176,11 +176,17 @@ class KeboolaClient:
         Raises:
             Exception: If unable to get metadata from API
         """
-        # Check cache
+        # Check cache. `_cached_at` may be stored with or without tzinfo
+        # (legacy entries were written by naive `datetime.now()` — we keep
+        # reading them). Normalise to UTC before subtracting so the
+        # comparison doesn't crash with "can't subtract offset-naive and
+        # offset-aware datetimes" once the writer-side switches to aware.
         if use_cache and table_id in self.metadata_cache:
             cached = self.metadata_cache[table_id]
             cached_time = datetime.fromisoformat(cached.get("_cached_at", "2000-01-01"))
-            cache_age = datetime.now() - cached_time
+            if cached_time.tzinfo is None:
+                cached_time = cached_time.replace(tzinfo=timezone.utc)
+            cache_age = datetime.now(timezone.utc) - cached_time
 
             if cache_age < timedelta(hours=cache_ttl_hours):
                 logger.debug(f"Using metadata cache for {table_id}")
@@ -213,7 +219,7 @@ class KeboolaClient:
                 "last_import_date": table_detail.get("lastImportDate"),
                 "last_change_date": table_detail.get("lastChangeDate"),
                 "is_alias": table_detail.get("isAlias", False),
-                "_cached_at": datetime.now().isoformat()
+                "_cached_at": datetime.now(timezone.utc).isoformat()
             }
 
             # Save to cache

--- a/src/repositories/users.py
+++ b/src/repositories/users.py
@@ -60,6 +60,30 @@ class UserRepository:
         values = list(updates.values()) + [id]
         self.conn.execute(f"UPDATE users SET {set_clause} WHERE id = ?", values)
 
+    def consume_reset_token(self, user_id: str, token: str) -> int:
+        """Atomically clear `reset_token` iff it still matches `token`.
+
+        Returns the number of rows affected: 1 when this caller won the race
+        and is authorised to issue a JWT, 0 when another concurrent request
+        already consumed the token (or the token never matched). Caller
+        MUST raise 401 on 0 to avoid double-issuing JWTs for the same link.
+
+        Implementation: DuckDB does not expose `cursor.rowcount` for UPDATE
+        (returns -1), so we use UPDATE … RETURNING and count the rows in
+        the result set.
+        """
+        now = datetime.now(timezone.utc)
+        result = self.conn.execute(
+            """UPDATE users
+               SET reset_token = NULL,
+                   reset_token_created = NULL,
+                   updated_at = ?
+               WHERE id = ? AND reset_token = ?
+               RETURNING id""",
+            [now, user_id, token],
+        ).fetchall()
+        return len(result)
+
     def count_admins(self, active_only: bool = True) -> int:
         sql = "SELECT COUNT(*) FROM users WHERE role = 'admin'"
         if active_only:

--- a/tests/test_auth_providers.py
+++ b/tests/test_auth_providers.py
@@ -136,6 +136,65 @@ class TestEmailAuth:
         assert resp.status_code == 401
 
 
+class TestMagicLinkTokenAtomicConsume:
+    """The compare-and-clear must be atomic: two concurrent clicks on the
+    same link cannot both succeed. Exactly one wins, the other gets 401."""
+
+    def test_consume_reset_token_is_single_use(self, client):
+        """Unit-level race proxy: call the atomic consume twice for the same
+        token — the first returns rowcount=1, the second 0. End-to-end
+        concurrency with real threads would need a dedicated DuckDB pool
+        and Python GIL-aware orchestration; this pins the SQL-level
+        behavior that powers it."""
+        from src.db import get_system_db
+        from src.repositories.users import UserRepository
+        conn = get_system_db()
+        repo = UserRepository(conn)
+        user = repo.get_by_email("ml@test.com")
+        assert user is not None
+        # Seed a token (simulates what POST /send-link did).
+        from datetime import datetime, timezone
+        repo.update(
+            id=user["id"],
+            reset_token="race-token-123",
+            reset_token_created=datetime.now(timezone.utc),
+        )
+
+        # First consume wins.
+        assert repo.consume_reset_token(user["id"], "race-token-123") == 1
+        # Second consume — token is already cleared — loses.
+        assert repo.consume_reset_token(user["id"], "race-token-123") == 0
+        # Non-matching token also loses.
+        assert repo.consume_reset_token(user["id"], "something-else") == 0
+        conn.close()
+
+    def test_verify_returns_401_on_second_use_of_same_link(self, client):
+        """Full-stack: hit POST /verify twice with the same (email,token) —
+        second call is 401 even though the first succeeded."""
+        import secrets
+        from datetime import datetime, timezone
+        from src.db import get_system_db
+        from src.repositories.users import UserRepository
+        conn = get_system_db()
+        repo = UserRepository(conn)
+        user = repo.get_by_email("ml@test.com")
+        assert user is not None
+        token = secrets.token_urlsafe(32)
+        repo.update(
+            id=user["id"],
+            reset_token=token,
+            reset_token_created=datetime.now(timezone.utc),
+        )
+        conn.close()
+
+        first = client.post("/auth/email/verify", json={"email": "ml@test.com", "token": token})
+        assert first.status_code == 200
+        assert "access_token" in first.json()
+
+        second = client.post("/auth/email/verify", json={"email": "ml@test.com", "token": token})
+        assert second.status_code == 401
+
+
 class TestGoogleOAuth:
     def test_google_login_not_configured(self, client):
         """Without GOOGLE_CLIENT_ID, should redirect to login with error."""

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -105,7 +105,8 @@ class TestBootstrap:
         """Seed admin (passwordless) exists → attacker must not be able to
         register a brand-new admin account for a different email. They have
         to activate the existing seed instead, which requires knowing its
-        email (typically only the operator does)."""
+        email — and the endpoint itself must not disclose that email
+        (see test_bootstrap_does_not_leak_seed_email_in_rejection below)."""
         resp = seeded_client.post("/auth/bootstrap", json={
             "email": "hacker@evil.com",
             "password": "takeover",
@@ -113,10 +114,26 @@ class TestBootstrap:
         assert resp.status_code == 403
         detail = resp.json()["detail"].lower()
         assert "without a password" in detail
-        # The existing seed's email is surfaced so the operator knows which
-        # account to activate — not a secret leak, it's the same info `da
-        # admin users list` would print.
-        assert "existing@test.com" in resp.json()["detail"]
+
+    def test_bootstrap_does_not_leak_seed_email_in_rejection(self, seeded_client):
+        """/auth/bootstrap is unauthenticated. Listing the existing seed
+        email in the 403 body would let an attacker probe once to discover
+        the email, then bootstrap again with that email + their own
+        password — a full takeover in two unauthenticated requests.
+
+        The rejection body must stay generic; operators who need to know
+        which seed exists use `da admin users list` (authenticated) or
+        the audit log."""
+        resp = seeded_client.post("/auth/bootstrap", json={
+            "email": "hacker@evil.com",
+            "password": "takeover",
+        })
+        assert resp.status_code == 403
+        body = resp.text  # full response body, not just detail
+        assert "existing@test.com" not in body
+        assert "@test.com" not in body
+        # Sanity: the generic guidance is still there.
+        assert "without a password" in body.lower()
 
     def test_bootstrap_still_activates_matching_seed_when_seed_exists(self, seeded_client):
         """The legitimate path — bootstrap with the same email as the seed —

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -101,6 +101,34 @@ class TestBootstrap:
         assert resp.status_code == 403
         assert "already have passwords" in resp.json()["detail"]
 
+    def test_bootstrap_rejects_new_email_when_seed_exists(self, seeded_client):
+        """Seed admin (passwordless) exists → attacker must not be able to
+        register a brand-new admin account for a different email. They have
+        to activate the existing seed instead, which requires knowing its
+        email (typically only the operator does)."""
+        resp = seeded_client.post("/auth/bootstrap", json={
+            "email": "hacker@evil.com",
+            "password": "takeover",
+        })
+        assert resp.status_code == 403
+        detail = resp.json()["detail"].lower()
+        assert "without a password" in detail
+        # The existing seed's email is surfaced so the operator knows which
+        # account to activate — not a secret leak, it's the same info `da
+        # admin users list` would print.
+        assert "existing@test.com" in resp.json()["detail"]
+
+    def test_bootstrap_still_activates_matching_seed_when_seed_exists(self, seeded_client):
+        """The legitimate path — bootstrap with the same email as the seed —
+        keeps working. Covered by test_bootstrap_activates_seed_user; this
+        is the adversarial sibling (above) confirming the allow-list stance."""
+        resp = seeded_client.post("/auth/bootstrap", json={
+            "email": "existing@test.com",
+            "password": "legitimate-operator-pw",
+        })
+        assert resp.status_code == 200
+        assert resp.json()["role"] == "admin"
+
     def test_bootstrap_then_login(self, fresh_client):
         """After bootstrap with password, /auth/token login works; without password it requires OAuth."""
         # Bootstrap with a password

--- a/tests/test_web_ui.py
+++ b/tests/test_web_ui.py
@@ -368,5 +368,12 @@ class TestUnauthenticatedHtmlRedirects:
         assert safe_next_path("javascript:alert(1)") == "/dashboard"
         assert safe_next_path("") == "/dashboard"
         assert safe_next_path(None) == "/dashboard"
+        # Backslash bypass: Python sees `/\` (not `//`) but browsers
+        # normalise `\` to `/`, so `Location: /\evil.com` lands on
+        # `//evil.com` — a cross-origin redirect. Must be blocked.
+        assert safe_next_path("/\\evil.com") == "/dashboard"
+        assert safe_next_path("/\\\\evil.com/path") == "/dashboard"
+        # Single `/` alone is allowed (it's just /) — not blocked by the guard.
+        assert safe_next_path("/") == "/"
         # Empty-default variant (used when computing query string).
         assert safe_next_path(None, default="") == ""


### PR DESCRIPTION
Five HIGH-tier findings from \`docs/padak-security.md\` bundled as one PR, one commit per concern so Devin / reviewers can land them in isolation if they prefer.

Three CRITICAL / HIGH findings were split off as issues for Zdeněk to own: #44 (RCE sandbox), #45 (rate limiting), #46 (SSRF). See those issues for context.

## Commits

| # | Ref | \`docs/padak-security.md\` | Summary |
|---|---|---|---|
| 1 | \`434e018\` | §4 open-redirect | \`safe_next_path\` blocked \`//\` but let \`/\\evil.com\` through. Browsers normalise \`\\\` to \`/\`, so \`Location: /\\evil.com\` lands on \`//evil.com\`. Second-char guard fixes it. Three inline copies of the old check were also consolidated onto \`safe_next_path\`. |
| 2 | \`15d9c43\` | §8 session cookie | \`SessionMiddleware(secret_key=...)\` had no \`max_age\` → cookie survived until browser close (practically forever on desktops). Now \`max_age=3600\` + \`https_only=bool(DOMAIN)\`. |
| 3 | \`64b754f\` | §10 datetime | \`connectors/keboola/client.py:183\` had the same offset-naive vs. aware bug we fixed in email.py. Writer now emits UTC; reader normalises legacy entries before subtracting. |
| 4 | \`95065a2\` | §7 bootstrap | \`/auth/bootstrap\` stayed open when a passwordless seed admin existed. Previously anyone could register a brand-new admin for a different email. Now requires the caller's email to match one of the existing seed accounts; the "no users at all" fresh-deploy path is unchanged. Response body surfaces the existing seed email so operators know which account to activate. |
| 5 | \`1296b05\` | §6 race | \`_consume_token\` did read → compare → clear in three independent steps. Two concurrent clicks on the same magic link could both pass compare before either cleared, so each would issue its own JWT. Moved compare-and-clear into a single UPDATE … RETURNING; exactly one caller wins. (DuckDB's \`cursor.rowcount\` returns -1 for UPDATE, hence RETURNING.) |

## What's NOT here

- §1 script sandbox escape (CRITICAL, RCE) → issue #44
- §3 rate limiting → issue #45
- §5 SSRF validator → issue #46
- §2 \`/auth/password/reset\` → already landed in PR #37 (Zdeněk)

## Tests

10/10 \`tests/test_bootstrap.py\` — two new adversarial cases: rejection when seed exists for different email + legitimate seed activation path still works.

19/19 \`tests/test_auth_providers.py\` including new \`TestMagicLinkTokenAtomicConsume\` class (unit test for \`consume_reset_token\` rowcount semantics + full-stack \`/auth/email/verify\` second-call-returns-401).

Expanded \`safe_next_path\` sanitiser tests in \`tests/test_web_ui.py\` with the \`/\\evil.com\` and \`/\\\\evil.com/path\` payloads.

## Base

Targeting \`ps/security\` — parallels the \`ps/wheel-name-fix\` deploy-staging pattern. Merge here first for Devin review, then \`ps/security\` → \`main\` once clean.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/47" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
