### PR TITLE
feat(memory): auto topic tagging via Haiku

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Added
+- **Automatic topic tagging** — Haiku assigns topics from a shared vocabulary (`data`, `automation`, `reports`, `alerts`, `metrics`, `queries`, `infrastructure`, `processes`, `integrations`, `debugging`, `performance`, `access`) to knowledge items at creation time (via `POST /api/memory`) and during collector runs; topics are stored in the existing `tags` field alongside free-form keywords; tagging is best-effort and never blocks item creation
+
 <!-- Add bullets here. Group: Added / Changed / Fixed / Removed / Internal.
      Mark breaking changes with **BREAKING** at the start of the bullet. -->
 

--- a/app/api/memory.py
+++ b/app/api/memory.py
@@ -106,13 +106,38 @@ async def create_knowledge(
 ):
     repo = KnowledgeRepository(conn)
     item_id = str(uuid.uuid4())
+
+    # Best-effort auto-tagging — runs only when an LLM extractor is configured.
+    tags = list(request.tags) if request.tags else []
+    try:
+        from config.loader import load_instance_config
+        from connectors.llm import create_extractor
+        from services.corporate_memory.tagger import auto_tag_items
+        cfg = load_instance_config()
+        ai_cfg = cfg.get("ai")
+        if ai_cfg:
+            extractor = create_extractor(ai_cfg)
+            stub = [{"id": item_id, "title": request.title, "content": request.content}]
+            assignments = auto_tag_items(stub, extractor)
+            topics = assignments.get(item_id, [])
+            if topics:
+                seen: set[str] = set()
+                merged: list[str] = []
+                for t in topics + tags:
+                    if t not in seen:
+                        seen.add(t)
+                        merged.append(t)
+                tags = merged
+    except Exception:
+        pass  # tagging is non-critical — never block item creation
+
     repo.create(
         id=item_id,
         title=request.title,
         content=request.content,
         category=request.category,
         source_user=user.get("email"),
-        tags=request.tags,
+        tags=tags or None,
     )
     return {"id": item_id, "status": "pending"}
 

--- a/services/corporate_memory/collector.py
+++ b/services/corporate_memory/collector.py
@@ -23,6 +23,7 @@ from connectors.llm import create_extractor
 from connectors.llm.exceptions import LLMError
 
 from .prompts import CATALOG_REFRESH_PROMPT, SENSITIVITY_CHECK_PROMPT
