### PR TITLE
fix(deploy): pass CADDY_TLS through to caddy container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 <!-- Add bullets here. Group: Added / Changed / Fixed / Removed / Internal.
      Mark breaking changes with **BREAKING** at the start of the bullet. -->
 
+### Fixed
+
+- `docker-compose.yml` caddy service now passes `CADDY_TLS` through to the container (`- CADDY_TLS` bare-form passthrough). Without it the `Caddyfile` `{$CADDY_TLS:default}` substitution always falls back to cert-file mode regardless of what the operator wrote into `.env`, and Caddy crash-loops on Let's Encrypt / internal-CA deployments. Should have shipped with #52; first attempt was #55, accidentally closed before merging.
+
 ### Internal
 
 - `CLAUDE.md` — non-negotiable changelog discipline: every PR touching user-visible behavior must update `CHANGELOG.md` under `## [Unreleased]` in the same PR.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,6 +127,12 @@ services:
       - caddy_config:/config
     environment:
       - DOMAIN=${DOMAIN:-localhost}
+      # Passes through whatever the operator set in .env. Caddyfile uses
+      # {$CADDY_TLS:tls /certs/fullchain.pem /certs/privkey.pem} so:
+      # - unset            → cert-file mode (corp PKI rotated by tls-rotate.sh)
+      # - "tls <email>"    → Let's Encrypt auto-issue
+      # - "tls internal"   → Caddy-managed self-signed
+      - CADDY_TLS
     depends_on:
       app:
         condition: service_healthy


### PR DESCRIPTION
## Hotfix for PR #52 / agnes-dev deploy

PR #52 parametrized the Caddyfile via \`{\$CADDY_TLS:default}\` but forgot to expose \`CADDY_TLS\` to the caddy service in \`docker-compose.yml\`. Result: Caddy ignores whatever the operator wrote into \`.env\` and falls back to the cert-file default → crash-loops with \`open /certs/fullchain.pem: no such file or directory\` on any LE or internal deployment.

Caught by Keboola's first \`agnes-dev\` recreate (\`agnes-dev.keboola.com\`).

## Fix

```diff
     environment:
       - DOMAIN=\${DOMAIN:-localhost}
+      - CADDY_TLS
```

Compose \`- CADDY_TLS\` (bare form, no \`=value\`) reads from \`.env\` / host shell at \`up\` time. No-op when \`CADDY_TLS\` is unset (default Caddyfile path kicks in); preserves cert-file behaviour for corp-PKI deployments.

## Test plan

- [ ] CI passes
- [ ] On agnes-dev VM (after this lands + cron picks up new compose): caddy container stays \`Up\`, port 443 reachable, valid LE cert
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/55" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
