### PR TITLE
release(0.11.1): hotfix CADDY_TLS passthrough + changelog discipline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 <!-- Add bullets here. Group: Added / Changed / Fixed / Removed / Internal.
      Mark breaking changes with **BREAKING** at the start of the bullet. -->
 
+## [0.11.1] — 2026-04-26
+
+Patch release — hotfix the missed Caddy env passthrough that should have shipped with 0.11.0, plus codify changelog discipline so this kind of drift gets caught at PR review time next time.
+
 ### Fixed
 
 - `docker-compose.yml` caddy service now passes `CADDY_TLS` through to the container (`- CADDY_TLS` bare-form passthrough). Without it the `Caddyfile` `{$CADDY_TLS:default}` substitution always falls back to cert-file mode regardless of what the operator wrote into `.env`, and Caddy crash-loops on Let's Encrypt / internal-CA deployments. Should have shipped with #52; first attempt was #55, accidentally closed before merging.
@@ -98,4 +102,5 @@ First tagged semver release. The `version = "2.x"` strings that appeared in earl
 
 - Test suite expanded to 1357+ tests (4 layers — unit, integration, web smoke, journey).
 
+[0.11.1]: https://github.com/keboola/agnes-the-ai-analyst/releases/tag/v0.11.1
 [0.11.0]: https://github.com/keboola/agnes-the-ai-analyst/releases/tag/v0.11.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.11.0"
+version = "0.11.1"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"


### PR DESCRIPTION
## Summary

Patch release.

- Bumps \`pyproject.toml\` 0.11.0 → 0.11.1
- Promotes the two \`[Unreleased]\` entries (#55 + #59) to \`[0.11.1]\` in CHANGELOG.md
- Appends fresh empty \`[Unreleased]\` skeleton above

## What ships

- **Fix** — CADDY_TLS env passthrough in docker-compose.yml (#55). Without it Caddy ignores operator-set \`.env\` value and crash-loops on LE / internal-CA deploys.
- **Internal** — CLAUDE.md changelog discipline rule (#59).

## After merge

\`\`\`bash
git fetch origin main
git tag v0.11.1 origin/main
git push origin v0.11.1
gh release create v0.11.1 --title "v0.11.1 — CADDY_TLS hotfix + changelog discipline" --notes-file ...
\`\`\`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/67" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
