### PR TITLE
feat(dev): add Windows PowerShell wrapper for local development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
-<!-- Add bullets here. Group: Added / Changed / Fixed / Removed / Internal.
-     Mark breaking changes with **BREAKING** at the start of the bullet. -->
+### Added
+
+- **Windows/PowerShell wrapper for local dev.** New `scripts/run-local-dev.ps1` mirrors `scripts/run-local-dev.sh` for operators on Windows where GNU Make / bash aren't available — same compose stack (`docker-compose.yml` + `.override.yml` + `.local-dev.yml`), same `LOCAL_DEV_GROUPS` default seeding, same `up` / `down` / `logs` actions. Run `.\scripts\run-local-dev.ps1` for the fast path (reuses existing image) or `.\scripts\run-local-dev.ps1 -Build` to force `--build` after `pyproject.toml` / `Dockerfile` changes. Verified on Docker Desktop for Windows. See `docs/local-development.md`.
 
 ## [0.12.1] — 2026-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ### Added
 
-- **Windows/PowerShell wrapper for local dev.** New `scripts/run-local-dev.ps1` mirrors `scripts/run-local-dev.sh` for operators on Windows where GNU Make / bash aren't available — same compose stack (`docker-compose.yml` + `.override.yml` + `.local-dev.yml`), same `LOCAL_DEV_GROUPS` default seeding, same `up` / `down` / `logs` actions. Run `.\scripts\run-local-dev.ps1` for the fast path (reuses existing image) or `.\scripts\run-local-dev.ps1 -Build` to force `--build` after `pyproject.toml` / `Dockerfile` changes. Verified on Docker Desktop for Windows. See `docs/local-development.md`.
+- **Windows/PowerShell wrapper for local dev.** New `scripts/run-local-dev.ps1` mirrors `scripts/run-local-dev.sh` for operators on Windows where GNU Make / bash aren't available — same compose stack (`docker-compose.yml` + `docker-compose.dev.yml` + `docker-compose.local-dev.yml`), same `LOCAL_DEV_GROUPS` default seeding, same `up` / `down` / `logs` actions. Run `.\scripts\run-local-dev.ps1` for the fast path (reuses existing image) or `.\scripts\run-local-dev.ps1 -Build` to force `--build` after `pyproject.toml` / `Dockerfile` changes. Verified on Docker Desktop for Windows. See `docs/local-development.md`.
 
 ## [0.12.1] — 2026-04-28
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -10,6 +10,15 @@ make local-dev
 
 Then open <http://localhost:8000>. You land on `/dashboard` already logged in as `dev@localhost` (role `admin`) and your `/profile` shows two mocked Workspace groups. No login screen, no `.env` file, no SMTP, no GCP project — just code.
 
