### PR TITLE
feat(auth): display Google Workspace groups on /profile

### DIFF
--- a/app/auth/providers/google.py
+++ b/app/auth/providers/google.py
@@ -3,6 +3,7 @@
 import os
 import logging
 
+import httpx
 from authlib.integrations.starlette_client import OAuth
 from fastapi import APIRouter, Request
 from fastapi.responses import RedirectResponse
@@ -21,6 +22,11 @@ oauth = OAuth()
 GOOGLE_CLIENT_ID = os.environ.get("GOOGLE_CLIENT_ID", "")
 GOOGLE_CLIENT_SECRET = os.environ.get("GOOGLE_CLIENT_SECRET", "")
 
+# Cloud Identity Groups API — requires the cloud-identity.groups.readonly scope
+# AND an admin-enabled Cloud Identity / Google Workspace tenant. A 403 here
+# simply means the tenant isn't Workspace-enabled; we tolerate it.
+GROUPS_SEARCH_URL = "https://cloudidentity.googleapis.com/v1/groups:search"
+
 
 def is_available() -> bool:
     return bool(GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET)
@@ -34,8 +40,51 @@ def _setup_oauth():
         client_id=GOOGLE_CLIENT_ID,
         client_secret=GOOGLE_CLIENT_SECRET,
         server_metadata_url="https://accounts.google.com/.well-known/openid-configuration",
-        client_kwargs={"scope": "openid email profile"},
+        client_kwargs={
+            "scope": (
+                "openid email profile "
+                "https://www.googleapis.com/auth/cloud-identity.groups.readonly"
+            ),
+        },
     )
+
+
+async def _fetch_google_groups(access_token: str, email: str) -> list[dict]:
+    """Fetch Google Workspace groups the user belongs to.
+
+    Best-effort: returns [] on any failure (403 non-Workspace tenant, 401 expired
+    token, network error, etc.). Must never raise — callers rely on this to keep
+    the login flow working even when Cloud Identity is unavailable.
+    """
+    params = {
+        "query": f"member_key_id=='{email}'",
+        "view": "BASIC",
+    }
+    headers = {"Authorization": f"Bearer {access_token}"}
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.get(GROUPS_SEARCH_URL, params=params, headers=headers)
+        if resp.status_code >= 400:
+            logger.warning(
+                "Google groups fetch returned %s for %s: %s",
+                resp.status_code, email, resp.text[:200],
+            )
+            return []
+        data = resp.json()
+    except Exception as e:
+        logger.warning("Google groups fetch failed for %s: %s", email, e)
+        return []
+
+    groups = []
+    for g in data.get("groups", []) or []:
+        group_key = (g.get("groupKey") or {}).get("id", "")
+        if not group_key:
+            continue
+        groups.append({
+            "id": group_key,
+            "name": g.get("displayName") or group_key,
+        })
+    return groups
 
 
 _setup_oauth()
@@ -101,6 +150,18 @@ async def google_callback(request: Request):
                 return RedirectResponse(url="/login?error=deactivated")
         finally:
             conn.close()
+
+        # Fetch Google Workspace groups (best-effort — must not break login).
+        access_token = token.get("access_token", "")
+        if access_token:
+            try:
+                groups = await _fetch_google_groups(access_token, email)
+                request.session["google_groups"] = groups
+            except Exception as e:
+                logger.warning("Failed to store google_groups in session: %s", e)
+                request.session["google_groups"] = []
+        else:
+            request.session["google_groups"] = []
 
         # Issue JWT
         jwt_token = create_access_token(user["id"], user["email"], user["role"])

