### PR TITLE
feat(sync+bq): smart local sync + BigQuery materialized query mode (supersedes #145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,145 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+<!-- Add bullets here. Group: Added / Changed / Fixed / Removed / Internal.
+     Mark breaking changes with **BREAKING** at the start of the bullet. -->
+
+## [0.25.0] — 2026-04-30
+
+Minor release. Adds **smart local sync** so analysts get RBAC-filtered parquets pulled at every Claude Code SessionStart and session logs pushed at SessionEnd, plus a new **BigQuery `query_mode='materialized'`** that lets admins register a scheduled SQL query whose result rides the same auto-sync flow as Keboola tables. The auto-sync set per analyst is the intersection of `query_mode IN ('local', 'materialized')` and the `resource_grants` rows — admins curate it via the existing RBAC layer, no new endpoints. The materialize path uses the `BqAccess` facade from #138 so cost-estimate logic and DuckDB-extension session setup live in one place. Devin review iteration during PR #145 surfaced and fixed a `null`-disable trap on the cost guardrail, an empty-hash re-download bug on materialized parquets, and a stale-`source_query` data-integrity gap on PUT — all baked in before this PR was opened.
+
+### Added
+
+- **BigQuery `query_mode='materialized'`** — admin registers a SQL query
+  via `da admin register-table --query-mode materialized --query @file.sql
+  --sync-schedule "every 6h"`; the sync trigger pass runs it through the
+  DuckDB BigQuery extension via the `BqAccess` facade on each tick that's
+  due (per-table `sync_schedule` honored via `is_table_due()`) and writes
+  the result to `/data/extracts/bigquery/data/<id>.parquet`. The
+  orchestrator picks the parquet up via standard local-parquet discovery
+  and the existing manifest + `da sync` flow distributes it to analysts.
+  Per-user RBAC filtering is unchanged: a materialized table is just
+  another row in `table_registry` with `resource_grants` controlling
+  which groups see it.
+- **Schema v19** adds `source_query TEXT` column to `table_registry` to
+  back the materialized mode. NULL for existing rows. The
+  `materialize_query()` function in the BigQuery extractor performs the
+  COPY atomically (`<id>.parquet.tmp` → `os.replace`) so a failed query
+  never leaves a half-written parquet.
+- BigQuery cost guardrail for `query_mode='materialized'` tables: before
+  each COPY the scheduler runs a BQ dry-run (reusing
+  `app.api.v2_scan._bq_dry_run_bytes` so cost-estimate logic lives in
+  exactly one place) and raises `MaterializeBudgetError` (skips the row)
+  when the estimate exceeds `data_source.bigquery.max_bytes_per_materialize`.
+  Default 10 GiB; explicit `0` disables (YAML `null` falls through to
+  the default — documented in `config/instance.yaml.example`).
+  Fail-open when the dry-run itself errors (library missing, DuckDB
+  three-part syntax the native BQ client can't parse, transient API
+  failure) — logs a warning instead of blocking the COPY.
+- Admin API: `POST /api/admin/register-table` and
+  `PUT /api/admin/registry/{id}` accept `source_query` field. Validator
+  enforces that `query_mode='materialized'` requires `source_query` and
+  `query_mode in ('local', 'remote')` forbids it. PUT also rejects
+  `source_query` set without `query_mode` in the same request body and
+  clears the stale `source_query` when switching the merged record away
+  from materialized mode.
+- CLI: `da admin register-table --query <SQL>` accepts inline SQL or
+  `@path/to.sql` shorthand for reading from disk. Reuses the existing
+  `--sync-schedule` flag for the cron string.
+- `da sync --quiet` flag suppresses Rich progress + multi-line summary,
+  intended for use from Claude Code SessionStart/SessionEnd hooks and
+  cron jobs. Errors still surface on stderr; the no-op case is silent.
+  The terse summary line in `--quiet` mode (`sync: N tables, M errors`)
+  lands on stderr so stdout stays clean for hook callers.
+- `da analyst setup` now installs `SessionStart` (pull) and `SessionEnd`
+  (upload) hooks into `<workspace>/.claude/settings.json`, idempotently,
+  preserving any existing user-owned hooks. Workspace-level (not
+  user-home) so the hooks fire only when Claude Code is opened in the
+  analyst workspace, not in unrelated sessions on the same machine.
+  Hooks assume `da` is on `PATH`. If the CLI is not installed system-wide
+  (e.g. via `pipx` or `pip install -e .`), the hooks no-op silently —
+  expected graceful degradation, never blocks a session.
+- `docs/setup/claude_settings.json` ships the same two hooks so operators
+  bootstrapping a fresh Claude Code workspace get auto-sync out of the box.
+
+### Changed
+
+- BigQuery `init_extract` no longer creates remote views for rows with
+  `query_mode='materialized'`; those live as parquets and surface via
+  the orchestrator's standard local-parquet discovery. Skipped rows do
+  not appear in `_meta` so cross-source view-name collisions remain
+  impossible.
+
+### Fixed
+
+- `docs/setup/claude_settings.json` no longer references the deleted
+  `server/scripts/collect_session.py` — the dead `SessionEnd` hook had
+  silently failed in every Claude Code session since the v1→v2 server
+  purge. Replaced with `da sync --upload-only --quiet`.
+
+### Internal
+
+- README mode-first source table; new "Local sync & auto-update" section
+  covering `da sync`, hooks, and admin RBAC for auto-sync membership.
+- `CLAUDE.md` schema chain extended to v19 with the `source_query`
+  description; four source modes documented in Connector Pattern (added
+  Materialized SQL); new "Local sync & Claude Code hooks" subsection
+  under Development.
+- `cli/skills/connectors.md` — "BigQuery: pick a mode" decision table
+  with cost / guardrail / registration example.
+- `docs/architecture.md` — new "BigQuery — Materialized SQL" subsection
+  describing the COPY pipeline, BqAccess integration, and cost guardrail.
+- BQ cost guardrail dry-run is performed via the native
+  `google-cloud-bigquery` client (through `BqAccess.client()`), which
+  does not parse DuckDB three-part identifiers (`bq."ds"."t"`). Queries
+  written in DuckDB syntax fall through fail-open and log a warning
+  instead of engaging the cap. Operators who need the cap to be
+  enforceable must register the materialized SQL using native BQ
+  identifiers (`\`project.ds.t\``).
+- Hardenings landed during devil's-advocate review of PR #145:
+  - `materialize_query` computes the parquet MD5 inline (after COPY,
+    before `os.replace`) instead of re-reading the file in
+    `_run_materialized_pass` — saves a full sequential read on the
+    request thread for multi-GB parquets.
+  - 0-row materializations log a `WARNING` so an empty result set
+    can't masquerade as "the SQL is fine, today there's nothing".
+  - The ATTACH-tolerated `except duckdb.Error: pass` is narrowed to
+    the "alias already attached" case; real errors (cross-project
+    permission, malformed project_id) propagate so the per-row
+    aggregator records them correctly instead of surfacing a
+    confusing downstream "bq is not attached".
+
+### Known limitations
+
+Operators should be aware of these production-only behaviours; tests
+cannot exercise them and they will be revisited in follow-up PRs:
+
+- **GCE metadata token expiry mid-COPY (catastrophic for very long
+  scans).** The DuckDB BQ extension caches the token in a session
+  SECRET created at session-open. A `materialize_query` call that
+  takes longer than the token's remaining lifetime (~1h) will see
+  silent 401s downstream and may produce a truncated parquet. No
+  current mitigation; if your materialized SQL scans more than ~30
+  GiB on a single COPY, run it via the BQ console / Storage Read
+  API offline and `da fetch` the result instead until token refresh
+  is wired into the BQ extension's session.
+- **DuckDB `bigquery` community extension is unpinned** —
+  `INSTALL bigquery FROM community; LOAD bigquery;` picks up the
+  latest published version on every cold start. A breaking change
+  upstream surfaces as a production failure with no test signal.
+- **Schema drift after a SQL edit silently breaks analyst queries.**
+  Editing `source_query` to drop a column writes a new parquet with
+  the new shape; analysts' queries that referenced the dropped
+  column 500 on the next sync without warning. No diff or version
+  field surfaces this. Workaround: announce changes in the team
+  channel before editing materialized SQL.
+- **`materialize_query` is not concurrency-locked.** Two concurrent
+  `/api/sync/trigger` calls for the same materialized row race on
+  `<id>.parquet.tmp`. `init_extract` has `_INIT_EXTRACT_LOCK` for
+  the remote-attach path, but the materialized path does not yet.
+  In practice: the cron scheduler is single-threaded and manual
+  triggers are rare, so the race window is small.
+
 ## [0.24.0] — 2026-04-30
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,9 +117,10 @@ The SyncOrchestrator scans `/data/extracts/*/extract.duckdb`, ATTACHes each into
           (serve)    (da sync)
 ```
 
-Three source types:
-- **Batch pull** (Keboola): DuckDB extension downloads to parquet, scheduled
-- **Remote attach** (BigQuery): DuckDB BQ extension, no download, queries go to BQ
+Source modes:
+- **Batch pull** (Keboola, `query_mode='local'`): DuckDB extension downloads to parquet, scheduled
+- **Remote attach** (BigQuery, `query_mode='remote'`): DuckDB BQ extension, no download, queries go to BQ
+- **Materialized SQL** (BigQuery, `query_mode='materialized'`): scheduler runs admin-registered SQL through DuckDB BQ extension (via `BqAccess` from `connectors/bigquery/access.py`) and writes the result to `/data/extracts/bigquery/data/<id>.parquet`. Distributed via the same manifest + `da sync` flow as Keboola tables. Cost guardrail via `data_source.bigquery.max_bytes_per_materialize` (default 10 GiB; set `0` to disable — YAML `null` falls through to the default).
 - **Real-time push** (Jira): Webhooks update parquets incrementally
 
 ## Configuration
@@ -147,6 +148,19 @@ curl -X POST http://localhost:8000/api/sync/trigger
 # Docker
 docker compose up
 ```
+
+### Local sync & Claude Code hooks
+
+`da sync` is the canonical analyst-side distribution path: pulls the RBAC-filtered manifest from the server, downloads parquets whose MD5 changed (skipping `query_mode='remote'` rows), rebuilds local DuckDB views over them.
+
+`da analyst setup` writes two hooks into `<workspace>/.claude/settings.json`:
+
+- `SessionStart` → `da sync --quiet` — pulls fresh parquets at the start of every Claude Code session
+- `SessionEnd`   → `da sync --upload-only --quiet` — uploads session jsonl + `CLAUDE.local.md` to the server
+
+Both pass `--quiet` so they don't pollute Claude Code stdout, and trail with `|| true` so a server outage never blocks a session. Workspace-level (not user-home) so the hooks fire only when Claude Code opens this analyst workspace, not in unrelated sessions on the same machine.
+
+Admin RBAC for auto-sync: `query_mode IN ('local', 'materialized')` plus a `resource_grants` row for one of the analyst's groups → table appears in their manifest → `da sync` downloads it. No per-user sync config; the admin layer is the single source of truth.
 
 ## Business Metrics
 
@@ -416,7 +430,7 @@ Module sets `lifecycle { ignore_changes = [metadata_startup_script] }` on `googl
 ## Key Implementation Details
 
 ### DuckDB Schema (src/db.py)
-- Schema v18 with auto-migration v1→…→v18 (v5 adds `users.active`, v6 adds `personal_access_tokens`, v7 adds `personal_access_tokens.last_used_ip`, v8/v9 added the legacy internal_roles/role-grants tables, v10 added `view_ownership` for cross-connector view-name collision detection (issue #81 Group C), v11 added marketplace_registry + marketplace_plugins + user_groups + plugin_access, v12 added users.groups JSON + user_groups.is_system, **v13 replaces internal_roles/group_mappings/user_role_grants/plugin_access with user_group_members + resource_grants and drops users.groups JSON**, v14 adds FK constraints on user_group_members + resource_grants after orphan cleanup, v15 adds knowledge_items context-engineering columns + contradictions + session_extraction_state, v16 adds verification_evidence, v17 adds knowledge_item_relations, **v18 drops stranded non-google memberships from google-managed groups** — see CHANGELOG and docs/RBAC.md)
+- Schema v19 with auto-migration v1→…→v19 (v5 adds `users.active`, v6 adds `personal_access_tokens`, v7 adds `personal_access_tokens.last_used_ip`, v8/v9 added the legacy internal_roles/role-grants tables, v10 added `view_ownership` for cross-connector view-name collision detection (issue #81 Group C), v11 added marketplace_registry + marketplace_plugins + user_groups + plugin_access, v12 added users.groups JSON + user_groups.is_system, **v13 replaces internal_roles/group_mappings/user_role_grants/plugin_access with user_group_members + resource_grants and drops users.groups JSON**, v14 adds FK constraints on user_group_members + resource_grants after orphan cleanup, v15 adds knowledge_items context-engineering columns + contradictions + session_extraction_state, v16 adds verification_evidence, v17 adds knowledge_item_relations, **v18 drops stranded non-google memberships from google-managed groups**, **v19 adds `source_query` TEXT to `table_registry` to back `query_mode='materialized'` (BigQuery scheduled-query parquet path)** — see CHANGELOG and docs/RBAC.md)
 - `table_registry`: id, name, source_type, bucket, source_table, query_mode, sync_schedule, etc.
 - `sync_state`, `sync_history`: track extraction progress
 - `users`, `dataset_permissions`, `audit_log`: auth + RBAC

--- a/README.md
+++ b/README.md
@@ -40,11 +40,14 @@ The orchestrator scans `/data/extracts/*/extract.duckdb`, attaches each into `an
 
 ## Supported Data Sources
 
-| Source | Mode | Description |
-|--------|------|-------------|
-| **Keboola** | Batch pull | DuckDB Keboola extension downloads tables to Parquet on a schedule |
-| **BigQuery** | Remote attach | DuckDB BQ extension; queries execute in BigQuery, no local download |
-| **Jira** | Real-time push | Webhook receiver updates Parquet files incrementally |
+| Mode | Distribution | Sources | Use when |
+|------|--------------|---------|----------|
+| **Batch pull** (`local`) | Parquet on disk, scheduled | Keboola | Source has a native bulk-export and the table fits on disk |
+| **Materialized SQL** (`materialized`) | Parquet on disk, scheduled query | BigQuery | Source table is too large to mirror; you want a curated subset on disk |
+| **Remote attach** (`remote`) | View only, no download | BigQuery | Table is too large to materialize; latency cost of remote query is acceptable |
+| **Real-time push** | Incremental parquet | Jira | Source is event-driven and you need sub-minute freshness |
+
+The first three modes are what `da sync` distributes to analysts. The fourth is server-side only — analysts query Jira data through the same `da sync`-distributed parquets.
 
 Adding a new source means creating `connectors/<name>/extractor.py` that produces `extract.duckdb` with a `_meta` table (`table_name`, `description`, `rows`, `size_bytes`, `extracted_at`, `query_mode`). The orchestrator attaches it automatically.
 
@@ -76,6 +79,44 @@ Once running, the FastAPI app is available at `http://localhost:8000` (or `https
 ```bash
 curl -X POST http://localhost:8000/api/sync/trigger
 ```
+
+## Local sync & auto-update
+
+Analysts run Claude Code against a local DuckDB built from RBAC-filtered parquets pulled from the server. `da sync` is the distribution path:
+
+```bash
+da sync             # delta-pull: manifest → MD5 compare → download changed → rebuild views
+da sync --quiet     # same, no progress output (for hooks/cron)
+da sync --upload-only  # push session jsonl + CLAUDE.local.md back to the server
+```
+
+`da analyst setup` writes Claude Code lifecycle hooks into `<workspace>/.claude/settings.json`:
+
+- `SessionStart` → `da sync --quiet` — fresh data on every session
+- `SessionEnd` → `da sync --upload-only --quiet` — uploads notes and session log
+
+Hooks live at workspace level so they only fire in this analyst workspace, not in unrelated Claude Code sessions on the same machine.
+
+### Admin: which tables auto-sync to whom
+
+The auto-sync set per analyst is the intersection of:
+
+1. Tables with `query_mode IN ('local', 'materialized')` — these have parquets on disk and end up in the manifest
+2. Tables granted to one of the analyst's groups via `resource_grants(group, ResourceType.TABLE, table_id)` (see [`docs/RBAC.md`](docs/RBAC.md))
+
+To enroll a new table for auto-sync, register it (or update its `query_mode`) and grant it to the relevant groups in `/admin/access`. New analysts get the same set on their next `da sync`.
+
+For BigQuery, register a `query_mode='materialized'` table with a SQL body:
+
+```bash
+da admin register-table orders_90d \
+    --source-type bigquery \
+    --query-mode materialized \
+    --query @docs/queries/orders_90d.sql \
+    --schedule "every 6h"
+```
+
+The scheduler runs the query through the DuckDB BigQuery extension on each tick that's due, writes the result as a parquet, and the analyst picks it up on the next `da sync`. Cost guardrail: `data_source.bigquery.max_bytes_per_materialize` (default 10 GiB) — operations exceeding the BQ dry-run estimate are skipped.
 
 ## Development Setup
 

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -12,7 +12,7 @@ import uuid
 from pathlib import Path
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 from typing import Optional, List, Dict, Any
 import duckdb
 
@@ -664,9 +664,33 @@ class RegisterTableRequest(BaseModel):
     source_type: Optional[str] = None
     bucket: Optional[str] = None
     source_table: Optional[str] = None
+    # Backs query_mode='materialized'. Stored verbatim in
+    # table_registry.source_query (schema v19); the trigger pass runs it
+    # through the DuckDB BQ extension via BqAccess and writes the result
+    # to /data/extracts/bigquery/data/<id>.parquet.
+    source_query: Optional[str] = None
     query_mode: str = "local"
     sync_schedule: Optional[str] = None
     profile_after_sync: bool = True
+
+    @model_validator(mode="after")
+    def _check_mode_query_coherence(self):
+        """Enforce query_mode ↔ source_query invariants up front so an admin
+        can't persist a remote/local row carrying an orphan source_query, and
+        materialized rows can't be registered without a SQL body."""
+        sq = (self.source_query or "").strip() or None
+        if self.query_mode == "materialized" and not sq:
+            raise ValueError(
+                "query_mode='materialized' requires a non-empty source_query"
+            )
+        if self.query_mode != "materialized" and sq:
+            raise ValueError(
+                "source_query is only valid when query_mode='materialized'"
+            )
+        # Normalise: stash the trimmed-or-None form so the persisted column
+        # never carries surrounding whitespace or empty-string sentinels.
+        self.source_query = sq
+        return self
 
     @field_validator("primary_key", mode="before")
     @classmethod
@@ -707,12 +731,66 @@ class RegisterTableRequest(BaseModel):
 def _validate_bigquery_register_payload(req: "RegisterTableRequest") -> None:
     """Enforce BQ-specific shape on a register/precheck request.
 
-    Mutates the model: forces ``query_mode='remote'`` and
-    ``profile_after_sync=False`` (per Decision 7 in #108) so a caller can't
-    accidentally enqueue a parquet profiling pass for a remote view that
-    has no local file. Raises HTTPException(422) for missing required
-    fields and HTTPException(400) for unsafe identifiers / bogus project_id.
+    Two BQ paths:
+
+    - ``query_mode='materialized'`` — admin-registered SQL writes a parquet on
+      schedule. Requires ``source_query``; ``bucket`` / ``source_table`` are
+      not used (the SQL inlines the references). Doesn't force any field; the
+      Pydantic ``model_validator`` already gated the query/mode coherence.
+
+    - ``query_mode='remote'`` (or default) — remote view over a single BQ
+      table. Requires ``bucket`` (BQ dataset) + ``source_table``. Mutates
+      the model: forces ``query_mode='remote'`` and ``profile_after_sync=False``
+      (per Decision 7 in #108) so a caller can't accidentally enqueue a
+      parquet profiling pass for a remote view that has no local file.
+
+    Raises HTTPException(422) for missing required fields and
+    HTTPException(400) for unsafe identifiers / bogus project_id.
     """
+    if req.query_mode == "materialized":
+        # Materialized BQ rows: the SQL body replaces dataset+table refs.
+        # Pydantic model_validator already verified source_query is non-empty;
+        # all we still need is a valid project_id and a safe view name.
+        if not req.source_query or not req.source_query.strip():
+            raise HTTPException(
+                status_code=422,
+                detail="bigquery materialized: 'source_query' is required",
+            )
+        raw_name = req.name or ""
+        if raw_name.strip() != raw_name or not _is_safe_identifier(raw_name):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"bigquery: view name {raw_name!r} is unsafe — must match "
+                    f"^[a-zA-Z_][a-zA-Z0-9_]{{0,63}}$ (DuckDB identifier rules) "
+                    "with no leading/trailing whitespace"
+                ),
+            )
+        from app.instance_config import get_value
+        project_id = get_value("data_source", "bigquery", "project", default="")
+        if not project_id:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "bigquery: data_source.bigquery.project is not set in "
+                    "instance.yaml; configure it via /admin/server-config or "
+                    "/api/admin/configure first"
+                ),
+            )
+        if not _is_safe_project_id(project_id):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"bigquery: data_source.bigquery.project {project_id!r} "
+                    "is malformed — must match GCP project_id grammar "
+                    "^[a-z][a-z0-9-]{4,28}[a-z0-9]$"
+                ),
+            )
+        # Materialized rows have no remote view to profile. Force-disable
+        # to keep the registry consistent across mode switches.
+        req.profile_after_sync = False
+        return
+
     if not req.bucket or not req.bucket.strip():
         raise HTTPException(
             status_code=422,
@@ -811,9 +889,34 @@ class UpdateTableRequest(BaseModel):
     source_type: Optional[str] = None
     bucket: Optional[str] = None
     source_table: Optional[str] = None
+    source_query: Optional[str] = None
     query_mode: Optional[str] = None
     sync_schedule: Optional[str] = None
     profile_after_sync: Optional[bool] = None
+
+    @model_validator(mode="after")
+    def _check_mode_query_coherence(self):
+        """Same invariant as RegisterTableRequest, but only fires when at
+        least one of query_mode / source_query is being touched in this
+        PUT — fields not in the body stay None and don't trigger anything."""
+        if self.query_mode is None and self.source_query is None:
+            return self
+        sq = (self.source_query or "").strip() or None
+        if self.query_mode == "materialized" and not sq:
+            raise ValueError(
+                "query_mode='materialized' requires a non-empty source_query"
+            )
+        if self.query_mode is not None and self.query_mode != "materialized" and sq:
+            raise ValueError(
+                "source_query is only valid when query_mode='materialized'"
+            )
+        if self.query_mode is None and sq:
+            raise ValueError(
+                "source_query requires query_mode='materialized' to be set "
+                "in the same request"
+            )
+        self.source_query = sq
+        return self
 
     @field_validator("primary_key", mode="before")
     @classmethod
@@ -1132,6 +1235,7 @@ def register_table(
         source_type=request.source_type,
         bucket=request.bucket,
         source_table=request.source_table,
+        source_query=request.source_query,
         query_mode=request.query_mode,
         sync_schedule=request.sync_schedule,
         profile_after_sync=request.profile_after_sync,
@@ -1152,6 +1256,24 @@ def register_table(
         return JSONResponse(
             status_code=201,
             content={"id": table_id, "name": request.name, "status": "registered"},
+        )
+
+    if request.query_mode == "materialized":
+        # Materialized BQ rows are picked up by the trigger pass on the next
+        # scheduled tick (or via POST /api/sync/trigger). No synchronous
+        # rebuild — the COPY can scan multi-GB and would block the request.
+        return JSONResponse(
+            status_code=201,
+            content={
+                "id": table_id,
+                "name": request.name,
+                "status": "registered",
+                "view_name": table_id,
+                "message": (
+                    "Materialized — parquet will be written on the next sync "
+                    "tick. Trigger now via POST /api/sync/trigger."
+                ),
+            },
         )
 
     # BQ post-register: rebuild extract + master views, with timeout fallback.
@@ -1360,14 +1482,23 @@ async def update_table(
         merged.update(updates)
         merged.pop("id", None)  # avoid duplicate id kwarg
 
+        # When switching the merged record away from materialized mode, drop
+        # the stale source_query — the request validator can't clear it via
+        # the `if v is not None` filter above. Without this, a remote/local
+        # row would carry an orphan source_query in the registry.
+        if merged.get("query_mode") != "materialized":
+            merged["source_query"] = None
+
         if merged.get("source_type") == "bigquery":
             # Reuse the register-time validator. It mutates the request to
-            # force query_mode='remote' / profile_after_sync=False — apply
-            # the same coercion to `merged` so the persisted row matches.
+            # force query_mode='remote' / profile_after_sync=False (or to
+            # leave a materialized row alone) — apply the same coercion to
+            # `merged` so the persisted row matches.
             synthetic = RegisterTableRequest(
                 name=merged.get("name") or table_id,
                 bucket=merged.get("bucket"),
                 source_table=merged.get("source_table"),
+                source_query=merged.get("source_query"),
                 source_type="bigquery",
                 query_mode=merged.get("query_mode") or "remote",
                 profile_after_sync=bool(merged.get("profile_after_sync") or False),
@@ -1380,6 +1511,7 @@ async def update_table(
             _validate_bigquery_register_payload(synthetic)
             merged["query_mode"] = synthetic.query_mode
             merged["profile_after_sync"] = synthetic.profile_after_sync
+            merged["source_query"] = synthetic.source_query
 
         repo.register(id=table_id, **merged)
 

--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -36,6 +36,112 @@ def _file_hash(path: Path) -> str:
     return h.hexdigest()
 
 
+def _materialize_table(
+    *,
+    table_id: str,
+    sql: str,
+    bq,
+    output_dir: str,
+    max_bytes: Optional[int],
+) -> dict:
+    """Thin wrapper around `connectors.bigquery.extractor.materialize_query`
+    so the trigger pass can be unit-tested by patching this seam without
+    touching the real BqAccess factory or the duckdb import."""
+    from connectors.bigquery.extractor import materialize_query
+    return materialize_query(
+        table_id=table_id, sql=sql, bq=bq,
+        output_dir=output_dir, max_bytes=max_bytes,
+    )
+
+
+def _run_materialized_pass(conn: duckdb.DuckDBPyConnection, bq) -> dict:
+    """Walk `table_registry` for `query_mode='materialized'` rows and run any
+    that are due. Honors per-table `sync_schedule` via `is_table_due()`,
+    writes the parquet via `_materialize_table`, computes the file hash
+    inline, and updates `sync_state` so the manifest can serve the row to
+    `da sync` without re-hashing on every request.
+
+    Returns:
+        ``{"materialized": [ids], "skipped": [ids], "errors": [{table, error}]}``
+
+    Errors are aggregated per row — one budget-blown table doesn't stop a
+    healthy sibling. ``MaterializeBudgetError`` is caught and rendered with
+    its structured fields so operator alerting can pick out the cap-vs-actual
+    bytes from the log line.
+    """
+    from src.scheduler import is_table_due
+    from app.instance_config import get_value
+    from connectors.bigquery.extractor import MaterializeBudgetError
+
+    output_dir = str(Path(_get_data_dir()) / "extracts" / "bigquery")
+
+    # Sentinel: max_bytes <= 0 (or None) disables the guardrail. `get_value()`
+    # treats YAML `null` as "missing" → returns the default; operators must use
+    # the explicit `0` sentinel to disable. See config/instance.yaml.example.
+    raw_max = get_value(
+        "data_source", "bigquery", "max_bytes_per_materialize",
+        default=10 * 2**30,
+    )
+    bq_max_bytes = (
+        raw_max if (raw_max is not None and isinstance(raw_max, int) and raw_max > 0)
+        else None
+    )
+
+    registry = TableRegistryRepository(conn)
+    state = SyncStateRepository(conn)
+
+    summary = {"materialized": [], "skipped": [], "errors": []}
+    for row in registry.list_all():
+        if row.get("query_mode") != "materialized":
+            continue
+
+        last = state.get_last_sync(row["id"])
+        last_iso = last.isoformat() if last else None
+        schedule = row.get("sync_schedule") or "every 1h"
+        if not is_table_due(schedule, last_iso):
+            summary["skipped"].append(row["id"])
+            continue
+
+        try:
+            stats = _materialize_table(
+                table_id=row["id"],
+                sql=row["source_query"],
+                bq=bq,
+                output_dir=output_dir,
+                max_bytes=bq_max_bytes,
+            )
+        except MaterializeBudgetError as e:
+            logger.warning(
+                "Materialize cap exceeded for %s: %s bytes > %s bytes",
+                e.table_id, f"{e.current:,}", f"{e.limit:,}",
+            )
+            summary["errors"].append({
+                "table": row["id"],
+                "error": str(e),
+                "current": e.current,
+                "limit": e.limit,
+            })
+            continue
+        except Exception as e:
+            logger.exception("Materialize failed for %s", row["id"])
+            summary["errors"].append({"table": row["id"], "error": str(e)})
+            continue
+
+        # Compute hash inline so the manifest can serve it immediately
+        # and `da sync` honors the delta-skip on unchanged tables.
+        parquet_path = Path(output_dir) / "data" / f"{row['id']}.parquet"
+        parquet_hash = _file_hash(parquet_path)
+        state.update_sync(
+            table_id=row["id"],
+            rows=stats["rows"],
+            file_size_bytes=stats["size_bytes"],
+            hash=parquet_hash,
+        )
+        summary["materialized"].append(row["id"])
+
+    return summary
+
+
 def _run_sync(tables: Optional[List[str]] = None):
     """Run extractor as subprocess + orchestrator rebuild.
 
@@ -199,6 +305,43 @@ sys.exit(compute_exit_code(result, len(configs)))
                         logger.info("Custom connector %s completed", connector_dir.name)
                 except subprocess.TimeoutExpired:
                     logger.error("Custom connector %s timed out", connector_dir.name)
+
+        # Materialized BigQuery pass — runs admin-registered SQL through the
+        # DuckDB BQ extension (via BqAccess) and writes parquet for due rows.
+        # The orchestrator rebuild below picks the parquets up via the
+        # standard local-parquet discovery. Wrapped so a misconfigured BQ
+        # facade doesn't kill the Keboola path.
+        try:
+            from app.instance_config import get_value as _get_value
+            bq_project = _get_value(
+                "data_source", "bigquery", "project", default=""
+            ) or ""
+            if bq_project:
+                from connectors.bigquery.access import get_bq_access
+                from src.db import get_system_db as _get_system_db
+                bq_access = get_bq_access()
+                mat_conn = _get_system_db()
+                try:
+                    mat_summary = _run_materialized_pass(mat_conn, bq_access)
+                finally:
+                    mat_conn.close()
+                print(
+                    f"[SYNC] Materialized BQ: {len(mat_summary['materialized'])} ok, "
+                    f"{len(mat_summary['skipped'])} skipped, "
+                    f"{len(mat_summary['errors'])} errors",
+                    file=_sys.stderr, flush=True,
+                )
+                for err in mat_summary["errors"]:
+                    print(
+                        f"[SYNC]   {err['table']}: {err['error']}",
+                        file=_sys.stderr, flush=True,
+                    )
+        except Exception as e:
+            print(
+                f"[SYNC] Materialized BQ pass FAILED: {e}",
+                file=_sys.stderr, flush=True,
+            )
+            traceback.print_exc()
 
         # Rebuild master views (reads extract.duckdb files, no write conflict)
         from src.orchestrator import SyncOrchestrator

--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -127,10 +127,14 @@ def _run_materialized_pass(conn: duckdb.DuckDBPyConnection, bq) -> dict:
             summary["errors"].append({"table": row["id"], "error": str(e)})
             continue
 
-        # Compute hash inline so the manifest can serve it immediately
-        # and `da sync` honors the delta-skip on unchanged tables.
-        parquet_path = Path(output_dir) / "data" / f"{row['id']}.parquet"
-        parquet_hash = _file_hash(parquet_path)
+        # `materialize_query` returns the parquet's MD5 inline — hashing
+        # there means we don't re-read a multi-GB file on the request
+        # thread. Fallback to `_file_hash(parquet_path)` if for some
+        # reason the stats dict didn't carry it (defensive).
+        parquet_hash = stats.get("hash")
+        if not parquet_hash:
+            parquet_path = Path(output_dir) / "data" / f"{row['id']}.parquet"
+            parquet_hash = _file_hash(parquet_path)
         state.update_sync(
             table_id=row["id"],
             rows=stats["rows"],

--- a/cli/commands/admin.py
+++ b/cli/commands/admin.py
@@ -63,11 +63,19 @@ def register_table(
     source_type: str = typer.Option("keboola", help="Source type: keboola | bigquery | jira | local"),
     bucket: str = typer.Option("", help="Source bucket (Keboola) or dataset (BigQuery)"),
     source_table: str = typer.Option("", help="Source table name in the bucket/dataset"),
-    query_mode: str = typer.Option("local", help="Query mode: local or remote (forced to 'remote' for bigquery)"),
+    query_mode: str = typer.Option("local", help="Query mode: local | remote | materialized"),
+    query: str = typer.Option(
+        "",
+        "--query",
+        help=(
+            "SQL body for query_mode='materialized' (BigQuery only). "
+            "Inline SQL or `@path/to.sql` to read from disk."
+        ),
+    ),
     description: str = typer.Option("", help="Table description"),
     sync_schedule: str = typer.Option(
         "",
-        help="Cron schedule (BigQuery only — note: scheduler not yet wired, see #79 / M3 of #108)",
+        help="Cron schedule (e.g. 'every 6h' / 'daily 03:00'); honored by materialized BQ rows",
     ),
     dry_run: bool = typer.Option(
         False,
@@ -77,11 +85,38 @@ def register_table(
 ):
     """Register a single table.
 
-    For BigQuery: dataset goes in --bucket, the BQ table/view name in
-    --source-table, the DuckDB view name in NAME. The server forces
-    query_mode=remote and profile_after_sync=False; --dry-run goes
-    through /precheck and prints rows + size + columns without writing.
+    Modes:
+    - **local** (Keboola): batch pull, parquet on disk.
+    - **remote** (BigQuery): view only, queries go to BQ. Requires
+      `--bucket` + `--source-table`.
+    - **materialized** (BigQuery): server-side scheduled SQL → parquet.
+      Requires `--query` (inline or `@file.sql`); `--bucket` /
+      `--source-table` ignored.
+
+    `--dry-run` goes through /precheck (BQ remote only — for materialized
+    rows, dry-run is a no-op since the SQL itself is the contract).
     """
+    from pathlib import Path
+
+    # Resolve --query @file.sql shorthand.
+    source_query = ""
+    if query:
+        if query.startswith("@"):
+            sql_path = Path(query[1:])
+            if not sql_path.exists():
+                typer.echo(f"Error: SQL file not found: {sql_path}", err=True)
+                raise typer.Exit(2)
+            source_query = sql_path.read_text(encoding="utf-8").strip()
+        else:
+            source_query = query.strip()
+
+    if query_mode == "materialized" and not source_query:
+        typer.echo(
+            "Error: --query-mode materialized requires --query (literal SQL or @path.sql)",
+            err=True,
+        )
+        raise typer.Exit(2)
+
     payload = {
         "name": name,
         "source_type": source_type,
@@ -90,6 +125,11 @@ def register_table(
         "query_mode": query_mode,
         "description": description,
     }
+    # Omit empty optional fields so the server-side validator doesn't see
+    # `source_query=""` on a remote/local row (which would trigger the
+    # "source_query forbidden" branch).
+    if source_query:
+        payload["source_query"] = source_query
     if sync_schedule:
         payload["sync_schedule"] = sync_schedule
 

--- a/cli/commands/analyst.py
+++ b/cli/commands/analyst.py
@@ -275,6 +275,45 @@ def _get_instance_name(server_url: str, token: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Helper: install SessionStart/End hooks into a Claude settings file
+# ---------------------------------------------------------------------------
+
+def _install_claude_hooks(settings_path: Path) -> None:
+    """Add SessionStart/SessionEnd hooks calling `da sync` to a Claude settings file.
+
+    Idempotent: replaces our prior `da sync` entries (matched by command substring
+    `da sync`) but preserves anyone else's hooks. Creates the file when missing.
+
+    The settings file is workspace-level (`<workspace>/.claude/settings.json`) so
+    the hooks only fire in this analyst workspace, not in unrelated Claude Code
+    sessions on the same machine.
+    """
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if settings_path.exists():
+        cfg = json.loads(settings_path.read_text(encoding="utf-8"))
+    else:
+        cfg = {}
+
+    hooks = cfg.setdefault("hooks", {})
+
+    def _replace_or_add(event: str, command: str) -> None:
+        existing = hooks.setdefault(event, [])
+        # Drop any prior entry whose every command is a `da sync` invocation.
+        # Third-party entries (PreToolUse: echo hi) and mixed entries are left alone.
+        for entry in list(existing):
+            entry_cmds = [h.get("command", "") for h in entry.get("hooks", [])]
+            if entry_cmds and all("da sync" in c for c in entry_cmds):
+                existing.remove(entry)
+        existing.append({"hooks": [{"type": "command", "command": command}]})
+
+    _replace_or_add("SessionStart", "da sync --quiet 2>/dev/null || true")
+    _replace_or_add("SessionEnd",   "da sync --upload-only --quiet 2>/dev/null || true")
+
+    settings_path.write_text(json.dumps(cfg, indent=2) + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
 # Helper: generate CLAUDE.md from template
 # ---------------------------------------------------------------------------
 
@@ -319,8 +358,12 @@ def _generate_claude_md(
 
     settings_path = workspace / ".claude" / "settings.json"
     if not settings_path.exists():
+        # First-run defaults: model + permissions. _install_claude_hooks below
+        # will merge in the SessionStart/End hooks on top of these.
         settings = {"model": "sonnet", "permissions": {"allow": ["Read", "Bash", "Grep", "Glob"]}}
         settings_path.write_text(json.dumps(settings, indent=2))
+
+    _install_claude_hooks(settings_path)
 
 
 # ---------------------------------------------------------------------------
@@ -400,6 +443,7 @@ def setup(
     typer.echo(f"  Server   : {server_url}")
     typer.echo(f"  Tables   : {n_downloaded} downloaded, {total_rows} total rows")
     typer.echo(f"  Workspace: {workspace}")
+    typer.echo(f"  Hooks    : SessionStart/End installed in {workspace}/.claude/settings.json")
     typer.echo("")
     typer.echo("Next steps:")
     typer.echo("  da sync          — refresh data")

--- a/cli/commands/analyst.py
+++ b/cli/commands/analyst.py
@@ -291,7 +291,14 @@ def _install_claude_hooks(settings_path: Path) -> None:
     settings_path.parent.mkdir(parents=True, exist_ok=True)
 
     if settings_path.exists():
-        cfg = json.loads(settings_path.read_text(encoding="utf-8"))
+        try:
+            cfg = json.loads(settings_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            typer.echo(
+                f"Warning: {settings_path} is not valid JSON; skipping hook install.",
+                err=True,
+            )
+            return
     else:
         cfg = {}
 

--- a/cli/commands/sync.py
+++ b/cli/commands/sync.py
@@ -31,6 +31,11 @@ def sync(
     upload_only: bool = typer.Option(False, "--upload-only", help="Only upload sessions/artifacts"),
     docs_only: bool = typer.Option(False, "--docs-only", help="Only sync documentation"),
     as_json: bool = typer.Option(False, "--json", help="Output as JSON"),
+    quiet: bool = typer.Option(
+        False,
+        "--quiet",
+        help="Suppress progress output (intended for hooks/cron)",
+    ),
     dry_run: bool = typer.Option(
         False,
         "--dry-run",
@@ -39,7 +44,12 @@ def sync(
 ):
     """Sync data between server and local machine."""
     if upload_only:
-        _upload(as_json, dry_run=dry_run)
+        _upload(as_json, dry_run=dry_run, quiet=quiet)
+        return
+
+    if quiet:
+        # Bypass Rich Progress entirely so hook stdout stays clean.
+        _sync_quiet(table=table, docs_only=docs_only, as_json=as_json, dry_run=dry_run)
         return
 
     with Progress(
@@ -388,11 +398,13 @@ def _is_valid_parquet(path: Path) -> bool:
         return False
 
 
-def _upload(as_json: bool, dry_run: bool = False):
+def _upload(as_json: bool, dry_run: bool = False, quiet: bool = False):
     """Upload sessions and CLAUDE.local.md to server.
 
     When `dry_run=True`, enumerate what would be uploaded without hitting the
-    API or mutating anything on disk.
+    API or mutating anything on disk. When `quiet=True`, suppress the trailing
+    "Uploaded N sessions" stdout line — error paths still surface on stderr
+    via api_post itself.
     """
     local_dir = _local_data_dir()
     sessions_dir = local_dir / "user" / "sessions"
@@ -448,7 +460,108 @@ def _upload(as_json: bool, dry_run: bool = False):
 
     if as_json:
         typer.echo(json.dumps(results, indent=2))
-    else:
+    elif not quiet:
         typer.echo(f"Uploaded {results['sessions']} sessions")
         if results["local_md"]:
             typer.echo("Uploaded CLAUDE.local.md")
+
+
+def _sync_quiet(table, docs_only, as_json, dry_run):
+    """Mirror of the Progress-block flow without any Rich UI.
+
+    Designed for Claude Code SessionStart/SessionEnd hooks and cron callers:
+    stdout stays empty in the no-op case, the terse one-line summary lands
+    on stderr so hook stdout pipes don't see it, and a manifest fetch
+    failure exits non-zero so the `|| true` shell fallback can swallow it
+    cleanly.
+
+    Skips remote-mode tables exactly like the noisy path; runs the
+    `_fetch_and_write_rules` corporate-memory step so analysts' .claude/
+    rules/ stay fresh between sessions.
+    """
+    try:
+        resp = api_get("/api/sync/manifest")
+        resp.raise_for_status()
+        manifest = resp.json()
+    except Exception as e:
+        typer.echo(f"sync: manifest fetch failed: {e}", err=True)
+        raise typer.Exit(1)
+
+    server_tables = manifest.get("tables", {})
+    local_state = get_sync_state()
+    local_tables = local_state.get("tables", {})
+
+    to_download = []
+    skipped_remote = []
+    for tid, info in server_tables.items():
+        if table and tid != table:
+            continue
+        if docs_only:
+            continue
+        if info.get("query_mode") == "remote":
+            skipped_remote.append(tid)
+            continue
+        local_hash = local_tables.get(tid, {}).get("hash", "")
+        server_hash = info.get("hash", "")
+        if server_hash != local_hash or tid not in local_tables or not server_hash:
+            to_download.append(tid)
+
+    if dry_run:
+        if as_json:
+            typer.echo(json.dumps(
+                {"dry_run": True, "would_download": to_download,
+                 "skipped_remote": skipped_remote},
+                indent=2,
+            ))
+        return
+
+    local_dir = _local_data_dir()
+    parquet_dir = local_dir / "server" / "parquet"
+    parquet_dir.mkdir(parents=True, exist_ok=True)
+
+    results = {
+        "downloaded": [], "skipped": [],
+        "skipped_remote": list(skipped_remote), "errors": [],
+    }
+    for tid in to_download:
+        target = parquet_dir / f"{tid}.parquet"
+        expected_hash = server_tables[tid].get("hash", "")
+        try:
+            stream_download(f"/api/data/{tid}/download", str(target))
+            if expected_hash:
+                if _md5_file(target) != expected_hash:
+                    target.unlink(missing_ok=True)
+                    raise ValueError("hash mismatch")
+            elif not _is_valid_parquet(target):
+                target.unlink(missing_ok=True)
+                raise ValueError("not a valid parquet")
+            local_tables[tid] = {
+                "hash": expected_hash,
+                "rows": server_tables[tid].get("rows", 0),
+                "size_bytes": server_tables[tid].get("size_bytes", 0),
+            }
+            results["downloaded"].append(tid)
+        except Exception as e:
+            results["errors"].append({"table": tid, "error": str(e)})
+
+    from datetime import datetime, timezone
+    local_state["tables"] = local_tables
+    local_state["last_sync"] = datetime.now(timezone.utc).isoformat()
+    save_sync_state(local_state)
+
+    if results["downloaded"]:
+        _rebuild_duckdb_views(local_dir, parquet_dir)
+
+    # Same corporate-memory rule fetch as the noisy path — keeps the
+    # `.claude/rules/km_*.md` files fresh between sessions even when the
+    # hook is the only thing invoking sync.
+    _fetch_and_write_rules(local_dir)
+
+    if as_json:
+        typer.echo(json.dumps(results, indent=2))
+    elif results["downloaded"] or results["errors"]:
+        typer.echo(
+            f"sync: {len(results['downloaded'])} tables, "
+            f"{len(results['errors'])} errors",
+            err=True,
+        )

--- a/cli/skills/connectors.md
+++ b/cli/skills/connectors.md
@@ -51,3 +51,28 @@ The `_meta` table must have columns:
 - Instance-level config: `config/instance.yaml` (connection details)
 - Table definitions: DuckDB `table_registry` table
 - Credentials: environment variables
+
+## BigQuery: pick a mode
+
+| Need | Mode | Why |
+|------|------|-----|
+| Latency under 100 ms, table fits on disk | `materialized` | Local parquet, no BQ roundtrip |
+| Table too large for analyst's disk, occasional ad-hoc query | `remote` | DuckDB BQ extension, no download |
+| Table too large for disk AND analyst hits it constantly | `materialized` with aggregation/filter | Scheduled COPY of a slice |
+| One-off subquery joined with local data | (no registry row) | Use `da query --register-bq …` for ad-hoc |
+
+Cost: `materialized` runs once per `sync_schedule` regardless of how many analysts query it; `remote` runs once per analyst-query. The break-even is roughly query frequency × bytes scanned vs. one COPY × bytes scanned.
+
+Guardrail: `data_source.bigquery.max_bytes_per_materialize` (default 10 GiB) blocks the COPY when BQ's dry-run estimate exceeds the cap. Set it explicitly per environment in `instance.yaml`.
+
+Register a materialized table:
+
+```bash
+da admin register-table orders_90d \
+    --source-type bigquery \
+    --query-mode materialized \
+    --query @docs/queries/orders_90d.sql \
+    --schedule "every 6h"
+```
+
+`--query` also accepts inline SQL.

--- a/connectors/bigquery/extractor.py
+++ b/connectors/bigquery/extractor.py
@@ -397,14 +397,22 @@ def materialize_query(
 
     # COPY through a BqAccess-managed session.
     with bq.duckdb_session() as conn:
-        # ATTACH the data project. Tolerated-fail when the session already
-        # has `bq` attached (test stubs may pre-populate; rare in production).
+        # ATTACH the data project. Test stubs pre-populate `bq` as an
+        # in-memory schema; production uses the real BQ extension. The
+        # only tolerated failure is "alias already in use" — anything else
+        # (auth, permission, malformed project_id) must surface so the
+        # caller's per-row try/except can record it. Devil's-advocate
+        # review found that swallowing the error blindly hid
+        # cross-project permission errors behind a confusing
+        # "bq is not attached" downstream message.
         try:
             conn.execute(
                 f"ATTACH 'project={bq.projects.data}' AS bq (TYPE bigquery, READ_ONLY)"
             )
-        except duckdb.Error:
-            pass
+        except duckdb.Error as e:
+            msg = str(e).lower()
+            if "already" not in msg and "in use" not in msg:
+                raise
 
         try:
             safe_path = str(tmp_path).replace("'", "''")
@@ -417,10 +425,40 @@ def materialize_query(
                 tmp_path.unlink()
             raise
 
+    # Compute the parquet hash inline before the atomic swap. The caller used
+    # to re-read the file in `_run_materialized_pass` to hash it via
+    # `_file_hash`, but that's a synchronous full-read on the FastAPI worker
+    # thread — a 10 GiB parquet means 50+ seconds of disk I/O blocking other
+    # requests. Hashing here keeps the open-file handle hot from the COPY
+    # round and removes the second read. Devil's-advocate review item.
+    import hashlib
+    h = hashlib.md5()
+    with open(tmp_path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    parquet_hash = h.hexdigest()
+
     size_bytes = tmp_path.stat().st_size
     os.replace(tmp_path, parquet_path)
 
-    return {"rows": int(rows), "size_bytes": size_bytes, "query_mode": "materialized"}
+    rows = int(rows)
+    if rows == 0:
+        # 0 rows is indistinguishable from "the SQL is wrong and nobody
+        # noticed" — surface it loudly so operators see it in the scheduler
+        # log line and the per-row error aggregation. Caller decides whether
+        # to alert.
+        logger.warning(
+            "Materialized %s produced 0 rows — verify the SQL filter is "
+            "intentional. Parquet written: %s",
+            table_id, parquet_path,
+        )
+
+    return {
+        "rows": rows,
+        "size_bytes": size_bytes,
+        "query_mode": "materialized",
+        "hash": parquet_hash,
+    }
 
 
 def _resolve_bq_project_id() -> str:

--- a/connectors/bigquery/extractor.py
+++ b/connectors/bigquery/extractor.py
@@ -9,7 +9,7 @@ import shutil
 import threading
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 import duckdb
 
@@ -182,6 +182,14 @@ def _init_extract_locked(
         _create_remote_attach_table(conn, project_id)
 
         for tc in table_configs:
+            # Materialized rows are written by the sync trigger pass via
+            # `materialize_query()` — they live as parquets in
+            # /data/extracts/bigquery/data/, picked up by the orchestrator's
+            # standard local-parquet discovery. Don't create a remote view
+            # here (would shadow the parquet via name collision).
+            if tc.get("query_mode") == "materialized":
+                continue
+
             table_name = tc["name"]
             dataset = tc.get("bucket", "")
             source_table = tc.get("source_table", table_name)
@@ -277,6 +285,142 @@ def _init_extract_locked(
         tmp_wal.unlink()
 
     return stats
+
+
+class MaterializeBudgetError(RuntimeError):
+    """Raised when a `materialize_query` BQ dry-run estimate exceeds the
+    configured `data_source.bigquery.max_bytes_per_materialize` cap.
+
+    The materialize trigger pass logs this and skips the row; the next
+    scheduled tick re-tries (in case the underlying table size dropped
+    or the operator raised the cap). Shape mirrors `BqAccessError` —
+    `current` and `limit` for operator triage.
+    """
+
+    def __init__(self, message: str, *, table_id: str, current: int, limit: int):
+        self.table_id = table_id
+        self.current = current
+        self.limit = limit
+        super().__init__(message)
+
+
+def materialize_query(
+    table_id: str,
+    sql: str,
+    *,
+    bq,  # connectors.bigquery.access.BqAccess (untyped here to avoid circular import at type-check)
+    output_dir: str,
+    max_bytes: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Run `sql` through the DuckDB BigQuery extension and write the result
+    to `<output_dir>/data/<table_id>.parquet` atomically.
+
+    Designed for `query_mode='materialized'` table_registry rows. The SQL
+    is admin-registered (validated upstream) and may reference DuckDB
+    three-part identifiers (`bq."dataset"."table"`) resolved by the
+    in-session ATTACH, OR native BQ identifiers via the `bigquery_query()`
+    table function — both work because the session has the bigquery
+    extension loaded with a SECRET token.
+
+    Cost guardrail: when `max_bytes` is a positive int, run a BQ dry-run
+    via `bq.client()` first; raise `MaterializeBudgetError` if the
+    estimate exceeds the cap. `max_bytes=None` or `max_bytes <= 0`
+    disables the guardrail (config sentinel, see
+    `data_source.bigquery.max_bytes_per_materialize`).
+
+    Dry-run is best-effort and fail-open: if the SQL uses DuckDB syntax
+    that the native BQ client can't parse (e.g. `bq."ds"."t"`), the
+    dry-run raises and we log a warning; the COPY still runs. This
+    matches the BqAccess facade's "client is for native BQ SQL only"
+    contract — operators who need the cap to engage write the registered
+    SQL using native BQ identifiers (`\\`project.ds.t\\``).
+
+    Atomic write: result lands in `<id>.parquet.tmp` first, then
+    `os.replace` swaps it in. A failed COPY leaves no partial file behind.
+
+    Args:
+        table_id: Logical id from table_registry; becomes the parquet
+            filename. Must pass `validate_identifier()` so it can't
+            inject path traversal.
+        sql: SELECT statement, no trailing semicolon.
+        bq: A `BqAccess` instance — provides `duckdb_session()` for the
+            COPY and `client()` for the dry-run.
+        output_dir: Connector root, e.g. `/data/extracts/bigquery`.
+            Parquet lands in `<output_dir>/data/<table_id>.parquet`.
+        max_bytes: Optional cap on BQ bytes scanned. None or <= 0 disables.
+
+    Returns:
+        {"rows": int, "size_bytes": int, "query_mode": "materialized"}
+
+    Raises:
+        ValueError: if `table_id` is unsafe.
+        MaterializeBudgetError: if `max_bytes > 0` and dry-run estimate exceeds it.
+        BqAccessError: from `bq.duckdb_session()` (auth_failed / bq_lib_missing /
+            not_configured) — caller catches and aggregates into the trigger
+            pass summary.
+        duckdb.Error: if the COPY itself fails (e.g. bad SQL, missing table).
+    """
+    if not validate_identifier(table_id, "materialize table_id"):
+        raise ValueError(f"unsafe table_id: {table_id!r}")
+
+    out_path = Path(output_dir)
+    data_dir = out_path / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    parquet_path = data_dir / f"{table_id}.parquet"
+    tmp_path = data_dir / f"{table_id}.parquet.tmp"
+    if tmp_path.exists():
+        tmp_path.unlink()
+
+    # Cost guardrail (best-effort — fail-open if dry-run can't parse the SQL).
+    if max_bytes is not None and max_bytes > 0:
+        try:
+            from app.api.v2_scan import _bq_dry_run_bytes  # reuse main's impl
+            estimated = _bq_dry_run_bytes(bq, sql)
+        except Exception as e:
+            logger.warning(
+                "BQ dry-run failed for materialize cost guardrail (fail-open): %s. "
+                "If the SQL uses DuckDB three-part names like bq.\"ds\".\"t\", "
+                "rewrite to native BQ identifiers (`project.ds.t`) for the "
+                "guardrail to engage. Proceeding with COPY.",
+                e,
+            )
+            estimated = 0
+        if estimated > max_bytes:
+            raise MaterializeBudgetError(
+                f"dry-run estimate {estimated:,} bytes exceeds cap "
+                f"{max_bytes:,} for table {table_id!r}",
+                table_id=table_id,
+                current=estimated,
+                limit=max_bytes,
+            )
+
+    # COPY through a BqAccess-managed session.
+    with bq.duckdb_session() as conn:
+        # ATTACH the data project. Tolerated-fail when the session already
+        # has `bq` attached (test stubs may pre-populate; rare in production).
+        try:
+            conn.execute(
+                f"ATTACH 'project={bq.projects.data}' AS bq (TYPE bigquery, READ_ONLY)"
+            )
+        except duckdb.Error:
+            pass
+
+        try:
+            safe_path = str(tmp_path).replace("'", "''")
+            conn.execute(f"COPY ({sql}) TO '{safe_path}' (FORMAT PARQUET)")
+            rows = conn.execute(
+                f"SELECT count(*) FROM read_parquet('{safe_path}')"
+            ).fetchone()[0]
+        except Exception:
+            if tmp_path.exists():
+                tmp_path.unlink()
+            raise
+
+    size_bytes = tmp_path.stat().st_size
+    os.replace(tmp_path, parquet_path)
+
+    return {"rows": int(rows), "size_bytes": size_bytes, "query_mode": "materialized"}
 
 
 def _resolve_bq_project_id() -> str:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -173,10 +173,19 @@ POST /api/sync/trigger (admin)
 
 `connectors/bigquery/extractor.py`
 
-- Uses the DuckDB BigQuery community extension.
+- Uses the DuckDB BigQuery community extension via the `BqAccess` facade in `connectors/bigquery/access.py`.
 - No data download — views proxy all queries directly to BigQuery.
 - Auth via `GOOGLE_APPLICATION_CREDENTIALS` (service account JSON) or ADC.
 - Populates `_remote_attach` with `extension='bigquery'` and no `token_env` (env-based auth).
+
+### BigQuery — Materialized SQL
+
+`connectors/bigquery/extractor.py::materialize_query` (added in v0.25.0)
+
+- Runs admin-registered SQL through the DuckDB BigQuery extension via `BqAccess.duckdb_session()` and writes the result to `/data/extracts/bigquery/data/<id>.parquet` atomically (`<id>.parquet.tmp` → `os.replace`).
+- Triggered by `_run_materialized_pass` in `app/api/sync.py` between custom-connectors and orchestrator rebuild on every `/api/sync/trigger`. Per-table `sync_schedule` honored via `is_table_due()`.
+- Cost guardrail: BQ dry-run via `app.api.v2_scan._bq_dry_run_bytes` (single source of truth for cost-estimate logic). `data_source.bigquery.max_bytes_per_materialize` (default 10 GiB; `0` disables). Fail-open when dry-run errors (DuckDB three-part syntax the native BQ client can't parse) — log warning + proceed.
+- Distribution: result parquet rides the same manifest + `da sync` flow as Keboola tables. Per-user RBAC unchanged (`resource_grants(group, ResourceType.TABLE, table_id)`).
 
 ### Jira — Real-Time Push
 

--- a/docs/setup/claude_settings.json
+++ b/docs/setup/claude_settings.json
@@ -1,11 +1,21 @@
 {
     "hooks": {
+        "SessionStart": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "da sync --quiet 2>/dev/null || true"
+                    }
+                ]
+            }
+        ],
         "SessionEnd": [
             {
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "python server/scripts/collect_session.py 2>/dev/null || true"
+                        "command": "da sync --upload-only --quiet 2>/dev/null || true"
                     }
                 ]
             }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.24.0"
+version = "0.25.0"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/scripts/smoke-test-materialized-bq.sh
+++ b/scripts/smoke-test-materialized-bq.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# Smoke test — query_mode='materialized' for BigQuery.
+#
+# Runs the full happy-path + 3 adversarial scenarios against a live Agnes
+# instance that has BigQuery configured. Cheap (uses bigquery-public-data
+# samples; ~36 rows, < 1 KB scan) — safe to run against staging.
+#
+# Usage:
+#   ./scripts/smoke-test-materialized-bq.sh [host:port]
+#
+# Required environment:
+#   AGNES_PAT       — admin PAT for the target instance
+#   BQ_TEST_BIG     — (optional) name of a BQ table > 10 GiB to test the
+#                     cost guardrail. Defaults to a public dataset that
+#                     scans ~50 GB on full SELECT.
+#
+# Defaults: AGNES_HOST=http://localhost:8000.
+#
+# Cleans up the test rows on exit (trap), even on SIGINT.
+
+set -euo pipefail
+
+HOST="${1:-${AGNES_HOST:-http://localhost:8000}}"
+PAT="${AGNES_PAT:?AGNES_PAT must be set (admin token)}"
+BIG_TABLE="${BQ_TEST_BIG:-bigquery-public-data.github_repos.commits}"
+
+PASS=0
+FAIL=0
+
+# Test rows we'll create — captured for cleanup.
+CREATED_IDS=()
+
+cleanup() {
+    echo
+    echo "--- Cleanup ---"
+    for tid in "${CREATED_IDS[@]}"; do
+        curl -sS -X DELETE "$HOST/api/admin/registry/$tid" \
+            -H "Authorization: Bearer $PAT" -o /dev/null -w "  DELETE %{http_code} $tid\n" || true
+    done
+}
+trap cleanup EXIT INT TERM
+
+check() {
+    local name="$1" ok="$2"
+    if [ "$ok" = "true" ]; then
+        echo "  PASS $name"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+http() {
+    # POST/PUT/DELETE helper that returns the HTTP status + body separately.
+    local method="$1" path="$2" body="${3:-}"
+    if [ -n "$body" ]; then
+        curl -sS -o /tmp/smoke-mat-body -w "%{http_code}" \
+            -X "$method" "$HOST$path" \
+            -H "Authorization: Bearer $PAT" \
+            -H "Content-Type: application/json" \
+            -d "$body"
+    else
+        curl -sS -o /tmp/smoke-mat-body -w "%{http_code}" \
+            -X "$method" "$HOST$path" \
+            -H "Authorization: Bearer $PAT"
+    fi
+}
+
+echo "Materialized BQ smoke: $HOST"
+echo "Big table for cost-guardrail test: $BIG_TABLE"
+echo "---"
+
+# ---------------------------------------------------------------------------
+# Scenario A — Happy path: register tiny materialized table, trigger,
+#              verify parquet on disk + manifest carries hash.
+# ---------------------------------------------------------------------------
+echo
+echo "[A] Happy path (Shakespeare sample, ~36 rows)"
+SQL_A='SELECT corpus, COUNT(*) AS c FROM `bigquery-public-data.samples.shakespeare` GROUP BY 1 ORDER BY 1'
+TID_A="smoke_mat_shakespeare_$(date +%s)"
+CREATED_IDS+=("$TID_A")
+
+STATUS=$(http POST /api/admin/register-table "{
+    \"name\": \"$TID_A\",
+    \"source_type\": \"bigquery\",
+    \"query_mode\": \"materialized\",
+    \"source_query\": $(printf '%s' "$SQL_A" | python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))"),
+    \"sync_schedule\": \"every 1m\"
+}")
+[ "$STATUS" = "201" ] && check "register 201" true || { check "register 201 (got $STATUS)" false; cat /tmp/smoke-mat-body; }
+
+echo "    triggering sync..."
+http POST /api/sync/trigger '{}' >/dev/null
+sleep 5  # background task
+
+# Manifest must list the row with query_mode + non-empty hash.
+http GET /api/sync/manifest >/dev/null
+HASH=$(python3 -c "
+import json
+m = json.load(open('/tmp/smoke-mat-body'))
+t = m.get('tables', {}).get('$TID_A')
+print(t.get('hash', '') if t else '')
+")
+[ -n "$HASH" ] && [ "$HASH" != "null" ] && check "manifest hash present" true || check "manifest hash present (got '$HASH')" false
+
+# Parquet on disk (assumes co-located filesystem, e.g. local docker compose).
+PARQUET="${DATA_DIR:-./data}/extracts/bigquery/data/$TID_A.parquet"
+if [ -f "$PARQUET" ]; then
+    ROWS=$(python3 -c "import duckdb; print(duckdb.connect().execute(\"SELECT count(*) FROM read_parquet('$PARQUET')\").fetchone()[0])" 2>/dev/null || echo "0")
+    [ "$ROWS" -gt 0 ] && check "parquet has $ROWS rows" true || check "parquet rows ($ROWS)" false
+else
+    echo "    note: parquet at $PARQUET not visible from this host (skip if Agnes is remote)"
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario B — Cost guardrail: register a large-scan materialized SQL,
+#              trigger, expect MaterializeBudgetError logged + row skipped.
+# ---------------------------------------------------------------------------
+echo
+echo "[B] Cost guardrail (\`$BIG_TABLE\` full SELECT)"
+TID_B="smoke_mat_huge_$(date +%s)"
+CREATED_IDS+=("$TID_B")
+SQL_B="SELECT * FROM \`$BIG_TABLE\`"
+
+STATUS=$(http POST /api/admin/register-table "{
+    \"name\": \"$TID_B\",
+    \"source_type\": \"bigquery\",
+    \"query_mode\": \"materialized\",
+    \"source_query\": $(printf '%s' "$SQL_B" | python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))"),
+    \"sync_schedule\": \"every 1m\"
+}")
+[ "$STATUS" = "201" ] && check "register 201" true || check "register 201 (got $STATUS)" false
+
+echo "    triggering sync (expect cap to fire)..."
+http POST /api/sync/trigger '{}' >/dev/null
+sleep 5
+
+# Manifest should NOT have a hash for the huge row (materialize was skipped).
+http GET /api/sync/manifest >/dev/null
+HUGE_HASH=$(python3 -c "
+import json
+m = json.load(open('/tmp/smoke-mat-body'))
+t = m.get('tables', {}).get('$TID_B')
+print(t.get('hash', '') if t else 'absent')
+")
+if [ "$HUGE_HASH" = "absent" ] || [ -z "$HUGE_HASH" ] || [ "$HUGE_HASH" = "null" ]; then
+    check "huge row skipped (no hash in manifest)" true
+else
+    check "huge row skipped (got hash '$HUGE_HASH' — guardrail did not fire)" false
+fi
+echo "    grep server logs for: 'MaterializeBudgetError' or 'Materialize cap exceeded'"
+
+# ---------------------------------------------------------------------------
+# Scenario C — 0-row warning: SQL with always-false WHERE.
+# ---------------------------------------------------------------------------
+echo
+echo "[C] 0-row WARNING (filter to empty result)"
+TID_C="smoke_mat_empty_$(date +%s)"
+CREATED_IDS+=("$TID_C")
+SQL_C='SELECT corpus FROM `bigquery-public-data.samples.shakespeare` WHERE 1=0'
+
+STATUS=$(http POST /api/admin/register-table "{
+    \"name\": \"$TID_C\",
+    \"source_type\": \"bigquery\",
+    \"query_mode\": \"materialized\",
+    \"source_query\": $(printf '%s' "$SQL_C" | python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))"),
+    \"sync_schedule\": \"every 1m\"
+}")
+[ "$STATUS" = "201" ] && check "register 201" true || check "register 201 (got $STATUS)" false
+
+http POST /api/sync/trigger '{}' >/dev/null
+sleep 5
+
+http GET /api/sync/manifest >/dev/null
+EMPTY_ROWS=$(python3 -c "
+import json
+m = json.load(open('/tmp/smoke-mat-body'))
+t = m.get('tables', {}).get('$TID_C')
+print(t.get('rows', 'absent') if t else 'absent')
+")
+[ "$EMPTY_ROWS" = "0" ] && check "empty-result rows=0 in manifest" true || check "empty-result rows ($EMPTY_ROWS)" false
+echo "    grep server logs for: 'produced 0 rows'"
+
+# ---------------------------------------------------------------------------
+# Scenario D — Mode-switch transition clears stale source_query.
+# ---------------------------------------------------------------------------
+echo
+echo "[D] Mode-switch materialized → remote clears source_query"
+TID_D="smoke_mat_switch_$(date +%s)"
+CREATED_IDS+=("$TID_D")
+
+STATUS=$(http POST /api/admin/register-table "{
+    \"name\": \"$TID_D\",
+    \"source_type\": \"bigquery\",
+    \"query_mode\": \"materialized\",
+    \"source_query\": \"SELECT 1\"
+}")
+[ "$STATUS" = "201" ] && check "register materialized" true || check "register materialized (got $STATUS)" false
+
+# Switch to remote, providing required bucket+source_table.
+STATUS=$(http PUT "/api/admin/registry/$TID_D" "{
+    \"query_mode\": \"remote\",
+    \"bucket\": \"samples\",
+    \"source_table\": \"shakespeare\"
+}")
+[ "$STATUS" = "200" ] && check "switch to remote 200" true || check "switch to remote (got $STATUS)" false
+
+http GET /api/admin/registry >/dev/null
+SWITCHED_SQ=$(python3 -c "
+import json
+r = json.load(open('/tmp/smoke-mat-body'))
+row = next((t for t in r.get('tables', []) if t['id'] == '$TID_D'), None)
+print(row.get('source_query') if row else 'NOT_FOUND')
+")
+[ "$SWITCHED_SQ" = "None" ] || [ -z "$SWITCHED_SQ" ] || [ "$SWITCHED_SQ" = "null" ] \
+    && check "source_query cleared on switch" true \
+    || check "source_query cleared (got '$SWITCHED_SQ')" false
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+echo "---"
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/src/db.py
+++ b/src/db.py
@@ -39,7 +39,7 @@ def _maybe_instrument(con, db_tag: str):
 
 _SAFE_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,63}$")
 
-SCHEMA_VERSION = 18
+SCHEMA_VERSION = 19
 
 _SYSTEM_SCHEMA = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -259,6 +259,7 @@ CREATE TABLE IF NOT EXISTS table_registry (
     source_type VARCHAR,
     bucket VARCHAR,
     source_table VARCHAR,
+    source_query TEXT,
     sync_strategy VARCHAR DEFAULT 'full_refresh',
     query_mode VARCHAR DEFAULT 'local',
     sync_schedule VARCHAR,
@@ -932,6 +933,16 @@ _V16_TO_V17_MIGRATIONS = [
 
 # v17 -> v18: see _v17_to_v18_finalize. Env-conditional, so kept as a Python
 # helper rather than a flat SQL list (the migrate-ladder calls it directly).
+
+
+# v18 -> v19: source_query column backs query_mode='materialized' for BigQuery.
+# Admin-registered SQL stored verbatim; scheduler runs it through the DuckDB BQ
+# extension (via BqAccess) and writes the result to
+# /data/extracts/bigquery/data/<id>.parquet so the existing manifest + da sync
+# flow distributes it to analysts. NULL on existing rows.
+_V18_TO_V19_MIGRATIONS = [
+    "ALTER TABLE table_registry ADD COLUMN IF NOT EXISTS source_query TEXT",
+]
 
 
 # Core role seed data — single source of truth. Used by both _seed_core_roles
@@ -1630,6 +1641,9 @@ def _ensure_schema(conn: duckdb.DuckDBPyConnection) -> None:
                     conn.execute(sql)
             if current < 18:
                 _v17_to_v18_finalize(conn)
+            if current < 19:
+                for sql in _V18_TO_V19_MIGRATIONS:
+                    conn.execute(sql)
             conn.execute(
                 "UPDATE schema_version SET version = ?, applied_at = current_timestamp",
                 [SCHEMA_VERSION],

--- a/src/repositories/table_registry.py
+++ b/src/repositories/table_registry.py
@@ -72,7 +72,9 @@ class TableRegistryRepository:
         primary_key: Union[None, str, List[str]] = None,
         description: Optional[str] = None, registered_by: Optional[str] = None,
         source_type: Optional[str] = None, bucket: Optional[str] = None,
-        source_table: Optional[str] = None, query_mode: str = "local",
+        source_table: Optional[str] = None,
+        source_query: Optional[str] = None,
+        query_mode: str = "local",
         sync_schedule: Optional[str] = None, profile_after_sync: bool = True,
         is_public: bool = True,
         registered_at: Optional[datetime] = None,
@@ -86,19 +88,21 @@ class TableRegistryRepository:
         self.conn.execute(
             """INSERT INTO table_registry (id, name, folder, sync_strategy,
                 primary_key, description, registered_by, registered_at,
-                source_type, bucket, source_table, query_mode,
+                source_type, bucket, source_table, source_query, query_mode,
                 sync_schedule, profile_after_sync, is_public)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT (id) DO UPDATE SET
                 name = excluded.name, folder = excluded.folder,
                 sync_strategy = excluded.sync_strategy, primary_key = excluded.primary_key,
                 description = excluded.description, registered_at = excluded.registered_at,
                 source_type = excluded.source_type, bucket = excluded.bucket,
-                source_table = excluded.source_table, query_mode = excluded.query_mode,
+                source_table = excluded.source_table, source_query = excluded.source_query,
+                query_mode = excluded.query_mode,
                 sync_schedule = excluded.sync_schedule, profile_after_sync = excluded.profile_after_sync,
                 is_public = excluded.is_public""",
             [id, name, folder, sync_strategy, encoded_pk, description, registered_by, ts,
-             source_type, bucket, source_table, query_mode, sync_schedule, profile_after_sync, is_public],
+             source_type, bucket, source_table, source_query, query_mode,
+             sync_schedule, profile_after_sync, is_public],
         )
 
     @staticmethod

--- a/tests/test_api_admin_materialized.py
+++ b/tests/test_api_admin_materialized.py
@@ -1,6 +1,11 @@
 """Admin API accepts source_query when query_mode='materialized', rejects
 mismatches between mode and query field.
 
+Tests that hit the remote-mode register path require `stub_bq_extractor`
+to bypass the post-register rebuild's real-BQ traffic. Materialized-only
+tests skip the BG path (the 201 fast-path returns before any rebuild
+fires) so they don't need the stub.
+
 Covers PR #145 (re-implementation against 0.24.0 base):
 - RegisterTableRequest + UpdateTableRequest model_validators
 - _validate_bigquery_register_payload materialized branch (skips bucket/
@@ -20,6 +25,26 @@ import pytest
 
 def _auth(token):
     return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def stub_bq_extractor(monkeypatch):
+    """Mirror tests/test_admin_bq_register.py — bypasses real-BQ traffic
+    in the post-register rebuild path so the test stays offline. Required
+    whenever the test seeds a remote-mode BQ row via the HTTP API."""
+    rebuild_mock = MagicMock(return_value={
+        "project_id": "my-test-project",
+        "tables_registered": 1, "errors": [], "skipped": False,
+    })
+    monkeypatch.setattr(
+        "connectors.bigquery.extractor.rebuild_from_registry",
+        rebuild_mock,
+    )
+    monkeypatch.setattr(
+        "src.orchestrator.SyncOrchestrator",
+        lambda *a, **kw: MagicMock(),
+    )
+    return rebuild_mock
 
 
 @pytest.fixture
@@ -135,7 +160,7 @@ def test_register_materialized_with_empty_source_query_rejected(seeded_app, bq_i
     assert 400 <= r.status_code < 500, r.json()
 
 
-def test_update_source_query_alone_requires_query_mode(seeded_app, bq_instance):
+def test_update_source_query_alone_requires_query_mode(seeded_app, bq_instance, stub_bq_extractor):
     """PUT body with source_query but no query_mode is incoherent — reject
     so non-materialized rows can't carry an orphan source_query."""
     c = seeded_app["client"]
@@ -164,7 +189,9 @@ def test_update_source_query_alone_requires_query_mode(seeded_app, bq_instance):
     assert 400 <= r2.status_code < 500, r2.json()
 
 
-def test_update_materialized_to_remote_clears_source_query(seeded_app, bq_instance):
+def test_update_materialized_to_remote_clears_source_query(
+    seeded_app, bq_instance, stub_bq_extractor,
+):
     """When admin switches a materialized table to remote/local, the stale
     source_query must be cleared in the DB — otherwise the registry shows
     a non-materialized row carrying an orphan SQL body."""

--- a/tests/test_api_admin_materialized.py
+++ b/tests/test_api_admin_materialized.py
@@ -1,0 +1,223 @@
+"""Admin API accepts source_query when query_mode='materialized', rejects
+mismatches between mode and query field.
+
+Covers PR #145 (re-implementation against 0.24.0 base):
+- RegisterTableRequest + UpdateTableRequest model_validators
+- _validate_bigquery_register_payload materialized branch (skips bucket/
+  source_table checks, requires source_query)
+- register_table 201 response for materialized BQ rows (no synchronous
+  materialize — cron tick or manual /api/sync/trigger picks them up)
+- update_table clears stale source_query when switching mode away from
+  materialized
+
+Shares the seeded_app + bq_instance fixtures from conftest /
+test_admin_bq_register.py for parity with the existing BQ test surface.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def bq_instance(monkeypatch):
+    """Force instance.yaml to look like a BigQuery deployment.
+
+    Mirrors tests/test_admin_bq_register.py::bq_instance so the
+    project_id read inside _validate_bigquery_register_payload succeeds.
+    """
+    fake_cfg = {
+        "data_source": {
+            "type": "bigquery",
+            "bigquery": {"project": "my-test-project", "location": "us"},
+        },
+    }
+    monkeypatch.setattr(
+        "app.instance_config.load_instance_config",
+        lambda: fake_cfg,
+        raising=False,
+    )
+    from app.instance_config import reset_cache
+    reset_cache()
+    yield fake_cfg
+    reset_cache()
+
+
+def _materialized_payload(**overrides):
+    p = {
+        "name": "orders_90d",
+        "source_type": "bigquery",
+        "query_mode": "materialized",
+        "source_query": "SELECT date FROM `prj.ds.orders`",
+        "sync_schedule": "every 6h",
+    }
+    p.update(overrides)
+    return p
+
+
+def test_register_materialized_requires_source_query(seeded_app, bq_instance):
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.post(
+        "/api/admin/register-table",
+        json={
+            "name": "missing_query",
+            "source_type": "bigquery",
+            "query_mode": "materialized",
+            # source_query missing
+        },
+        headers=_auth(token),
+    )
+    assert 400 <= r.status_code < 500, r.json()
+    detail = str(r.json().get("detail", "")).lower()
+    assert "source_query" in detail or "materialized" in detail
+
+
+def test_register_materialized_accepts_source_query(seeded_app, bq_instance):
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.post(
+        "/api/admin/register-table",
+        json=_materialized_payload(name="orders_90d_a"),
+        headers=_auth(token),
+    )
+    assert r.status_code == 201, r.json()
+    body = r.json()
+    assert body["status"] == "registered"
+    assert "Materialized" in body.get("message", "")
+
+
+def test_register_remote_rejects_source_query(seeded_app, bq_instance):
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.post(
+        "/api/admin/register-table",
+        json={
+            "name": "live_orders",
+            "source_type": "bigquery",
+            "bucket": "analytics",
+            "source_table": "orders",
+            "query_mode": "remote",
+            "source_query": "SELECT 1",
+        },
+        headers=_auth(token),
+    )
+    assert 400 <= r.status_code < 500, r.json()
+
+
+def test_register_local_rejects_source_query(seeded_app):
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.post(
+        "/api/admin/register-table",
+        json={
+            "name": "kbc_orders",
+            "source_type": "keboola",
+            "query_mode": "local",
+            "source_query": "SELECT 1",
+        },
+        headers=_auth(token),
+    )
+    assert 400 <= r.status_code < 500, r.json()
+
+
+def test_register_materialized_with_empty_source_query_rejected(seeded_app, bq_instance):
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.post(
+        "/api/admin/register-table",
+        json=_materialized_payload(name="empty_q", source_query=""),
+        headers=_auth(token),
+    )
+    assert 400 <= r.status_code < 500, r.json()
+
+
+def test_update_source_query_alone_requires_query_mode(seeded_app, bq_instance):
+    """PUT body with source_query but no query_mode is incoherent — reject
+    so non-materialized rows can't carry an orphan source_query."""
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+
+    # Seed a remote-mode row.
+    r = c.post(
+        "/api/admin/register-table",
+        json={
+            "name": "live_orphan",
+            "source_type": "bigquery",
+            "bucket": "analytics",
+            "source_table": "orders",
+            "query_mode": "remote",
+        },
+        headers=_auth(token),
+    )
+    assert r.status_code in (200, 202), r.json()  # synchronous or async
+    table_id = r.json()["id"]
+
+    r2 = c.put(
+        f"/api/admin/registry/{table_id}",
+        json={"source_query": "SELECT 1"},
+        headers=_auth(token),
+    )
+    assert 400 <= r2.status_code < 500, r2.json()
+
+
+def test_update_materialized_to_remote_clears_source_query(seeded_app, bq_instance):
+    """When admin switches a materialized table to remote/local, the stale
+    source_query must be cleared in the DB — otherwise the registry shows
+    a non-materialized row carrying an orphan SQL body."""
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+
+    # Seed a materialized table with a source_query.
+    r = c.post(
+        "/api/admin/register-table",
+        json=_materialized_payload(name="switcher"),
+        headers=_auth(token),
+    )
+    assert r.status_code == 201, r.json()
+    table_id = r.json()["id"]
+
+    # Switch to remote — must include bucket+source_table for the new mode
+    # (the merged validator runs the BQ payload check on the merged record).
+    r2 = c.put(
+        f"/api/admin/registry/{table_id}",
+        json={
+            "query_mode": "remote",
+            "bucket": "analytics",
+            "source_table": "orders_90d",
+        },
+        headers=_auth(token),
+    )
+    assert r2.status_code == 200, r2.json()
+
+    # Verify in the registry: query_mode flipped, source_query cleared.
+    r3 = c.get("/api/admin/registry", headers=_auth(token))
+    assert r3.status_code == 200, r3.json()
+    row = next((t for t in r3.json()["tables"] if t["id"] == table_id), None)
+    assert row is not None, f"Table {table_id} not found in registry"
+    assert row["query_mode"] == "remote"
+    assert row["source_query"] in (None, "")
+
+
+def test_register_materialized_persists_source_query_in_registry(seeded_app, bq_instance):
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.post(
+        "/api/admin/register-table",
+        json=_materialized_payload(
+            name="persist_q",
+            source_query="SELECT col FROM `prj.ds.t` WHERE x = 1",
+        ),
+        headers=_auth(token),
+    )
+    assert r.status_code == 201, r.json()
+    table_id = r.json()["id"]
+
+    r2 = c.get("/api/admin/registry", headers=_auth(token))
+    row = next((t for t in r2.json()["tables"] if t["id"] == table_id), None)
+    assert row is not None
+    assert row["query_mode"] == "materialized"
+    assert "WHERE x = 1" in row["source_query"]

--- a/tests/test_bq_cost_guardrail.py
+++ b/tests/test_bq_cost_guardrail.py
@@ -1,0 +1,137 @@
+"""materialize_query refuses to run when dry-run estimate exceeds the cap.
+
+The cap is wired through `data_source.bigquery.max_bytes_per_materialize`
+(read by the trigger pass; default 10 GiB; set 0 to disable). The dry-run
+itself reuses `app.api.v2_scan._bq_dry_run_bytes` so cost-estimate logic
+lives in exactly one place. Fail-open behaviour (DuckDB-syntax SQL the
+native BQ client can't parse → estimate=0 → COPY proceeds with a warning)
+is documented and exercised here too.
+"""
+import duckdb
+import pytest
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+from connectors.bigquery.access import BqAccess, BqProjects
+from connectors.bigquery.extractor import materialize_query, MaterializeBudgetError
+
+
+def _bq_with_seed(tables: dict[str, str] | None = None) -> BqAccess:
+    """Stub BqAccess seeded with in-memory tables (same recipe as
+    test_bq_materialize)."""
+    tables = tables or {}
+
+    @contextmanager
+    def _session(_projects):
+        conn = duckdb.connect(":memory:")
+        try:
+            conn.execute("ATTACH ':memory:' AS bq")
+            for s in {ref.rsplit(".", 1)[0] for ref in tables}:
+                conn.execute(f"CREATE SCHEMA IF NOT EXISTS {s}")
+            for ref, body in tables.items():
+                conn.execute(f"CREATE OR REPLACE TABLE {ref} AS {body}")
+            yield conn
+        finally:
+            conn.close()
+
+    return BqAccess(
+        BqProjects(billing="test-billing", data="test-data"),
+        client_factory=lambda _p: MagicMock(),
+        duckdb_session_factory=_session,
+    )
+
+
+def test_refuses_when_estimate_exceeds_cap(tmp_path):
+    out = tmp_path / "extracts" / "bigquery"
+    out.mkdir(parents=True)
+
+    bq = _bq_with_seed({"bq.test.tiny": "SELECT 1 AS n"})
+
+    with patch(
+        "app.api.v2_scan._bq_dry_run_bytes", return_value=100 * 2**30
+    ):
+        with pytest.raises(MaterializeBudgetError) as exc:
+            materialize_query(
+                table_id="huge",
+                sql="SELECT * FROM bq.test.tiny",
+                bq=bq,
+                output_dir=str(out),
+                max_bytes=10 * 2**30,
+            )
+    err = exc.value
+    assert err.table_id == "huge"
+    assert err.current == 100 * 2**30
+    assert err.limit == 10 * 2**30
+
+
+def test_proceeds_when_estimate_under_cap(tmp_path):
+    out = tmp_path / "extracts" / "bigquery"
+    out.mkdir(parents=True)
+
+    bq = _bq_with_seed({"bq.test.tiny": "SELECT 1 AS n"})
+
+    with patch("app.api.v2_scan._bq_dry_run_bytes", return_value=1024):
+        stats = materialize_query(
+            table_id="tiny",
+            sql="SELECT * FROM bq.test.tiny",
+            bq=bq,
+            output_dir=str(out),
+            max_bytes=10 * 2**30,
+        )
+    assert stats["rows"] == 1
+
+
+def test_no_cap_skips_dry_run(tmp_path):
+    """When max_bytes=None (default), no dry-run is performed."""
+    out = tmp_path / "extracts" / "bigquery"
+    out.mkdir(parents=True)
+    bq = _bq_with_seed({"bq.test.tiny": "SELECT 1 AS n"})
+
+    with patch("app.api.v2_scan._bq_dry_run_bytes") as mock_dry:
+        stats = materialize_query(
+            table_id="t1",
+            sql="SELECT * FROM bq.test.tiny",
+            bq=bq,
+            output_dir=str(out),
+        )
+    mock_dry.assert_not_called()
+    assert stats["rows"] == 1
+
+
+def test_zero_max_bytes_skips_dry_run(tmp_path):
+    """Sentinel: max_bytes=0 disables the guardrail (config docs)."""
+    out = tmp_path / "extracts" / "bigquery"
+    out.mkdir(parents=True)
+    bq = _bq_with_seed({"bq.test.tiny": "SELECT 1 AS n"})
+
+    with patch("app.api.v2_scan._bq_dry_run_bytes") as mock_dry:
+        stats = materialize_query(
+            table_id="t1",
+            sql="SELECT * FROM bq.test.tiny",
+            bq=bq,
+            output_dir=str(out),
+            max_bytes=0,
+        )
+    mock_dry.assert_not_called()
+    assert stats["rows"] == 1
+
+
+def test_dry_run_failure_is_fail_open(tmp_path):
+    """If the dry-run errors (DuckDB syntax, missing google lib, transient
+    upstream failure) we don't block — log + proceed with COPY. Operators
+    who need hard-fail watch logs for the warning."""
+    out = tmp_path / "extracts" / "bigquery"
+    out.mkdir(parents=True)
+    bq = _bq_with_seed({"bq.test.tiny": "SELECT 1 AS n"})
+
+    with patch(
+        "app.api.v2_scan._bq_dry_run_bytes", side_effect=RuntimeError("boom")
+    ):
+        stats = materialize_query(
+            table_id="t1",
+            sql="SELECT * FROM bq.test.tiny",
+            bq=bq,
+            output_dir=str(out),
+            max_bytes=10 * 2**30,
+        )
+    assert stats["rows"] == 1

--- a/tests/test_bq_init_extract_skips.py
+++ b/tests/test_bq_init_extract_skips.py
@@ -1,0 +1,98 @@
+"""init_extract skips rows with query_mode='materialized'.
+
+Materialized rows are written by the sync trigger pass via
+`materialize_query()`; they live as parquets in /data/extracts/bigquery/data/
+and surface via the orchestrator's standard local-parquet discovery.
+Creating a remote view in extract.duckdb for the same name would shadow
+the parquet via cross-source name collision.
+
+Pattern matches `tests/test_bigquery_extractor.py::TestViewVsTableTemplates`
+(uses `_CapturingProxy` to wrap a real DuckDB conn and stub BQ-specific calls).
+"""
+import duckdb
+from unittest.mock import MagicMock
+
+
+class _CapturingProxy:
+    """Wraps a real DuckDB connection, captures SQL, stubs BQ-specific calls.
+
+    DuckDBPyConnection.execute is C-level read-only, so we wrap rather than
+    monkey-patch. Shape lifted directly from tests/test_bigquery_extractor.py
+    to keep stub behavior consistent across the BQ test suite.
+    """
+
+    def __init__(self, real_conn, captured: list):
+        self._real = real_conn
+        self._captured = captured
+
+    def execute(self, sql, *args, **kwargs):
+        self._captured.append(sql)
+        stripped_u = sql.strip().upper()
+        if stripped_u.startswith(("INSTALL ", "LOAD ", "CREATE SECRET")):
+            return MagicMock()
+        if stripped_u.startswith("ATTACH ") and "BIGQUERY" in stripped_u:
+            return MagicMock()
+        if stripped_u.startswith("DETACH "):
+            return MagicMock()
+        if 'FROM bq.' in sql or 'FROM bigquery_query' in sql:
+            return MagicMock()
+        return self._real.execute(sql, *args, **kwargs)
+
+    def close(self):
+        return self._real.close()
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+def test_init_extract_skips_materialized_rows(tmp_path, monkeypatch):
+    """A registry mix of remote + materialized rows: only the remote row
+    gets a `_meta` entry; the materialized row is silently skipped."""
+    from connectors.bigquery.extractor import init_extract
+
+    monkeypatch.setattr(
+        "connectors.bigquery.extractor.get_metadata_token",
+        lambda: "test-token",
+    )
+    monkeypatch.setattr(
+        "connectors.bigquery.extractor._detect_table_type",
+        lambda *a, **kw: "BASE TABLE",
+    )
+
+    captured: list[str] = []
+    real_connect = duckdb.connect
+
+    def spy_connect(*a, **kw):
+        return _CapturingProxy(real_connect(*a, **kw), captured)
+
+    monkeypatch.setattr(
+        "connectors.bigquery.extractor.duckdb.connect", spy_connect
+    )
+
+    configs = [
+        {
+            "name": "live_orders", "bucket": "dset", "source_table": "live",
+            "query_mode": "remote", "description": "",
+        },
+        {
+            "name": "agg_90d", "bucket": "dset", "source_table": "live",
+            "query_mode": "materialized",
+            "source_query": "SELECT 1",
+            "description": "",
+        },
+    ]
+    stats = init_extract(str(tmp_path), "test-project", configs)
+
+    db_path = tmp_path / "extract.duckdb"
+    assert db_path.exists(), "extract.duckdb should be written"
+
+    db = duckdb.connect(str(db_path))
+    meta = db.execute(
+        "SELECT table_name, query_mode FROM _meta ORDER BY table_name"
+    ).fetchall()
+    db.close()
+
+    assert meta == [("live_orders", "remote")]
+    assert stats["tables_registered"] == 1
+    # No CREATE VIEW for the materialized row
+    assert not any("agg_90d" in s for s in captured if "CREATE" in s.upper())

--- a/tests/test_bq_materialize.py
+++ b/tests/test_bq_materialize.py
@@ -1,0 +1,139 @@
+"""BigQuery `materialize_query` writes parquet via BqAccess + DuckDB COPY.
+
+The function takes a `BqAccess` instance so the BQ extension session and
+SECRET token live in one place across the codebase (cf. `v2_scan` / `v2_sample`
+/ `v2_schema`). Tests inject a stub BqAccess whose `duckdb_session()` yields
+an in-memory connection with a pre-attached `bq` catalog containing fixture
+tables, exercising the COPY path end-to-end without any GCP traffic.
+"""
+import duckdb
+import pytest
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from connectors.bigquery.access import BqAccess, BqProjects
+from connectors.bigquery.extractor import materialize_query, MaterializeBudgetError
+
+
+def _make_stub_bq(tables: dict[str, str] | None = None) -> BqAccess:
+    """Return a BqAccess wired to factories that yield an in-memory DuckDB
+    with a pretend `bq` catalog containing test tables. `tables` maps
+    DuckDB-three-part references like `'bq.test.orders'` to a SELECT
+    expression to seed them with.
+    """
+    tables = tables or {}
+
+    @contextmanager
+    def _session(_projects):
+        conn = duckdb.connect(":memory:")
+        try:
+            conn.execute("ATTACH ':memory:' AS bq")
+            schemas = {ref.rsplit(".", 1)[0] for ref in tables}
+            for s in schemas:
+                conn.execute(f"CREATE SCHEMA IF NOT EXISTS {s}")
+            for ref, body in tables.items():
+                conn.execute(f"CREATE OR REPLACE TABLE {ref} AS {body}")
+            yield conn
+        finally:
+            conn.close()
+
+    # client_factory returns a stub whose .query(sql, job_config=...) yields
+    # a job whose .total_bytes_processed defaults to 0 (fail-open).
+    def _client(_projects):
+        client = MagicMock()
+        job = MagicMock()
+        job.total_bytes_processed = 0
+        client.query.return_value = job
+        return client
+
+    return BqAccess(
+        BqProjects(billing="test-billing", data="test-data"),
+        client_factory=_client,
+        duckdb_session_factory=_session,
+    )
+
+
+def test_materialize_writes_parquet_and_returns_stats(tmp_path):
+    out = tmp_path / "extracts" / "bigquery"
+    out.mkdir(parents=True)
+
+    bq = _make_stub_bq({
+        "bq.test.orders": (
+            "SELECT 'EU' AS region, 100 AS revenue UNION ALL "
+            "SELECT 'US' AS region, 250 AS revenue"
+        )
+    })
+
+    stats = materialize_query(
+        table_id="orders_summary",
+        sql="SELECT region, SUM(revenue) AS revenue FROM bq.test.orders GROUP BY 1",
+        bq=bq,
+        output_dir=str(out),
+    )
+
+    parquet_path = out / "data" / "orders_summary.parquet"
+    assert parquet_path.exists()
+    assert stats["rows"] == 2
+    assert stats["size_bytes"] > 0
+    assert stats["query_mode"] == "materialized"
+
+    # Parquet readable end-to-end
+    rows = duckdb.connect().execute(
+        f"SELECT region, revenue FROM read_parquet('{parquet_path}') ORDER BY region"
+    ).fetchall()
+    assert rows == [("EU", 100), ("US", 250)]
+
+
+def test_materialize_atomic_on_failure(tmp_path):
+    """Bad SQL must not leave a half-written parquet behind."""
+    out = tmp_path / "extracts" / "bigquery"
+    out.mkdir(parents=True)
+    parquet_path = out / "data" / "broken.parquet"
+
+    bq = _make_stub_bq({"bq.test.orders": "SELECT 1 AS n"})
+
+    with pytest.raises(Exception):
+        materialize_query(
+            table_id="broken",
+            sql="SELECT * FROM bq.test.does_not_exist",
+            bq=bq,
+            output_dir=str(out),
+        )
+    assert not parquet_path.exists()
+    # Tmp also cleaned
+    assert not (out / "data" / "broken.parquet.tmp").exists()
+
+
+def test_materialize_rejects_unsafe_table_id(tmp_path):
+    """table_id becomes the parquet filename — block path traversal up front."""
+    out = tmp_path / "extracts" / "bigquery"
+    out.mkdir(parents=True)
+    bq = _make_stub_bq()
+
+    with pytest.raises(ValueError, match="unsafe"):
+        materialize_query(
+            table_id="../etc/passwd",
+            sql="SELECT 1",
+            bq=bq,
+            output_dir=str(out),
+        )
+
+
+def test_materialize_overwrites_existing_parquet(tmp_path):
+    out = tmp_path / "extracts" / "bigquery"
+    out.mkdir(parents=True)
+    bq = _make_stub_bq({"bq.test.tiny": "SELECT 1 AS n"})
+
+    materialize_query(
+        table_id="t1", sql="SELECT 1 AS n",
+        bq=bq, output_dir=str(out),
+    )
+    materialize_query(
+        table_id="t1", sql="SELECT 2 AS n",
+        bq=bq, output_dir=str(out),
+    )
+    rows = duckdb.connect().execute(
+        f"SELECT n FROM read_parquet('{out}/data/t1.parquet')"
+    ).fetchall()
+    assert rows == [(2,)]

--- a/tests/test_cli_admin_materialized.py
+++ b/tests/test_cli_admin_materialized.py
@@ -1,0 +1,157 @@
+"""`da admin register-table --query-mode materialized --query @file.sql`
+sends source_query in the payload; existing local/remote paths still work
+unchanged."""
+from typer.testing import CliRunner
+from unittest.mock import MagicMock
+
+from cli.main import app
+
+
+def _fake_resp(status_code, body=None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json = lambda: body or {"id": "x", "name": "x", "status": "registered"}
+    return resp
+
+
+def test_register_materialized_with_inline_query(monkeypatch):
+    captured = {}
+
+    def fake_post(path, json):
+        captured["path"] = path
+        captured["json"] = json
+        return _fake_resp(201)
+
+    monkeypatch.setattr("cli.commands.admin.api_post", fake_post)
+
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "admin", "register-table", "orders_90d",
+        "--source-type", "bigquery",
+        "--query-mode", "materialized",
+        "--query", "SELECT date FROM `prj.ds.orders`",
+        "--sync-schedule", "every 6h",
+    ])
+
+    assert result.exit_code == 0, result.stdout
+    assert captured["path"] == "/api/admin/register-table"
+    assert captured["json"]["query_mode"] == "materialized"
+    assert captured["json"]["source_query"] == "SELECT date FROM `prj.ds.orders`"
+    assert captured["json"]["sync_schedule"] == "every 6h"
+
+
+def test_register_materialized_reads_query_from_file(tmp_path, monkeypatch):
+    sql_file = tmp_path / "orders.sql"
+    sql_file.write_text(
+        "SELECT date, SUM(revenue) FROM `prj.ds.orders` GROUP BY 1\n"
+    )
+
+    captured = {}
+
+    def fake_post(path, json):
+        captured["json"] = json
+        return _fake_resp(201)
+
+    monkeypatch.setattr("cli.commands.admin.api_post", fake_post)
+
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "admin", "register-table", "orders_90d",
+        "--source-type", "bigquery",
+        "--query-mode", "materialized",
+        "--query", f"@{sql_file}",
+        "--sync-schedule", "daily 03:00",
+    ])
+
+    assert result.exit_code == 0, result.stdout
+    assert "SELECT date, SUM(revenue)" in captured["json"]["source_query"]
+    assert not captured["json"]["source_query"].endswith("\n")
+
+
+def test_register_materialized_without_query_fails(monkeypatch):
+    """--query-mode materialized without --query is a client-side error,
+    no API call made."""
+    called = {"count": 0}
+
+    def fake_post(*args, **kwargs):
+        called["count"] += 1
+        return _fake_resp(201)
+
+    monkeypatch.setattr("cli.commands.admin.api_post", fake_post)
+
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "admin", "register-table", "orders_90d",
+        "--source-type", "bigquery",
+        "--query-mode", "materialized",
+    ])
+
+    assert result.exit_code != 0
+    assert called["count"] == 0
+    combined = result.stdout + (result.stderr or "")
+    assert "--query" in combined
+
+
+def test_register_local_mode_does_not_send_source_query(monkeypatch):
+    """Default local mode shouldn't send source_query — server-side
+    validator forbids it on local."""
+    captured = {}
+
+    def fake_post(path, json):
+        captured["json"] = json
+        return _fake_resp(201)
+
+    monkeypatch.setattr("cli.commands.admin.api_post", fake_post)
+
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "admin", "register-table", "kbc_orders",
+        "--source-type", "keboola",
+        "--bucket", "in.c-crm",
+    ])
+
+    assert result.exit_code == 0
+    assert "source_query" not in captured["json"]
+    assert "sync_schedule" not in captured["json"]
+
+
+def test_register_query_at_path_missing_file_fails(monkeypatch):
+    """@file.sql where the file doesn't exist surfaces a clear error."""
+    monkeypatch.setattr(
+        "cli.commands.admin.api_post", lambda *a, **kw: _fake_resp(201),
+    )
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "admin", "register-table", "x",
+        "--source-type", "bigquery",
+        "--query-mode", "materialized",
+        "--query", "@/tmp/definitely-does-not-exist-9b4f7e2c.sql",
+    ])
+    assert result.exit_code != 0
+
+
+def test_register_remote_path_unchanged(monkeypatch):
+    """The pre-existing --bucket / --source-table / --query-mode remote
+    flow still works without --query."""
+    captured = {}
+
+    def fake_post(path, json):
+        captured["json"] = json
+        return _fake_resp(200)
+
+    monkeypatch.setattr("cli.commands.admin.api_post", fake_post)
+
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "admin", "register-table", "live_orders",
+        "--source-type", "bigquery",
+        "--bucket", "analytics",
+        "--source-table", "orders",
+        "--query-mode", "remote",
+    ])
+
+    assert result.exit_code == 0
+    assert captured["json"]["query_mode"] == "remote"
+    assert "source_query" not in captured["json"]
+    assert captured["json"]["bucket"] == "analytics"
+    assert captured["json"]["source_table"] == "orders"

--- a/tests/test_cli_analyst_setup_hooks.py
+++ b/tests/test_cli_analyst_setup_hooks.py
@@ -1,0 +1,82 @@
+"""`_install_claude_hooks` writes SessionStart/End hooks idempotently into
+a Claude settings file (workspace-level for analyst workspaces)."""
+import json
+from pathlib import Path
+
+from cli.commands.analyst import _install_claude_hooks
+
+
+def test_install_creates_settings_when_missing(tmp_path):
+    settings = tmp_path / ".claude" / "settings.json"
+    _install_claude_hooks(settings)
+
+    cfg = json.loads(settings.read_text())
+    starts = cfg["hooks"]["SessionStart"]
+    cmds = [h["command"] for e in starts for h in e["hooks"]]
+    assert any("da sync --quiet" in c and "--upload-only" not in c for c in cmds), cmds
+
+    ends = cfg["hooks"]["SessionEnd"]
+    end_cmds = [h["command"] for e in ends for h in e["hooks"]]
+    assert any("da sync --upload-only" in c for c in end_cmds), end_cmds
+
+
+def test_install_preserves_existing_unrelated_hooks(tmp_path):
+    settings = tmp_path / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True)
+    settings.write_text(json.dumps({
+        "hooks": {
+            "PreToolUse": [{"hooks": [{"type": "command", "command": "echo hi"}]}],
+        },
+        "permissions": {"allow": ["Bash(git status:*)"]},
+        "model": "sonnet",
+    }))
+
+    _install_claude_hooks(settings)
+
+    cfg = json.loads(settings.read_text())
+    # Unrelated hook event preserved
+    assert cfg["hooks"]["PreToolUse"][0]["hooks"][0]["command"] == "echo hi"
+    # Unrelated top-level keys preserved
+    assert cfg["permissions"]["allow"] == ["Bash(git status:*)"]
+    assert cfg["model"] == "sonnet"
+    # Our new hooks added
+    assert "SessionStart" in cfg["hooks"]
+    assert "SessionEnd" in cfg["hooks"]
+
+
+def test_install_is_idempotent(tmp_path):
+    settings = tmp_path / ".claude" / "settings.json"
+    _install_claude_hooks(settings)
+    first = json.loads(settings.read_text())
+    _install_claude_hooks(settings)
+    second = json.loads(settings.read_text())
+    # No duplicate entries
+    assert first["hooks"]["SessionStart"] == second["hooks"]["SessionStart"]
+    assert first["hooks"]["SessionEnd"] == second["hooks"]["SessionEnd"]
+    assert len(second["hooks"]["SessionStart"]) == 1
+    assert len(second["hooks"]["SessionEnd"]) == 1
+
+
+def test_install_replaces_old_da_sync_entry_without_duplicating(tmp_path):
+    """If the user already has a `da sync` entry from a prior version, our
+    install replaces it cleanly rather than appending a second copy."""
+    settings = tmp_path / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True)
+    settings.write_text(json.dumps({
+        "hooks": {
+            "SessionStart": [
+                {"hooks": [{"type": "command", "command": "da sync"}]},  # old shape
+                {"hooks": [{"type": "command", "command": "echo not-ours"}]},
+            ]
+        }
+    }))
+
+    _install_claude_hooks(settings)
+
+    cfg = json.loads(settings.read_text())
+    starts = cfg["hooks"]["SessionStart"]
+    assert len(starts) == 2  # one ours, one third-party
+    cmds = [h["command"] for e in starts for h in e["hooks"]]
+    assert "da sync --quiet 2>/dev/null || true" in cmds
+    assert "echo not-ours" in cmds
+    assert all(c == "echo not-ours" or "da sync --quiet" in c for c in cmds), cmds

--- a/tests/test_cli_analyst_setup_hooks.py
+++ b/tests/test_cli_analyst_setup_hooks.py
@@ -80,3 +80,18 @@ def test_install_replaces_old_da_sync_entry_without_duplicating(tmp_path):
     assert "da sync --quiet 2>/dev/null || true" in cmds
     assert "echo not-ours" in cmds
     assert all(c == "echo not-ours" or "da sync --quiet" in c for c in cmds), cmds
+
+
+def test_install_skips_malformed_existing_settings(tmp_path, capsys):
+    """If the settings file is corrupted JSON, warn on stderr and bail —
+    don't crash the surrounding `da analyst setup` flow."""
+    settings = tmp_path / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True)
+    settings.write_text("{not valid json")
+
+    _install_claude_hooks(settings)  # must not raise
+
+    captured = capsys.readouterr()
+    assert "not valid JSON" in captured.err
+    # File untouched
+    assert settings.read_text() == "{not valid json"

--- a/tests/test_cli_sync_quiet.py
+++ b/tests/test_cli_sync_quiet.py
@@ -1,0 +1,138 @@
+"""`da sync --quiet` truly suppresses stdout chatter, including the download
+loop and final summary.
+
+Without --quiet, the same fixture prints "Downloading", "Downloaded:", etc.;
+with --quiet, stdout stays empty and the terse one-liner lands on stderr.
+The first test forces the download loop to run so the contrast between
+noisy/quiet stdout is observable (mutation-tests the flag — see PR #145
+for the original empty-manifest test that passed even without --quiet).
+"""
+import json
+from typer.testing import CliRunner
+from unittest.mock import patch, MagicMock
+
+from cli.main import app
+
+
+def _fake_manifest_one_table():
+    resp = MagicMock()
+    resp.json.return_value = {
+        "tables": {
+            "orders": {
+                "hash": "abc123",
+                "rows": 5,
+                "size_bytes": 100,
+                "query_mode": "local",
+                "source_type": "keboola",
+            }
+        },
+        "assets": {},
+        "server_time": "2026-04-30T00:00:00Z",
+    }
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _stub_download(_url, target_path):
+    from pathlib import Path
+    Path(target_path).write_bytes(b"PAR1" + b"\x00" * 16 + b"PAR1")
+
+
+def test_quiet_suppresses_stdout_when_downloading(tmp_path, monkeypatch):
+    """Manifest has tables that actually trigger downloads. Without --quiet
+    stdout would contain 'Downloading' / 'Downloaded:'. With --quiet stdout
+    stays empty and the terse summary lands on stderr."""
+    monkeypatch.setenv("DA_LOCAL_DIR", str(tmp_path))
+    monkeypatch.setenv("DA_CONFIG_DIR", str(tmp_path / "_cfg"))
+    runner = CliRunner()
+
+    with patch("cli.commands.sync.api_get", return_value=_fake_manifest_one_table()), \
+         patch("cli.commands.sync.stream_download", side_effect=_stub_download), \
+         patch("cli.commands.sync._md5_file", return_value="abc123"), \
+         patch("cli.commands.sync._rebuild_duckdb_views"), \
+         patch("cli.commands.sync._fetch_and_write_rules"):
+        result = runner.invoke(app, ["sync", "--quiet"])
+
+    assert result.exit_code == 0, result.stdout
+    assert result.stdout == "", f"expected empty stdout, got: {result.stdout!r}"
+    assert "sync: 1 tables" in result.stderr
+
+
+def test_noisy_mode_prints_to_stdout(tmp_path, monkeypatch):
+    """Anchor: the noisy path DOES print download chatter to stdout, so the
+    contrast in the quiet test above is meaningful."""
+    monkeypatch.setenv("DA_LOCAL_DIR", str(tmp_path))
+    monkeypatch.setenv("DA_CONFIG_DIR", str(tmp_path / "_cfg"))
+    runner = CliRunner()
+
+    with patch("cli.commands.sync.api_get", return_value=_fake_manifest_one_table()), \
+         patch("cli.commands.sync.stream_download", side_effect=_stub_download), \
+         patch("cli.commands.sync._md5_file", return_value="abc123"), \
+         patch("cli.commands.sync._rebuild_duckdb_views"), \
+         patch("cli.commands.sync._fetch_and_write_rules"):
+        result = runner.invoke(app, ["sync"])
+
+    assert result.exit_code == 0, result.stdout
+    assert "Downloaded:" in result.stdout
+
+
+def test_quiet_manifest_failure_exits_nonzero(tmp_path, monkeypatch):
+    """SessionStart hook contract: server unreachable → non-zero exit (so
+    `|| true` swallows it cleanly), error message on stderr."""
+    monkeypatch.setenv("DA_LOCAL_DIR", str(tmp_path))
+    monkeypatch.setenv("DA_CONFIG_DIR", str(tmp_path / "_cfg"))
+    runner = CliRunner()
+
+    fake_resp = MagicMock()
+    fake_resp.raise_for_status.side_effect = RuntimeError("boom")
+
+    with patch("cli.commands.sync.api_get", return_value=fake_resp):
+        result = runner.invoke(app, ["sync", "--quiet"])
+
+    assert result.exit_code == 1
+    assert "manifest fetch failed" in result.stderr
+
+
+def test_quiet_skips_remote_mode_tables(tmp_path, monkeypatch):
+    """Materialized rows go through the download path; remote rows do not.
+    Locks in the contract that --quiet honors the same skipped_remote
+    filter as the noisy path."""
+    monkeypatch.setenv("DA_LOCAL_DIR", str(tmp_path))
+    monkeypatch.setenv("DA_CONFIG_DIR", str(tmp_path / "_cfg"))
+
+    resp = MagicMock()
+    resp.json.return_value = {
+        "tables": {
+            "live_orders": {
+                "hash": "x", "rows": 0, "size_bytes": 0,
+                "query_mode": "remote", "source_type": "bigquery",
+            },
+            "agg_90d": {
+                "hash": "abc", "rows": 5, "size_bytes": 100,
+                "query_mode": "materialized", "source_type": "bigquery",
+            },
+        },
+        "assets": {},
+        "server_time": "2026-04-30T00:00:00Z",
+    }
+    resp.raise_for_status = MagicMock()
+
+    runner = CliRunner()
+    download_calls = []
+
+    def _spy_download(url, target):
+        download_calls.append(url)
+        from pathlib import Path
+        Path(target).write_bytes(b"PAR1" + b"\x00" * 16 + b"PAR1")
+
+    with patch("cli.commands.sync.api_get", return_value=resp), \
+         patch("cli.commands.sync.stream_download", side_effect=_spy_download), \
+         patch("cli.commands.sync._md5_file", return_value="abc"), \
+         patch("cli.commands.sync._rebuild_duckdb_views"), \
+         patch("cli.commands.sync._fetch_and_write_rules"):
+        result = runner.invoke(app, ["sync", "--quiet"])
+
+    assert result.exit_code == 0, result.stdout
+    # Remote table never downloaded; materialized table downloaded.
+    assert any("agg_90d" in u for u in download_calls)
+    assert not any("live_orders" in u for u in download_calls)

--- a/tests/test_db_migration_v19.py
+++ b/tests/test_db_migration_v19.py
@@ -1,0 +1,71 @@
+"""v19 adds source_query column to table_registry.
+
+Backs query_mode='materialized' for BigQuery: admin registers a SQL body
+that the scheduler runs through the DuckDB BQ extension and writes as a
+parquet to /data/extracts/bigquery/data/<id>.parquet.
+"""
+import duckdb
+
+from src.db import SCHEMA_VERSION, _ensure_schema, get_schema_version
+
+
+def test_schema_version_is_19():
+    assert SCHEMA_VERSION == 19
+
+
+def test_v19_adds_source_query(tmp_path):
+    db_path = tmp_path / "system.duckdb"
+    conn = duckdb.connect(str(db_path))
+    _ensure_schema(conn)
+
+    cols = {
+        r[0] for r in conn.execute(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_name = 'table_registry'"
+        ).fetchall()
+    }
+    assert "source_query" in cols, f"source_query missing from {cols}"
+    assert get_schema_version(conn) == 19
+    conn.close()
+
+
+def test_v18_db_migrates_to_v19(tmp_path):
+    """Pre-existing v18 DB without source_query upgrades cleanly without losing data."""
+    db_path = tmp_path / "system.duckdb"
+    conn = duckdb.connect(str(db_path))
+
+    # Simulate a v18 DB at minimal but realistic shape: just the schema_version
+    # row + a table_registry row whose existing columns must survive the v19 ALTER.
+    conn.execute(
+        "CREATE TABLE schema_version (version INTEGER, "
+        "applied_at TIMESTAMP DEFAULT current_timestamp)"
+    )
+    conn.execute("INSERT INTO schema_version (version) VALUES (18)")
+    conn.execute("""CREATE TABLE table_registry (
+        id VARCHAR PRIMARY KEY, name VARCHAR NOT NULL,
+        source_type VARCHAR, bucket VARCHAR, source_table VARCHAR,
+        sync_strategy VARCHAR DEFAULT 'full_refresh',
+        query_mode VARCHAR DEFAULT 'local',
+        sync_schedule VARCHAR, profile_after_sync BOOLEAN DEFAULT true,
+        primary_key VARCHAR, folder VARCHAR, description TEXT,
+        registered_by VARCHAR, is_public BOOLEAN DEFAULT true,
+        registered_at TIMESTAMP DEFAULT current_timestamp
+    )""")
+    conn.execute("INSERT INTO table_registry (id, name) VALUES ('foo', 'foo')")
+
+    _ensure_schema(conn)
+
+    assert get_schema_version(conn) == 19
+    cols = {
+        r[0] for r in conn.execute(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_name = 'table_registry'"
+        ).fetchall()
+    }
+    assert "source_query" in cols
+    # Existing row preserved, new column NULL
+    row = conn.execute(
+        "SELECT id, source_query FROM table_registry WHERE id='foo'"
+    ).fetchone()
+    assert row == ("foo", None)
+    conn.close()

--- a/tests/test_materialized_e2e.py
+++ b/tests/test_materialized_e2e.py
@@ -1,0 +1,321 @@
+"""End-to-end integration coverage for query_mode='materialized'.
+
+Unit tests verify each piece in isolation; this file glues them together:
+
+1. Admin POST /api/admin/register-table (materialized) → registry row written
+2. _run_materialized_pass writes parquet + sync_state with correct hash
+3. GET /api/sync/manifest (per-user) returns the row with query_mode +
+   the parquet hash, filtered by RBAC
+4. Mode-switch transitions (remote → materialized, materialized → SQL edit
+   preserves registered_at) maintain registry invariants.
+
+Devil's-advocate review found these were the gaps the unit tests left
+open. Each piece passes in isolation; this file proves they compose.
+"""
+import duckdb
+import hashlib
+import pytest
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from connectors.bigquery.access import BqAccess, BqProjects
+from src.repositories.table_registry import TableRegistryRepository
+from src.repositories.sync_state import SyncStateRepository
+
+
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def bq_instance(monkeypatch):
+    """Force instance.yaml to look like a BigQuery deployment so the BQ
+    register validator's project_id check passes."""
+    fake_cfg = {
+        "data_source": {
+            "type": "bigquery",
+            "bigquery": {"project": "my-test-project", "location": "us"},
+        },
+    }
+    monkeypatch.setattr(
+        "app.instance_config.load_instance_config",
+        lambda: fake_cfg,
+        raising=False,
+    )
+    from app.instance_config import reset_cache
+    reset_cache()
+    yield fake_cfg
+    reset_cache()
+
+
+@pytest.fixture
+def stub_bq_extractor(monkeypatch):
+    """Mirror tests/test_admin_bq_register.py::stub_bq_extractor — replaces
+    rebuild_from_registry + SyncOrchestrator so the API's post-register
+    materialize doesn't hit real BQ during HTTP-driven tests."""
+    rebuild_mock = MagicMock(return_value={
+        "project_id": "my-test-project",
+        "tables_registered": 1,
+        "errors": [],
+        "skipped": False,
+    })
+    monkeypatch.setattr(
+        "connectors.bigquery.extractor.rebuild_from_registry",
+        rebuild_mock,
+    )
+    orch_mock = MagicMock()
+    monkeypatch.setattr(
+        "src.orchestrator.SyncOrchestrator",
+        lambda *a, **kw: orch_mock,
+    )
+    return {"rebuild": rebuild_mock, "orchestrator": orch_mock}
+
+
+@pytest.fixture
+def stub_bq():
+    """Real-shape BqAccess wired to in-memory DuckDB factories so the
+    materialize_query path can run end-to-end without GCP."""
+    @contextmanager
+    def _session(_p):
+        conn = duckdb.connect(":memory:")
+        try:
+            conn.execute("ATTACH ':memory:' AS bq")
+            conn.execute("CREATE SCHEMA bq.test")
+            conn.execute(
+                "CREATE OR REPLACE TABLE bq.test.orders AS "
+                "SELECT 'EU' AS region, 100 AS revenue UNION ALL "
+                "SELECT 'US' AS region, 250 AS revenue"
+            )
+            yield conn
+        finally:
+            conn.close()
+    return BqAccess(
+        BqProjects(billing="my-test-project", data="my-test-project"),
+        client_factory=lambda _p: MagicMock(),
+        duckdb_session_factory=_session,
+    )
+
+
+def test_e2e_register_then_materialize_then_manifest_via_repo(
+    bq_instance, stub_bq, tmp_path, monkeypatch,
+):
+    """Glue test: register row at the repository layer (skips HTTP/auth),
+    run the materialized pass, verify sync_state, then exercise the
+    `_build_manifest_for_user` admin path. Catches integration breakage
+    that unit tests miss because each only sees one layer."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    db_path = tmp_path / "system.duckdb"
+    conn = duckdb.connect(str(db_path))
+    from src.db import _ensure_schema
+    _ensure_schema(conn)
+
+    table_id = "orders_summary_e2e"
+    repo = TableRegistryRepository(conn)
+    repo.register(
+        id=table_id, name=table_id, source_type="bigquery",
+        query_mode="materialized",
+        source_query="SELECT region, SUM(revenue) AS revenue "
+                     "FROM bq.test.orders GROUP BY 1",
+        sync_schedule="every 1m",
+    )
+
+    # Run the materialized pass.
+    from app.api import sync as sync_mod
+    summary = sync_mod._run_materialized_pass(conn, stub_bq)
+    assert table_id in summary["materialized"], summary
+    assert not summary["errors"]
+
+    # Parquet on disk.
+    parquet_path = (
+        tmp_path / "data" / "extracts" / "bigquery" / "data"
+        / f"{table_id}.parquet"
+    )
+    assert parquet_path.exists(), f"Expected {parquet_path} to exist"
+
+    # sync_state hash matches the file's MD5.
+    expected_hash = hashlib.md5(parquet_path.read_bytes()).hexdigest()
+    state = SyncStateRepository(conn)
+    row = state.get_table_state(table_id)
+    assert row is not None
+    assert row["hash"] == expected_hash
+    assert row["rows"] == 2
+
+    # Manifest builder exposes query_mode + hash to admin (no RBAC filter).
+    admin_user = {"id": "u-admin", "email": "admin@test", "role": "admin"}
+    manifest = sync_mod._build_manifest_for_user(conn, admin_user)
+    assert table_id in manifest["tables"]
+    entry = manifest["tables"][table_id]
+    assert entry["query_mode"] == "materialized"
+    assert entry["hash"] == expected_hash
+    assert entry["rows"] == 2
+
+    conn.close()
+
+
+def test_remote_to_materialized_transition_clears_bucket_table(
+    seeded_app, bq_instance, stub_bq_extractor,
+):
+    """Switching a remote BQ row to materialized must accept source_query
+    and the merged validator must not trip on the now-irrelevant
+    bucket/source_table fields."""
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+
+    # Seed a remote row.
+    r = c.post("/api/admin/register-table", json={
+        "name": "live_to_mat",
+        "source_type": "bigquery",
+        "bucket": "analytics",
+        "source_table": "orders",
+        "query_mode": "remote",
+    }, headers=_auth(token))
+    assert r.status_code in (200, 202), r.json()
+    table_id = r.json()["id"]
+
+    # Switch to materialized — must include source_query for the validator.
+    r2 = c.put(f"/api/admin/registry/{table_id}", json={
+        "query_mode": "materialized",
+        "source_query": "SELECT 1 AS n",
+    }, headers=_auth(token))
+    assert r2.status_code == 200, r2.json()
+
+    # Verify the merged record reflects the switch.
+    r3 = c.get("/api/admin/registry", headers=_auth(token))
+    row = next((t for t in r3.json()["tables"] if t["id"] == table_id), None)
+    assert row is not None
+    assert row["query_mode"] == "materialized"
+    assert row["source_query"] == "SELECT 1 AS n"
+
+
+def test_materialized_sql_edit_preserves_registered_at(
+    seeded_app, bq_instance, stub_bq_extractor, monkeypatch,
+):
+    """Editing source_query on an existing materialized row must not
+    reset registered_at — the row's registration history is preserved
+    across SQL edits (issue #130 invariant)."""
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+
+    # Seed a materialized row.
+    r = c.post("/api/admin/register-table", json={
+        "name": "sql_edit_target",
+        "source_type": "bigquery",
+        "query_mode": "materialized",
+        "source_query": "SELECT 1 AS n",
+    }, headers=_auth(token))
+    assert r.status_code == 201, r.json()
+    table_id = r.json()["id"]
+
+    # Capture the original registered_at.
+    r2 = c.get("/api/admin/registry", headers=_auth(token))
+    row = next((t for t in r2.json()["tables"] if t["id"] == table_id), None)
+    original_ts = row["registered_at"]
+    assert original_ts is not None
+
+    # Edit the SQL.
+    import time
+    time.sleep(0.01)  # ensure a clock tick elapses so a fresh stamp would differ
+    r3 = c.put(f"/api/admin/registry/{table_id}", json={
+        "query_mode": "materialized",
+        "source_query": "SELECT 2 AS n",
+    }, headers=_auth(token))
+    assert r3.status_code == 200, r3.json()
+
+    r4 = c.get("/api/admin/registry", headers=_auth(token))
+    row = next((t for t in r4.json()["tables"] if t["id"] == table_id), None)
+    assert row["source_query"] == "SELECT 2 AS n"
+    # registered_at preserved across edit
+    assert row["registered_at"] == original_ts, (
+        f"Expected registered_at preserved (issue #130 contract). "
+        f"Original: {original_ts}, after edit: {row['registered_at']}"
+    )
+
+
+def test_materialized_zero_rows_logs_warning(stub_bq, tmp_path, caplog):
+    """Devil's-advocate item: an SQL filter that returns 0 rows is
+    indistinguishable from 'SQL is wrong'. Confirm we log a WARNING so
+    operators can grep on it."""
+    import logging
+    from connectors.bigquery.extractor import materialize_query
+
+    out = tmp_path / "extracts" / "bigquery"
+    out.mkdir(parents=True)
+
+    # Add an empty BQ table to the stub for this test.
+    @contextmanager
+    def _session_empty(_p):
+        conn = duckdb.connect(":memory:")
+        try:
+            conn.execute("ATTACH ':memory:' AS bq")
+            conn.execute("CREATE SCHEMA bq.test")
+            conn.execute("CREATE OR REPLACE TABLE bq.test.empty AS "
+                         "SELECT 1 AS n WHERE FALSE")
+            yield conn
+        finally:
+            conn.close()
+
+    bq_empty = BqAccess(
+        BqProjects(billing="t", data="t"),
+        client_factory=lambda _p: MagicMock(),
+        duckdb_session_factory=_session_empty,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="connectors.bigquery.extractor"):
+        stats = materialize_query(
+            table_id="empty_t",
+            sql="SELECT * FROM bq.test.empty",
+            bq=bq_empty,
+            output_dir=str(out),
+        )
+
+    assert stats["rows"] == 0
+    assert any("0 rows" in rec.message for rec in caplog.records), (
+        f"Expected '0 rows' WARNING; got: {[r.message for r in caplog.records]}"
+    )
+
+
+def test_attach_real_error_propagates(stub_bq, tmp_path):
+    """ATTACH 'project=...' that fails for a real reason (not the
+    'already attached' tolerated case) must propagate so callers see
+    the actual error instead of a confusing downstream 'bq is not
+    attached' message."""
+    from connectors.bigquery.extractor import materialize_query
+
+    out = tmp_path / "extracts" / "bigquery"
+    out.mkdir(parents=True)
+
+    @contextmanager
+    def _session_attach_fails(_p):
+        conn = duckdb.connect(":memory:")
+        try:
+            # Force ATTACH 'project=...' to raise something other than
+            # "already attached" by intercepting via execute wrapper —
+            # since DuckDB's real connection doesn't accept attribute
+            # patches, we use a thin proxy for this test.
+            class _Proxy:
+                def __init__(self, real):
+                    self._real = real
+                def execute(self, sql, *a, **kw):
+                    if sql.startswith("ATTACH 'project="):
+                        raise duckdb.Error("fake permission denied: missing serviceusage.services.use")
+                    return self._real.execute(sql, *a, **kw)
+                def __getattr__(self, name):
+                    return getattr(self._real, name)
+                def close(self):
+                    return self._real.close()
+            yield _Proxy(conn)
+        finally:
+            conn.close()
+
+    bq_bad = BqAccess(
+        BqProjects(billing="t", data="t"),
+        client_factory=lambda _p: MagicMock(),
+        duckdb_session_factory=_session_attach_fails,
+    )
+
+    with pytest.raises(duckdb.Error, match="permission denied"):
+        materialize_query(
+            table_id="x", sql="SELECT 1",
+            bq=bq_bad, output_dir=str(out),
+        )

--- a/tests/test_setup_hooks_template.py
+++ b/tests/test_setup_hooks_template.py
@@ -1,0 +1,33 @@
+"""The shipped Claude settings template must point hooks at `da sync`, not the deleted server/scripts."""
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = REPO_ROOT / "docs" / "setup" / "claude_settings.json"
+
+
+def test_template_has_session_start_da_sync():
+    cfg = json.loads(TEMPLATE.read_text())
+    starts = cfg.get("hooks", {}).get("SessionStart", [])
+    assert starts, "SessionStart hook missing"
+    cmds = [h["command"] for entry in starts for h in entry.get("hooks", [])]
+    assert any("da sync" in c and "--upload-only" not in c for c in cmds), (
+        f"Expected `da sync` in SessionStart, got {cmds}"
+    )
+
+
+def test_template_has_session_end_upload():
+    cfg = json.loads(TEMPLATE.read_text())
+    ends = cfg.get("hooks", {}).get("SessionEnd", [])
+    cmds = [h["command"] for entry in ends for h in entry.get("hooks", [])]
+    assert any("da sync --upload-only" in c for c in cmds), (
+        f"Expected `da sync --upload-only` in SessionEnd, got {cmds}"
+    )
+
+
+def test_template_drops_dead_server_scripts_reference():
+    raw = TEMPLATE.read_text()
+    assert "server/scripts/collect_session.py" not in raw, (
+        "Template still references the deleted server/scripts/collect_session.py — "
+        "the SessionEnd hook would silently fail."
+    )

--- a/tests/test_sync_trigger_materialized.py
+++ b/tests/test_sync_trigger_materialized.py
@@ -1,0 +1,231 @@
+"""_run_materialized_pass walks table_registry for materialized BQ rows
+and runs each that is due via _materialize_table.
+
+Tests inject a stub BqAccess (factories never called by these tests since
+_materialize_table is patched) and assert that scheduling, error
+aggregation, sync_state hash, and the disable-sentinel all behave
+correctly.
+"""
+import duckdb
+import pytest
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from src.db import _ensure_schema
+from src.repositories.table_registry import TableRegistryRepository
+from src.repositories.sync_state import SyncStateRepository
+from connectors.bigquery.access import BqAccess, BqProjects
+
+
+@pytest.fixture
+def system_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "system.duckdb"
+    conn = duckdb.connect(str(db_path))
+    _ensure_schema(conn)
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def stub_bq():
+    """A BqAccess instance that the tests don't actually exercise (the test
+    patches `_materialize_table`); just needs to be a valid BqAccess so the
+    type contract doesn't break."""
+    @contextmanager
+    def _session(_p):
+        conn = duckdb.connect(":memory:")
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    return BqAccess(
+        BqProjects(billing="t", data="t"),
+        client_factory=lambda _p: MagicMock(),
+        duckdb_session_factory=_session,
+    )
+
+
+def test_materialized_pass_calls_materialize_for_due_rows(system_db, stub_bq, tmp_path):
+    repo = TableRegistryRepository(system_db)
+    repo.register(
+        id="orders_90d", name="orders_90d",
+        source_type="bigquery", query_mode="materialized",
+        source_query="SELECT 1 AS n",
+        sync_schedule="every 1m",  # always due in tests (no prior sync)
+    )
+
+    # Pre-create the parquet so _file_hash returns non-empty
+    parquet_dir = tmp_path / "data" / "extracts" / "bigquery" / "data"
+    parquet_dir.mkdir(parents=True, exist_ok=True)
+    (parquet_dir / "orders_90d.parquet").write_bytes(
+        b"PAR1" + b"\x00" * 16 + b"PAR1"
+    )
+
+    from app.api import sync as sync_mod
+
+    with patch("app.api.sync._materialize_table") as mock_mat:
+        mock_mat.return_value = {
+            "rows": 1, "size_bytes": 100, "query_mode": "materialized",
+        }
+        summary = sync_mod._run_materialized_pass(system_db, stub_bq)
+
+    mock_mat.assert_called_once()
+    call_kwargs = mock_mat.call_args.kwargs
+    assert call_kwargs["table_id"] == "orders_90d"
+    assert "SELECT 1 AS n" in call_kwargs["sql"]
+    assert call_kwargs["bq"] is stub_bq
+    # Default cap (10 GiB) flows through when no instance.yaml override
+    assert call_kwargs["max_bytes"] == 10 * 2**30
+    assert "orders_90d" in summary["materialized"]
+    assert not summary["errors"]
+
+
+def test_materialized_pass_skips_undue_rows(system_db, stub_bq):
+    repo = TableRegistryRepository(system_db)
+    repo.register(
+        id="orders_daily", name="orders_daily",
+        source_type="bigquery", query_mode="materialized",
+        source_query="SELECT 1",
+        sync_schedule="daily 03:00",
+    )
+    state = SyncStateRepository(system_db)
+    state.update_sync(
+        table_id="orders_daily", rows=1, file_size_bytes=10, hash="x",
+    )
+
+    from app.api import sync as sync_mod
+
+    with patch("app.api.sync._materialize_table") as mock_mat:
+        summary = sync_mod._run_materialized_pass(system_db, stub_bq)
+
+    mock_mat.assert_not_called()
+    assert "orders_daily" in summary["skipped"]
+
+
+def test_materialized_pass_skips_non_materialized_rows(system_db, stub_bq):
+    repo = TableRegistryRepository(system_db)
+    repo.register(id="t1", name="t1", source_type="keboola", query_mode="local")
+    repo.register(id="t2", name="t2", source_type="bigquery", query_mode="remote")
+
+    from app.api import sync as sync_mod
+
+    with patch("app.api.sync._materialize_table") as mock_mat:
+        summary = sync_mod._run_materialized_pass(system_db, stub_bq)
+
+    mock_mat.assert_not_called()
+    assert summary == {"materialized": [], "skipped": [], "errors": []}
+
+
+def test_materialized_pass_collects_errors_per_row(system_db, stub_bq, tmp_path):
+    """One row failing must not stop a healthy sibling."""
+    repo = TableRegistryRepository(system_db)
+    repo.register(
+        id="ok", name="ok", source_type="bigquery",
+        query_mode="materialized", source_query="SELECT 1",
+        sync_schedule="every 1m",
+    )
+    repo.register(
+        id="bad", name="bad", source_type="bigquery",
+        query_mode="materialized", source_query="SELECT broken",
+        sync_schedule="every 1m",
+    )
+
+    parquet_dir = tmp_path / "data" / "extracts" / "bigquery" / "data"
+    parquet_dir.mkdir(parents=True, exist_ok=True)
+    (parquet_dir / "ok.parquet").write_bytes(b"PAR1" + b"\x00" * 16 + b"PAR1")
+
+    from app.api import sync as sync_mod
+
+    def _fake(table_id, sql, bq, output_dir, max_bytes):
+        if table_id == "bad":
+            raise RuntimeError("simulated COPY failure")
+        return {"rows": 1, "size_bytes": 100, "query_mode": "materialized"}
+
+    with patch("app.api.sync._materialize_table", side_effect=_fake):
+        summary = sync_mod._run_materialized_pass(system_db, stub_bq)
+
+    assert summary["materialized"] == ["ok"]
+    assert len(summary["errors"]) == 1
+    assert summary["errors"][0]["table"] == "bad"
+    assert "simulated" in summary["errors"][0]["error"]
+
+
+def test_materialized_pass_records_parquet_hash(system_db, stub_bq, tmp_path):
+    """sync_state.hash must be the MD5 of the parquet file — otherwise the
+    manifest reports an empty hash and every da sync re-downloads."""
+    repo = TableRegistryRepository(system_db)
+    repo.register(
+        id="hashed", name="hashed",
+        source_type="bigquery", query_mode="materialized",
+        source_query="SELECT 1",
+        sync_schedule="every 1m",
+    )
+
+    parquet_dir = tmp_path / "data" / "extracts" / "bigquery" / "data"
+    parquet_dir.mkdir(parents=True, exist_ok=True)
+    parquet_path = parquet_dir / "hashed.parquet"
+
+    def _fake(**kwargs):
+        parquet_path.write_bytes(b"PAR1" + b"\x00" * 16 + b"PAR1")
+        return {"rows": 1, "size_bytes": 24, "query_mode": "materialized"}
+
+    from app.api import sync as sync_mod
+
+    with patch("app.api.sync._materialize_table", side_effect=_fake):
+        sync_mod._run_materialized_pass(system_db, stub_bq)
+
+    state = SyncStateRepository(system_db)
+    row = state.get_table_state("hashed")
+    assert row is not None
+    import hashlib
+    expected = hashlib.md5(b"PAR1" + b"\x00" * 16 + b"PAR1").hexdigest()
+    assert row["hash"] == expected
+
+
+def test_materialized_pass_zero_max_bytes_disables_guardrail(
+    system_db, stub_bq, tmp_path, monkeypatch
+):
+    """`max_bytes_per_materialize: 0` in instance.yaml → None passed downstream
+    so materialize_query skips the dry-run entirely."""
+    repo = TableRegistryRepository(system_db)
+    repo.register(
+        id="big", name="big", source_type="bigquery",
+        query_mode="materialized", source_query="SELECT 1",
+        sync_schedule="every 1m",
+    )
+
+    parquet_dir = tmp_path / "data" / "extracts" / "bigquery" / "data"
+    parquet_dir.mkdir(parents=True, exist_ok=True)
+    (parquet_dir / "big.parquet").write_bytes(
+        b"PAR1" + b"\x00" * 16 + b"PAR1"
+    )
+
+    monkeypatch.setattr(
+        "app.api.sync.get_value",
+        lambda *args, **kwargs: 0 if args[-1] == "max_bytes_per_materialize" else "",
+        raising=False,
+    )
+
+    from app.api import sync as sync_mod
+
+    captured = {}
+
+    def _spy(**kwargs):
+        captured.update(kwargs)
+        return {"rows": 1, "size_bytes": 100, "query_mode": "materialized"}
+
+    # The function reads `get_value` via a local import in the body — patch
+    # the import target instead.
+    with patch(
+        "app.instance_config.get_value",
+        side_effect=lambda *args, **kw: (
+            0 if args[-1] == "max_bytes_per_materialize"
+            else kw.get("default", "")
+        ),
+    ), patch("app.api.sync._materialize_table", side_effect=_spy):
+        sync_mod._run_materialized_pass(system_db, stub_bq)
+
+    assert captured["max_bytes"] is None

--- a/tests/test_table_registry_source_query.py
+++ b/tests/test_table_registry_source_query.py
@@ -1,0 +1,93 @@
+"""Repository round-trips source_query column for query_mode='materialized'.
+
+Lives alongside the schema-v19 migration: register() now accepts source_query
+as an Optional[str] kwarg, and the column flows through SELECT * via list/get.
+"""
+import duckdb
+import pytest
+
+from src.db import _ensure_schema
+from src.repositories.table_registry import TableRegistryRepository
+
+
+@pytest.fixture
+def repo(tmp_path):
+    conn = duckdb.connect(str(tmp_path / "system.duckdb"))
+    _ensure_schema(conn)
+    return TableRegistryRepository(conn)
+
+
+def test_register_persists_source_query(repo):
+    repo.register(
+        id="orders_90d",
+        name="orders_90d",
+        source_type="bigquery",
+        query_mode="materialized",
+        source_query=(
+            "SELECT date, SUM(revenue) FROM `prj.ds.orders` "
+            "WHERE date >= DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY) GROUP BY 1"
+        ),
+        sync_schedule="every 6h",
+    )
+    row = repo.get("orders_90d")
+    assert row is not None
+    assert row["query_mode"] == "materialized"
+    assert "INTERVAL 90 DAY" in row["source_query"]
+    assert row["sync_schedule"] == "every 6h"
+
+
+def test_register_omitted_source_query_stays_null(repo):
+    """Default registrations (Keboola local) must not stamp an empty string."""
+    repo.register(id="t1", name="t1", source_type="keboola", query_mode="local")
+    row = repo.get("t1")
+    assert row is not None
+    assert row["source_query"] is None
+
+
+def test_list_all_includes_source_query(repo):
+    repo.register(
+        id="m1", name="m1", source_type="bigquery",
+        query_mode="materialized", source_query="SELECT 1",
+    )
+    rows = repo.list_all()
+    assert len(rows) == 1
+    assert rows[0]["source_query"] == "SELECT 1"
+
+
+def test_register_updates_source_query_on_conflict(repo):
+    """Re-registering the same id must overwrite source_query (admin edit)."""
+    repo.register(
+        id="m1", name="m1", source_type="bigquery",
+        query_mode="materialized", source_query="SELECT 1",
+    )
+    repo.register(
+        id="m1", name="m1", source_type="bigquery",
+        query_mode="materialized", source_query="SELECT 2",
+    )
+    row = repo.get("m1")
+    assert row["source_query"] == "SELECT 2"
+
+
+def test_register_preserves_registered_at_when_supplied(repo):
+    """source_query addition must not break the existing registered_at
+    preservation contract (admin edits keep the original timestamp)."""
+    from datetime import datetime, timezone
+
+    original = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    repo.register(
+        id="t", name="t", source_type="bigquery",
+        query_mode="materialized", source_query="SELECT 1",
+        registered_at=original,
+    )
+    repo.register(
+        id="t", name="t", source_type="bigquery",
+        query_mode="materialized", source_query="SELECT 2",
+        registered_at=original,
+    )
+    row = repo.get("t")
+    assert row["source_query"] == "SELECT 2"
+    # Don't assert exact equality on naive vs aware (DuckDB strips tz);
+    # just confirm the year+month+day didn't slide forward to 'now'.
+    assert row["registered_at"].year == 2026
+    assert row["registered_at"].month == 1
+    assert row["registered_at"].day == 1


### PR DESCRIPTION
## Summary

End-to-end smart local sync for AI analysts. **Reimplemented from PR #145** against the 0.24.0 base because main advanced 26 commits (schema v14-v18, `BqAccess` facade, register-table flow rework) and a merge would have hidden the architectural decisions inside conflict resolution.

**Phase A — Auto-sync hooks**
- `da sync --quiet` for hook/cron use (clean stdout, terse stderr summary, non-zero exit on failure)
- `da analyst setup` installs `SessionStart` (pull) + `SessionEnd` (upload) hooks idempotently into `<workspace>/.claude/settings.json` — workspace-level, not user-home
- Replaces broken `SessionEnd` reference in `docs/setup/claude_settings.json` (`server/scripts/collect_session.py` was deleted in the v1→v2 server purge)
- `_install_claude_hooks` handles malformed existing settings.json gracefully

**Phase B — BigQuery `query_mode='materialized'`**
- Schema v19: new `source_query TEXT` column on `table_registry`
- `materialize_query()` routes through the **`BqAccess` facade** (`connectors/bigquery/access.py`) so cost-estimate logic and DuckDB-extension session setup live in one place. Reuses `app.api.v2_scan._bq_dry_run_bytes` for cost guardrail.
- Cost guardrail: configurable cap via `data_source.bigquery.max_bytes_per_materialize` (default 10 GiB; **explicit 0 disables** — YAML `null` falls through to default)
- `/api/sync/trigger` walks materialized rows via `is_table_due()`, computes parquet MD5 inline (so manifest serves it immediately and `da sync` honors delta-skip)
- Admin API: `RegisterTableRequest` + `UpdateTableRequest` accept `source_query` with `model_validator` enforcing mode/query coherence; `_validate_bigquery_register_payload` branches on `query_mode='materialized'`
- `da admin register-table --query <SQL>` accepts inline SQL or `@path/to.sql` shorthand. Reuses main's existing `--sync-schedule` flag.

**Phase C — Documentation**
- README mode-first source table + new "Local sync & auto-update" section
- CLAUDE.md schema chain → v19, four source modes (Materialized SQL added), new "Local sync & Claude Code hooks" subsection
- `cli/skills/connectors.md` "BigQuery: pick a mode" decision table
- `docs/architecture.md` "BigQuery — Materialized SQL" subsection

## RBAC story (no new code)

Auto-sync set per analyst is the intersection of:
1. Tables with `query_mode IN ('local', 'materialized')` (manifest scope)
2. Tables granted to one of the analyst's groups via `resource_grants(group, ResourceType.TABLE, table_id)`

`/api/sync/manifest` already filters per user via `can_access_table` → `resource_grants`. Admins curate auto-sync membership via `query_mode` + the existing RBAC layer; no new endpoints.

## Devil's advocate review

A pre-PR adversarial review surfaced 7 production failure modes; the fixes are baked in:

| # | Issue | Status |
|---|---|---|
| 1 | `null`-disable trap on guardrail | **Fixed** — `0` sentinel; `null` documented as falls-through |
| 2 | Empty hash → every `da sync` re-downloads materialized parquet | **Fixed** — hash recorded inline in `materialize_query` |
| 3 | Stale `source_query` on PUT mode-switch | **Fixed** — `merged` dict cleared when `query_mode != 'materialized'` |
| 4 | 0-row materialization silent | **Fixed** — `WARNING` log per row |
| 5 | ATTACH `except duckdb.Error: pass` swallows real errors | **Fixed** — narrowed to "already attached" case |
| 6 | `_file_hash` blocks request thread on multi-GB parquets | **Fixed** — hash inline (no second read) |
| 7 | DuckDB BQ ext can't dry-run `bq."ds"."t"` syntax (cosmetic guardrail) | **Documented** — operators write native BQ identifiers if cap matters |

Known limitations (CHANGELOG `### Internal`): GCE token expiry mid-COPY for very long scans, unpinned community extension, schema drift on SQL edit, no concurrency lock on `materialize_query`.

## Plan reference

`docs/superpowers/plans/2026-04-30-local-sync-and-materialized-bq.md` (the original plan; details may differ from the implementation post-rebase, kept on the old branch for audit).

## Audit trail

- **Tag `pr145-final`** (commit `91b5cf7`) preserves the previous PR's working state. `git checkout pr145-final` retrieves it; the original `plan/local-sync-and-materialized-bq` branch on origin remains untouched.
- **PR #145** stays open as an audit reference (Devin findings + review thread); will be closed with a "superseded by this PR" comment after merge here.

## Test plan

- [x] **168 cílených testů procházejí** — full sweep across schema v19, repo, BQ extractor (materialize/cost/skip), sync trigger, admin API, CLI register-table, CLI sync --quiet, hooks, and end-to-end integration. `pytest tests/test_db_migration_v19.py tests/test_table_registry_source_query.py tests/test_bq_materialize.py tests/test_bq_cost_guardrail.py tests/test_bq_init_extract_skips.py tests/test_sync_trigger_materialized.py tests/test_api_admin_materialized.py tests/test_cli_admin_materialized.py tests/test_cli_sync_quiet.py tests/test_setup_hooks_template.py tests/test_cli_analyst_setup_hooks.py tests/test_materialized_e2e.py tests/test_admin_bq_register.py tests/test_cli_sync.py` — 168 passed.
- [ ] Manual: register a small materialized BQ table against a real BQ project, trigger sync, confirm parquet appears at `/data/extracts/bigquery/data/<id>.parquet` and is downloaded by `da sync`.
- [ ] Manual: open Claude Code in `da analyst setup`-bootstrapped workspace; confirm SessionStart pulls fresh parquets and SessionEnd uploads jsonl.
- [ ] Manual: register a materialized SQL exceeding `max_bytes_per_materialize`; confirm trigger logs structured `MaterializeBudgetError` with `current` / `limit` and skips the row.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
