### PR TITLE
release(0.12.0): cut release for #81/#83/#44/#88 security + OSS work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 <!-- Add bullets here. Group: Added / Changed / Fixed / Removed / Internal.
      Mark breaking changes with **BREAKING** at the start of the bullet. -->
 
+## [0.12.0] — 2026-04-28
+
+Security and OSS-readiness release. Closes the issue #81 connector → orchestrator trust boundary on both the rebuild path and the read-only query path (Group A) plus extractor-side identifier validation (Group D); adds view-name collision detection with schema v10 (Group C); surfaces Keboola partial-failure as exit code 2 (Group B). Closes the Jira webhook fail-open + path-traversal hole (#83). Gates the entire Script API on the admin role (#44). Wave 1 of the OSS vendor-neutralization moves generic ops scripts out of `scripts/grpn/` into `scripts/ops/` and replaces customer identifiers across code, tests, and planning docs with placeholders (#88). Multiple **BREAKING** changes — operators should grep this section for `BREAKING` before bumping their pin.
+
 ### Added
 
 - **Schema v10** introduces `view_ownership` to detect cross-connector

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.11.5"
+version = "0.12.0"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Rename `[Unreleased]` → `[0.12.0] — 2026-04-28` in `CHANGELOG.md`, append a new empty `[Unreleased]` skeleton at the top, add a one-paragraph intro summarising the merged scope.
- Bump `pyproject.toml` version `0.11.5` → `0.12.0`.

This is a release-only PR — no code changes. Content released:

- **#81 A** (#95) connector → orchestrator trust boundary hardening (rebuild + read-only paths) — CRITICAL
- **#81 B** (#99) Keboola partial-failure exit code 2 — **BREAKING (ops)**
- **#81 C** (#100) view-name collision detection, schema v10
- **#81 D** (#97) extractor-side identifier validation
- **#83** (#93) Jira webhook fail-closed + path traversal — **BREAKING (security CRITICAL)**
- **#44** (#92) Script API admin-only — **BREAKING (security)**
- **#88 wave 1** (#94) `scripts/grpn/` → `scripts/ops/` + customer-identifier neutralization in code, tests, planning docs — **BREAKING (ops)** for downstream consumer infra repos that copy the scripts

#82/#85/#87 (auth + API + deploy hardening) is **not** in this release — that branch is still in flight and stays in `[Unreleased]` for the next cut.

## Post-merge

After this PR merges:
- tag the merge commit `v0.12.0` and push it
- the merge to `main` triggers `release.yml`, which produces `:stable`, `:stable-2026.04.N`

## Test plan

- [ ] `CHANGELOG.md` parses cleanly — `## [Unreleased]` skeleton present above `## [0.12.0]`
- [ ] `pyproject.toml` reports 0.12.0 (`grep '^version' pyproject.toml`)
- [ ] No customer-specific tokens introduced (the `grpn`/`Groupon`/`prj-grp-…` strings already in `[0.12.0]` body describe the OSS-neutralization itself — pre-existing on `main`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
