### PR TITLE
fix(ci): smoke-test stale route + rollback ghcr auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,6 +224,19 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      # Required for the rollback step's `docker push` to GHCR. The
+      # `build-and-push` job logs in for itself; this job needs its own
+      # login since GitHub Actions tokens are scoped per-job. Without it,
+      # the rollback hits "unauthenticated: User cannot be authenticated
+      # with the token provided" and silently leaves :stable pointing at
+      # the broken image (real incident: PR #137 / 4ec5ff44).
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Start Agnes from built image
         run: |
           # Create empty .env (docker-compose.yml requires env_file: .env, gitignored)
@@ -239,6 +252,12 @@ jobs:
 
       - name: Automatic rollback on failure
         if: failure()
+        env:
+          # Required for the `gh issue create` call below — without GH_TOKEN
+          # the gh CLI fails the auth check and the issue creation falls
+          # through the `|| echo` fallback, so an operator never sees the
+          # rollback alert.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           IMAGE_TAG="${{ needs.build-and-push.outputs.image_tag }}"
           VERSION="${{ needs.build-and-push.outputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,11 @@ on:
 permissions:
   contents: write
   packages: write
+  # `issues: write` lets the smoke-test job's rollback step open a
+  # GitHub issue alerting operators when an auto-rollback fires. Without
+  # this, the `gh issue create` call hits 403 and the `|| echo` fallback
+  # silently swallows it — operators see :stable revert with no alert.
+  issues: write
 
 # When a developer pushes a brand-new branch with code changes, GitHub fires
 # both a `create` and a `push` event for the same commit. Without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 ## [Unreleased]
 
 ### Internal
-- `scripts/smoke-test.sh`: assertion 8 now hits `/api/admin/registry` (the current admin tables endpoint). The old `/api/admin/tables` URL was renamed long ago and the smoke test was returning 404 on every run — it only surfaced as a deploy failure when the full release pipeline first triggered the rollback path on the post-#137 deploy (run 25151878647).
+- `scripts/smoke-test.sh`: assertion 8 now hits `/api/admin/registry` (the current admin tables endpoint). The old `/api/admin/tables` URL was renamed long ago and the smoke test was returning 404 on every run — it only surfaced as a deploy failure when the full release pipeline first triggered the rollback path on the post-#137 deploy (run 25151878647). Same stale URL was also fixed in `CLAUDE.md`, `README.md`, and `dev_docs/server.md` — the routes now correctly point at `POST /api/admin/register-table` (create) and `PUT /api/admin/registry/{id}` (update).
 - `.github/workflows/release.yml` smoke-test job: added `Log in to GHCR` step. The auto-rollback's `docker push :stable` was hitting `unauthenticated: User cannot be authenticated with the token provided` because the smoke-test job had no GHCR login of its own. Result: a failed deploy left `:stable` pointing at the broken image. The rollback step also got an explicit `GH_TOKEN` env, and the workflow's top-level `permissions` block gained `issues: write`, so its `gh issue create` call actually creates the alert issue (was silently swallowed by the `|| echo` fallback because of both the missing env var AND the missing scope).
 
 ## [0.21.0] — 2026-04-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
-## [0.21.0] — 2026-04-30
+### Internal
+- `scripts/smoke-test.sh`: assertion 8 now hits `/api/admin/registry` (the current admin tables endpoint). The old `/api/admin/tables` URL was renamed long ago and the smoke test was returning 404 on every run — it only surfaced as a deploy failure when the full release pipeline first triggered the rollback path on the post-#137 deploy (run 25151878647).
+- `.github/workflows/release.yml` smoke-test job: added `Log in to GHCR` step. The auto-rollback's `docker push :stable` was hitting `unauthenticated: User cannot be authenticated with the token provided` because the smoke-test job had no GHCR login of its own. Result: a failed deploy left `:stable` pointing at the broken image. The rollback step also got an explicit `GH_TOKEN` env so its `gh issue create` call actually creates the alert issue (was silently swallowed by the `|| echo` fallback).
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ### Internal
 - `scripts/smoke-test.sh`: assertion 8 now hits `/api/admin/registry` (the current admin tables endpoint). The old `/api/admin/tables` URL was renamed long ago and the smoke test was returning 404 on every run — it only surfaced as a deploy failure when the full release pipeline first triggered the rollback path on the post-#137 deploy (run 25151878647).
-- `.github/workflows/release.yml` smoke-test job: added `Log in to GHCR` step. The auto-rollback's `docker push :stable` was hitting `unauthenticated: User cannot be authenticated with the token provided` because the smoke-test job had no GHCR login of its own. Result: a failed deploy left `:stable` pointing at the broken image. The rollback step also got an explicit `GH_TOKEN` env so its `gh issue create` call actually creates the alert issue (was silently swallowed by the `|| echo` fallback).
+- `.github/workflows/release.yml` smoke-test job: added `Log in to GHCR` step. The auto-rollback's `docker push :stable` was hitting `unauthenticated: User cannot be authenticated with the token provided` because the smoke-test job had no GHCR login of its own. Result: a failed deploy left `:stable` pointing at the broken image. The rollback step also got an explicit `GH_TOKEN` env, and the workflow's top-level `permissions` block gained `issues: write`, so its `gh issue create` call actually creates the alert issue (was silently swallowed by the `|| echo` fallback because of both the missing env var AND the missing scope).
+
+## [0.21.0] — 2026-04-30
 
 ### Internal
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Ask the user for:
 4. Create `.env` from `config/.env.template`
 
 ### Step 3: Register Tables
