### PR TITLE
fix(tls-rotate): chown CERT_DIR to UID 999 so the app container can read its own certs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Fixed
+- **`scripts/ops/agnes-tls-rotate.sh` now chowns `/data/state/certs/` to UID 999 (the `agnes` user inside the app image) on every run.** Previously the script only `mkdir -p`'d and `chmod 700`'d the directory, leaving ownership to whoever happened to create it first — root when systemd fired the timer before docker-compose-up, or UID 999 when the container's volume init touched it first. Race-dependent. When root won, the resulting `drwx------ root:root` directory was unreadable by the UID-999 container, `_read_agnes_ca_pem()` returned `None`, and the `/install` setup prompt silently dropped the cross-platform TLS trust block (Step 0 from #137) — operators on those VMs ended up with no client-side cert bootstrap and a broken `claude plugin marketplace add` against the self-signed host. The chown is unconditional + idempotent (`|| true` for hosts where the numeric GID can't be set), so re-running the timer self-heals existing VMs without manual `chown` on the operator's part. Files inside the directory keep their existing modes — `fullchain.pem` is `0644` (world-readable, so root- or 999-owned both work for the agnes container) and `privkey.pem` is `0600` (only Caddy reads it, and Caddy's container runs as root).
+
 ## [0.23.0] — 2026-04-30
 
 ### Added

--- a/scripts/ops/agnes-tls-rotate.sh
+++ b/scripts/ops/agnes-tls-rotate.sh
@@ -36,6 +36,17 @@ set -a; . /opt/agnes/.env; set +a
 
 CERT_DIR=/data/state/certs
 mkdir -p "$CERT_DIR"
+# Match the agnes UID baked into the app image (Dockerfile: useradd --uid 999).
+# Without this, whoever happens to win the create race (this script as root
+# vs. the app container's first volume-init touch as 999) decides ownership;
+# when root wins, mode 700 leaves the container unable to read its own certs
+# and `_read_agnes_ca_pem()` silently returns None, suppressing the trust-
+# bootstrap block in the /install setup prompt. `|| true` keeps the script
+# resilient on hosts where the GID is reserved (chgrp on a non-existent
+# numeric GID is fine on Linux but pedantically fails on some BSD-derived
+# tooling); if the chown itself fails we keep going and surface the
+# resulting permission error from the next refetch step instead.
+chown 999:999 "$CERT_DIR" || true
 chmod 700 "$CERT_DIR"
 
 CHANGED=0


### PR DESCRIPTION
## Summary
- `scripts/ops/agnes-tls-rotate.sh` now `chown 999:999`'s `/data/state/certs/` after `mkdir -p`, matching the `agnes` UID baked into the app image (`Dockerfile:30 useradd --system --uid 999`).
- Without it, ownership of the cert dir is decided by whichever process wins the create race on first boot — root when the systemd timer fires before docker-compose-up, UID 999 when the container's volume init touches the path first. Mode 700 + root ownership = container can't traverse → can't read `fullchain.pem` → `_read_agnes_ca_pem()` silently returns `None` → the cross-platform TLS trust block (Step 0 from #137) drops out of the `/install` setup prompt. Operators on unlucky-race VMs got a setup prompt that couldn't bootstrap client trust against the self-signed host.
- The chown is unconditional + idempotent (`|| true` to absorb host-side GID-reservation edge cases without aborting the rotate). Existing VMs self-heal on next timer tick — no manual `chown` needed.

## Why now
Observed empirically across two same-codebase, same-`:stable`-image VMs: one had `drwx------ root:root /data/state/certs/` (Step 0 missing from setup prompt), the other had `drwx------ 999:systemd-journal /data/state/certs/` (Step 0 present). Same `agnes-tls-rotate.sh` (byte-identical), same systemd timer unit, same self-signed cert origin. Root cause was the un-chowned `mkdir -p` + race ordering on first boot.

## Notes
- Files inside `CERT_DIR` keep their existing modes: `fullchain.pem` is `0644` (world-readable, so root- or 999-owned both work for the container) and `privkey.pem` is `0600` (only Caddy reads it; Caddy's container runs as root). No need to chown individual files — only the dir traversal bit was load-bearing.
- The Dockerfile UID is hard-coded to 999 (`useradd --system --uid 999 agnes`); pulling it dynamically would require either parsing the running image or threading it through `.env`. Hard-coding the literal in the rotate script keeps the script standalone — a comment points at the Dockerfile line so the next refactor catches the dependency.

## Test plan
- [ ] On a fresh VM: confirm `ls -la /data/state/certs/` shows `999:999` after first timer fire.
- [ ] On an existing VM with a root-owned cert dir: trigger the timer (`sudo systemctl start agnes-tls-rotate.service`), confirm dir flips to `999:999`, confirm container can read `fullchain.pem` (`docker exec agnes-app-1 head -1 /data/state/certs/fullchain.pem`), confirm the `/install` setup prompt now starts with Step 0.
- [ ] Re-run the timer a second time on a self-signed-fallback VM (no `TLS_FULLCHAIN_URL`-served cert): confirm idempotency, no churn.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
