### PR TITLE
fix(ui): render shared header full-width on corporate memory pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Fixed
+
+- Corporate memory pages (`/corporate-memory`, `/corporate-memory/admin`) now render the shared app header at full viewport width, matching the dashboard. Previously the `_app_header.html` include sat inside `.container-memory` (max-width: 1000px) and was cropped on wide viewports.
+
 ## [0.15.0] — 2026-04-29
 
 ### Added

--- a/app/web/templates/corporate_memory.html
+++ b/app/web/templates/corporate_memory.html
@@ -562,10 +562,10 @@
     {% include '_theme.html' %}
 </head>
 <body>
-    <div class="container-memory">
-        <!-- Header -->
-        {% include '_app_header.html' %}
+    <!-- Header (outside container so it spans full viewport, matching dashboard) -->
+    {% include '_app_header.html' %}
 
+    <div class="container-memory">
         <!-- Stats Bar -->
         <div class="stats-bar">
             <div class="stat-item">

--- a/app/web/templates/corporate_memory_admin.html
+++ b/app/web/templates/corporate_memory_admin.html
@@ -840,10 +840,10 @@
     {% include '_theme.html' %}
 </head>
 <body>
-    <div class="container-memory">
-        <!-- Header -->
-        {% include '_app_header.html' %}
+    <!-- Header (outside container so it spans full viewport, matching dashboard) -->
+    {% include '_app_header.html' %}
 
+    <div class="container-memory">
         <!-- Stats Bar -->
         <div class="stats-bar">
             <div class="stat-item highlight">


### PR DESCRIPTION
## Summary

The `_app_header.html` include on `/corporate-memory` and `/corporate-memory/admin`
was placed *inside* `<div class=\"container-memory\">` (max-width: 1000px), so on
wide viewports the header was cropped to 1000px instead of spanning the viewport
like every other page that uses the shared header (dashboard, admin/*, etc.).

This PR moves the include out of the container, matching dashboard.html's pattern.
Page content stays constrained by `.container-memory`; only the chrome changes.

## Changes

- `app/web/templates/corporate_memory.html` — header moved before `.container-memory`
- `app/web/templates/corporate_memory_admin.html` — same
- `CHANGELOG.md` — entry under `### Fixed`

## Test plan

- [ ] Open `/corporate-memory` on wide viewport → header spans full width
- [ ] Open `/corporate-memory/admin` on wide viewport → header spans full width
- [ ] Page content (stats bar, knowledge list) still capped at ~1000px
- [ ] No regression on the existing mobile breakpoint (`@media max-width: 768px`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