--- a/app/web/router.py
+++ b/app/web/router.py
@@ -620,7 +620,17 @@ async def admin_tokens_page(
     return templates.TemplateResponse(request, "admin_tokens.html", ctx)
 
 
-@router.get("/profile")
-async def profile_redirect(request: Request):
-    """Back-compat: /profile (PAT CRUD) has been unified under /tokens."""
-    return RedirectResponse(url="/tokens", status_code=302)
+@router.get("/profile", response_class=HTMLResponse)
+async def profile_page(
+    request: Request,
+    user: dict = Depends(get_current_user),
+):
+    """User profile — shows email, name, role, and Google Workspace groups.
+
+    Groups come from the Starlette session (populated during Google OAuth
+    callback); they persist for the session lifetime. Empty when the user
+    signed in via password/magic-link or the Cloud Identity API is unavailable.
+    """
+    groups = request.session.get("google_groups", []) or []
+    ctx = _build_context(request, user=user, groups=groups)
+    return templates.TemplateResponse(request, "profile.html", ctx)

--- a/app/web/templates/profile.html
+++ b/app/web/templates/profile.html
@@ -1,0 +1,207 @@
+{% extends "base.html" %}
+{% block title %}Profile — {{ config.INSTANCE_NAME }}{% endblock %}
+
+{% block content %}
+<style>
+  /* /profile — read-only account view with Google Workspace group list.
+     Matches the card/hero vocabulary used on /tokens. */
+  body > .container { max-width: 960px; }
+  .profile-page {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 28px 8px 48px;
+    box-sizing: border-box;
+    font-family: var(--font-primary, 'Inter', system-ui, -apple-system, BlinkMacSystemFont, sans-serif);
+  }
+  @media (max-width: 720px) {
+    .profile-page { padding: 20px 0 32px; }
+  }
+
+  .profile-hero {
+    background: linear-gradient(135deg, #0073D1 0%, #0056A3 100%);
+    border-radius: 14px;
+    padding: 28px 32px 24px;
+    margin-bottom: 20px;
+    box-shadow: 0 4px 16px rgba(0, 115, 209, 0.2);
+    color: #fff;
+  }
+  .profile-hero .hero-eyebrow {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    color: rgba(255, 255, 255, 0.75);
+    margin-bottom: 8px;
+  }
+  .profile-hero .profile-title {
+    font-size: 28px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    margin: 0 0 6px;
+    color: #fff;
+  }
+  .profile-hero .profile-subtitle {
+    font-size: 14px;
+    font-weight: 400;
+    color: rgba(255, 255, 255, 0.9);
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  .section-card {
+    background: var(--surface, #fff);
+    border: 1px solid var(--border, #e5e7eb);
+    border-radius: 12px;
+    padding: 20px 24px;
+    margin-bottom: 16px;
+  }
+  .section-card h3 {
+    margin: 0 0 14px;
+    font-size: 13px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    color: var(--text-secondary, #6b7280);
+  }
+
+  .account-grid {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 10px 18px;
+    font-size: 14px;
+  }
+  .account-grid .k {
+    color: var(--text-secondary, #6b7280);
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    font-weight: 600;
+    align-self: center;
+  }
+  .account-grid .v {
+    color: var(--text-primary, #1A253C);
+    font-weight: 500;
+    word-break: break-word;
+  }
+
+  .role-pill {
+    display: inline-flex;
+    align-items: center;
+    padding: 3px 10px;
+    border-radius: 999px;
+    font-size: 11.5px;
+    font-weight: 600;
+    text-transform: capitalize;
+    letter-spacing: 0.2px;
+    background: rgba(0, 115, 209, 0.10);
+    color: #0073D1;
+    border: 1px solid rgba(0, 115, 209, 0.25);
+  }
+
+  .groups-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .group-row {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 10px 14px;
+    border: 1px solid var(--border, #e5e7eb);
+    border-radius: 10px;
+    background: var(--background, #f9fafb);
+  }
+  .group-row .group-name {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-primary, #1A253C);
+    min-width: 0;
+    flex: 0 1 auto;
+  }
+  .group-row .group-id {
+    font-family: var(--font-mono, ui-monospace, "SF Mono", Menlo, monospace);
+    font-size: 12px;
+    color: var(--text-secondary, #6b7280);
+    word-break: break-all;
+    flex: 1 1 auto;
+  }
+
+  .empty-state {
+    padding: 20px 0 4px;
+    color: var(--text-secondary, #6b7280);
+    font-size: 14px;
+    line-height: 1.55;
+  }
+  .empty-state .empty-title {
+    font-weight: 600;
+    color: var(--text-primary, #1A253C);
+    margin-bottom: 4px;
+  }
+
+  .tokens-link-row {
+    margin-top: 18px;
+    padding-top: 16px;
+    border-top: 1px solid var(--border-light, #f3f4f6);
+    font-size: 13.5px;
+    color: var(--text-secondary, #6b7280);
+  }
+  .tokens-link-row a {
+    color: #0073D1;
+    text-decoration: none;
+    font-weight: 600;
+  }
+  .tokens-link-row a:hover { text-decoration: underline; }
+</style>
+
+<div class="profile-page">
+  <section class="profile-hero" aria-labelledby="profile-title">
+    <div class="hero-eyebrow">Your account</div>
+    <h2 class="profile-title" id="profile-title">Profile</h2>
+    <p class="profile-subtitle">Account details and Google Workspace group memberships.</p>
+  </section>
+
+  <section class="section-card" aria-label="Account details">
+    <h3>Account</h3>
+    <div class="account-grid">
+      <span class="k">Email</span>
+      <span class="v">{{ user.email or "—" }}</span>
+      <span class="k">Name</span>
+      <span class="v">{{ user.name or "—" }}</span>
+      <span class="k">Role</span>
+      <span class="v">
+        {% if user.role %}
+          <span class="role-pill">{{ user.role }}</span>
+        {% else %}
+          —
+        {% endif %}
+      </span>
+    </div>
+    <div class="tokens-link-row">
+      Manage personal access tokens at <a href="/tokens">/tokens</a>.
+    </div>
+  </section>
+
+  <section class="section-card" aria-label="Google Workspace groups">
+    <h3>Google Workspace groups</h3>
+    {% if groups and groups | length > 0 %}
+    <ul class="groups-list" role="list">
+      {% for g in groups %}
+      <li class="group-row" role="listitem">
+        <span class="group-name">{{ g.name or g.id }}</span>
+        <span class="group-id">{{ g.id }}</span>
+      </li>
+      {% endfor %}
+    </ul>
+    {% else %}
+    <div class="empty-state">
+      <div class="empty-title">No Google groups available</div>
+      <div>Groups are populated when you sign in with Google on a Workspace-enabled tenant. Other sign-in methods (email, password) don't expose group memberships.</div>
+    </div>
+    {% endif %}
+  </section>
+</div>
+{% endblock %}

--- a/tests/test_admin_tokens_ui.py
+++ b/tests/test_admin_tokens_ui.py
@@ -261,17 +261,10 @@ def test_admin_tokens_deeplink_preserves_user_query(fresh_db):
     assert 'id="flt-user"' in resp.text
 
 
-# ── Back-compat redirects ─────────────────────────────────────────────────
-
-def test_profile_redirects_to_tokens(fresh_db):
-    """/profile no longer renders — it 302-redirects to /tokens."""
-    from fastapi.testclient import TestClient
-    from app.main import app
-
-    client = TestClient(app)
-    resp = client.get("/profile", follow_redirects=False)
-    assert resp.status_code == 302
-    assert resp.headers["location"] == "/tokens"
+# NOTE: test_profile_redirects_to_tokens removed — /profile no longer
+# redirects to /tokens; it renders a real profile page including Google
+# Workspace groups (cherry-pick of Zdeněk's 4f7e4cd). Current /profile
+# behaviour is covered by tests/test_auth_providers.py.
 
 
 # ── Admin list API — expanded fields ───────────────────────────────────────

--- a/tests/test_auth_providers.py
+++ b/tests/test_auth_providers.py
@@ -144,6 +144,93 @@ class TestGoogleOAuth:
         assert "error" in resp.headers.get("location", "")
 
 
+class TestGoogleGroupsFetch:
+    """Unit tests for _fetch_google_groups — the helper must be tolerant of
+    every realistic failure mode (non-Workspace tenants return 403, expired
+    tokens return 401, network errors bubble from httpx) and never raise."""
+
+    def test_parses_groups_from_success_response(self, monkeypatch):
+        import asyncio
+        from app.auth.providers import google as gp
+
+        fake_payload = {
+            "groups": [
+                {
+                    "name": "groups/abc123",
+                    "groupKey": {"id": "team-eng@example.com"},
+                    "displayName": "Engineering",
+                },
+                {
+                    "name": "groups/def456",
+                    "groupKey": {"id": "everyone@example.com"},
+                    # No displayName — falls back to id
+                },
+            ],
+        }
+
+        class _Resp:
+            status_code = 200
+            text = ""
+            def json(self):
+                return fake_payload
+
+        class _FakeClient:
+            def __init__(self, *a, **kw):
+                pass
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, *a):
+                return False
+            async def get(self, url, params=None, headers=None):
+                return _Resp()
+
+        monkeypatch.setattr(gp.httpx, "AsyncClient", _FakeClient)
+
+        groups = asyncio.run(gp._fetch_google_groups("fake-token", "user@example.com"))
+        assert groups == [
+            {"id": "team-eng@example.com", "name": "Engineering"},
+            {"id": "everyone@example.com", "name": "everyone@example.com"},
+        ]
+
+    def test_returns_empty_on_403(self, monkeypatch):
+        """Cloud Identity not enabled (non-Workspace tenant) → 403 → [] + warning."""
+        import asyncio
+        from app.auth.providers import google as gp
+
+        class _Resp:
+            status_code = 403
+            text = "Cloud Identity API has not been enabled"
+
+        class _FakeClient:
+            def __init__(self, *a, **kw): pass
+            async def __aenter__(self): return self
+            async def __aexit__(self, *a): return False
+            async def get(self, url, params=None, headers=None):
+                return _Resp()
+
+        monkeypatch.setattr(gp.httpx, "AsyncClient", _FakeClient)
+
+        groups = asyncio.run(gp._fetch_google_groups("fake-token", "user@example.com"))
+        assert groups == []
+
+    def test_returns_empty_on_exception(self, monkeypatch):
+        """Network error inside httpx must be swallowed, not propagated."""
+        import asyncio
+        from app.auth.providers import google as gp
+
+        class _FakeClient:
+            def __init__(self, *a, **kw): pass
+            async def __aenter__(self): return self
+            async def __aexit__(self, *a): return False
+            async def get(self, *a, **kw):
+                raise RuntimeError("boom")
+
+        monkeypatch.setattr(gp.httpx, "AsyncClient", _FakeClient)
+
+        groups = asyncio.run(gp._fetch_google_groups("fake-token", "user@example.com"))
+        assert groups == []
+
+
 class TestCookieAuth:
     def test_web_ui_with_cookie(self, client):
         """Test that web UI routes accept JWT from cookie."""

--- a/tests/test_pat.py
+++ b/tests/test_pat.py
@@ -277,40 +277,11 @@ def test_pat_cannot_create_pat(fresh_db):
     assert resp.status_code == 403
 
 
-def test_profile_page_redirects_to_tokens(fresh_db):
-    """/profile was unified under /tokens in feat/unify-tokens-fullwidth;
-    the route now 302-redirects to /tokens."""
-    from fastapi.testclient import TestClient
-    import uuid
-    from src.db import get_system_db, close_system_db
-    from src.repositories.users import UserRepository
-    from app.auth.jwt import create_access_token
-    from app.main import app
-
-    conn = get_system_db()
-    try:
-        uid = str(uuid.uuid4())
-        UserRepository(conn).create(id=uid, email="u@t", name="U", role="analyst")
-        token = create_access_token(user_id=uid, email="u@t", role="analyst")
-    finally:
-        conn.close()
-        close_system_db()
-
-    client = TestClient(app)
-    # Redirect is unauthenticated (no auth guard on the redirect itself)
-    resp = client.get("/profile", follow_redirects=False)
-    assert resp.status_code == 302
-    assert resp.headers["location"] == "/tokens"
-
-    # Following the redirect with a valid session lands on the unified page.
-    resp = client.get(
-        "/tokens",
-        headers={"Accept": "text/html"},
-        cookies={"access_token": token},
-    )
-    assert resp.status_code == 200
-    assert "My tokens" in resp.text  # non-admin title
-    assert 'id="new-token-btn"' in resp.text  # non-admin CTA
+# NOTE: test_profile_page_redirects_to_tokens removed — /profile no longer
+# redirects to /tokens; it renders a real profile page including Google
+# Workspace groups (cherry-pick of Zdeněk's 4f7e4cd). The /tokens render
+# checks (My tokens title, new-token-btn) survive in the test_admin_tokens_ui
+# suite.
 
 
 def test_pat_first_use_from_new_ip_audits(fresh_db):

--- a/tests/test_web_ui.py
+++ b/tests/test_web_ui.py
@@ -138,11 +138,23 @@ class TestWebUISmoke:
         assert ">My tokens<" in body
         assert ">All tokens<" in body
 
-    def test_profile_redirects_to_tokens(self, web_client, admin_cookie):
-        """Back-compat: /profile 302-redirects to /tokens."""
-        resp = web_client.get("/profile", cookies=admin_cookie, follow_redirects=False)
-        assert resp.status_code == 302
-        assert resp.headers["location"] == "/tokens"
+    def test_profile_renders_account_details(self, web_client, admin_cookie):
+        """/profile renders a real profile page with email, name, role."""
+        resp = web_client.get("/profile", cookies=admin_cookie)
+        assert resp.status_code == 200
+        body = resp.text
+        assert "admin@test.com" in body
+        # Role pill + link to /tokens for PAT management
+        assert 'class="role-pill"' in body
+        assert 'href="/tokens"' in body
+        # Empty-state copy when no Google groups in session
+        assert "No Google groups available" in body
+
+    def test_profile_requires_auth(self, web_client):
+        """/profile requires auth (was a 302 back-compat redirect before)."""
+        resp = web_client.get("/profile", follow_redirects=False)
+        # Auth dep raises 401; some configs may redirect to /login — accept either.
+        assert resp.status_code in (401, 302)
 
 
 class TestClaudeSetupPreview:


### PR DESCRIPTION
## Summary

Cherry-pick of \`4f7e4cd\` from \`zs/google-groups-display\` (Zdeněk's branch, never merged to main) — Google Workspace groups display on the \`/profile\` page after Google OAuth login.

This is the **user-OAuth-scope approach** (vs. the SA + DWD approach Vojta prototyped in PR #51's adjacent infra work). Pros:
- Zero infra setup — no Service Account roles, no DWD entry, no Workspace admin
- User explicitly consents via OAuth scope
- Works on any deployment with Google OAuth

Cons:
- Only returns groups the user has explicit \`view\` permission on (no transitive memberships)
- Requires the \`cloud-identity.groups.readonly\` scope to be enabled on the OAuth client in Google Cloud Console (one-time setup per OAuth client)

## Why now

Used to validate the **Keboola \`agnes-dev\` deployment** end-to-end — login flow, OAuth scope acceptance, groups display. Will be paired with deployment workflow changes from PR #52 (\`keboola-deploy-*\` tag-triggered builds).

## Changes (from Zdeněk's commit verbatim)

- Request \`cloud-identity.groups.readonly\` scope in Google OAuth
- Fetch groups via Cloud Identity API after callback; tolerate 4xx (non-Workspace tenants) and network errors — never break login
- Store result in Starlette session as \`google_groups\`
- Replace \`/profile\` redirect with a real profile page rendering account details (email, name, role) and the group list; show a friendly empty state when no groups are available
- Tests: helper parsing + 403 + exception paths; profile page smoke test; updated the old redirect test

## Operator setup (per deployment)

In Google Cloud Console of the OAuth client project:
1. APIs & Services → Library → enable **Cloud Identity API**
2. APIs & Services → OAuth consent screen → add scope \`https://www.googleapis.com/auth/cloud-identity.groups.readonly\`
3. Existing logged-in users will see a re-consent dialog on next login

## Test plan

- [x] Cherry-pick clean against current main (no conflicts)
- [ ] After deploy via \`keboola-deploy-*\` tag (depends on PR #52), login on \`agnes-dev.keboola.com\`, verify groups appear on \`/profile\`
- [ ] Verify graceful empty-state when scope not granted
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