+On Windows (or anywhere GNU Make / bash aren't available), `scripts\run-local-dev.ps1` is the feature-equivalent sibling — same compose stack, same `LOCAL_DEV_GROUPS` default. Verified on Docker Desktop for Windows.
+
+```powershell
+.\scripts\run-local-dev.ps1            # up — reuses existing image (auto-builds first run)
+.\scripts\run-local-dev.ps1 -Build     # up --build — after pyproject.toml / Dockerfile changes
+.\scripts\run-local-dev.ps1 down       # stop + remove containers (data volume preserved)
+.\scripts\run-local-dev.ps1 logs       # tail logs
+```
+
 What `make local-dev` actually does:
 
 - Stacks three Compose files: `docker-compose.yml` (base) + `docker-compose.dev.yml` (hot-reload + source bind mount) + `docker-compose.local-dev.yml` (LOCAL_DEV_MODE overlay).

--- a/scripts/run-local-dev.ps1
+++ b/scripts/run-local-dev.ps1
@@ -1,0 +1,108 @@
+<#
+.SYNOPSIS
+    Windows/PowerShell sibling of scripts/run-local-dev.sh.
+
+.DESCRIPTION
+    Runs Agnes locally with auth bypass + dev-mode magic links. Stacks three compose files:
+      1. docker-compose.yml          - base services
+      2. docker-compose.override.yml - hot-reload + source bind mount
+      3. docker-compose.local-dev.yml - LOCAL_DEV_MODE=1, drops .env requirement
+
+    After startup visit http://localhost:8000 - you'll land on /dashboard logged in as
+    dev@localhost (role=admin). No login screen, no email delivery needed.
+
+    Source code is bind-mounted from the host, so Python changes are picked up by
+    uvicorn --reload. Rebuild is only needed when pyproject.toml or Dockerfile change
+    (e.g. after a `git pull` that adds deps). Use -Build for those cases.
+
+.PARAMETER Action
+    up    (default) docker compose up. The image is auto-built on first run.
+    down  docker compose down (stop + remove containers; data volume preserved).
+    logs  docker compose logs -f (tail).
+
+.PARAMETER Build
+    Force --build on `up`. Use after pulling changes that touch pyproject.toml or
+    Dockerfile, or when you hit ModuleNotFoundError from a stale cached image.
+
+.PARAMETER ExtraArgs
+    Anything else (e.g. -d, --remove-orphans) passes through to docker compose.
+
+.EXAMPLE
+    .\scripts\run-local-dev.ps1
+    # up - fast path; reuses existing image (auto-builds if none exists yet)
+
+.EXAMPLE
+    .\scripts\run-local-dev.ps1 -Build
+    # up --build - force rebuild after dep / Dockerfile changes
+
+.EXAMPLE
+    .\scripts\run-local-dev.ps1 up -d
+    # detached
+
+.EXAMPLE
+    .\scripts\run-local-dev.ps1 down
+    # stop + remove containers (data volume preserved)
+
+.EXAMPLE
+    .\scripts\run-local-dev.ps1 logs
+    # tail logs from the running stack
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)]
+    [ValidateSet('up', 'down', 'logs')]
+    [string]$Action = 'up',
+
+    [switch]$Build,
+
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$ExtraArgs
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Run from the repo root regardless of where the user invoked from. Script lives
+# at scripts/run-local-dev.ps1, so the repo root is the parent of $PSScriptRoot.
+Set-Location (Split-Path -Parent $PSScriptRoot)
+
+# docker-compose.yml declares env_file: .env on several services. Compose
+# validates that path even for profiled services that never start, so make
+# sure it exists.
+if (-not (Test-Path .env)) {
+    New-Item -ItemType File -Path .env -Force | Out-Null
+}
+
+# Default LOCAL_DEV_GROUPS so /profile and group-aware code see *something* on
+# first boot. Mirrors scripts/run-local-dev.sh. Override/disable:
+#   $env:LOCAL_DEV_GROUPS = '[...]'; .\scripts\run-local-dev.ps1
+#   $env:LOCAL_DEV_GROUPS = '';      .\scripts\run-local-dev.ps1   # exercise no-groups path
+# Test-Path on Env: distinguishes unset (apply default) from set-to-empty
+# (honor operator intent) — same contract as the bash sibling.
+if (-not (Test-Path Env:LOCAL_DEV_GROUPS)) {
+    $env:LOCAL_DEV_GROUPS = '[{"id":"local-dev-engineers@example.com","name":"Local Dev Engineers"},{"id":"local-dev-admins@example.com","name":"Local Dev Admins"}]'
+}
+
+$composeFiles = @(
+    '-f', 'docker-compose.yml',
+    '-f', 'docker-compose.override.yml',
+    '-f', 'docker-compose.local-dev.yml'
+)
+
+switch ($Action) {
+    'up' {
+        $cmd = @('up')
+        if ($Build) { $cmd += '--build' }
+    }
+    'down' {
+        $cmd = @('down')
+    }
+    'logs' {
+        $cmd = @('logs', '-f')
+    }
+}
+
+if ($ExtraArgs) { $cmd += $ExtraArgs }
+
+Write-Host "> docker compose $($composeFiles + $cmd -join ' ')" -ForegroundColor Cyan
+& docker compose @composeFiles @cmd
+exit $LASTEXITCODE

--- a/scripts/run-local-dev.ps1
+++ b/scripts/run-local-dev.ps1
@@ -5,7 +5,7 @@
 .DESCRIPTION
     Runs Agnes locally with auth bypass + dev-mode magic links. Stacks three compose files:
       1. docker-compose.yml          - base services
-      2. docker-compose.override.yml - hot-reload + source bind mount
+      2. docker-compose.dev.yml - hot-reload + source bind mount
       3. docker-compose.local-dev.yml - LOCAL_DEV_MODE=1, drops .env requirement
 
     After startup visit http://localhost:8000 - you'll land on /dashboard logged in as