+from .tagger import auto_tag_items
 
 # Fields preserved across re-collections when item already exists
 GOVERNANCE_FIELDS = (
@@ -478,7 +479,27 @@ def collect_all(dry_run: bool = False) -> dict:
 
     stats["items_pending"] = sum(1 for item in final_items.values() if item.get("status") == "pending")
 
-    # Step 8: Build updated knowledge.json
+    # Step 8: Auto-tag new items with topic vocabulary (best-effort)
+    new_items = [item for item_id, item in final_items.items() if item_id not in existing_ids]
+    if new_items:
+        try:
+            topic_assignments = auto_tag_items(new_items, extractor)
+            for item_id, topics in topic_assignments.items():
+                if item_id in final_items and topics:
+                    existing_tags = final_items[item_id].get("tags") or []
+                    # Prepend topics before free-form keywords (dedup, preserve order)
+                    seen: set[str] = set()
+                    merged: list[str] = []
+                    for t in topics + existing_tags:
+                        if t not in seen:
+                            seen.add(t)
+                            merged.append(t)
+                    final_items[item_id]["tags"] = merged
+            logger.info("Auto-tagged %d new item(s) with topics", len(topic_assignments))
+        except Exception as e:
+            logger.warning("auto_tag_items failed (non-fatal): %s", e)
+
+    # Step 9: Build updated knowledge.json
     updated = {
         "items": final_items,
         "metadata": {

--- a/services/corporate_memory/prompts.py
+++ b/services/corporate_memory/prompts.py
@@ -60,3 +60,16 @@ Tags: {tags}
 ---
 
 Set safe=true if the item is safe to share, or safe=false with a reason if it contains sensitive data."""
+
+TOPIC_TAG_PROMPT = """Assign topics from the vocabulary to each knowledge item.
+
+Vocabulary (use ONLY these values): {vocab_list}
+
+Items:
+{items_text}
+
+Rules:
+- Assign 1-3 topics per item from the vocabulary above.
+- Pick topics that describe the SUBJECT of the item, not how it was written.
+- If nothing fits, assign the single closest match.
+- Return every item id exactly once."""

--- a/services/corporate_memory/tagger.py
+++ b/services/corporate_memory/tagger.py
@@ -1,0 +1,115 @@
+"""Automatic topic tagging for corporate memory knowledge items.
+
+Uses Haiku to assign topics from a shared vocabulary to knowledge items.
+Topics are stored in the existing `tags` field alongside free-form keywords.
+The vocabulary is hardcoded for V1; a future admin UI will let operators
+extend or replace it without a code change.
+"""
+
+import logging
+from typing import Any
+
+from connectors.llm.exceptions import LLMError
+
+logger = logging.getLogger(__name__)
+
+# Starter topic vocabulary. Intentionally broad so most knowledge items map to
+# at least one topic. Future: expose via instance.yaml so operators can
+# customise without a code deploy.
+TOPIC_VOCABULARY: list[str] = [
+    "data",
+    "automation",
+    "reports",
+    "alerts",
+    "metrics",
+    "queries",
+    "infrastructure",
+    "processes",
+    "integrations",
+    "debugging",
+    "performance",
+    "access",
+]
+
+# JSON schema for Haiku structured output — batch assignment
+_TOPIC_TAG_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "assignments": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "topics": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                },
+                "required": ["id", "topics"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["assignments"],
+    "additionalProperties": False,
+}
+
+
+def _build_prompt(items: list[dict], vocabulary: list[str]) -> str:
+    vocab_list = ", ".join(f'"{t}"' for t in vocabulary)
+    items_text = "\n".join(
+        f"- id={item['id']} | title={item.get('title','')} | content={item.get('content','')[:200]}"
+        for item in items
+    )
+    return (
+        f"Assign topics from the vocabulary to each knowledge item.\n\n"
+        f"Vocabulary (use ONLY these values): [{vocab_list}]\n\n"
+        f"Items:\n{items_text}\n\n"
+        f"Rules:\n"
+        f"- Assign 1-3 topics per item from the vocabulary above.\n"
+        f"- Pick topics that describe the SUBJECT of the item, not how it was written.\n"
+        f"- If nothing fits, assign the single closest match.\n"
+        f"- Return every item id exactly once."
+    )
+
+
+def auto_tag_items(items: list[dict], extractor: Any) -> dict[str, list[str]]:
+    """Batch-tag items with topics from TOPIC_VOCABULARY.
+
+    Returns a mapping {item_id: [topic, ...]}. On any LLM error returns {}
+    so callers can treat tagging as best-effort.
+
+    Args:
+        items: List of dicts with at least 'id', 'title', 'content'.
+        extractor: LLM extractor (connectors.llm.BaseExtractor).
+    """
+    if not items:
+        return {}
+
+    prompt = _build_prompt(items, TOPIC_VOCABULARY)
+    try:
+        result = extractor.extract_json(
+            prompt,
+            max_tokens=1024,
+            json_schema=_TOPIC_TAG_SCHEMA,
+            schema_name="topic_tag_assignment",
+        )
+    except LLMError as e:
+        logger.warning("auto_tag_items: LLM error — %s", type(e).__name__)
+        return {}
+    except Exception as e:
+        logger.warning("auto_tag_items: unexpected error — %s", e)
+        return {}
+
+    assignments: dict[str, list[str]] = {}
+    vocab_set = set(TOPIC_VOCABULARY)
+    for entry in result.get("assignments", []):
+        item_id = entry.get("id", "")
+        if not item_id:
+            continue
+        # Keep only vocabulary terms; drop any hallucinated values
+        valid_topics = [t for t in (entry.get("topics") or []) if t in vocab_set]
+        assignments[item_id] = valid_topics
+
+    return assignments

--- a/tests/test_tagger.py
+++ b/tests/test_tagger.py
@@ -1,0 +1,124 @@
+"""Tests for services/corporate_memory/tagger.py — auto topic tagging."""
+
+import pytest
+from services.corporate_memory.tagger import (
+    TOPIC_VOCABULARY,
+    auto_tag_items,
+    _build_prompt,
+)
+from connectors.llm.exceptions import LLMError
+
+
+class _FakeExtractor:
+    """Controllable fake extractor for testing."""
+
+    def __init__(self, response=None, raises=None):
+        self._response = response
+        self._raises = raises
+        self.calls: list[dict] = []
+
+    def extract_json(self, prompt, max_tokens, json_schema, schema_name):
+        self.calls.append({"prompt": prompt, "max_tokens": max_tokens})
+        if self._raises:
+            raise self._raises
+        return self._response or {}
+
+
+class TestTopicVocabulary:
+    def test_vocabulary_is_non_empty(self):
+        assert len(TOPIC_VOCABULARY) >= 5
+
+    def test_vocabulary_contains_expected_topics(self):
+        for topic in ("data", "automation", "reports", "metrics"):
+            assert topic in TOPIC_VOCABULARY, f"'{topic}' should be in TOPIC_VOCABULARY"
+
+    def test_vocabulary_has_no_duplicates(self):
+        assert len(TOPIC_VOCABULARY) == len(set(TOPIC_VOCABULARY))
+
+
+class TestBuildPrompt:
+    def test_includes_all_vocab_terms(self):
+        items = [{"id": "a", "title": "T", "content": "C"}]
+        prompt = _build_prompt(items, TOPIC_VOCABULARY)
+        for term in TOPIC_VOCABULARY:
+            assert term in prompt
+
+    def test_includes_item_id(self):
+        items = [{"id": "km_abc123", "title": "My title", "content": "My content"}]
+        prompt = _build_prompt(items, TOPIC_VOCABULARY)
+        assert "km_abc123" in prompt
+
+    def test_truncates_long_content(self):
+        long_content = "x" * 500
+        items = [{"id": "a", "title": "T", "content": long_content}]
+        prompt = _build_prompt(items, TOPIC_VOCABULARY)
+        # Only first 200 chars of content should appear
+        assert "x" * 200 in prompt
+        assert "x" * 300 not in prompt
+
+
+class TestAutoTagItems:
+    def test_returns_empty_for_empty_input(self):
+        extractor = _FakeExtractor()
+        result = auto_tag_items([], extractor)
+        assert result == {}
+        assert extractor.calls == []
+
+    def test_parses_valid_response(self):
+        extractor = _FakeExtractor(response={
+            "assignments": [
+                {"id": "item1", "topics": ["data", "queries"]},
+                {"id": "item2", "topics": ["automation"]},
+            ]
+        })
+        items = [
+            {"id": "item1", "title": "SQL tips", "content": "use indexes"},
+            {"id": "item2", "title": "CI setup", "content": "automate builds"},
+        ]
+        result = auto_tag_items(items, extractor)
+        assert result["item1"] == ["data", "queries"]
+        assert result["item2"] == ["automation"]
+
+    def test_filters_out_vocabulary_hallucinations(self):
+        """Topics not in TOPIC_VOCABULARY must be dropped."""
+        extractor = _FakeExtractor(response={
+            "assignments": [
+                {"id": "x", "topics": ["data", "MADE_UP_TOPIC", "queries"]},
+            ]
+        })
+        result = auto_tag_items([{"id": "x", "title": "T", "content": "C"}], extractor)
+        assert "MADE_UP_TOPIC" not in result.get("x", [])
+        assert "data" in result.get("x", [])
+
+    def test_skips_entries_without_id(self):
+        extractor = _FakeExtractor(response={
+            "assignments": [
+                {"id": "", "topics": ["data"]},
+                {"id": "good", "topics": ["reports"]},
+            ]
+        })
+        result = auto_tag_items([{"id": "good", "title": "T", "content": "C"}], extractor)
+        assert "" not in result
+        assert result.get("good") == ["reports"]
+
+    def test_returns_empty_on_llm_error(self):
+        extractor = _FakeExtractor(raises=LLMError("boom"))
+        result = auto_tag_items([{"id": "a", "title": "T", "content": "C"}], extractor)
+        assert result == {}
+
+    def test_returns_empty_on_unexpected_exception(self):
+        extractor = _FakeExtractor(raises=RuntimeError("network down"))
+        result = auto_tag_items([{"id": "a", "title": "T", "content": "C"}], extractor)
+        assert result == {}
+
+    def test_returns_empty_when_assignments_missing(self):
+        extractor = _FakeExtractor(response={})
+        result = auto_tag_items([{"id": "a", "title": "T", "content": "C"}], extractor)
+        assert result == {}
+
+    def test_handles_empty_topics_list(self):
+        extractor = _FakeExtractor(response={
+            "assignments": [{"id": "a", "topics": []}]
+        })
+        result = auto_tag_items([{"id": "a", "title": "T", "content": "C"}], extractor)
+        assert result.get("a") == []


### PR DESCRIPTION
## Summary

- New `services/corporate_memory/tagger.py` — `auto_tag_items()` batch-calls Haiku with a hardcoded starter vocabulary (`data`, `automation`, `reports`, `alerts`, `metrics`, `queries`, `infrastructure`, `processes`, `integrations`, `debugging`, `performance`, `access`) and returns validated topic assignments (hallucinated terms dropped)
- Wired into `POST /api/memory` (best-effort; never blocks item creation even if LLM unavailable)
- Wired into `collector.py` after sensitivity check — new items get topics merged into their `tags` field alongside existing free-form keywords
- Topics stored in the existing `tags` column, no schema change needed

## Test plan

- [x] `tests/test_tagger.py` — 14 new tests: vocabulary invariants, prompt construction, happy path parsing, hallucination filtering, LLM error tolerance
- [x] All 14 new tests pass (`pytest tests/test_tagger.py -v`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
