### PR TITLE
release(0.12.1): hotfix for snapshot integrity bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.12.1] — 2026-04-28
+
+Hotfix release for the snapshot-integrity bug shipped in 0.12.0. The unconditional `_SYSTEM_SCHEMA` self-heal pass that landed with #106 ran before the pre-migration snapshot was taken, contaminating the snapshot with the modern binary's full table set instead of capturing the true on-disk pre-migration state. Functionally rollback still worked (extra empty tables are harmless), but operators inspecting `system.duckdb.pre-migrate` for rollback debugging saw a misleading view. Fix: gate the self-heal call on `current >= SCHEMA_VERSION`, so the migration path takes its snapshot before any DDL touches the DB. Plus two regression tests pinning both the split-brain self-heal contract and the snapshot-integrity contract.
+
 ### Fixed
 
 - **Pre-migration snapshot integrity** — the snapshot file written

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.12.0"
+version = "0.12.1"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"


### PR DESCRIPTION
## Summary

Cut release **0.12.1** containing the snapshot-integrity hotfix for the bug shipped in 0.12.0 (#106).

Renames `[Unreleased]` → `[0.12.1] — 2026-04-28` in `CHANGELOG.md`, adds a new empty `[Unreleased]` section on top, bumps `pyproject.toml 0.12.0 → 0.12.1`. Single PR landed under `[Unreleased]` since 0.12.0 cut: #75 (snapshot integrity fix + regression tests).

## What ships

- **Bug fix**: gate self-heal `_SYSTEM_SCHEMA` call on `current >= SCHEMA_VERSION` so the migration path takes its pre-migration snapshot before any DDL touches the DB. Previously the unconditional hoist at the top of `_ensure_schema` (added in #106) ran first, so the snapshot copy at `<DATA_DIR>/state/system.duckdb.pre-migrate` contained the modern binary's full table set instead of the true pre-migration state. Functionally rollback still worked (extra empty tables are harmless), but operators inspecting the snapshot file for rollback debugging saw a misleading view.
- **Regression tests**:
  - `test_split_brain_future_version_with_missing_tables_self_heals` — pins the split-brain self-heal contract.
  - `test_pre_migration_snapshot_excludes_post_self_heal_tables` — pins the snapshot-integrity contract; sanity-checked it fails on the original unconditional hoist with 6 leaked tables.

## Test plan

- [x] Verified locally before #75 merged: full suite **1577 passed, 23 skipped, 0 failed**
- [ ] CI green on this PR (test + docker-build)

## Tag plan after merge

```bash
git checkout main && git pull
git tag v0.12.1 origin/main
git push origin v0.12.1
# → release.yml builds + publishes :stable, :stable-2026.04.N
# → GitHub Release follow-up with prose mirroring v0.12.0 / v0.11.5 format
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
