### PR TITLE
ci(release): build dev image on branch creation from main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,16 @@ on:
       - "docs/**"
       - "*.md"
       - "LICENSE"
+  # Branch creation. Required because `paths-ignore` on the `push` event
+  # diffs the new ref against the default branch — a branch created from
+  # main with no extra commits has zero diff, so every file matches
+  # paths-ignore and the workflow is skipped. Devs spinning up a personal
+  # branch off main to deploy main's exact state to their dev VM
+  # (`:dev-<user>-latest` floating tag) need an image to be published, so
+  # we trigger explicitly on branch create. Tag creates are filtered out
+  # at the job level so we don't double-build with `keboola-deploy.yml`
+  # (which owns `keboola-deploy-*` tag pushes).
+  create:
   workflow_dispatch:  # manual trigger for explicit dev-<slug> builds
 
 permissions:
@@ -17,6 +27,9 @@ permissions:
 
 jobs:
   test:
+    # Skip the `create` event for tags — those are owned by keboola-deploy.yml
+    # and shouldn't double-build here. Branch creates DO run.
+    if: github.event_name != 'create' || github.event.ref_type == 'branch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -38,10 +51,18 @@ jobs:
 
   build-and-push:
     needs: test
-    # Only publish images from main pushes or manual triggers.
-    # Non-main branch pushes run tests only; use workflow_dispatch
-    # for explicit dev-<slug> image builds when needed.
-    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    # Publish on:
+    #   - any push (main → :stable-* / non-main → :dev-* + :dev-<slug>);
+    #   - branch creation (a fresh branch off main with no extra commits
+    #     should still produce a `:dev-<slug>` + `:dev-<prefix>-latest`
+    #     image so the developer's VM, which pins to that floating tag,
+    #     can deploy main's exact state without manually changing code);
+    #   - manual workflow_dispatch.
+    # Tag creates are excluded — `keboola-deploy.yml` owns tag pushes.
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'create' && github.event.ref_type == 'branch')
     runs-on: ubuntu-latest
     outputs:
       image_tag: ${{ steps.meta.outputs.versioned_tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,18 @@ permissions:
   contents: write
   packages: write
 
+# When a developer pushes a brand-new branch with code changes, GitHub fires
+# both a `create` and a `push` event for the same commit. Without
+# concurrency control, both runs would claim distinct CalVer version tags
+# (dev-YYYY.MM.N and dev-YYYY.MM.N+1) and race to push overlapping floating
+# tags (:dev, :dev-<slug>, :dev-<prefix>-latest). Group by ref and cancel
+# in-progress duplicates so only the most recent event survives — the
+# zero-diff case (only `create` fires, no `push`) is unaffected since
+# there's only one run.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     # Skip the `create` event for tags — those are owned by keboola-deploy.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 ### Fixed
 
 - Corporate memory pages (`/corporate-memory`, `/corporate-memory/admin`) now render the shared app header at full viewport width, matching the dashboard. Previously the `_app_header.html` include sat inside `.container-memory` (max-width: 1000px) and was cropped on wide viewports.
+- `release.yml` now publishes a `:dev-<slug>` + `:dev-<prefix>-latest` image when a fresh branch is pushed off `main` with no extra commits. Pre-fix, `paths-ignore` on the `push` event diffed the new ref against the default branch — a same-SHA branch had zero diff, every file matched paths-ignore, and the workflow was skipped, so a developer creating a personal branch off main to deploy main's exact state to their dev VM (which pins to `:dev-<user>-latest`) had to either commit something or trigger the workflow manually. The `build-and-push` job's `if` was also tightened to `main || workflow_dispatch` only, which prevented branch-push images regardless. Both fixed: added `create:` trigger (filtered to branch refs at the job level so tag creates don't double-build with `keboola-deploy.yml`), and broadened `build-and-push.if` to also publish on non-main branch pushes / branch creates.
 
 ## [0.15.0] — 2026-04-29
 


### PR DESCRIPTION
## Why

Two related quirks in `release.yml` prevented a dev VM workflow from working:

1. **`paths-ignore` on `push` skips same-SHA branch pushes.** GitHub evaluates that filter by diffing the new ref against the default branch — a branch created from `main` with no extra commits has zero diff, so every file matches `paths-ignore` and the workflow is skipped.
2. **`build-and-push.if` was `main || workflow_dispatch` only.** Branch pushes never produced an image regardless of trigger evaluation, even though `CLAUDE.md` says they should.

The combined effect: a developer who wants to spin up their dev VM with main's exact state (no code change, just a fresh branch off main → `:dev-<user>-latest` tag → VM cron picks up) has to either pollute the branch with empty commits or trigger the workflow manually.

## What

- Add `create:` event to the workflow. `paths-ignore` is keyed off the `push` event only, so `create` runs always.
- Filter tag creates out at the job level (`if: github.event_name != 'create' || github.event.ref_type == 'branch'`) so we don't double-build with `keboola-deploy.yml`.
- Broaden `build-and-push.if` to publish on push (any branch) + workflow_dispatch + branch create. `smoke-test` stays gated to `main`.

## Test plan

- [ ] CI on this PR passes (test job exercises the new trigger filter).
- [ ] After merge, deleting + recreating a branch like `zs/test_branch` from `main` triggers a build and produces `:dev-zs-test_branch` + `:dev-zs-latest` images on GHCR.
- [ ] Pushing a docs-only commit to an existing branch still respects `paths-ignore` (workflow is skipped on push).
- [ ] Pushing a tag (e.g. `keboola-deploy-foo`) does NOT double-build here; it's still owned by `keboola-deploy.yml`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
