### PR TITLE
fix(tests): refresh nightly docker-e2e asserts after auth + health refactors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 <!-- Add bullets here. Group: Added / Changed / Fixed / Removed / Internal.
      Mark breaking changes with **BREAKING** at the start of the bullet. -->
 
+### Internal
+
+- Fix nightly `docker-e2e` CI failures: refresh two stale assertions that had drifted from the live API. `tests/test_docker_full.py::test_app_returns_html_on_root` now expects the auth-aware `302 → /login` (root has redirected since the auth middleware landed); `tests/test_e2e_docker.py::TestDockerHealth::test_health_has_duckdb` now reads `services["duckdb_state"]` (current health-payload shape, already validated by `tests/test_api.py`). No application behavior change — these only ran in the scheduled nightly job, so the drift went unnoticed for several PRs.
+
 ## [0.11.1] — 2026-04-26
 
 Patch release — hotfix the missed Caddy env passthrough that should have shipped with 0.11.0, plus codify changelog discipline so this kind of drift gets caught at PR review time next time.

--- a/tests/test_docker_full.py
+++ b/tests/test_docker_full.py
@@ -49,9 +49,10 @@ def test_app_health():
 
 
 def test_app_returns_html_on_root():
-    """GET / returns 200 (HTML dashboard)."""
-    resp = httpx.get(f"{DOCKER_BASE_URL}/", timeout=10)
-    assert resp.status_code == 200
+    """GET / redirects unauthenticated callers — / always 302s to /login or /dashboard."""
+    resp = httpx.get(f"{DOCKER_BASE_URL}/", timeout=10, follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers.get("location") in ("/login", "/dashboard")
 
 
 def test_bootstrap_creates_admin():

--- a/tests/test_e2e_docker.py
+++ b/tests/test_e2e_docker.py
@@ -78,8 +78,9 @@ class TestDockerHealth:
         import httpx
         resp = httpx.get(f"{docker_env}/api/health")
         data = resp.json()
-        checks = data.get("checks", {})
-        assert "duckdb" in checks or "database" in checks
+        services = data.get("services", {})
+        assert "duckdb_state" in services
+        assert services["duckdb_state"]["status"] == "ok"
 
 
 class TestDockerFullFlow:


### PR DESCRIPTION
## Summary

Two assertions in the docker-marker test files had drifted from the live API and were only caught by the scheduled nightly CI job ([run #24947963804](https://github.com/keboola/agnes-the-ai-analyst/actions/runs/24947963804), 2026-04-26 04:12 UTC). Test-only changes — no application behavior touched.

### What was wrong

- **`tests/test_docker_full.py::test_app_returns_html_on_root`** asserted `200` on `GET /` — but `app/web/router.py:189-193` has redirected unauthenticated callers to `/login` (and authenticated to `/dashboard`) ever since the auth middleware landed. The test was authored before that refactor.
- **`tests/test_e2e_docker.py::TestDockerHealth::test_health_has_duckdb`** read `data["checks"]["duckdb" | "database"]` — but `app/api/health.py` returns `{"services": {"duckdb_state": ..., "data": ..., "users": ...}}`. The schema rename happened in an earlier health refactor and only the unit-test layer (`tests/test_api.py::TestHealth`) was updated.

### Fix

- Root-redirect test now uses `follow_redirects=False` and asserts `302 + location ∈ {/login, /dashboard}` — same pattern as the passing `tests/test_api_complete.py::TestWebUI::test_root_redirects`.
- Health-check test now reads `services["duckdb_state"]["status"] == "ok"` — same pattern as the passing `tests/test_api.py::TestHealth::test_health_has_duckdb_check`. Both test layers now agree on the response shape.

### Why this slipped

The `pytest.mark.docker` marker means these tests only run under the scheduled nightly CI workflow, not on push events. The drift accumulated quietly over PRs #54-#56 (auth middleware + health refactors) and only surfaced when the nightly cron fired against the released `0.11.1` main.

## Test plan

- [x] `pytest tests/test_docker_full.py tests/test_e2e_docker.py -m docker --collect-only` → 7 tests collected, no syntax errors
- [x] Sanity: `pytest tests/test_api.py::TestHealth tests/test_api_complete.py::TestWebUI::test_root_redirects -v` → 3/3 passed (same endpoints, non-docker layer)
- [ ] CI: nightly `docker-e2e` job goes green on next scheduled run (or on manual workflow_dispatch)

## CHANGELOG

Entry added under `## [Unreleased] → ### Internal` per the non-negotiable rule in CLAUDE.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/69" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