@@ -84,7 +84,7 @@ if (-not (Test-Path Env:LOCAL_DEV_GROUPS)) {
 
 $composeFiles = @(
     '-f', 'docker-compose.yml',
-    '-f', 'docker-compose.override.yml',
+    '-f', 'docker-compose.dev.yml',
     '-f', 'docker-compose.local-dev.yml'
 )
 

--- a/scripts/run-local-dev.ps1
+++ b/scripts/run-local-dev.ps1
@@ -67,48 +67,63 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-# Run from the repo root regardless of where the user invoked from. Script lives
-# at scripts/run-local-dev.ps1, so the repo root is the parent of $PSScriptRoot.
-Set-Location (Split-Path -Parent $PSScriptRoot)
+# PowerShell scripts execute in the caller's runspace (unlike bash, which forks
+# a child process), so Set-Location and $env:* assignments leak back into the
+# user's shell after the script exits. Wrap the body in Push-Location /
+# Pop-Location with try/finally and snapshot the LOCAL_DEV_GROUPS env-var so
+# the operator's session is restored on any exit path (success, error, Ctrl+C
+# during `up`/`logs`).
+Push-Location (Split-Path -Parent $PSScriptRoot)
+$localDevGroupsWasSet = Test-Path Env:LOCAL_DEV_GROUPS
+$localDevGroupsOriginal = if ($localDevGroupsWasSet) { $env:LOCAL_DEV_GROUPS } else { $null }
+try {
+    # docker-compose.yml declares env_file: .env on several services. Compose
+    # validates that path even for profiled services that never start, so make
+    # sure it exists.
+    if (-not (Test-Path .env)) {
+        New-Item -ItemType File -Path .env -Force | Out-Null
+    }
 
-# docker-compose.yml declares env_file: .env on several services. Compose
-# validates that path even for profiled services that never start, so make
-# sure it exists.
-if (-not (Test-Path .env)) {
-    New-Item -ItemType File -Path .env -Force | Out-Null
+    # Default LOCAL_DEV_GROUPS so /profile and group-aware code see *something* on
+    # first boot. Mirrors scripts/run-local-dev.sh. Override/disable:
+    #   $env:LOCAL_DEV_GROUPS = '[...]'; .\scripts\run-local-dev.ps1
+    #   $env:LOCAL_DEV_GROUPS = '';      .\scripts\run-local-dev.ps1   # exercise no-groups path
+    # Test-Path on Env: distinguishes unset (apply default) from set-to-empty
+    # (honor operator intent) — same contract as the bash sibling.
+    if (-not $localDevGroupsWasSet) {
+        $env:LOCAL_DEV_GROUPS = '[{"id":"local-dev-engineers@example.com","name":"Local Dev Engineers"},{"id":"local-dev-admins@example.com","name":"Local Dev Admins"}]'
+    }
+
+    $composeFiles = @(
+        '-f', 'docker-compose.yml',
+        '-f', 'docker-compose.dev.yml',
+        '-f', 'docker-compose.local-dev.yml'
+    )
+
+    switch ($Action) {
+        'up' {
+            $cmd = @('up')
+            if ($Build) { $cmd += '--build' }
+        }
+        'down' {
+            $cmd = @('down')
+        }
+        'logs' {
+            $cmd = @('logs', '-f')
+        }
+    }
+
+    if ($ExtraArgs) { $cmd += $ExtraArgs }
+
+    Write-Host "> docker compose $($composeFiles + $cmd -join ' ')" -ForegroundColor Cyan
+    & docker compose @composeFiles @cmd
+} finally {
+    Pop-Location
+    if ($localDevGroupsWasSet) {
+        $env:LOCAL_DEV_GROUPS = $localDevGroupsOriginal
+    } else {
+        Remove-Item Env:LOCAL_DEV_GROUPS -ErrorAction SilentlyContinue
+    }
 }
 
-# Default LOCAL_DEV_GROUPS so /profile and group-aware code see *something* on
-# first boot. Mirrors scripts/run-local-dev.sh. Override/disable:
-#   $env:LOCAL_DEV_GROUPS = '[...]'; .\scripts\run-local-dev.ps1
-#   $env:LOCAL_DEV_GROUPS = '';      .\scripts\run-local-dev.ps1   # exercise no-groups path
-# Test-Path on Env: distinguishes unset (apply default) from set-to-empty
-# (honor operator intent) — same contract as the bash sibling.
-if (-not (Test-Path Env:LOCAL_DEV_GROUPS)) {
-    $env:LOCAL_DEV_GROUPS = '[{"id":"local-dev-engineers@example.com","name":"Local Dev Engineers"},{"id":"local-dev-admins@example.com","name":"Local Dev Admins"}]'
-}
-
-$composeFiles = @(
-    '-f', 'docker-compose.yml',
-    '-f', 'docker-compose.dev.yml',
-    '-f', 'docker-compose.local-dev.yml'
-)
-
-switch ($Action) {
-    'up' {
-        $cmd = @('up')
-        if ($Build) { $cmd += '--build' }
-    }
-    'down' {
-        $cmd = @('down')
-    }
-    'logs' {
-        $cmd = @('logs', '-f')
-    }
-}
-
-if ($ExtraArgs) { $cmd += $ExtraArgs }
-
-Write-Host "> docker compose $($composeFiles + $cmd -join ' ')" -ForegroundColor Cyan
-& docker compose @composeFiles @cmd
 exit $LASTEXITCODE

--- a/scripts/run-local-dev.ps1
+++ b/scripts/run-local-dev.ps1
@@ -24,8 +24,9 @@
     Force --build on `up`. Use after pulling changes that touch pyproject.toml or
     Dockerfile, or when you hit ModuleNotFoundError from a stale cached image.
 
-.PARAMETER ExtraArgs
-    Anything else (e.g. -d, --remove-orphans) passes through to docker compose.
+.NOTES
+    Anything else on the command line (e.g. -d, --remove-orphans) lands in
+    PowerShell's automatic $args variable and is forwarded to docker compose.
 
 .EXAMPLE
     .\scripts\run-local-dev.ps1
@@ -47,22 +48,20 @@
     .\scripts\run-local-dev.ps1 logs
     # tail logs from the running stack
 #>
-# Deliberately NOT [CmdletBinding()]: that auto-injects common parameters
-# (-Debug, -Verbose, -ErrorAction, etc.) which PowerShell binds via prefix
-# match BEFORE ValueFromRemainingArguments. Documented examples like
-# `up -d` (detached) and `down -v` (remove volumes) would silently get
-# eaten by `-Debug` / `-Verbose` instead of reaching docker compose.
-# Plain `param()` keeps the binder honest — anything unrecognized falls
-# through to $ExtraArgs and on to docker compose.
+# Deliberately keep this a SIMPLE (non-advanced) script — no [CmdletBinding()]
+# and no [Parameter(...)] attributes. Both promote the script to an advanced
+# function, which auto-injects the common parameters (-Debug, -Verbose,
+# -ErrorAction, ...) that PowerShell binds via prefix match. Documented
+# examples like `up -d` (detached) and `down -v` (remove volumes) would
+# silently have `-d` / `-v` eaten by `-Debug` / `-Verbose` instead of reaching
+# docker compose. [ValidateSet(...)] and [switch] do NOT promote and stay.
+# Unbound positional args land in PowerShell's automatic $args variable in a
+# non-advanced script; we forward them to docker compose.
 param(
-    [Parameter(Position = 0)]
     [ValidateSet('up', 'down', 'logs')]
     [string]$Action = 'up',
 
-    [switch]$Build,
-
-    [Parameter(ValueFromRemainingArguments = $true)]
-    [string[]]$ExtraArgs
+    [switch]$Build
 )
 
 $ErrorActionPreference = 'Stop'
@@ -113,7 +112,7 @@ try {
         }
     }
 
-    if ($ExtraArgs) { $cmd += $ExtraArgs }
+    if ($args) { $cmd += $args }
 
     Write-Host "> docker compose $($composeFiles + $cmd -join ' ')" -ForegroundColor Cyan
     & docker compose @composeFiles @cmd

--- a/scripts/run-local-dev.ps1
+++ b/scripts/run-local-dev.ps1
@@ -47,7 +47,13 @@
     .\scripts\run-local-dev.ps1 logs
     # tail logs from the running stack
 #>
-[CmdletBinding()]
+# Deliberately NOT [CmdletBinding()]: that auto-injects common parameters
+# (-Debug, -Verbose, -ErrorAction, etc.) which PowerShell binds via prefix
+# match BEFORE ValueFromRemainingArguments. Documented examples like
+# `up -d` (detached) and `down -v` (remove volumes) would silently get
+# eaten by `-Debug` / `-Verbose` instead of reaching docker compose.
+# Plain `param()` keeps the binder honest — anything unrecognized falls
+# through to $ExtraArgs and on to docker compose.
 param(
     [Parameter(Position = 0)]
     [ValidateSet('up', 'down', 'logs')]


### PR DESCRIPTION
Introduces a new PowerShell script `scripts/run-local-dev.ps1` to facilitate local development on Windows, mirroring the existing Bash script. This addition allows users to run the same Docker Compose stack with equivalent commands for starting, stopping, and logging. The script is documented in `docs/local-development.md`, ensuring a smooth onboarding experience for Windows users.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/80" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