-1. Use the FastAPI admin API (`POST /api/admin/tables/{id}`) or webapp UI to register tables
+1. Use the FastAPI admin API (`POST /api/admin/register-table`, then `PUT /api/admin/registry/{id}` for updates) or webapp UI to register tables
 2. Tables are stored in DuckDB `table_registry` with source_type, bucket, source_table, query_mode
 3. For migration from old format: `python scripts/migrate_registry_to_duckdb.py`
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ pytest tests/ -v
 |------|---------|
 | `config/instance.yaml` | Instance-specific settings: branding, data source type, auth provider, Google domain |
 | `.env` | Secrets and environment variables — never committed |
-| `system.duckdb` `table_registry` table | Table definitions managed via `POST /api/admin/tables/{id}` or the web UI |
+| `system.duckdb` `table_registry` table | Table definitions managed via `POST /api/admin/register-table` (or `PUT /api/admin/registry/{id}` to update) or the web UI |
 
 Copy the example to get started:
 

--- a/dev_docs/server.md
+++ b/dev_docs/server.md
@@ -218,7 +218,7 @@ The FastAPI app is available at `https://your-instance.example.com`.
 
 - **Google OAuth**: restricted to `allowed_domain` set in `config/instance.yaml`
 - **Email magic link**: available out of the box (no external service required)
-- **Admin API**: `POST /api/admin/tables/{id}` — register/update tables
+- **Admin API**: `POST /api/admin/register-table` (register), `PUT /api/admin/registry/{id}` (update), `GET /api/admin/registry` (list) — manage tables
 - **Sync API**: `POST /api/sync/trigger` — trigger data extraction
 
 ### Google OAuth setup

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -136,17 +136,21 @@ else
     echo "  SKIP catalog (no token)"
 fi
 
-# 8. Admin tables endpoint (authenticated)
+# 8. Admin registry endpoint (authenticated)
+# NOTE: was /api/admin/tables until that endpoint was renamed to
+# /api/admin/registry; this assertion went stale and only surfaced when the
+# auto-rollback workflow first fired (smoke test was failing for many
+# releases without anyone noticing).
 if [ -n "$TOKEN" ]; then
-    TABLES_HTTP=$(curl -s -o /tmp/smoke_tables.json -w "%{http_code}" "$HOST/api/admin/tables" \
+    TABLES_HTTP=$(curl -s -o /tmp/smoke_tables.json -w "%{http_code}" "$HOST/api/admin/registry" \
       -H "Authorization: Bearer $TOKEN" 2>/dev/null || echo "000")
     if [[ "$TABLES_HTTP" =~ ^(200|403)$ ]]; then
-        check "admin tables endpoint (HTTP $TABLES_HTTP)" "true"
+        check "admin registry endpoint (HTTP $TABLES_HTTP)" "true"
     else
-        check "admin tables endpoint (HTTP $TABLES_HTTP)" "false"
+        check "admin registry endpoint (HTTP $TABLES_HTTP)" "false"
     fi
 else
-    echo "  SKIP admin tables (no token)"
+    echo "  SKIP admin registry (no token)"
 fi
 
 # 9. Marketplace.zip endpoint (with PAT auth if available)


### PR DESCRIPTION
## Why

PR #137's deploy run (25151878647) failed at the smoke-test stage and the auto-rollback workflow ALSO failed silently — leaving \`:stable\` pointing at a broken image and no GitHub issue created to alert operators.

## What changes

### 1. \`scripts/smoke-test.sh\`
Updated the admin-tables assertion to call \`/api/admin/registry\` (current route) instead of \`/api/admin/tables\` (renamed long ago). The 404 from this stale URL was treated as a deployment regression and triggered the rollback; in reality the test was wrong and had been wrong since #120 (61f6b8d). It only surfaced now because no smoke test had failed for other reasons in between.

### 2. \`.github/workflows/release.yml\` — smoke-test job
Added \`Log in to GHCR\` step. The rollback step's \`docker pull\` / \`docker tag\` / \`docker push\` of \`:stable\` failed with \`unauthenticated: User cannot be authenticated with the token provided\`. The build-and-push job logs in for itself; the smoke-test job had no equivalent.

### 3. \`.github/workflows/release.yml\` — rollback step
Added \`env: GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}\`. The \`gh issue create\` call in the rollback step was failing the auth check, but the \`|| echo "Failed to create..."\` fallback swallowed it. Result: rollback issues never got created.

## Manual cleanup needed (separate from this PR)

\`:stable\` is currently pointing at the broken PR #137 image (digest \`fb30a9d5...ec33484\`). Need to manually retag back to \`stable-2026.04.505\`:

\`\`\`bash
# With docker daemon + ghcr write token:
echo \$GHCR_PAT | docker login ghcr.io -u <username> --password-stdin
docker pull ghcr.io/keboola/agnes-the-ai-analyst:stable-2026.04.505
docker tag  ghcr.io/keboola/agnes-the-ai-analyst:stable-2026.04.505 ghcr.io/keboola/agnes-the-ai-analyst:stable
docker push ghcr.io/keboola/agnes-the-ai-analyst:stable

# Or with crane (no docker daemon needed):
crane copy ghcr.io/keboola/agnes-the-ai-analyst:stable-2026.04.505 ghcr.io/keboola/agnes-the-ai-analyst:stable
\`\`\`

Once this PR merges, future smoke-test failures will roll back automatically.

## Test plan

- [x] \`scripts/smoke-test.sh\` change verified by inspection (route exists at \`app/api/admin.py:870\`)
- [ ] Workflow changes will be exercised on the next failed deploy (no easy local repro)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
