### PR TITLE
feat(sync+bq): smart local sync + BigQuery materialized query mode (supersedes #145, #147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,15 @@ Minor release. Adds **smart local sync** so analysts get RBAC-filtered parquets 
   --sync-schedule "every 6h"`; the sync trigger pass runs it through the
   DuckDB BigQuery extension via the `BqAccess` facade on each tick that's
   due (per-table `sync_schedule` honored via `is_table_due()`) and writes
-  the result to `/data/extracts/bigquery/data/<id>.parquet`. The
-  orchestrator picks the parquet up via standard local-parquet discovery
-  and the existing manifest + `da sync` flow distributes it to analysts.
-  Per-user RBAC filtering is unchanged: a materialized table is just
-  another row in `table_registry` with `resource_grants` controlling
-  which groups see it.
+  the result to `/data/extracts/bigquery/data/<name>.parquet`. The
+  manifest endpoint exposes the row to `da sync`, which distributes the
+  parquet to analysts; analysts query it through their **local** DuckDB
+  view. The server-side orchestrator does **not** create a master view
+  for materialized tables — they are intentionally local-only for
+  analyst distribution, mirroring the v2 fetch primitives' "queryable
+  via `da fetch` not via remote" contract. Per-user RBAC filtering is
+  unchanged: a materialized table is just another row in
+  `table_registry` with `resource_grants` controlling which groups see it.
 - **Schema v19** adds `source_query TEXT` column to `table_registry` to
   back the materialized mode. NULL for existing rows. The
   `materialize_query()` function in the BigQuery extractor performs the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,145 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+<!-- Add bullets here. Group: Added / Changed / Fixed / Removed / Internal.
+     Mark breaking changes with **BREAKING** at the start of the bullet. -->
+
+## [0.25.0] — 2026-04-30
+
+Minor release. Adds **smart local sync** so analysts get RBAC-filtered parquets pulled at every Claude Code SessionStart and session logs pushed at SessionEnd, plus a new **BigQuery `query_mode='materialized'`** that lets admins register a scheduled SQL query whose result rides the same auto-sync flow as Keboola tables. The auto-sync set per analyst is the intersection of `query_mode IN ('local', 'materialized')` and the `resource_grants` rows — admins curate it via the existing RBAC layer, no new endpoints. The materialize path uses the `BqAccess` facade from #138 so cost-estimate logic and DuckDB-extension session setup live in one place. Devin review iteration during PR #145 surfaced and fixed a `null`-disable trap on the cost guardrail, an empty-hash re-download bug on materialized parquets, and a stale-`source_query` data-integrity gap on PUT — all baked in before this PR was opened.
+
+### Added
+
+- **BigQuery `query_mode='materialized'`** — admin registers a SQL query
+  via `da admin register-table --query-mode materialized --query @file.sql
+  --sync-schedule "every 6h"`; the sync trigger pass runs it through the
+  DuckDB BigQuery extension via the `BqAccess` facade on each tick that's
+  due (per-table `sync_schedule` honored via `is_table_due()`) and writes
+  the result to `/data/extracts/bigquery/data/<id>.parquet`. The
+  orchestrator picks the parquet up via standard local-parquet discovery
+  and the existing manifest + `da sync` flow distributes it to analysts.
+  Per-user RBAC filtering is unchanged: a materialized table is just
+  another row in `table_registry` with `resource_grants` controlling
+  which groups see it.
+- **Schema v19** adds `source_query TEXT` column to `table_registry` to
+  back the materialized mode. NULL for existing rows. The
+  `materialize_query()` function in the BigQuery extractor performs the
+  COPY atomically (`<id>.parquet.tmp` → `os.replace`) so a failed query
+  never leaves a half-written parquet.
+- BigQuery cost guardrail for `query_mode='materialized'` tables: before
+  each COPY the scheduler runs a BQ dry-run (reusing
+  `app.api.v2_scan._bq_dry_run_bytes` so cost-estimate logic lives in
+  exactly one place) and raises `MaterializeBudgetError` (skips the row)
+  when the estimate exceeds `data_source.bigquery.max_bytes_per_materialize`.
+  Default 10 GiB; explicit `0` disables (YAML `null` falls through to
+  the default — documented in `config/instance.yaml.example`).
+  Fail-open when the dry-run itself errors (library missing, DuckDB
+  three-part syntax the native BQ client can't parse, transient API
+  failure) — logs a warning instead of blocking the COPY.
+- Admin API: `POST /api/admin/register-table` and
+  `PUT /api/admin/registry/{id}` accept `source_query` field. Validator
+  enforces that `query_mode='materialized'` requires `source_query` and
+  `query_mode in ('local', 'remote')` forbids it. PUT also rejects
+  `source_query` set without `query_mode` in the same request body and
+  clears the stale `source_query` when switching the merged record away
+  from materialized mode.
+- CLI: `da admin register-table --query <SQL>` accepts inline SQL or
+  `@path/to.sql` shorthand for reading from disk. Reuses the existing
+  `--sync-schedule` flag for the cron string.
+- `da sync --quiet` flag suppresses Rich progress + multi-line summary,
+  intended for use from Claude Code SessionStart/SessionEnd hooks and
+  cron jobs. Errors still surface on stderr; the no-op case is silent.
+  The terse summary line in `--quiet` mode (`sync: N tables, M errors`)
+  lands on stderr so stdout stays clean for hook callers.
+- `da analyst setup` now installs `SessionStart` (pull) and `SessionEnd`
+  (upload) hooks into `<workspace>/.claude/settings.json`, idempotently,
+  preserving any existing user-owned hooks. Workspace-level (not
+  user-home) so the hooks fire only when Claude Code is opened in the
+  analyst workspace, not in unrelated sessions on the same machine.
+  Hooks assume `da` is on `PATH`. If the CLI is not installed system-wide
+  (e.g. via `pipx` or `pip install -e .`), the hooks no-op silently —
+  expected graceful degradation, never blocks a session.
+- `docs/setup/claude_settings.json` ships the same two hooks so operators
+  bootstrapping a fresh Claude Code workspace get auto-sync out of the box.
+
+### Changed
+
+- BigQuery `init_extract` no longer creates remote views for rows with
+  `query_mode='materialized'`; those live as parquets and surface via
+  the orchestrator's standard local-parquet discovery. Skipped rows do
+  not appear in `_meta` so cross-source view-name collisions remain
+  impossible.
+
+### Fixed
+
+- `docs/setup/claude_settings.json` no longer references the deleted
+  `server/scripts/collect_session.py` — the dead `SessionEnd` hook had
+  silently failed in every Claude Code session since the v1→v2 server
+  purge. Replaced with `da sync --upload-only --quiet`.
+
+### Internal
+
+- README mode-first source table; new "Local sync & auto-update" section
+  covering `da sync`, hooks, and admin RBAC for auto-sync membership.
+- `CLAUDE.md` schema chain extended to v19 with the `source_query`
+  description; four source modes documented in Connector Pattern (added
+  Materialized SQL); new "Local sync & Claude Code hooks" subsection
+  under Development.
+- `cli/skills/connectors.md` — "BigQuery: pick a mode" decision table
+  with cost / guardrail / registration example.
+- `docs/architecture.md` — new "BigQuery — Materialized SQL" subsection
+  describing the COPY pipeline, BqAccess integration, and cost guardrail.
+- BQ cost guardrail dry-run is performed via the native
+  `google-cloud-bigquery` client (through `BqAccess.client()`), which
+  does not parse DuckDB three-part identifiers (`bq."ds"."t"`). Queries
+  written in DuckDB syntax fall through fail-open and log a warning
+  instead of engaging the cap. Operators who need the cap to be
+  enforceable must register the materialized SQL using native BQ
+  identifiers (`\`project.ds.t\``).
+- Hardenings landed during devil's-advocate review of PR #145:
+  - `materialize_query` computes the parquet MD5 inline (after COPY,
+    before `os.replace`) instead of re-reading the file in
+    `_run_materialized_pass` — saves a full sequential read on the
+    request thread for multi-GB parquets.
+  - 0-row materializations log a `WARNING` so an empty result set
+    can't masquerade as "the SQL is fine, today there's nothing".
+  - The ATTACH-tolerated `except duckdb.Error: pass` is narrowed to
+    the "alias already attached" case; real errors (cross-project
+    permission, malformed project_id) propagate so the per-row
+    aggregator records them correctly instead of surfacing a
+    confusing downstream "bq is not attached".
+
+### Known limitations
+
+Operators should be aware of these production-only behaviours; tests
+cannot exercise them and they will be revisited in follow-up PRs:
+
+- **GCE metadata token expiry mid-COPY (catastrophic for very long
+  scans).** The DuckDB BQ extension caches the token in a session
+  SECRET created at session-open. A `materialize_query` call that
+  takes longer than the token's remaining lifetime (~1h) will see
+  silent 401s downstream and may produce a truncated parquet. No
+  current mitigation; if your materialized SQL scans more than ~30
+  GiB on a single COPY, run it via the BQ console / Storage Read
+  API offline and `da fetch` the result instead until token refresh
+  is wired into the BQ extension's session.
+- **DuckDB `bigquery` community extension is unpinned** —
+  `INSTALL bigquery FROM community; LOAD bigquery;` picks up the
+  latest published version on every cold start. A breaking change
+  upstream surfaces as a production failure with no test signal.
+- **Schema drift after a SQL edit silently breaks analyst queries.**
+  Editing `source_query` to drop a column writes a new parquet with
+  the new shape; analysts' queries that referenced the dropped
+  column 500 on the next sync without warning. No diff or version
+  field surfaces this. Workaround: announce changes in the team
+  channel before editing materialized SQL.
+- **`materialize_query` is not concurrency-locked.** Two concurrent
+  `/api/sync/trigger` calls for the same materialized row race on
+  `<id>.parquet.tmp`. `init_extract` has `_INIT_EXTRACT_LOCK` for
+  the remote-attach path, but the materialized path does not yet.
+  In practice: the cron scheduler is single-threaded and manual
+  triggers are rare, so the race window is small.
+
 ## [0.24.0] — 2026-04-30
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,9 +117,10 @@ The SyncOrchestrator scans `/data/extracts/*/extract.duckdb`, ATTACHes each into
           (serve)    (da sync)
 ```
 
-Three source types:
-- **Batch pull** (Keboola): DuckDB extension downloads to parquet, scheduled
-- **Remote attach** (BigQuery): DuckDB BQ extension, no download, queries go to BQ
+Source modes:
+- **Batch pull** (Keboola, `query_mode='local'`): DuckDB extension downloads to parquet, scheduled
+- **Remote attach** (BigQuery, `query_mode='remote'`): DuckDB BQ extension, no download, queries go to BQ
+- **Materialized SQL** (BigQuery, `query_mode='materialized'`): scheduler runs admin-registered SQL through DuckDB BQ extension (via `BqAccess` from `connectors/bigquery/access.py`) and writes the result to `/data/extracts/bigquery/data/<id>.parquet`. Distributed via the same manifest + `da sync` flow as Keboola tables. Cost guardrail via `data_source.bigquery.max_bytes_per_materialize` (default 10 GiB; set `0` to disable — YAML `null` falls through to the default).
 - **Real-time push** (Jira): Webhooks update parquets incrementally
 
 ## Configuration
@@ -147,6 +148,19 @@ curl -X POST http://localhost:8000/api/sync/trigger
 # Docker
 docker compose up
 ```
+
+### Local sync & Claude Code hooks
+
+`da sync` is the canonical analyst-side distribution path: pulls the RBAC-filtered manifest from the server, downloads parquets whose MD5 changed (skipping `query_mode='remote'` rows), rebuilds local DuckDB views over them.
+
+`da analyst setup` writes two hooks into `<workspace>/.claude/settings.json`:
+
+- `SessionStart` → `da sync --quiet` — pulls fresh parquets at the start of every Claude Code session
+- `SessionEnd`   → `da sync --upload-only --quiet` — uploads session jsonl + `CLAUDE.local.md` to the server
+
+Both pass `--quiet` so they don't pollute Claude Code stdout, and trail with `|| true` so a server outage never blocks a session. Workspace-level (not user-home) so the hooks fire only when Claude Code opens this analyst workspace, not in unrelated sessions on the same machine.
+
+Admin RBAC for auto-sync: `query_mode IN ('local', 'materialized')` plus a `resource_grants` row for one of the analyst's groups → table appears in their manifest → `da sync` downloads it. No per-user sync config; the admin layer is the single source of truth.
 
 ## Business Metrics
 
@@ -416,7 +430,7 @@ Module sets `lifecycle { ignore_changes = [metadata_startup_script] }` on `googl
 ## Key Implementation Details
 
 ### DuckDB Schema (src/db.py)
-- Schema v18 with auto-migration v1→…→v18 (v5 adds `users.active`, v6 adds `personal_access_tokens`, v7 adds `personal_access_tokens.last_used_ip`, v8/v9 added the legacy internal_roles/role-grants tables, v10 added `view_ownership` for cross-connector view-name collision detection (issue #81 Group C), v11 added marketplace_registry + marketplace_plugins + user_groups + plugin_access, v12 added users.groups JSON + user_groups.is_system, **v13 replaces internal_roles/group_mappings/user_role_grants/plugin_access with user_group_members + resource_grants and drops users.groups JSON**, v14 adds FK constraints on user_group_members + resource_grants after orphan cleanup, v15 adds knowledge_items context-engineering columns + contradictions + session_extraction_state, v16 adds verification_evidence, v17 adds knowledge_item_relations, **v18 drops stranded non-google memberships from google-managed groups** — see CHANGELOG and docs/RBAC.md)
+- Schema v19 with auto-migration v1→…→v19 (v5 adds `users.active`, v6 adds `personal_access_tokens`, v7 adds `personal_access_tokens.last_used_ip`, v8/v9 added the legacy internal_roles/role-grants tables, v10 added `view_ownership` for cross-connector view-name collision detection (issue #81 Group C), v11 added marketplace_registry + marketplace_plugins + user_groups + plugin_access, v12 added users.groups JSON + user_groups.is_system, **v13 replaces internal_roles/group_mappings/user_role_grants/plugin_access with user_group_members + resource_grants and drops users.groups JSON**, v14 adds FK constraints on user_group_members + resource_grants after orphan cleanup, v15 adds knowledge_items context-engineering columns + contradictions + session_extraction_state, v16 adds verification_evidence, v17 adds knowledge_item_relations, **v18 drops stranded non-google memberships from google-managed groups**, **v19 adds `source_query` TEXT to `table_registry` to back `query_mode='materialized'` (BigQuery scheduled-query parquet path)** — see CHANGELOG and docs/RBAC.md)
 - `table_registry`: id, name, source_type, bucket, source_table, query_mode, sync_schedule, etc.
 - `sync_state`, `sync_history`: track extraction progress
 - `users`, `dataset_permissions`, `audit_log`: auth + RBAC

--- a/README.md
+++ b/README.md
@@ -40,11 +40,14 @@ The orchestrator scans `/data/extracts/*/extract.duckdb`, attaches each into `an
 
 ## Supported Data Sources
 
-| Source | Mode | Description |
-|--------|------|-------------|
-| **Keboola** | Batch pull | DuckDB Keboola extension downloads tables to Parquet on a schedule |
-| **BigQuery** | Remote attach | DuckDB BQ extension; queries execute in BigQuery, no local download |
-| **Jira** | Real-time push | Webhook receiver updates Parquet files incrementally |
+| Mode | Distribution | Sources | Use when |
+|------|--------------|---------|----------|
+| **Batch pull** (`local`) | Parquet on disk, scheduled | Keboola | Source has a native bulk-export and the table fits on disk |
+| **Materialized SQL** (`materialized`) | Parquet on disk, scheduled query | BigQuery | Source table is too large to mirror; you want a curated subset on disk |
+| **Remote attach** (`remote`) | View only, no download | BigQuery | Table is too large to materialize; latency cost of remote query is acceptable |
+| **Real-time push** | Incremental parquet | Jira | Source is event-driven and you need sub-minute freshness |
+
+The first three modes are what `da sync` distributes to analysts. The fourth is server-side only — analysts query Jira data through the same `da sync`-distributed parquets.
 
 Adding a new source means creating `connectors/<name>/extractor.py` that produces `extract.duckdb` with a `_meta` table (`table_name`, `description`, `rows`, `size_bytes`, `extracted_at`, `query_mode`). The orchestrator attaches it automatically.
 
@@ -76,6 +79,44 @@ Once running, the FastAPI app is available at `http://localhost:8000` (or `https
 ```bash
 curl -X POST http://localhost:8000/api/sync/trigger
 ```
+
+## Local sync & auto-update
+
+Analysts run Claude Code against a local DuckDB built from RBAC-filtered parquets pulled from the server. `da sync` is the distribution path:
+
+```bash
+da sync             # delta-pull: manifest → MD5 compare → download changed → rebuild views
+da sync --quiet     # same, no progress output (for hooks/cron)
+da sync --upload-only  # push session jsonl + CLAUDE.local.md back to the server
+```
+
+`da analyst setup` writes Claude Code lifecycle hooks into `<workspace>/.claude/settings.json`:
+
+- `SessionStart` → `da sync --quiet` — fresh data on every session
+- `SessionEnd` → `da sync --upload-only --quiet` — uploads notes and session log
+
+Hooks live at workspace level so they only fire in this analyst workspace, not in unrelated Claude Code sessions on the same machine.
+
+### Admin: which tables auto-sync to whom
+
+The auto-sync set per analyst is the intersection of:
+
+1. Tables with `query_mode IN ('local', 'materialized')` — these have parquets on disk and end up in the manifest
+2. Tables granted to one of the analyst's groups via `resource_grants(group, ResourceType.TABLE, table_id)` (see [`docs/RBAC.md`](docs/RBAC.md))
+
+To enroll a new table for auto-sync, register it (or update its `query_mode`) and grant it to the relevant groups in `/admin/access`. New analysts get the same set on their next `da sync`.
+
+For BigQuery, register a `query_mode='materialized'` table with a SQL body:
+
+```bash
+da admin register-table orders_90d \
+    --source-type bigquery \
+    --query-mode materialized \
+    --query @docs/queries/orders_90d.sql \
+    --schedule "every 6h"
+```
+
+The scheduler runs the query through the DuckDB BigQuery extension on each tick that's due, writes the result as a parquet, and the analyst picks it up on the next `da sync`. Cost guardrail: `data_source.bigquery.max_bytes_per_materialize` (default 10 GiB) — operations exceeding the BQ dry-run estimate are skipped.
 
 ## Development Setup
 

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -1388,6 +1388,28 @@ def register_table_precheck(
     # checks identifier safety, validates project_id from instance.yaml).
     _validate_bigquery_register_payload(request)
 
+    # Materialized BQ rows have no `dataset.source_table` to round-trip —
+    # the SQL body is the contract. Skip the BQ-jobs-API call and return a
+    # validation-only precheck so the CLI's `--dry-run --query-mode
+    # materialized` path doesn't crash on an empty fully-qualified name.
+    if request.query_mode == "materialized":
+        return {
+            "ok": True,
+            "table": {
+                "name": request.name,
+                "source_type": "bigquery",
+                "query_mode": "materialized",
+                "source_query": request.source_query,
+                "rows": None,
+                "size_bytes": None,
+                "columns": [],
+                "note": (
+                    "materialized precheck is validation-only — the SQL is "
+                    "evaluated for cost on each scheduled materialize tick"
+                ),
+            },
+        }
+
     # Round-trip the BQ jobs API to confirm the table exists and the SA can
     # see it. Imports kept local to avoid pulling google-cloud-bigquery into
     # the import chain on non-BQ instances.

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -956,8 +956,20 @@ class ConfigureRequest(BaseModel):
 @router.get("/discover-tables")
 async def discover_tables(
     user: dict = Depends(require_admin),
+    dataset: Optional[str] = None,
 ):
-    """Discover all available tables from the configured data source."""
+    """Discover available tables from the configured data source.
+
+    For ``data_source.type='keboola'`` returns the full Storage API table
+    list (single round-trip). For ``data_source.type='bigquery'``:
+
+    - Without ``dataset``: list datasets in the configured project.
+    - With ``dataset=name``: list tables (BASE TABLE + VIEW) in that dataset.
+
+    Two-step shape avoids paying the per-dataset list_tables cost up-front
+    on projects with hundreds of datasets — the UI populates the dataset
+    dropdown first, then fetches tables only for the selected dataset.
+    """
     try:
         from app.instance_config import get_data_source_type
         source_type = get_data_source_type()
@@ -973,10 +985,87 @@ async def discover_tables(
             client = KeboolaClient(token=token, url=url)
             tables = client.discover_all_tables()
             return {"tables": tables, "count": len(tables), "source": "keboola"}
-        else:
-            return {"tables": [], "count": 0, "source": source_type, "error": "Discovery not implemented for this source"}
+
+        if source_type == "bigquery":
+            return _discover_bigquery(dataset=dataset)
+
+        return {
+            "tables": [],
+            "count": 0,
+            "source": source_type,
+            "error": f"Discovery not implemented for source_type={source_type!r}",
+        }
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Discovery failed: {e}")
+
+
+def _discover_bigquery(dataset: Optional[str]) -> Dict[str, Any]:
+    """List BQ datasets (when ``dataset`` is None) or tables-in-dataset.
+
+    Routes through ``BqAccess.client()`` so config / auth / error
+    translation matches the rest of the BQ surface (#138 facade). Returns
+    the same shape as the Keboola path so the UI doesn't have to branch.
+    """
+    from connectors.bigquery.access import (
+        get_bq_access,
+        BqAccessError,
+        translate_bq_error,
+    )
+
+    try:
+        bq = get_bq_access()
+        client = bq.client()
+    except BqAccessError as e:
+        raise HTTPException(
+            status_code=BqAccessError.HTTP_STATUS.get(e.kind, 500),
+            detail={"error": e.message, "kind": e.kind, "details": e.details},
+        )
+
+    try:
+        if dataset is None:
+            datasets = []
+            for ds in client.list_datasets():
+                datasets.append({
+                    "dataset_id": ds.dataset_id,
+                    "full_id": f"{ds.project}.{ds.dataset_id}",
+                })
+            return {
+                "datasets": sorted(datasets, key=lambda d: d["dataset_id"]),
+                "count": len(datasets),
+                "source": "bigquery",
+            }
+
+        # List tables in the named dataset. `list_tables` returns
+        # `TableListItem` with `table_id` + `table_type` ('TABLE', 'VIEW',
+        # 'MATERIALIZED_VIEW', 'EXTERNAL', 'SNAPSHOT'). UI maps TABLE → Type
+        # selector "table" and VIEW/MATERIALIZED_VIEW → "view"; the rest are
+        # passed through with their raw type so the operator can decide.
+        tables = []
+        for t in client.list_tables(dataset):
+            tables.append({
+                "table_id": t.table_id,
+                "table_type": t.table_type,
+                "full_id": f"{t.project}.{t.dataset_id}.{t.table_id}",
+            })
+        return {
+            "tables": sorted(tables, key=lambda t: t["table_id"]),
+            "count": len(tables),
+            "source": "bigquery",
+            "dataset": dataset,
+        }
+    except Exception as e:
+        # `translate_bq_error` re-raises non-Google exceptions unchanged,
+        # so wrap in HTTPException to keep the JSON-shape contract.
+        try:
+            err = translate_bq_error(e, bq.projects, bad_request_status="upstream_error")
+        except Exception:
+            raise HTTPException(status_code=502, detail=f"BQ discovery failed: {e}")
+        raise HTTPException(
+            status_code=BqAccessError.HTTP_STATUS.get(err.kind, 502),
+            detail={"error": err.message, "kind": err.kind, "details": err.details},
+        )
 
 
 @router.get("/registry")

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -896,17 +896,54 @@ class UpdateTableRequest(BaseModel):
 
     @model_validator(mode="after")
     def _check_mode_query_coherence(self):
-        """Same invariant as RegisterTableRequest, but only fires when at
-        least one of query_mode / source_query is being touched in this
-        PUT — fields not in the body stay None and don't trigger anything."""
+        """PUT semantics — only the fields explicitly in the body are
+        validated. The body is overlaid on the existing row at the handler
+        level (see ``update_table``), so omitted fields keep their stored
+        values and the synthetic ``RegisterTableRequest`` constructed against
+        the merged record runs the strict cross-field check before persist.
+
+        The only invariants enforceable from the PUT body alone:
+
+        - explicit ``source_query='SELECT ...'`` paired with ``query_mode``
+          that isn't materialized → coherent reject (the SQL would be dead);
+        - explicit ``source_query='SELECT ...'`` without any ``query_mode``
+          in the body → reject; the operator must commit to materialized;
+        - explicit empty/whitespace ``source_query=''`` paired with
+          ``query_mode='materialized'`` → reject (operator clearly
+          mistyped — they sent the field).
+
+        Pre-fix this validator also rejected ``{"query_mode": "materialized",
+        "sync_schedule": "every 12h"}`` because ``source_query`` was None
+        — but that's the canonical "edit the schedule on a materialized
+        row" use-case from the Edit modal, which always sends
+        ``query_mode`` to indicate intent. Devin BUG_0002 on PR #148
+        commit 2219255.
+        """
         if self.query_mode is None and self.source_query is None:
             return self
-        sq = (self.source_query or "").strip() or None
-        if self.query_mode == "materialized" and not sq:
+
+        sq_raw = self.source_query
+        sq = (sq_raw or "").strip() or None
+
+        # Operator explicitly sent source_query as empty/whitespace while
+        # claiming materialized — typo / bad form data, reject.
+        if (
+            self.query_mode == "materialized"
+            and sq_raw is not None
+            and not sq
+        ):
             raise ValueError(
                 "query_mode='materialized' requires a non-empty source_query"
             )
-        if self.query_mode is not None and self.query_mode != "materialized" and sq:
+
+        # source_query only makes sense with materialized mode. Allow None
+        # (omitted) to flow through; only reject when explicitly set with
+        # the wrong mode.
+        if (
+            self.query_mode is not None
+            and self.query_mode != "materialized"
+            and sq
+        ):
             raise ValueError(
                 "source_query is only valid when query_mode='materialized'"
             )
@@ -915,7 +952,12 @@ class UpdateTableRequest(BaseModel):
                 "source_query requires query_mode='materialized' to be set "
                 "in the same request"
             )
-        self.source_query = sq
+
+        # Normalise: drop whitespace-only strings to None so the persisted
+        # column is clean. Don't touch when source_query was None to begin
+        # with — that signals "PUT didn't touch this field, keep existing".
+        if sq_raw is not None:
+            self.source_query = sq
         return self
 
     @field_validator("primary_key", mode="before")

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -12,7 +12,7 @@ import uuid
 from pathlib import Path
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 from typing import Optional, List, Dict, Any
 import duckdb
 
@@ -664,9 +664,33 @@ class RegisterTableRequest(BaseModel):
     source_type: Optional[str] = None
     bucket: Optional[str] = None
     source_table: Optional[str] = None
+    # Backs query_mode='materialized'. Stored verbatim in
+    # table_registry.source_query (schema v19); the trigger pass runs it
+    # through the DuckDB BQ extension via BqAccess and writes the result
+    # to /data/extracts/bigquery/data/<id>.parquet.
+    source_query: Optional[str] = None
     query_mode: str = "local"
     sync_schedule: Optional[str] = None
     profile_after_sync: bool = True
+
+    @model_validator(mode="after")
+    def _check_mode_query_coherence(self):
+        """Enforce query_mode ↔ source_query invariants up front so an admin
+        can't persist a remote/local row carrying an orphan source_query, and
+        materialized rows can't be registered without a SQL body."""
+        sq = (self.source_query or "").strip() or None
+        if self.query_mode == "materialized" and not sq:
+            raise ValueError(
+                "query_mode='materialized' requires a non-empty source_query"
+            )
+        if self.query_mode != "materialized" and sq:
+            raise ValueError(
+                "source_query is only valid when query_mode='materialized'"
+            )
+        # Normalise: stash the trimmed-or-None form so the persisted column
+        # never carries surrounding whitespace or empty-string sentinels.
+        self.source_query = sq
+        return self
 
     @field_validator("primary_key", mode="before")
     @classmethod
@@ -707,12 +731,66 @@ class RegisterTableRequest(BaseModel):
 def _validate_bigquery_register_payload(req: "RegisterTableRequest") -> None:
     """Enforce BQ-specific shape on a register/precheck request.
 
-    Mutates the model: forces ``query_mode='remote'`` and
-    ``profile_after_sync=False`` (per Decision 7 in #108) so a caller can't
-    accidentally enqueue a parquet profiling pass for a remote view that
-    has no local file. Raises HTTPException(422) for missing required
-    fields and HTTPException(400) for unsafe identifiers / bogus project_id.
+    Two BQ paths:
+
+    - ``query_mode='materialized'`` — admin-registered SQL writes a parquet on
+      schedule. Requires ``source_query``; ``bucket`` / ``source_table`` are
+      not used (the SQL inlines the references). Doesn't force any field; the
+      Pydantic ``model_validator`` already gated the query/mode coherence.
+
+    - ``query_mode='remote'`` (or default) — remote view over a single BQ
+      table. Requires ``bucket`` (BQ dataset) + ``source_table``. Mutates
+      the model: forces ``query_mode='remote'`` and ``profile_after_sync=False``
+      (per Decision 7 in #108) so a caller can't accidentally enqueue a
+      parquet profiling pass for a remote view that has no local file.
+
+    Raises HTTPException(422) for missing required fields and
+    HTTPException(400) for unsafe identifiers / bogus project_id.
     """
+    if req.query_mode == "materialized":
+        # Materialized BQ rows: the SQL body replaces dataset+table refs.
+        # Pydantic model_validator already verified source_query is non-empty;
+        # all we still need is a valid project_id and a safe view name.
+        if not req.source_query or not req.source_query.strip():
+            raise HTTPException(
+                status_code=422,
+                detail="bigquery materialized: 'source_query' is required",
+            )
+        raw_name = req.name or ""
+        if raw_name.strip() != raw_name or not _is_safe_identifier(raw_name):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"bigquery: view name {raw_name!r} is unsafe — must match "
+                    f"^[a-zA-Z_][a-zA-Z0-9_]{{0,63}}$ (DuckDB identifier rules) "
+                    "with no leading/trailing whitespace"
+                ),
+            )
+        from app.instance_config import get_value
+        project_id = get_value("data_source", "bigquery", "project", default="")
+        if not project_id:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "bigquery: data_source.bigquery.project is not set in "
+                    "instance.yaml; configure it via /admin/server-config or "
+                    "/api/admin/configure first"
+                ),
+            )
+        if not _is_safe_project_id(project_id):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"bigquery: data_source.bigquery.project {project_id!r} "
+                    "is malformed — must match GCP project_id grammar "
+                    "^[a-z][a-z0-9-]{4,28}[a-z0-9]$"
+                ),
+            )
+        # Materialized rows have no remote view to profile. Force-disable
+        # to keep the registry consistent across mode switches.
+        req.profile_after_sync = False
+        return
+
     if not req.bucket or not req.bucket.strip():
         raise HTTPException(
             status_code=422,
@@ -811,9 +889,34 @@ class UpdateTableRequest(BaseModel):
     source_type: Optional[str] = None
     bucket: Optional[str] = None
     source_table: Optional[str] = None
+    source_query: Optional[str] = None
     query_mode: Optional[str] = None
     sync_schedule: Optional[str] = None
     profile_after_sync: Optional[bool] = None
+
+    @model_validator(mode="after")
+    def _check_mode_query_coherence(self):
+        """Same invariant as RegisterTableRequest, but only fires when at
+        least one of query_mode / source_query is being touched in this
+        PUT — fields not in the body stay None and don't trigger anything."""
+        if self.query_mode is None and self.source_query is None:
+            return self
+        sq = (self.source_query or "").strip() or None
+        if self.query_mode == "materialized" and not sq:
+            raise ValueError(
+                "query_mode='materialized' requires a non-empty source_query"
+            )
+        if self.query_mode is not None and self.query_mode != "materialized" and sq:
+            raise ValueError(
+                "source_query is only valid when query_mode='materialized'"
+            )
+        if self.query_mode is None and sq:
+            raise ValueError(
+                "source_query requires query_mode='materialized' to be set "
+                "in the same request"
+            )
+        self.source_query = sq
+        return self
 
     @field_validator("primary_key", mode="before")
     @classmethod
@@ -1132,6 +1235,7 @@ def register_table(
         source_type=request.source_type,
         bucket=request.bucket,
         source_table=request.source_table,
+        source_query=request.source_query,
         query_mode=request.query_mode,
         sync_schedule=request.sync_schedule,
         profile_after_sync=request.profile_after_sync,
@@ -1152,6 +1256,24 @@ def register_table(
         return JSONResponse(
             status_code=201,
             content={"id": table_id, "name": request.name, "status": "registered"},
+        )
+
+    if request.query_mode == "materialized":
+        # Materialized BQ rows are picked up by the trigger pass on the next
+        # scheduled tick (or via POST /api/sync/trigger). No synchronous
+        # rebuild — the COPY can scan multi-GB and would block the request.
+        return JSONResponse(
+            status_code=201,
+            content={
+                "id": table_id,
+                "name": request.name,
+                "status": "registered",
+                "view_name": table_id,
+                "message": (
+                    "Materialized — parquet will be written on the next sync "
+                    "tick. Trigger now via POST /api/sync/trigger."
+                ),
+            },
         )
 
     # BQ post-register: rebuild extract + master views, with timeout fallback.
@@ -1360,14 +1482,23 @@ async def update_table(
         merged.update(updates)
         merged.pop("id", None)  # avoid duplicate id kwarg
 
+        # When switching the merged record away from materialized mode, drop
+        # the stale source_query — the request validator can't clear it via
+        # the `if v is not None` filter above. Without this, a remote/local
+        # row would carry an orphan source_query in the registry.
+        if merged.get("query_mode") != "materialized":
+            merged["source_query"] = None
+
         if merged.get("source_type") == "bigquery":
             # Reuse the register-time validator. It mutates the request to
-            # force query_mode='remote' / profile_after_sync=False — apply
-            # the same coercion to `merged` so the persisted row matches.
+            # force query_mode='remote' / profile_after_sync=False (or to
+            # leave a materialized row alone) — apply the same coercion to
+            # `merged` so the persisted row matches.
             synthetic = RegisterTableRequest(
                 name=merged.get("name") or table_id,
                 bucket=merged.get("bucket"),
                 source_table=merged.get("source_table"),
+                source_query=merged.get("source_query"),
                 source_type="bigquery",
                 query_mode=merged.get("query_mode") or "remote",
                 profile_after_sync=bool(merged.get("profile_after_sync") or False),
@@ -1380,6 +1511,7 @@ async def update_table(
             _validate_bigquery_register_payload(synthetic)
             merged["query_mode"] = synthetic.query_mode
             merged["profile_after_sync"] = synthetic.profile_after_sync
+            merged["source_query"] = synthetic.source_query
 
         repo.register(id=table_id, **merged)
 

--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -295,32 +295,49 @@ sys.exit(compute_exit_code(result, len(configs)))
 
             print(f"[SYNC] Starting extractor subprocess for {len(table_configs)} tables", file=_sys.stderr, flush=True)
 
-            result = subprocess.run(
-                cmd, input=_json.dumps(serializable), capture_output=True, text=True,
-                timeout=1800, env=env,
-                cwd=str(Path(__file__).parent.parent.parent),
-            )
-
-            if result.stdout:
-                print(f"[SYNC] Extractor stdout: {result.stdout.strip()[-500:]}", file=_sys.stderr, flush=True)
-            if result.stderr:
-                print(f"[SYNC] Extractor stderr: {result.stderr[-500:]}", file=_sys.stderr, flush=True)
-            # Issue #81 Group B: three exit codes. 0 = full success,
-            # 1 = full failure, 2 = partial. Partial is a data-quality
-            # alert, not a crash — the orchestrator's per-table _meta
-            # machinery already captured which tables succeeded; we just
-            # need to log loudly so operator alerting can pick it up.
-            if result.returncode == 0:
-                print(f"[SYNC] Extractor OK", file=_sys.stderr, flush=True)
-            elif result.returncode == 2:
+            try:
+                result = subprocess.run(
+                    cmd, input=_json.dumps(serializable), capture_output=True, text=True,
+                    timeout=1800, env=env,
+                    cwd=str(Path(__file__).parent.parent.parent),
+                )
+            except subprocess.TimeoutExpired:
+                # Catch the timeout LOCALLY so the materialized BQ pass and
+                # orchestrator rebuild below still fire. Pre-fix the timeout
+                # propagated to the outer except handler and skipped the rest
+                # of `_run_sync` — on a dual-source deployment a slow Keboola
+                # extractor would silently block all materialized parquets +
+                # master-view rebuild until the next trigger. Devin BUG_0001
+                # on PR #148 commit 2219255. Mirrors the per-custom-connector
+                # timeout pattern below (line ~347).
                 print(
-                    f"[SYNC] Extractor PARTIAL FAILURE (exit 2) — some tables "
-                    f"succeeded, some failed; see stderr for per-table errors. "
-                    f"Successful tables will still be published by the orchestrator.",
+                    "[SYNC] Extractor timed out after 1800s — continuing to "
+                    "materialized pass + orchestrator rebuild",
                     file=_sys.stderr, flush=True,
                 )
-            else:
-                print(f"[SYNC] Extractor FAILED (exit {result.returncode})", file=_sys.stderr, flush=True)
+                result = None
+
+            if result is not None:
+                if result.stdout:
+                    print(f"[SYNC] Extractor stdout: {result.stdout.strip()[-500:]}", file=_sys.stderr, flush=True)
+                if result.stderr:
+                    print(f"[SYNC] Extractor stderr: {result.stderr[-500:]}", file=_sys.stderr, flush=True)
+                # Issue #81 Group B: three exit codes. 0 = full success,
+                # 1 = full failure, 2 = partial. Partial is a data-quality
+                # alert, not a crash — the orchestrator's per-table _meta
+                # machinery already captured which tables succeeded; we just
+                # need to log loudly so operator alerting can pick it up.
+                if result.returncode == 0:
+                    print(f"[SYNC] Extractor OK", file=_sys.stderr, flush=True)
+                elif result.returncode == 2:
+                    print(
+                        f"[SYNC] Extractor PARTIAL FAILURE (exit 2) — some tables "
+                        f"succeeded, some failed; see stderr for per-table errors. "
+                        f"Successful tables will still be published by the orchestrator.",
+                        file=_sys.stderr, flush=True,
+                    )
+                else:
+                    print(f"[SYNC] Extractor FAILED (exit {result.returncode})", file=_sys.stderr, flush=True)
 
             # Run custom connectors (Tier A: local mount) — only when there
             # were local-mode tables to drive the extractor. Custom connectors

--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -234,20 +234,38 @@ def _run_sync(tables: Optional[List[str]] = None):
                 except Exception as e:
                     logger.warning("Auto-discovery failed: %s", e)
 
-            if not table_configs:
-                logger.warning("No tables to sync for source_type=%s", source_type)
-                return
+        # CRITICAL: don't early-return when local-mode tables are empty.
+        # `list_local("bigquery")` is always empty on BQ-only deployments
+        # (BQ rows are always remote or materialized, never local), so an
+        # early return would prevent the materialized pass AND the
+        # orchestrator rebuild from ever firing on a BQ-only instance.
+        # Devin BUG_0002 on PR #148 commit 2fa44f2. Just flag whether the
+        # Keboola subprocess + custom-connectors should run; everything
+        # below (materialized pass, orchestrator rebuild, profiler) runs
+        # unconditionally so a registry with materialized rows but no
+        # local rows still publishes them.
+        run_extractor_subprocess = bool(table_configs)
+        if not run_extractor_subprocess:
+            logger.info(
+                "No local-mode tables to sync for source_type=%s — "
+                "skipping extractor subprocess; materialized pass + "
+                "orchestrator rebuild still run.",
+                source_type,
+            )
 
-        # Serialize configs — strip non-serializable fields
-        serializable = []
-        for tc in table_configs:
-            serializable.append({k: (v.isoformat() if hasattr(v, 'isoformat') else v)
-                                 for k, v in tc.items() if v is not None})
-
-        # Run extractor subprocess with table configs via stdin
-        # Subprocess does NOT open system.duckdb — no lock conflict
         env = {**os.environ}
-        cmd = [sys.executable, "-c", """
+        import sys as _sys
+
+        if run_extractor_subprocess:
+            # Serialize configs — strip non-serializable fields
+            serializable = []
+            for tc in table_configs:
+                serializable.append({k: (v.isoformat() if hasattr(v, 'isoformat') else v)
+                                     for k, v in tc.items() if v is not None})
+
+            # Run extractor subprocess with table configs via stdin
+            # Subprocess does NOT open system.duckdb — no lock conflict
+            cmd = [sys.executable, "-c", """
 import json, sys, os, logging
 from pathlib import Path
 
@@ -275,58 +293,59 @@ print(json.dumps(result))
 sys.exit(compute_exit_code(result, len(configs)))
 """]
 
-        import sys as _sys
-        print(f"[SYNC] Starting extractor subprocess for {len(table_configs)} tables", file=_sys.stderr, flush=True)
+            print(f"[SYNC] Starting extractor subprocess for {len(table_configs)} tables", file=_sys.stderr, flush=True)
 
-        result = subprocess.run(
-            cmd, input=_json.dumps(serializable), capture_output=True, text=True,
-            timeout=1800, env=env,
-            cwd=str(Path(__file__).parent.parent.parent),
-        )
-
-        if result.stdout:
-            print(f"[SYNC] Extractor stdout: {result.stdout.strip()[-500:]}", file=_sys.stderr, flush=True)
-        if result.stderr:
-            print(f"[SYNC] Extractor stderr: {result.stderr[-500:]}", file=_sys.stderr, flush=True)
-        # Issue #81 Group B: three exit codes. 0 = full success,
-        # 1 = full failure, 2 = partial. Partial is a data-quality
-        # alert, not a crash — the orchestrator's per-table _meta
-        # machinery already captured which tables succeeded; we just
-        # need to log loudly so operator alerting can pick it up.
-        if result.returncode == 0:
-            print(f"[SYNC] Extractor OK", file=_sys.stderr, flush=True)
-        elif result.returncode == 2:
-            print(
-                f"[SYNC] Extractor PARTIAL FAILURE (exit 2) — some tables "
-                f"succeeded, some failed; see stderr for per-table errors. "
-                f"Successful tables will still be published by the orchestrator.",
-                file=_sys.stderr, flush=True,
+            result = subprocess.run(
+                cmd, input=_json.dumps(serializable), capture_output=True, text=True,
+                timeout=1800, env=env,
+                cwd=str(Path(__file__).parent.parent.parent),
             )
-        else:
-            print(f"[SYNC] Extractor FAILED (exit {result.returncode})", file=_sys.stderr, flush=True)
 
-        # Run custom connectors (Tier A: local mount)
-        connectors_dir = Path(os.environ.get("CONNECTORS_DIR", str(Path(__file__).parent.parent.parent / "connectors" / "custom")))
-        if connectors_dir.exists():
-            for connector_dir in sorted(connectors_dir.iterdir()):
-                if not connector_dir.is_dir():
-                    continue
-                extractor = connector_dir / "extractor.py"
-                if not extractor.exists():
-                    continue
-                logger.info("Running custom connector: %s", connector_dir.name)
-                try:
-                    custom_result = subprocess.run(
-                        [sys.executable, str(extractor)],
-                        env=env, capture_output=True, text=True, timeout=600,
-                        cwd=str(Path(__file__).parent.parent.parent),
-                    )
-                    if custom_result.returncode != 0:
-                        logger.error("Custom connector %s failed: %s", connector_dir.name, custom_result.stderr[-500:])
-                    else:
-                        logger.info("Custom connector %s completed", connector_dir.name)
-                except subprocess.TimeoutExpired:
-                    logger.error("Custom connector %s timed out", connector_dir.name)
+            if result.stdout:
+                print(f"[SYNC] Extractor stdout: {result.stdout.strip()[-500:]}", file=_sys.stderr, flush=True)
+            if result.stderr:
+                print(f"[SYNC] Extractor stderr: {result.stderr[-500:]}", file=_sys.stderr, flush=True)
+            # Issue #81 Group B: three exit codes. 0 = full success,
+            # 1 = full failure, 2 = partial. Partial is a data-quality
+            # alert, not a crash — the orchestrator's per-table _meta
+            # machinery already captured which tables succeeded; we just
+            # need to log loudly so operator alerting can pick it up.
+            if result.returncode == 0:
+                print(f"[SYNC] Extractor OK", file=_sys.stderr, flush=True)
+            elif result.returncode == 2:
+                print(
+                    f"[SYNC] Extractor PARTIAL FAILURE (exit 2) — some tables "
+                    f"succeeded, some failed; see stderr for per-table errors. "
+                    f"Successful tables will still be published by the orchestrator.",
+                    file=_sys.stderr, flush=True,
+                )
+            else:
+                print(f"[SYNC] Extractor FAILED (exit {result.returncode})", file=_sys.stderr, flush=True)
+
+            # Run custom connectors (Tier A: local mount) — only when there
+            # were local-mode tables to drive the extractor. Custom connectors
+            # currently piggyback on the same env as the Keboola extractor.
+            connectors_dir = Path(os.environ.get("CONNECTORS_DIR", str(Path(__file__).parent.parent.parent / "connectors" / "custom")))
+            if connectors_dir.exists():
+                for connector_dir in sorted(connectors_dir.iterdir()):
+                    if not connector_dir.is_dir():
+                        continue
+                    extractor = connector_dir / "extractor.py"
+                    if not extractor.exists():
+                        continue
+                    logger.info("Running custom connector: %s", connector_dir.name)
+                    try:
+                        custom_result = subprocess.run(
+                            [sys.executable, str(extractor)],
+                            env=env, capture_output=True, text=True, timeout=600,
+                            cwd=str(Path(__file__).parent.parent.parent),
+                        )
+                        if custom_result.returncode != 0:
+                            logger.error("Custom connector %s failed: %s", connector_dir.name, custom_result.stderr[-500:])
+                        else:
+                            logger.info("Custom connector %s completed", connector_dir.name)
+                    except subprocess.TimeoutExpired:
+                        logger.error("Custom connector %s timed out", connector_dir.name)
 
         # Materialized BigQuery pass — runs admin-registered SQL through the
         # DuckDB BQ extension (via BqAccess) and writes parquet for due rows.

--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -78,14 +78,23 @@ def _run_materialized_pass(conn: duckdb.DuckDBPyConnection, bq) -> dict:
     # Sentinel: max_bytes <= 0 (or None) disables the guardrail. `get_value()`
     # treats YAML `null` as "missing" → returns the default; operators must use
     # the explicit `0` sentinel to disable. See config/instance.yaml.example.
+    # YAML accepts floats too (e.g. `10737418240.0`), and operators may
+    # write `1e10` for readability; coerce to int and tolerate non-numeric
+    # entries by falling through to the disable path with a warning.
     raw_max = get_value(
         "data_source", "bigquery", "max_bytes_per_materialize",
         default=10 * 2**30,
     )
-    bq_max_bytes = (
-        raw_max if (raw_max is not None and isinstance(raw_max, int) and raw_max > 0)
-        else None
-    )
+    try:
+        n = int(raw_max) if raw_max is not None else 0
+    except (TypeError, ValueError):
+        logger.warning(
+            "data_source.bigquery.max_bytes_per_materialize is not numeric "
+            "(%r); cost guardrail disabled. Set an integer or 0 to disable.",
+            raw_max,
+        )
+        n = 0
+    bq_max_bytes = n if n > 0 else None
 
     registry = TableRegistryRepository(conn)
     state = SyncStateRepository(conn)

--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -95,16 +95,25 @@ def _run_materialized_pass(conn: duckdb.DuckDBPyConnection, bq) -> dict:
         if row.get("query_mode") != "materialized":
             continue
 
-        last = state.get_last_sync(row["id"])
+        # Convention across connectors: sync_state.table_id and the parquet
+        # filename are keyed by `table_registry.name` (matches Keboola's
+        # `_meta.table_name`) so the manifest's `registry_by_name` lookup
+        # at `_build_manifest_for_user` resolves cleanly. Without this,
+        # admins who register `name="Orders_90d"` (id slugified to
+        # `orders_90d`) would see `query_mode` default to `"local"` in the
+        # manifest because the lookup misses on `id`.
+        ref_name = row["name"]
+
+        last = state.get_last_sync(ref_name)
         last_iso = last.isoformat() if last else None
         schedule = row.get("sync_schedule") or "every 1h"
         if not is_table_due(schedule, last_iso):
-            summary["skipped"].append(row["id"])
+            summary["skipped"].append(ref_name)
             continue
 
         try:
             stats = _materialize_table(
-                table_id=row["id"],
+                table_id=ref_name,
                 sql=row["source_query"],
                 bq=bq,
                 output_dir=output_dir,
@@ -116,15 +125,15 @@ def _run_materialized_pass(conn: duckdb.DuckDBPyConnection, bq) -> dict:
                 e.table_id, f"{e.current:,}", f"{e.limit:,}",
             )
             summary["errors"].append({
-                "table": row["id"],
+                "table": ref_name,
                 "error": str(e),
                 "current": e.current,
                 "limit": e.limit,
             })
             continue
         except Exception as e:
-            logger.exception("Materialize failed for %s", row["id"])
-            summary["errors"].append({"table": row["id"], "error": str(e)})
+            logger.exception("Materialize failed for %s", ref_name)
+            summary["errors"].append({"table": ref_name, "error": str(e)})
             continue
 
         # `materialize_query` returns the parquet's MD5 inline — hashing
@@ -133,15 +142,15 @@ def _run_materialized_pass(conn: duckdb.DuckDBPyConnection, bq) -> dict:
         # reason the stats dict didn't carry it (defensive).
         parquet_hash = stats.get("hash")
         if not parquet_hash:
-            parquet_path = Path(output_dir) / "data" / f"{row['id']}.parquet"
+            parquet_path = Path(output_dir) / "data" / f"{ref_name}.parquet"
             parquet_hash = _file_hash(parquet_path)
         state.update_sync(
-            table_id=row["id"],
+            table_id=ref_name,
             rows=stats["rows"],
             file_size_bytes=stats["size_bytes"],
             hash=parquet_hash,
         )
-        summary["materialized"].append(row["id"])
+        summary["materialized"].append(ref_name)
 
     return summary
 

--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -36,6 +36,112 @@ def _file_hash(path: Path) -> str:
     return h.hexdigest()
 
 
+def _materialize_table(
+    *,
+    table_id: str,
+    sql: str,
+    bq,
+    output_dir: str,
+    max_bytes: Optional[int],
+) -> dict:
+    """Thin wrapper around `connectors.bigquery.extractor.materialize_query`
+    so the trigger pass can be unit-tested by patching this seam without
+    touching the real BqAccess factory or the duckdb import."""
+    from connectors.bigquery.extractor import materialize_query
+    return materialize_query(
+        table_id=table_id, sql=sql, bq=bq,
+        output_dir=output_dir, max_bytes=max_bytes,
+    )
+
+
+def _run_materialized_pass(conn: duckdb.DuckDBPyConnection, bq) -> dict:
+    """Walk `table_registry` for `query_mode='materialized'` rows and run any
+    that are due. Honors per-table `sync_schedule` via `is_table_due()`,
+    writes the parquet via `_materialize_table`, computes the file hash
+    inline, and updates `sync_state` so the manifest can serve the row to
+    `da sync` without re-hashing on every request.
+
+    Returns:
+        ``{"materialized": [ids], "skipped": [ids], "errors": [{table, error}]}``
+
+    Errors are aggregated per row — one budget-blown table doesn't stop a
+    healthy sibling. ``MaterializeBudgetError`` is caught and rendered with
+    its structured fields so operator alerting can pick out the cap-vs-actual
+    bytes from the log line.
+    """
+    from src.scheduler import is_table_due
+    from app.instance_config import get_value
+    from connectors.bigquery.extractor import MaterializeBudgetError
+
+    output_dir = str(Path(_get_data_dir()) / "extracts" / "bigquery")
+
+    # Sentinel: max_bytes <= 0 (or None) disables the guardrail. `get_value()`
+    # treats YAML `null` as "missing" → returns the default; operators must use
+    # the explicit `0` sentinel to disable. See config/instance.yaml.example.
+    raw_max = get_value(
+        "data_source", "bigquery", "max_bytes_per_materialize",
+        default=10 * 2**30,
+    )
+    bq_max_bytes = (
+        raw_max if (raw_max is not None and isinstance(raw_max, int) and raw_max > 0)
+        else None
+    )
+
+    registry = TableRegistryRepository(conn)
+    state = SyncStateRepository(conn)
+
+    summary = {"materialized": [], "skipped": [], "errors": []}
+    for row in registry.list_all():
+        if row.get("query_mode") != "materialized":
+            continue
+
+        last = state.get_last_sync(row["id"])
+        last_iso = last.isoformat() if last else None
+        schedule = row.get("sync_schedule") or "every 1h"
+        if not is_table_due(schedule, last_iso):
+            summary["skipped"].append(row["id"])
+            continue
+
+        try:
+            stats = _materialize_table(
+                table_id=row["id"],
+                sql=row["source_query"],
+                bq=bq,
+                output_dir=output_dir,
+                max_bytes=bq_max_bytes,
+            )
+        except MaterializeBudgetError as e:
+            logger.warning(
+                "Materialize cap exceeded for %s: %s bytes > %s bytes",
+                e.table_id, f"{e.current:,}", f"{e.limit:,}",
+            )
+            summary["errors"].append({
+                "table": row["id"],
+                "error": str(e),
+                "current": e.current,
+                "limit": e.limit,
+            })
+            continue
+        except Exception as e:
+            logger.exception("Materialize failed for %s", row["id"])
+            summary["errors"].append({"table": row["id"], "error": str(e)})
+            continue
+
+        # Compute hash inline so the manifest can serve it immediately
+        # and `da sync` honors the delta-skip on unchanged tables.
+        parquet_path = Path(output_dir) / "data" / f"{row['id']}.parquet"
+        parquet_hash = _file_hash(parquet_path)
+        state.update_sync(
+            table_id=row["id"],
+            rows=stats["rows"],
+            file_size_bytes=stats["size_bytes"],
+            hash=parquet_hash,
+        )
+        summary["materialized"].append(row["id"])
+
+    return summary
+
+
 def _run_sync(tables: Optional[List[str]] = None):
     """Run extractor as subprocess + orchestrator rebuild.
 
@@ -199,6 +305,43 @@ sys.exit(compute_exit_code(result, len(configs)))
                         logger.info("Custom connector %s completed", connector_dir.name)
                 except subprocess.TimeoutExpired:
                     logger.error("Custom connector %s timed out", connector_dir.name)
+
+        # Materialized BigQuery pass — runs admin-registered SQL through the
+        # DuckDB BQ extension (via BqAccess) and writes parquet for due rows.
+        # The orchestrator rebuild below picks the parquets up via the
+        # standard local-parquet discovery. Wrapped so a misconfigured BQ
+        # facade doesn't kill the Keboola path.
+        try:
+            from app.instance_config import get_value as _get_value
+            bq_project = _get_value(
+                "data_source", "bigquery", "project", default=""
+            ) or ""
+            if bq_project:
+                from connectors.bigquery.access import get_bq_access
+                from src.db import get_system_db as _get_system_db
+                bq_access = get_bq_access()
+                mat_conn = _get_system_db()
+                try:
+                    mat_summary = _run_materialized_pass(mat_conn, bq_access)
+                finally:
+                    mat_conn.close()
+                print(
+                    f"[SYNC] Materialized BQ: {len(mat_summary['materialized'])} ok, "
+                    f"{len(mat_summary['skipped'])} skipped, "
+                    f"{len(mat_summary['errors'])} errors",
+                    file=_sys.stderr, flush=True,
+                )
+                for err in mat_summary["errors"]:
+                    print(
+                        f"[SYNC]   {err['table']}: {err['error']}",
+                        file=_sys.stderr, flush=True,
+                    )
+        except Exception as e:
+            print(
+                f"[SYNC] Materialized BQ pass FAILED: {e}",
+                file=_sys.stderr, flush=True,
+            )
+            traceback.print_exc()
 
         # Rebuild master views (reads extract.duckdb files, no write conflict)
         from src.orchestrator import SyncOrchestrator

--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -127,10 +127,14 @@ def _run_materialized_pass(conn: duckdb.DuckDBPyConnection, bq) -> dict:
             summary["errors"].append({"table": row["id"], "error": str(e)})
             continue
 
-        # Compute hash inline so the manifest can serve it immediately
-        # and `da sync` honors the delta-skip on unchanged tables.
-        parquet_path = Path(output_dir) / "data" / f"{row['id']}.parquet"
-        parquet_hash = _file_hash(parquet_path)
+        # `materialize_query` returns the parquet's MD5 inline — hashing
+        # there means we don't re-read a multi-GB file on the request
+        # thread. Fallback to `_file_hash(parquet_path)` if for some
+        # reason the stats dict didn't carry it (defensive).
+        parquet_hash = stats.get("hash")
+        if not parquet_hash:
+            parquet_path = Path(output_dir) / "data" / f"{row['id']}.parquet"
+            parquet_hash = _file_hash(parquet_path)
         state.update_sync(
             table_id=row["id"],
             rows=stats["rows"],

--- a/app/web/templates/admin_tables.html
+++ b/app/web/templates/admin_tables.html
@@ -760,7 +760,7 @@
                     </div>
                     <div>
                         <div class="panel-title">Register BigQuery Table</div>
-                        <div class="panel-subtitle">Register a BQ table, view, or custom SQL query for analyst access</div>
+                        <div class="panel-subtitle">Make a BQ table or query available to analysts</div>
                     </div>
                 </div>
                 <button class="btn btn-primary" onclick="openBigQueryRegisterModal()">
@@ -768,11 +768,14 @@
                 </button>
             </div>
             <div class="panel-body-empty">
-                Pick the entity type in the modal — <strong>Table</strong> (a BQ table queried on demand),
-                <strong>View</strong> (a BQ view, same trade-off),
-                or <strong>Custom SQL Query</strong> (a scheduled SELECT that materializes to a local parquet
-                analysts download via <code>da sync</code>). Dataset + table autocomplete is not implemented yet —
-                type them by hand.
+                The form starts with one question — <strong>Live from BigQuery</strong> (each
+                analyst query goes straight to BQ; always current) or <strong>Synced
+                locally</strong> (Agnes runs a SELECT on a schedule and serves a local copy;
+                sub-100&nbsp;ms queries). Synced gives you a follow-up: full table or your
+                own SQL.
+                Dataset and table inputs autocomplete from your BQ project — click
+                <strong>Discover</strong> to populate the dataset list and
+                <strong>List tables</strong> for the per-dataset table list.
             </div>
         </div>
         {% else %}
@@ -863,26 +866,65 @@
             </div>
             <div class="modal-body">
                 {% if data_source_type == 'bigquery' %}
-                {# BigQuery path — `Mode` controls remote-view vs. materialized-parquet.
-                   `bqQueryMode` toggles between the dataset/source-table fields
-                   (remote) and the source_query textarea (materialized). #}
+                {# Two orthogonal questions: (1) live vs synced, (2) when synced,
+                   whole table vs custom SQL. Visibility classes:
+                     bq-access-live    — only when accessMode='live'
+                     bq-access-synced  — only when accessMode='synced'
+                     bq-source-table   — only when accessMode='live' OR
+                                         (accessMode='synced' AND syncMode='whole')
+                     bq-source-custom  — only when accessMode='synced' AND syncMode='custom'
+                   Backend payload: live → query_mode='remote'; synced/whole →
+                   query_mode='materialized' with auto-built SELECT *; synced/custom
+                   → query_mode='materialized' with admin SQL. Server auto-detects
+                   BASE TABLE vs VIEW at register time, so the UI doesn't ask. #}
                 <div class="form-group">
-                    <label class="form-label" for="bqEntityType">Type</label>
-                    <select class="form-select" id="bqEntityType" onchange="onBqTypeChange()">
-                        <option value="table">Table — query a BQ table on demand (no local copy)</option>
-                        <option value="view">View — query a BQ view on demand (jobs API)</option>
-                        <option value="query">Custom SQL Query — scheduled SELECT writes parquet, distributed via da sync</option>
-                    </select>
-                    <div class="form-hint" id="bqEntityHint">
-                        <!-- Filled by onBqTypeChange() — describes trade-offs for the
-                             selected entity type. Default text matches `table`. -->
-                        <strong>Table:</strong> latency ~seconds (BQ roundtrip per query); 0 disk;
-                        cost = bytes scanned per analyst-query. Best for tables that fit on disk
-                        but you want to avoid sync overhead, or tables analysts only touch
-                        occasionally.
+                    <label class="form-label">How should analysts access this data?</label>
+                    <div class="bq-access-radio-group" style="display:flex; gap:12px; margin-top:6px;">
+                        <label style="flex:1; padding:12px; border:1px solid var(--border); border-radius:8px; cursor:pointer;">
+                            <input type="radio" name="bqAccessMode" value="live" checked onchange="onBqAccessModeChange()">
+                            <strong>Live from BigQuery</strong>
+                            <div style="font-size:12px; color:var(--text-secondary); margin-top:4px;">
+                                Each analyst query goes straight to BQ. Always current.
+                                Latency ≈ seconds; 0 disk on the analyst machine; cost =
+                                bytes scanned per query. Best for huge tables or when
+                                freshness matters.
+                            </div>
+                        </label>
+                        <label style="flex:1; padding:12px; border:1px solid var(--border); border-radius:8px; cursor:pointer;">
+                            <input type="radio" name="bqAccessMode" value="synced" onchange="onBqAccessModeChange()">
+                            <strong>Synced locally</strong>
+                            <div style="font-size:12px; color:var(--text-secondary); margin-top:4px;">
+                                Agnes runs a SELECT on a schedule and ships a parquet
+                                to analysts. Analyst-side latency &lt;100&nbsp;ms; disk =
+                                snapshot size. Best when analysts hit the same data
+                                often and speed beats freshness.
+                            </div>
+                        </label>
                     </div>
                 </div>
-                <div class="form-group bq-type-table bq-type-view">
+                <div class="form-group bq-access-synced" style="display:none;">
+                    <label class="form-label">What to sync?</label>
+                    <div class="bq-sync-radio-group" style="display:flex; gap:12px; margin-top:6px;">
+                        <label style="flex:1; padding:12px; border:1px solid var(--border); border-radius:8px; cursor:pointer;">
+                            <input type="radio" name="bqSyncMode" value="whole" checked onchange="onBqSyncModeChange()">
+                            <strong>Whole table</strong>
+                            <div style="font-size:12px; color:var(--text-secondary); margin-top:4px;">
+                                Agnes runs <code>SELECT *</code> automatically. No SQL
+                                required. Disk + sync cost = full table size.
+                            </div>
+                        </label>
+                        <label style="flex:1; padding:12px; border:1px solid var(--border); border-radius:8px; cursor:pointer;">
+                            <input type="radio" name="bqSyncMode" value="custom" onchange="onBqSyncModeChange()">
+                            <strong>Custom query</strong>
+                            <div style="font-size:12px; color:var(--text-secondary); margin-top:4px;">
+                                You write the SELECT — filter, project, or aggregate
+                                before the sync. Cuts disk + cost; cap via
+                                <code>max_bytes_per_materialize</code> guardrail.
+                            </div>
+                        </label>
+                    </div>
+                </div>
+                <div class="form-group bq-source-table">
                     <label class="form-label" for="bqDataset">
                         Dataset
                         <button type="button" class="btn btn-secondary btn-sm"
@@ -895,7 +937,7 @@
                     <div class="form-hint">BigQuery dataset name (no project prefix — read from instance.yaml).
                         Click <strong>Discover</strong> to populate the autocomplete from the BQ project's dataset list.</div>
                 </div>
-                <div class="form-group bq-type-table bq-type-view">
+                <div class="form-group bq-source-table">
                     <label class="form-label" for="bqSourceTable">
                         Source Table / View
                         <button type="button" class="btn btn-secondary btn-sm"
@@ -905,11 +947,11 @@
                     </label>
                     <input type="text" class="form-input" id="bqSourceTable" list="bqTableList" placeholder="e.g. orders">
                     <datalist id="bqTableList"></datalist>
-                    <div class="form-hint">Table or view name within the dataset. The server auto-detects
-                        BASE TABLE vs VIEW at registration time. Click <strong>List tables</strong> after
-                        filling Dataset to populate the autocomplete from BQ.</div>
+                    <div class="form-hint">Table or view name within the dataset. Agnes auto-detects whether
+                        it's a BASE TABLE or a VIEW and routes the query path accordingly. Click
+                        <strong>List tables</strong> after filling Dataset to populate the autocomplete.</div>
                 </div>
-                <div class="form-group bq-type-query" style="display:none;">
+                <div class="form-group bq-source-custom" style="display:none;">
                     <label class="form-label" for="bqSourceQuery">
                         SQL
                         <button type="button" class="btn btn-secondary btn-sm"
@@ -930,7 +972,9 @@
                 <div class="form-group">
                     <label class="form-label" for="bqViewName">View Name</label>
                     <input type="text" class="form-input" id="bqViewName" placeholder="orders_90d">
-                    <div class="form-hint">DuckDB view name analysts will use. Required for Custom SQL; defaults to the source table for Table/View.</div>
+                    <div class="form-hint">Name analysts use to query the data (e.g.
+                        <code>SELECT * FROM orders_90d</code>). Required for Custom query; defaults
+                        to the source table for the other modes.</div>
                 </div>
                 <div class="form-group">
                     <label class="form-label" for="bqDescription">Description <span class="optional">(optional)</span></label>
@@ -941,12 +985,13 @@
                     <input type="text" class="form-input" id="bqFolder" placeholder="e.g. crm, finance, marketing">
                     <div class="form-hint">Logical grouping for catalog organization</div>
                 </div>
-                <div class="form-group">
-                    <label class="form-label" for="bqSyncSchedule">Sync Schedule <span class="optional">(optional, default <code>every 1h</code> for Custom SQL)</span></label>
+                <div class="form-group bq-access-synced" style="display:none;">
+                    <label class="form-label" for="bqSyncSchedule">Sync Schedule <span class="optional">(optional, default <code>every 1h</code>)</span></label>
                     <input type="text" class="form-input" id="bqSyncSchedule" placeholder="every 6h">
                     <div class="form-hint">
-                        Examples: <code>every 15m</code>, <code>every 6h</code>, <code>daily 03:00</code>, <code>daily 07:00,13:00,18:00</code> (UTC).
-                        Honored by Custom SQL (materialized) — Table/View are queried live and ignore this field.
+                        How often Agnes refreshes the local copy. Examples:
+                        <code>every 15m</code>, <code>every 6h</code>,
+                        <code>daily 03:00</code>, <code>daily 07:00,13:00,18:00</code> (UTC).
                     </div>
                 </div>
                 <div class="form-group" id="bqPrecheckSummary" style="display:none;">
@@ -1033,39 +1078,71 @@
                      Table/View, SQL textarea for Query). Hidden for Keboola
                      rows. Wired by populateEditModal(table). -->
                 <div class="form-group bq-edit-only" style="display:none;">
-                    <label class="form-label" for="editBqEntityType">Type</label>
-                    <select class="form-select" id="editBqEntityType" onchange="onEditBqTypeChange()">
-                        <option value="table">Table — query a BQ table on demand</option>
-                        <option value="view">View — query a BQ view on demand (jobs API)</option>
-                        <option value="query">Custom SQL Query — scheduled SELECT writes parquet</option>
-                    </select>
+                    <label class="form-label">How should analysts access this data?</label>
+                    <div style="display:flex; gap:12px; margin-top:6px;">
+                        <label style="flex:1; padding:10px; border:1px solid var(--border); border-radius:8px; cursor:pointer;">
+                            <input type="radio" name="editBqAccessMode" value="live" onchange="onEditBqAccessModeChange()">
+                            <strong>Live from BigQuery</strong>
+                            <div style="font-size:12px; color:var(--text-secondary); margin-top:4px;">
+                                Each query goes to BQ. No local copy.
+                            </div>
+                        </label>
+                        <label style="flex:1; padding:10px; border:1px solid var(--border); border-radius:8px; cursor:pointer;">
+                            <input type="radio" name="editBqAccessMode" value="synced" onchange="onEditBqAccessModeChange()">
+                            <strong>Synced locally</strong>
+                            <div style="font-size:12px; color:var(--text-secondary); margin-top:4px;">
+                                Scheduled SELECT → parquet, queried locally.
+                            </div>
+                        </label>
+                    </div>
                     <div class="form-hint" id="editBqModeWarning" style="display:none;
-                         color:#EA580C;background:rgba(234,88,12,.08);padding:8px;border-radius:6px;">
-                        <!-- Filled by onEditBqTypeChange() when switching mode
-                             on an existing row — warns that parquet/source data
-                             will be discarded. -->
+                         color:#EA580C;background:rgba(234,88,12,.08);padding:8px;border-radius:6px;margin-top:8px;">
+                        <!-- Filled by onEditBqAccessModeChange() when switching
+                             modes on an existing row — warns about parquet
+                             drop / scheduling impact. -->
                     </div>
                 </div>
-                <div class="form-group bq-edit-only bq-edit-type-table bq-edit-type-view" style="display:none;">
+                <div class="form-group bq-edit-only bq-edit-access-synced" style="display:none;">
+                    <label class="form-label">What to sync?</label>
+                    <div style="display:flex; gap:12px; margin-top:6px;">
+                        <label style="flex:1; padding:10px; border:1px solid var(--border); border-radius:8px; cursor:pointer;">
+                            <input type="radio" name="editBqSyncMode" value="whole" onchange="onEditBqSyncModeChange()">
+                            <strong>Whole table</strong>
+                            <div style="font-size:12px; color:var(--text-secondary); margin-top:4px;">
+                                <code>SELECT *</code> on a schedule.
+                            </div>
+                        </label>
+                        <label style="flex:1; padding:10px; border:1px solid var(--border); border-radius:8px; cursor:pointer;">
+                            <input type="radio" name="editBqSyncMode" value="custom" onchange="onEditBqSyncModeChange()">
+                            <strong>Custom query</strong>
+                            <div style="font-size:12px; color:var(--text-secondary); margin-top:4px;">
+                                Filter / aggregate before sync.
+                            </div>
+                        </label>
+                    </div>
+                </div>
+                <div class="form-group bq-edit-only bq-edit-source-table" style="display:none;">
                     <label class="form-label" for="editBqDataset">Dataset</label>
                     <input type="text" class="form-input" id="editBqDataset" placeholder="e.g. analytics">
                 </div>
-                <div class="form-group bq-edit-only bq-edit-type-table bq-edit-type-view" style="display:none;">
+                <div class="form-group bq-edit-only bq-edit-source-table" style="display:none;">
                     <label class="form-label" for="editBqSourceTable">Source Table / View</label>
                     <input type="text" class="form-input" id="editBqSourceTable" placeholder="e.g. orders">
+                    <div class="form-hint">Agnes auto-detects whether this is a table or a view.</div>
                 </div>
-                <div class="form-group bq-edit-only bq-edit-type-query" style="display:none;">
+                <div class="form-group bq-edit-only bq-edit-source-custom" style="display:none;">
                     <label class="form-label" for="editBqSourceQuery">SQL</label>
                     <textarea class="form-textarea" id="editBqSourceQuery" rows="8"></textarea>
                     <div class="form-hint">SELECT statement, no trailing semicolon. Native BQ
                         identifiers recommended for the cost guardrail to engage.</div>
                 </div>
-                <div class="form-group bq-edit-only" style="display:none;">
+                <div class="form-group bq-edit-only bq-edit-access-synced" style="display:none;">
                     <label class="form-label" for="editBqSyncSchedule">Sync Schedule
-                        <span class="optional">(optional, materialized only)</span></label>
+                        <span class="optional">(optional)</span></label>
                     <input type="text" class="form-input" id="editBqSyncSchedule" placeholder="every 6h">
-                    <div class="form-hint"><code>every 15m</code>, <code>every 6h</code>,
-                        <code>daily 03:00</code> (UTC). Honored by Custom SQL.</div>
+                    <div class="form-hint">How often Agnes refreshes the local copy.
+                        <code>every 15m</code>, <code>every 6h</code>,
+                        <code>daily 03:00</code> (UTC).</div>
                 </div>
 
                 <!-- Keboola-only fields (existing). Hidden for BQ rows. -->
@@ -1395,21 +1472,34 @@
         };
     }
 
+    function _getBqAccessMode() {
+        // Q1 radio. Default 'live' if nothing's checked yet (model-validator
+        // safety net for the initial render).
+        var el = document.querySelector('input[name="bqAccessMode"]:checked');
+        return el ? el.value : 'live';
+    }
+
+    function _getBqSyncMode() {
+        // Q2 radio (only meaningful when access mode is 'synced').
+        var el = document.querySelector('input[name="bqSyncMode"]:checked');
+        return el ? el.value : 'whole';
+    }
+
     function _buildBigQueryPayload() {
-        // The UI's Type selector is operator-facing UX (Table / View / Custom
-        // SQL Query); the backend payload maps it onto query_mode (remote
-        // vs materialized). Table and View both go to query_mode='remote' —
-        // the BQ extractor auto-detects the entity type via INFORMATION_SCHEMA
-        // at register time and routes BASE TABLE through the Storage Read
-        // API while VIEW goes through bigquery_query() (jobs API). Query
-        // is materialized.
-        var entityType = document.getElementById('bqEntityType').value || 'table';
+        // Two-question form maps to backend `query_mode`:
+        //   live          → query_mode='remote'        (server auto-detects
+        //                                               BASE TABLE vs VIEW)
+        //   synced/whole  → query_mode='materialized'  (auto SELECT *)
+        //   synced/custom → query_mode='materialized'  (admin SQL)
+        // The UI never asks "Table vs View" — that's a server-side detail.
+        var accessMode = _getBqAccessMode();
+        var syncMode = _getBqSyncMode();
         var viewName = document.getElementById('bqViewName').value.trim();
         var description = document.getElementById('bqDescription').value.trim() || null;
         var folder = document.getElementById('bqFolder').value.trim() || null;
         var syncSchedule = document.getElementById('bqSyncSchedule').value.trim() || null;
 
-        if (entityType === 'query') {
+        if (accessMode === 'synced' && syncMode === 'custom') {
             return {
                 name: viewName,
                 source_type: 'bigquery',
@@ -1422,12 +1512,31 @@
             };
         }
 
-        // Table / View — query_mode='remote', server auto-detects entity
-        // shape on register. The frontend doesn't send entity_type because
-        // we don't trust an operator-asserted type (a typo'd "view" on a
-        // BASE TABLE would silently route the wrong way).
         var dataset = document.getElementById('bqDataset').value.trim();
         var sourceTable = document.getElementById('bqSourceTable').value.trim();
+
+        if (accessMode === 'synced' && syncMode === 'whole') {
+            // Whole-table sync. We don't ship the project to the browser, so
+            // the SQL uses DuckDB three-part syntax against the materialize
+            // session's ATTACH alias. Native BQ dry-run can't parse this form
+            // (DuckDB identifier quoting), so the cost guardrail falls
+            // fail-open with a warning — operator who needs the cap to engage
+            // picks Custom query and writes backtick-quoted native BQ
+            // identifiers.
+            return {
+                name: viewName || sourceTable,
+                source_type: 'bigquery',
+                query_mode: 'materialized',
+                source_query: 'SELECT * FROM bq."' + dataset + '"."' + sourceTable + '"',
+                profile_after_sync: false,
+                description: description,
+                folder: folder,
+                sync_schedule: syncSchedule,
+            };
+        }
+
+        // Live access — server auto-detects BASE TABLE vs VIEW at register
+        // time, so the UI doesn't make the operator pick.
         return {
             name: viewName || sourceTable,
             source_type: 'bigquery',
@@ -1441,49 +1550,47 @@
         };
     }
 
-    var _BQ_HINT_BY_TYPE = {
-        'table':
-            "<strong>Table:</strong> latency ~seconds (BQ roundtrip per query); 0 disk; "
-            + "cost = bytes scanned per analyst-query. Best for tables that fit on disk "
-            + "but you want to avoid sync overhead, or tables analysts only touch "
-            + "occasionally. Server uses BQ Storage Read API for full-table scans.",
-        'view':
-            "<strong>View:</strong> same on-demand semantics as Table, but the server "
-            + "routes through <code>bigquery_query()</code> (jobs API) instead of the "
-            + "Storage Read API — required because BQ views can't be attached as "
-            + "tables. Latency slightly higher than Table; cost the same per query.",
-        'query':
-            "<strong>Custom SQL:</strong> the scheduler runs your SELECT on "
-            + "<code>sync_schedule</code> and writes the result as a parquet that "
-            + "<code>da sync</code> distributes to analysts. Latency on the analyst "
-            + "side is <100 ms (local read); cost = one BQ scan per schedule tick "
-            + "regardless of how many analysts query it. Cap via "
-            + "<code>data_source.bigquery.max_bytes_per_materialize</code> "
-            + "(default 10 GiB).",
-    };
-
-    function onBqTypeChange() {
-        // Show / hide the per-type field groups. Table and View share
-        // bqDataset + bqSourceTable (both have the same input shape, server
-        // auto-detects which is which). Query swaps in bqSourceQuery + the
-        // "Use table as base" prefill button. View Name + Description +
-        // Folder + Sync Schedule are shared.
-        var entityType = document.getElementById('bqEntityType').value;
-        var byClass = {
-            'table': document.querySelectorAll('.bq-type-table'),
-            'view': document.querySelectorAll('.bq-type-view'),
-            'query': document.querySelectorAll('.bq-type-query'),
-        };
-        // A field with both `bq-type-table` and `bq-type-view` shows for
-        // either selection. Resolve via "is this element tagged for the
-        // current type?".
-        Object.keys(byClass).forEach(function(t) {
-            byClass[t].forEach(function(el) {
-                el.style.display = el.classList.contains('bq-type-' + entityType) ? '' : 'none';
-            });
+    function onBqAccessModeChange() {
+        // Q1: toggle live ↔ synced. Q2 (sync mode) is meaningful only when
+        // synced; default it to 'whole' on first reveal so the form stays
+        // consistent without forcing the operator to click twice.
+        var accessMode = _getBqAccessMode();
+        var liveFields = document.querySelectorAll('.bq-access-live');
+        var syncedFields = document.querySelectorAll('.bq-access-synced');
+        liveFields.forEach(function(el) {
+            el.style.display = (accessMode === 'live') ? '' : 'none';
         });
-        var hint = document.getElementById('bqEntityHint');
-        if (hint) hint.innerHTML = _BQ_HINT_BY_TYPE[entityType] || '';
+        syncedFields.forEach(function(el) {
+            el.style.display = (accessMode === 'synced') ? '' : 'none';
+        });
+        // Q2 is fresh on first reveal; trigger its handler to apply the
+        // source-table vs source-custom visibility rules.
+        if (accessMode === 'synced') {
+            onBqSyncModeChange();
+        } else {
+            // Live mode: show source-table fields, hide custom-SQL textarea.
+            document.querySelectorAll('.bq-source-table').forEach(function(el) {
+                el.style.display = '';
+            });
+            document.querySelectorAll('.bq-source-custom').forEach(function(el) {
+                el.style.display = 'none';
+            });
+        }
+    }
+
+    function onBqSyncModeChange() {
+        // Q2: toggle whole-table ↔ custom-SQL. Whole reuses the
+        // dataset/source-table inputs (server-side SELECT *), Custom shows
+        // the SQL textarea. Only fires when access mode is already 'synced'.
+        var syncMode = _getBqSyncMode();
+        var tableFields = document.querySelectorAll('.bq-source-table');
+        var customFields = document.querySelectorAll('.bq-source-custom');
+        tableFields.forEach(function(el) {
+            el.style.display = (syncMode === 'whole') ? '' : 'none';
+        });
+        customFields.forEach(function(el) {
+            el.style.display = (syncMode === 'custom') ? '' : 'none';
+        });
     }
 
     function discoverBqDatasets() {
@@ -1719,10 +1826,26 @@
 
     // ── Edit Modal ──────────────────────────────────────────────
 
-    // Original mode captured at openEditModal-time so onEditBqTypeChange can
-    // detect "operator just switched it" vs "loaded from registry" and only
-    // surface the destructive-edit warning on a real change.
+    // Original mode captured at openEditModal-time so the access-mode
+    // change handler can detect "operator just switched it" vs "loaded
+    // from registry" and only surface the destructive-edit warning on a
+    // real change.
     let _editOriginalQueryMode = null;
+
+    function _getEditBqAccessMode() {
+        var el = document.querySelector('input[name="editBqAccessMode"]:checked');
+        return el ? el.value : 'live';
+    }
+
+    function _getEditBqSyncMode() {
+        var el = document.querySelector('input[name="editBqSyncMode"]:checked');
+        return el ? el.value : 'whole';
+    }
+
+    function _setEditBqRadio(name, value) {
+        var el = document.querySelector('input[name="' + name + '"][value="' + value + '"]');
+        if (el) el.checked = true;
+    }
 
     function openEditModal(table) {
         currentEditTableId = table.id;
@@ -1744,21 +1867,35 @@
         document.getElementById('editFolder').value = table.folder || '';
 
         if (isBigQuery) {
-            // Map registry's query_mode back onto the operator-facing Type
-            // selector. We can't distinguish Table from View at the registry
-            // level (the entity_type the extractor detects isn't persisted),
-            // so a remote row defaults to Table; operator can flip to View if
-            // the underlying BQ entity is actually a view.
+            // Map registry's query_mode back onto the two-question radio:
+            //   query_mode='remote'       → access=live
+            //   query_mode='materialized' → access=synced. We can't recover
+            //     whether the row was originally registered as Whole or
+            //     Custom (registry doesn't store that distinction — both
+            //     produce a `source_query`), so we default to Custom when
+            //     a non-empty source_query exists; operator can flip to
+            //     Whole if it was auto-generated SELECT *.
             var qmode = (table.query_mode || 'remote');
-            var entityType = (qmode === 'materialized') ? 'query' : 'table';
-            document.getElementById('editBqEntityType').value = entityType;
+            var sq = (table.source_query || '');
+
+            if (qmode === 'materialized') {
+                _setEditBqRadio('editBqAccessMode', 'synced');
+                // Heuristic: treat `SELECT * FROM bq."ds"."t"` (whole-table
+                // auto-build) as Whole; anything else as Custom.
+                var isAutoSelectStar = /^\s*SELECT\s+\*\s+FROM\s+bq\.".+"\.".+"\s*$/i.test(sq);
+                _setEditBqRadio('editBqSyncMode', isAutoSelectStar ? 'whole' : 'custom');
+            } else {
+                _setEditBqRadio('editBqAccessMode', 'live');
+                _setEditBqRadio('editBqSyncMode', 'whole');
+            }
+
             document.getElementById('editBqDataset').value = table.bucket || '';
             document.getElementById('editBqSourceTable').value = table.source_table || '';
-            document.getElementById('editBqSourceQuery').value = table.source_query || '';
+            document.getElementById('editBqSourceQuery').value = sq;
             document.getElementById('editBqSyncSchedule').value = table.sync_schedule || '';
             document.getElementById('editBqModeWarning').style.display = 'none';
             _editOriginalQueryMode = qmode;
-            onEditBqTypeChange();  // fire to set field visibility
+            onEditBqAccessModeChange();  // fire to set field visibility
         } else {
             document.getElementById('editStrategy').value = table.sync_strategy || 'full_refresh';
             document.getElementById('editPrimaryKey').value = (table.primary_key || []).join(', ');
@@ -1769,36 +1906,50 @@
         document.getElementById('editModal').classList.add('active');
     }
 
-    function onEditBqTypeChange() {
-        var entityType = document.getElementById('editBqEntityType').value;
-        var byClass = {
-            'table': document.querySelectorAll('.bq-edit-type-table'),
-            'view': document.querySelectorAll('.bq-edit-type-view'),
-            'query': document.querySelectorAll('.bq-edit-type-query'),
-        };
-        Object.keys(byClass).forEach(function(t) {
-            byClass[t].forEach(function(el) {
-                el.style.display = el.classList.contains('bq-edit-type-' + entityType) ? '' : 'none';
-            });
+    function onEditBqAccessModeChange() {
+        var accessMode = _getEditBqAccessMode();
+        document.querySelectorAll('.bq-edit-access-synced').forEach(function(el) {
+            el.style.display = (accessMode === 'synced') ? '' : 'none';
         });
 
-        // Mode-switch warning: surfacing the cost of a destructive edit so
-        // an operator who just wanted to fix a typo doesn't accidentally
-        // discard their materialized parquet.
-        var newMode = (entityType === 'query') ? 'materialized' : 'remote';
+        if (accessMode === 'synced') {
+            onEditBqSyncModeChange();
+        } else {
+            // Live: dataset+table inputs visible, SQL textarea hidden.
+            document.querySelectorAll('.bq-edit-source-table').forEach(function(el) {
+                el.style.display = '';
+            });
+            document.querySelectorAll('.bq-edit-source-custom').forEach(function(el) {
+                el.style.display = 'none';
+            });
+        }
+
+        // Mode-switch warning: only fire when the operator actually flipped
+        // access mode from what was loaded — typo-fix edits stay quiet.
+        var newMode = (accessMode === 'synced') ? 'materialized' : 'remote';
         var warn = document.getElementById('editBqModeWarning');
         if (_editOriginalQueryMode && newMode !== _editOriginalQueryMode) {
             var msg;
             if (_editOriginalQueryMode === 'materialized' && newMode === 'remote') {
-                msg = '⚠ Switching from Custom SQL → Table/View will drop the materialized parquet on next sync. Analysts who synced this table will get a remote view instead of a local file. The cron schedule field becomes ignored.';
+                msg = '⚠ Switching Synced locally → Live from BigQuery will drop the materialized parquet on the next sync. Analysts who already pulled this table will start getting live BQ queries instead of a local copy; the sync schedule becomes ignored.';
             } else {
-                msg = '⚠ Switching from Table/View → Custom SQL: the next scheduled sync runs your SQL and writes a parquet. Analysts will start receiving local data on their next da sync; the dataset/source-table fields become ignored. Remember to set a sync_schedule.';
+                msg = '⚠ Switching Live from BigQuery → Synced locally: the next scheduled sync runs a SELECT and writes a parquet. Analysts will start reading the local copy on their next `da sync`. Remember to set a sync schedule.';
             }
             warn.textContent = msg;
             warn.style.display = '';
         } else {
             warn.style.display = 'none';
         }
+    }
+
+    function onEditBqSyncModeChange() {
+        var syncMode = _getEditBqSyncMode();
+        document.querySelectorAll('.bq-edit-source-table').forEach(function(el) {
+            el.style.display = (syncMode === 'whole') ? '' : 'none';
+        });
+        document.querySelectorAll('.bq-edit-source-custom').forEach(function(el) {
+            el.style.display = (syncMode === 'custom') ? '' : 'none';
+        });
     }
 
     function closeEditModal() {
@@ -1821,7 +1972,15 @@
         var payload;
 
         if (sourceType === 'bigquery') {
-            var entityType = document.getElementById('editBqEntityType').value;
+            // Two-question state machine — same as Register modal:
+            //   live          → query_mode='remote'
+            //   synced/whole  → materialized + auto SELECT *
+            //   synced/custom → materialized + admin SQL
+            var accessMode = _getEditBqAccessMode();
+            var syncMode = _getEditBqSyncMode();
+            var dataset = document.getElementById('editBqDataset').value.trim();
+            var sourceTable = document.getElementById('editBqSourceTable').value.trim();
+
             payload = {
                 description: document.getElementById('editDescription').value.trim() || null,
                 folder: document.getElementById('editFolder').value.trim() || null,
@@ -1829,21 +1988,30 @@
                 sync_schedule:
                     document.getElementById('editBqSyncSchedule').value.trim() || null,
             };
-            if (entityType === 'query') {
+
+            if (accessMode === 'synced' && syncMode === 'custom') {
                 payload.query_mode = 'materialized';
                 payload.source_query =
                     document.getElementById('editBqSourceQuery').value.trim();
-                // Server validator clears bucket/source_table when mode is
-                // materialized (UpdateTableRequest), but be explicit so the
-                // PATCH semantics don't carry stale fields forward.
+                // PUT semantics: an explicit null clears the prior value so
+                // a remote→materialized switch doesn't carry stale
+                // bucket/source_table forward through the synthetic
+                // RegisterTableRequest validator.
                 payload.bucket = null;
                 payload.source_table = null;
+            } else if (accessMode === 'synced' && syncMode === 'whole') {
+                payload.query_mode = 'materialized';
+                payload.source_query =
+                    'SELECT * FROM bq."' + dataset + '"."' + sourceTable + '"';
+                // Keep bucket/source_table on the row so a future
+                // Whole→Custom switch can prefill from them.
+                payload.bucket = dataset || null;
+                payload.source_table = sourceTable || null;
             } else {
+                // Live.
                 payload.query_mode = 'remote';
-                payload.bucket =
-                    document.getElementById('editBqDataset').value.trim() || null;
-                payload.source_table =
-                    document.getElementById('editBqSourceTable').value.trim() || null;
+                payload.bucket = dataset || null;
+                payload.source_table = sourceTable || null;
                 payload.source_query = null;
             }
         } else {

--- a/app/web/templates/admin_tables.html
+++ b/app/web/templates/admin_tables.html
@@ -883,14 +883,31 @@
                     </div>
                 </div>
                 <div class="form-group bq-type-table bq-type-view">
-                    <label class="form-label" for="bqDataset">Dataset</label>
-                    <input type="text" class="form-input" id="bqDataset" placeholder="e.g. analytics">
-                    <div class="form-hint">BigQuery dataset name (no project prefix — read from instance.yaml).</div>
+                    <label class="form-label" for="bqDataset">
+                        Dataset
+                        <button type="button" class="btn btn-secondary btn-sm"
+                                onclick="discoverBqDatasets()" style="float:right; margin-top:-3px;">
+                            Discover
+                        </button>
+                    </label>
+                    <input type="text" class="form-input" id="bqDataset" list="bqDatasetList" placeholder="e.g. analytics">
+                    <datalist id="bqDatasetList"></datalist>
+                    <div class="form-hint">BigQuery dataset name (no project prefix — read from instance.yaml).
+                        Click <strong>Discover</strong> to populate the autocomplete from the BQ project's dataset list.</div>
                 </div>
                 <div class="form-group bq-type-table bq-type-view">
-                    <label class="form-label" for="bqSourceTable">Source Table / View</label>
-                    <input type="text" class="form-input" id="bqSourceTable" placeholder="e.g. orders">
-                    <div class="form-hint">Table or view name within the dataset. The server detects which it is at registration time.</div>
+                    <label class="form-label" for="bqSourceTable">
+                        Source Table / View
+                        <button type="button" class="btn btn-secondary btn-sm"
+                                onclick="discoverBqTables()" style="float:right; margin-top:-3px;">
+                            List tables
+                        </button>
+                    </label>
+                    <input type="text" class="form-input" id="bqSourceTable" list="bqTableList" placeholder="e.g. orders">
+                    <datalist id="bqTableList"></datalist>
+                    <div class="form-hint">Table or view name within the dataset. The server auto-detects
+                        BASE TABLE vs VIEW at registration time. Click <strong>List tables</strong> after
+                        filling Dataset to populate the autocomplete from BQ.</div>
                 </div>
                 <div class="form-group bq-type-query" style="display:none;">
                     <label class="form-label" for="bqSourceQuery">
@@ -1467,6 +1484,72 @@
         });
         var hint = document.getElementById('bqEntityHint');
         if (hint) hint.innerHTML = _BQ_HINT_BY_TYPE[entityType] || '';
+    }
+
+    function discoverBqDatasets() {
+        // GET /api/admin/discover-tables (no `dataset`) → list datasets in
+        // the configured BQ project. Populate the bqDatasetList <datalist>
+        // so the input shows them as autocomplete suggestions. The endpoint
+        // routes through BqAccess so config / auth errors come back as the
+        // standard {error, kind, details} shape.
+        fetch('/api/admin/discover-tables')
+            .then(function(r) {
+                if (!r.ok) return r.json().then(function(d) {
+                    var msg = (d && d.detail && d.detail.error) || (d && d.detail) || 'BQ discovery failed';
+                    throw new Error(msg);
+                });
+                return r.json();
+            })
+            .then(function(data) {
+                var dl = document.getElementById('bqDatasetList');
+                dl.innerHTML = '';
+                (data.datasets || []).forEach(function(ds) {
+                    var opt = document.createElement('option');
+                    opt.value = ds.dataset_id;
+                    opt.label = ds.full_id || ds.dataset_id;
+                    dl.appendChild(opt);
+                });
+                showToast('Loaded ' + (data.count || 0) + ' datasets', 'success');
+            })
+            .catch(function(err) {
+                showToast(err.message || 'Discovery failed', 'error');
+            });
+    }
+
+    function discoverBqTables() {
+        // GET /api/admin/discover-tables?dataset=NAME → list tables + views
+        // in the dataset. Two-step (dataset → tables) avoids paying the
+        // per-dataset list_tables() cost up front on big projects.
+        var dataset = document.getElementById('bqDataset').value.trim();
+        if (!dataset) {
+            showToast('Fill Dataset first', 'error');
+            return;
+        }
+        fetch('/api/admin/discover-tables?dataset=' + encodeURIComponent(dataset))
+            .then(function(r) {
+                if (!r.ok) return r.json().then(function(d) {
+                    var msg = (d && d.detail && d.detail.error) || (d && d.detail) || 'BQ table discovery failed';
+                    throw new Error(msg);
+                });
+                return r.json();
+            })
+            .then(function(data) {
+                var dl = document.getElementById('bqTableList');
+                dl.innerHTML = '';
+                (data.tables || []).forEach(function(t) {
+                    var opt = document.createElement('option');
+                    opt.value = t.table_id;
+                    // BQ entity types: TABLE, VIEW, MATERIALIZED_VIEW,
+                    // EXTERNAL, SNAPSHOT — surface so the operator can
+                    // pick the right Type selector option.
+                    opt.label = t.table_id + (t.table_type ? '  (' + t.table_type + ')' : '');
+                    dl.appendChild(opt);
+                });
+                showToast('Loaded ' + (data.count || 0) + ' tables in ' + dataset, 'success');
+            })
+            .catch(function(err) {
+                showToast(err.message || 'Table list failed', 'error');
+            });
     }
 
     function prefillFromTable() {

--- a/app/web/templates/admin_tables.html
+++ b/app/web/templates/admin_tables.html
@@ -859,21 +859,45 @@
             </div>
             <div class="modal-body">
                 {% if data_source_type == 'bigquery' %}
-                {# BigQuery path — registers a remote view that queries BQ directly. #}
+                {# BigQuery path — `Mode` controls remote-view vs. materialized-parquet.
+                   `bqQueryMode` toggles between the dataset/source-table fields
+                   (remote) and the source_query textarea (materialized). #}
                 <div class="form-group">
+                    <label class="form-label" for="bqQueryMode">Mode</label>
+                    <select class="form-select" id="bqQueryMode" onchange="onBqModeChange()">
+                        <option value="remote">Remote — view, queries go to BQ on demand</option>
+                        <option value="materialized">Materialized — scheduled SQL writes parquet, distributed via da sync</option>
+                    </select>
+                    <div class="form-hint">
+                        <strong>Remote</strong>: pick an existing BQ table; analysts query it through the view (each query roundtrips to BQ).<br>
+                        <strong>Materialized</strong>: write SQL; the scheduler runs it on the cron schedule and ships the parquet to analysts (queries are local, sub-100 ms).
+                    </div>
+                </div>
+                <div class="form-group bq-mode-remote">
                     <label class="form-label" for="bqDataset">Dataset</label>
                     <input type="text" class="form-input" id="bqDataset" placeholder="e.g. analytics">
                     <div class="form-hint">BigQuery dataset name (no project prefix — that's read from instance.yaml)</div>
                 </div>
-                <div class="form-group">
+                <div class="form-group bq-mode-remote">
                     <label class="form-label" for="bqSourceTable">Source Table</label>
                     <input type="text" class="form-input" id="bqSourceTable" placeholder="e.g. orders">
                     <div class="form-hint">BigQuery table or view name within the dataset</div>
                 </div>
+                <div class="form-group bq-mode-materialized" style="display:none;">
+                    <label class="form-label" for="bqSourceQuery">SQL</label>
+                    <textarea class="form-textarea" id="bqSourceQuery" rows="8"
+                        placeholder="SELECT date, SUM(revenue) AS revenue&#10;FROM `project.dataset.orders`&#10;WHERE date >= DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY)&#10;GROUP BY 1"></textarea>
+                    <div class="form-hint">
+                        SELECT statement, no trailing semicolon. Native BQ identifiers
+                        (<code>`project.dataset.table`</code>) recommended — DuckDB three-part
+                        names like <code>bq."ds"."t"</code> work for the COPY but disable the
+                        cost guardrail's BQ dry-run.
+                    </div>
+                </div>
                 <div class="form-group">
                     <label class="form-label" for="bqViewName">View Name</label>
-                    <input type="text" class="form-input" id="bqViewName" placeholder="defaults to source table">
-                    <div class="form-hint">DuckDB view name analysts will use; defaults to the source table</div>
+                    <input type="text" class="form-input" id="bqViewName" placeholder="orders_90d">
+                    <div class="form-hint">DuckDB view name analysts will use. Required for materialized; defaults to the source table for remote.</div>
                 </div>
                 <div class="form-group">
                     <label class="form-label" for="bqDescription">Description <span class="optional">(optional)</span></label>
@@ -1290,23 +1314,55 @@
     }
 
     function _buildBigQueryPayload() {
+        var mode = document.getElementById('bqQueryMode').value || 'remote';
+        var viewName = document.getElementById('bqViewName').value.trim();
+        var description = document.getElementById('bqDescription').value.trim() || null;
+        var folder = document.getElementById('bqFolder').value.trim() || null;
+        var syncSchedule = document.getElementById('bqSyncSchedule').value.trim() || null;
+
+        if (mode === 'materialized') {
+            return {
+                name: viewName,
+                source_type: 'bigquery',
+                query_mode: 'materialized',
+                source_query: document.getElementById('bqSourceQuery').value.trim(),
+                profile_after_sync: false,
+                description: description,
+                folder: folder,
+                sync_schedule: syncSchedule,
+            };
+        }
+
+        // Remote (default) path — bucket + source_table, viewName defaults
+        // to source_table when empty (preserves pre-existing UX).
         var dataset = document.getElementById('bqDataset').value.trim();
         var sourceTable = document.getElementById('bqSourceTable').value.trim();
-        var viewName = document.getElementById('bqViewName').value.trim() || sourceTable;
         return {
-            name: viewName,
+            name: viewName || sourceTable,
             source_type: 'bigquery',
             bucket: dataset,
             source_table: sourceTable,
-            // The server forces these for BQ rows, but we set them explicitly
-            // so the network log + audit-log entry reflect the operator's
-            // intent rather than a server-side mutation.
             query_mode: 'remote',
             profile_after_sync: false,
-            description: document.getElementById('bqDescription').value.trim() || null,
-            folder: document.getElementById('bqFolder').value.trim() || null,
-            sync_schedule: document.getElementById('bqSyncSchedule').value.trim() || null,
+            description: description,
+            folder: folder,
+            sync_schedule: syncSchedule,
         };
+    }
+
+    function onBqModeChange() {
+        // Show / hide the per-mode field groups. Remote uses bqDataset +
+        // bqSourceTable; materialized uses bqSourceQuery. Both modes share
+        // bqViewName, bqDescription, bqFolder, bqSyncSchedule.
+        var mode = document.getElementById('bqQueryMode').value;
+        var remoteFields = document.querySelectorAll('.bq-mode-remote');
+        var matFields = document.querySelectorAll('.bq-mode-materialized');
+        remoteFields.forEach(function(el) {
+            el.style.display = (mode === 'remote') ? '' : 'none';
+        });
+        matFields.forEach(function(el) {
+            el.style.display = (mode === 'materialized') ? '' : 'none';
+        });
     }
 
     function registerTable() {

--- a/app/web/templates/admin_tables.html
+++ b/app/web/templates/admin_tables.html
@@ -748,7 +748,7 @@
     <div class="content">
 
         {% if data_source_type == 'bigquery' %}
-        <!-- ── BigQuery Register Panel (M1: no discovery, manual entry) ── -->
+        <!-- ── BigQuery Register Panel ── -->
         <div class="panel" data-test="bq-register-panel">
             <div class="panel-header">
                 <div class="panel-header-left">
@@ -760,7 +760,7 @@
                     </div>
                     <div>
                         <div class="panel-title">Register BigQuery Table</div>
-                        <div class="panel-subtitle">Manually register a BQ table or view as a remote DuckDB view</div>
+                        <div class="panel-subtitle">Register a BQ table, view, or custom SQL query for analyst access</div>
                     </div>
                 </div>
                 <button class="btn btn-primary" onclick="openBigQueryRegisterModal()">
@@ -768,7 +768,11 @@
                 </button>
             </div>
             <div class="panel-body-empty">
-                BigQuery dataset/table discovery lands in Milestone 2 of issue #108. For now, enter the dataset + table by hand.
+                Pick the entity type in the modal — <strong>Table</strong> (a BQ table queried on demand),
+                <strong>View</strong> (a BQ view, same trade-off),
+                or <strong>Custom SQL Query</strong> (a scheduled SELECT that materializes to a local parquet
+                analysts download via <code>da sync</code>). Dataset + table autocomplete is not implemented yet —
+                type them by hand.
             </div>
         </div>
         {% else %}
@@ -863,28 +867,40 @@
                    `bqQueryMode` toggles between the dataset/source-table fields
                    (remote) and the source_query textarea (materialized). #}
                 <div class="form-group">
-                    <label class="form-label" for="bqQueryMode">Mode</label>
-                    <select class="form-select" id="bqQueryMode" onchange="onBqModeChange()">
-                        <option value="remote">Remote — view, queries go to BQ on demand</option>
-                        <option value="materialized">Materialized — scheduled SQL writes parquet, distributed via da sync</option>
+                    <label class="form-label" for="bqEntityType">Type</label>
+                    <select class="form-select" id="bqEntityType" onchange="onBqTypeChange()">
+                        <option value="table">Table — query a BQ table on demand (no local copy)</option>
+                        <option value="view">View — query a BQ view on demand (jobs API)</option>
+                        <option value="query">Custom SQL Query — scheduled SELECT writes parquet, distributed via da sync</option>
                     </select>
-                    <div class="form-hint">
-                        <strong>Remote</strong>: pick an existing BQ table; analysts query it through the view (each query roundtrips to BQ).<br>
-                        <strong>Materialized</strong>: write SQL; the scheduler runs it on the cron schedule and ships the parquet to analysts (queries are local, sub-100 ms).
+                    <div class="form-hint" id="bqEntityHint">
+                        <!-- Filled by onBqTypeChange() — describes trade-offs for the
+                             selected entity type. Default text matches `table`. -->
+                        <strong>Table:</strong> latency ~seconds (BQ roundtrip per query); 0 disk;
+                        cost = bytes scanned per analyst-query. Best for tables that fit on disk
+                        but you want to avoid sync overhead, or tables analysts only touch
+                        occasionally.
                     </div>
                 </div>
-                <div class="form-group bq-mode-remote">
+                <div class="form-group bq-type-table bq-type-view">
                     <label class="form-label" for="bqDataset">Dataset</label>
                     <input type="text" class="form-input" id="bqDataset" placeholder="e.g. analytics">
-                    <div class="form-hint">BigQuery dataset name (no project prefix — that's read from instance.yaml)</div>
+                    <div class="form-hint">BigQuery dataset name (no project prefix — read from instance.yaml).</div>
                 </div>
-                <div class="form-group bq-mode-remote">
-                    <label class="form-label" for="bqSourceTable">Source Table</label>
+                <div class="form-group bq-type-table bq-type-view">
+                    <label class="form-label" for="bqSourceTable">Source Table / View</label>
                     <input type="text" class="form-input" id="bqSourceTable" placeholder="e.g. orders">
-                    <div class="form-hint">BigQuery table or view name within the dataset</div>
+                    <div class="form-hint">Table or view name within the dataset. The server detects which it is at registration time.</div>
                 </div>
-                <div class="form-group bq-mode-materialized" style="display:none;">
-                    <label class="form-label" for="bqSourceQuery">SQL</label>
+                <div class="form-group bq-type-query" style="display:none;">
+                    <label class="form-label" for="bqSourceQuery">
+                        SQL
+                        <button type="button" class="btn btn-secondary btn-sm"
+                                onclick="prefillFromTable()" style="float:right; margin-top:-3px;"
+                                title="Prefill SELECT * FROM `project.dataset.table` so you only edit the WHERE / projection">
+                            Use table as base
+                        </button>
+                    </label>
                     <textarea class="form-textarea" id="bqSourceQuery" rows="8"
                         placeholder="SELECT date, SUM(revenue) AS revenue&#10;FROM `project.dataset.orders`&#10;WHERE date >= DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY)&#10;GROUP BY 1"></textarea>
                     <div class="form-hint">
@@ -897,7 +913,7 @@
                 <div class="form-group">
                     <label class="form-label" for="bqViewName">View Name</label>
                     <input type="text" class="form-input" id="bqViewName" placeholder="orders_90d">
-                    <div class="form-hint">DuckDB view name analysts will use. Required for materialized; defaults to the source table for remote.</div>
+                    <div class="form-hint">DuckDB view name analysts will use. Required for Custom SQL; defaults to the source table for Table/View.</div>
                 </div>
                 <div class="form-group">
                     <label class="form-label" for="bqDescription">Description <span class="optional">(optional)</span></label>
@@ -909,9 +925,12 @@
                     <div class="form-hint">Logical grouping for catalog organization</div>
                 </div>
                 <div class="form-group">
-                    <label class="form-label" for="bqSyncSchedule">Sync Schedule <span class="optional">(optional)</span></label>
-                    <input type="text" class="form-input" id="bqSyncSchedule" placeholder="e.g. 0 6 * * *">
-                    <div class="form-hint">Cron expression. Note: scheduler does not yet evaluate this — see #79; addressed in M3 of #108.</div>
+                    <label class="form-label" for="bqSyncSchedule">Sync Schedule <span class="optional">(optional, default <code>every 1h</code> for Custom SQL)</span></label>
+                    <input type="text" class="form-input" id="bqSyncSchedule" placeholder="every 6h">
+                    <div class="form-hint">
+                        Examples: <code>every 15m</code>, <code>every 6h</code>, <code>daily 03:00</code>, <code>daily 07:00,13:00,18:00</code> (UTC).
+                        Honored by Custom SQL (materialized) — Table/View are queried live and ignore this field.
+                    </div>
                 </div>
                 <div class="form-group" id="bqPrecheckSummary" style="display:none;">
                     <div class="form-label">Source check</div>
@@ -1314,13 +1333,20 @@
     }
 
     function _buildBigQueryPayload() {
-        var mode = document.getElementById('bqQueryMode').value || 'remote';
+        // The UI's Type selector is operator-facing UX (Table / View / Custom
+        // SQL Query); the backend payload maps it onto query_mode (remote
+        // vs materialized). Table and View both go to query_mode='remote' —
+        // the BQ extractor auto-detects the entity type via INFORMATION_SCHEMA
+        // at register time and routes BASE TABLE through the Storage Read
+        // API while VIEW goes through bigquery_query() (jobs API). Query
+        // is materialized.
+        var entityType = document.getElementById('bqEntityType').value || 'table';
         var viewName = document.getElementById('bqViewName').value.trim();
         var description = document.getElementById('bqDescription').value.trim() || null;
         var folder = document.getElementById('bqFolder').value.trim() || null;
         var syncSchedule = document.getElementById('bqSyncSchedule').value.trim() || null;
 
-        if (mode === 'materialized') {
+        if (entityType === 'query') {
             return {
                 name: viewName,
                 source_type: 'bigquery',
@@ -1333,8 +1359,10 @@
             };
         }
 
-        // Remote (default) path — bucket + source_table, viewName defaults
-        // to source_table when empty (preserves pre-existing UX).
+        // Table / View — query_mode='remote', server auto-detects entity
+        // shape on register. The frontend doesn't send entity_type because
+        // we don't trust an operator-asserted type (a typo'd "view" on a
+        // BASE TABLE would silently route the wrong way).
         var dataset = document.getElementById('bqDataset').value.trim();
         var sourceTable = document.getElementById('bqSourceTable').value.trim();
         return {
@@ -1350,19 +1378,74 @@
         };
     }
 
-    function onBqModeChange() {
-        // Show / hide the per-mode field groups. Remote uses bqDataset +
-        // bqSourceTable; materialized uses bqSourceQuery. Both modes share
-        // bqViewName, bqDescription, bqFolder, bqSyncSchedule.
-        var mode = document.getElementById('bqQueryMode').value;
-        var remoteFields = document.querySelectorAll('.bq-mode-remote');
-        var matFields = document.querySelectorAll('.bq-mode-materialized');
-        remoteFields.forEach(function(el) {
-            el.style.display = (mode === 'remote') ? '' : 'none';
+    var _BQ_HINT_BY_TYPE = {
+        'table':
+            "<strong>Table:</strong> latency ~seconds (BQ roundtrip per query); 0 disk; "
+            + "cost = bytes scanned per analyst-query. Best for tables that fit on disk "
+            + "but you want to avoid sync overhead, or tables analysts only touch "
+            + "occasionally. Server uses BQ Storage Read API for full-table scans.",
+        'view':
+            "<strong>View:</strong> same on-demand semantics as Table, but the server "
+            + "routes through <code>bigquery_query()</code> (jobs API) instead of the "
+            + "Storage Read API — required because BQ views can't be attached as "
+            + "tables. Latency slightly higher than Table; cost the same per query.",
+        'query':
+            "<strong>Custom SQL:</strong> the scheduler runs your SELECT on "
+            + "<code>sync_schedule</code> and writes the result as a parquet that "
+            + "<code>da sync</code> distributes to analysts. Latency on the analyst "
+            + "side is <100 ms (local read); cost = one BQ scan per schedule tick "
+            + "regardless of how many analysts query it. Cap via "
+            + "<code>data_source.bigquery.max_bytes_per_materialize</code> "
+            + "(default 10 GiB).",
+    };
+
+    function onBqTypeChange() {
+        // Show / hide the per-type field groups. Table and View share
+        // bqDataset + bqSourceTable (both have the same input shape, server
+        // auto-detects which is which). Query swaps in bqSourceQuery + the
+        // "Use table as base" prefill button. View Name + Description +
+        // Folder + Sync Schedule are shared.
+        var entityType = document.getElementById('bqEntityType').value;
+        var byClass = {
+            'table': document.querySelectorAll('.bq-type-table'),
+            'view': document.querySelectorAll('.bq-type-view'),
+            'query': document.querySelectorAll('.bq-type-query'),
+        };
+        // A field with both `bq-type-table` and `bq-type-view` shows for
+        // either selection. Resolve via "is this element tagged for the
+        // current type?".
+        Object.keys(byClass).forEach(function(t) {
+            byClass[t].forEach(function(el) {
+                el.style.display = el.classList.contains('bq-type-' + entityType) ? '' : 'none';
+            });
         });
-        matFields.forEach(function(el) {
-            el.style.display = (mode === 'materialized') ? '' : 'none';
-        });
+        var hint = document.getElementById('bqEntityHint');
+        if (hint) hint.innerHTML = _BQ_HINT_BY_TYPE[entityType] || '';
+    }
+
+    function prefillFromTable() {
+        // Convenience for the Custom SQL path: prompt for project.dataset.table
+        // and prefill `SELECT * FROM \`...\`` so the operator only edits the
+        // WHERE / projection. We can't know the project from the form (it's
+        // server-side config), so the prompt accepts both `dataset.table` and
+        // `project.dataset.table`. Empty / cancel → no change.
+        var existing = document.getElementById('bqSourceQuery').value.trim();
+        if (existing && !confirm('SQL field is not empty — overwrite with prefill?')) {
+            return;
+        }
+        var ref = window.prompt(
+            'Enter the source table as `dataset.table` or `project.dataset.table` '
+            + '(it will be wrapped in backticks):',
+            ''
+        );
+        if (!ref) return;
+        ref = ref.trim().replace(/^`|`$/g, '');
+        var stub =
+            'SELECT *\n'
+            + 'FROM `' + ref + '`\n'
+            + 'WHERE -- TODO: filter or aggregate before the COPY runs (10 GiB cap)\n'
+            + 'LIMIT 1000';
+        document.getElementById('bqSourceQuery').value = stub;
     }
 
     function registerTable() {

--- a/app/web/templates/admin_tables.html
+++ b/app/web/templates/admin_tables.html
@@ -1008,8 +1008,51 @@
                 <div class="form-group">
                     <label class="form-label" for="editTableId">Table ID</label>
                     <input type="text" class="form-input" id="editTableId" readonly>
+                    <div class="form-hint">Slugified id, immutable. Source type:
+                        <strong id="editSourceTypeBadge">—</strong></div>
                 </div>
-                <div class="form-group">
+
+                <!-- BQ-only fields (Type selector + Dataset/Source Table for
+                     Table/View, SQL textarea for Query). Hidden for Keboola
+                     rows. Wired by populateEditModal(table). -->
+                <div class="form-group bq-edit-only" style="display:none;">
+                    <label class="form-label" for="editBqEntityType">Type</label>
+                    <select class="form-select" id="editBqEntityType" onchange="onEditBqTypeChange()">
+                        <option value="table">Table — query a BQ table on demand</option>
+                        <option value="view">View — query a BQ view on demand (jobs API)</option>
+                        <option value="query">Custom SQL Query — scheduled SELECT writes parquet</option>
+                    </select>
+                    <div class="form-hint" id="editBqModeWarning" style="display:none;
+                         color:#EA580C;background:rgba(234,88,12,.08);padding:8px;border-radius:6px;">
+                        <!-- Filled by onEditBqTypeChange() when switching mode
+                             on an existing row — warns that parquet/source data
+                             will be discarded. -->
+                    </div>
+                </div>
+                <div class="form-group bq-edit-only bq-edit-type-table bq-edit-type-view" style="display:none;">
+                    <label class="form-label" for="editBqDataset">Dataset</label>
+                    <input type="text" class="form-input" id="editBqDataset" placeholder="e.g. analytics">
+                </div>
+                <div class="form-group bq-edit-only bq-edit-type-table bq-edit-type-view" style="display:none;">
+                    <label class="form-label" for="editBqSourceTable">Source Table / View</label>
+                    <input type="text" class="form-input" id="editBqSourceTable" placeholder="e.g. orders">
+                </div>
+                <div class="form-group bq-edit-only bq-edit-type-query" style="display:none;">
+                    <label class="form-label" for="editBqSourceQuery">SQL</label>
+                    <textarea class="form-textarea" id="editBqSourceQuery" rows="8"></textarea>
+                    <div class="form-hint">SELECT statement, no trailing semicolon. Native BQ
+                        identifiers recommended for the cost guardrail to engage.</div>
+                </div>
+                <div class="form-group bq-edit-only" style="display:none;">
+                    <label class="form-label" for="editBqSyncSchedule">Sync Schedule
+                        <span class="optional">(optional, materialized only)</span></label>
+                    <input type="text" class="form-input" id="editBqSyncSchedule" placeholder="every 6h">
+                    <div class="form-hint"><code>every 15m</code>, <code>every 6h</code>,
+                        <code>daily 03:00</code> (UTC). Honored by Custom SQL.</div>
+                </div>
+
+                <!-- Keboola-only fields (existing). Hidden for BQ rows. -->
+                <div class="form-group keboola-edit-only">
                     <label class="form-label" for="editStrategy">Sync Strategy</label>
                     <select class="form-select" id="editStrategy">
                         <option value="full_refresh">Full Refresh</option>
@@ -1017,17 +1060,20 @@
                         <option value="partitioned">Partitioned</option>
                     </select>
                 </div>
-                <div class="form-group">
+                <div class="form-group keboola-edit-only">
                     <label class="form-label" for="editPrimaryKey">Primary Key</label>
                     <input type="text" class="form-input" id="editPrimaryKey" placeholder="e.g. id">
                 </div>
+
+                <!-- Shared between BQ + Keboola -->
                 <div class="form-group">
                     <label class="form-label" for="editDescription">Description <span class="optional">(optional)</span></label>
                     <textarea class="form-textarea" id="editDescription" placeholder="Brief description of the table contents..."></textarea>
                 </div>
                 <div class="form-group">
-                    <label class="form-label" for="editDataset">Dataset Group <span class="optional">(optional)</span></label>
-                    <input type="text" class="form-input" id="editDataset" placeholder="e.g. crm, finance, marketing">
+                    <label class="form-label" for="editFolder">Folder <span class="optional">(optional)</span></label>
+                    <input type="text" class="form-input" id="editFolder" placeholder="e.g. crm, finance, marketing">
+                    <div class="form-hint">Logical grouping for catalog organization (does not affect storage).</div>
                 </div>
             </div>
             <div class="modal-footer">
@@ -1590,20 +1636,92 @@
 
     // ── Edit Modal ──────────────────────────────────────────────
 
+    // Original mode captured at openEditModal-time so onEditBqTypeChange can
+    // detect "operator just switched it" vs "loaded from registry" and only
+    // surface the destructive-edit warning on a real change.
+    let _editOriginalQueryMode = null;
+
     function openEditModal(table) {
         currentEditTableId = table.id;
         document.getElementById('editTableId').value = table.id || '';
-        document.getElementById('editStrategy').value = table.sync_strategy || 'full_refresh';
-        document.getElementById('editPrimaryKey').value = (table.primary_key || []).join(', ');
+
+        var sourceType = (table.source_type || '').toLowerCase();
+        document.getElementById('editSourceTypeBadge').textContent = sourceType || '—';
+
+        var isBigQuery = (sourceType === 'bigquery');
+        document.querySelectorAll('.bq-edit-only').forEach(function(el) {
+            el.style.display = isBigQuery ? '' : 'none';
+        });
+        document.querySelectorAll('.keboola-edit-only').forEach(function(el) {
+            el.style.display = isBigQuery ? 'none' : '';
+        });
+
+        // Shared fields.
         document.getElementById('editDescription').value = table.description || '';
-        document.getElementById('editDataset').value = table.dataset || '';
+        document.getElementById('editFolder').value = table.folder || '';
+
+        if (isBigQuery) {
+            // Map registry's query_mode back onto the operator-facing Type
+            // selector. We can't distinguish Table from View at the registry
+            // level (the entity_type the extractor detects isn't persisted),
+            // so a remote row defaults to Table; operator can flip to View if
+            // the underlying BQ entity is actually a view.
+            var qmode = (table.query_mode || 'remote');
+            var entityType = (qmode === 'materialized') ? 'query' : 'table';
+            document.getElementById('editBqEntityType').value = entityType;
+            document.getElementById('editBqDataset').value = table.bucket || '';
+            document.getElementById('editBqSourceTable').value = table.source_table || '';
+            document.getElementById('editBqSourceQuery').value = table.source_query || '';
+            document.getElementById('editBqSyncSchedule').value = table.sync_schedule || '';
+            document.getElementById('editBqModeWarning').style.display = 'none';
+            _editOriginalQueryMode = qmode;
+            onEditBqTypeChange();  // fire to set field visibility
+        } else {
+            document.getElementById('editStrategy').value = table.sync_strategy || 'full_refresh';
+            document.getElementById('editPrimaryKey').value = (table.primary_key || []).join(', ');
+            _editOriginalQueryMode = null;
+        }
+
         document.getElementById('editSubmitBtn').disabled = false;
         document.getElementById('editModal').classList.add('active');
+    }
+
+    function onEditBqTypeChange() {
+        var entityType = document.getElementById('editBqEntityType').value;
+        var byClass = {
+            'table': document.querySelectorAll('.bq-edit-type-table'),
+            'view': document.querySelectorAll('.bq-edit-type-view'),
+            'query': document.querySelectorAll('.bq-edit-type-query'),
+        };
+        Object.keys(byClass).forEach(function(t) {
+            byClass[t].forEach(function(el) {
+                el.style.display = el.classList.contains('bq-edit-type-' + entityType) ? '' : 'none';
+            });
+        });
+
+        // Mode-switch warning: surfacing the cost of a destructive edit so
+        // an operator who just wanted to fix a typo doesn't accidentally
+        // discard their materialized parquet.
+        var newMode = (entityType === 'query') ? 'materialized' : 'remote';
+        var warn = document.getElementById('editBqModeWarning');
+        if (_editOriginalQueryMode && newMode !== _editOriginalQueryMode) {
+            var msg;
+            if (_editOriginalQueryMode === 'materialized' && newMode === 'remote') {
+                msg = '⚠ Switching from Custom SQL → Table/View will drop the materialized parquet on next sync. Analysts who synced this table will get a remote view instead of a local file. The cron schedule field becomes ignored.';
+            } else {
+                msg = '⚠ Switching from Table/View → Custom SQL: the next scheduled sync runs your SQL and writes a parquet. Analysts will start receiving local data on their next da sync; the dataset/source-table fields become ignored. Remember to set a sync_schedule.';
+            }
+            warn.textContent = msg;
+            warn.style.display = '';
+        } else {
+            warn.style.display = 'none';
+        }
     }
 
     function closeEditModal() {
         document.getElementById('editModal').classList.remove('active');
         currentEditTableId = null;
+        _editOriginalQueryMode = null;
     }
 
     function saveTableEdit() {
@@ -1613,20 +1731,52 @@
         btn.disabled = true;
         btn.textContent = 'Saving...';
 
-        var pk = document.getElementById('editPrimaryKey').value.trim();
-        var primaryKey = pk ? pk.split(',').map(function(s) { return s.trim(); }).filter(Boolean) : [];
+        // Branch on whether this row is a BigQuery row. Source-type is
+        // immutable post-register (no UI control to flip it), so we can
+        // trust the badge text we set in openEditModal.
+        var sourceType = document.getElementById('editSourceTypeBadge').textContent;
+        var payload;
 
-        // UpdateTableRequest contract: no `dataset` field (it's `folder` for
-        // catalog grouping in the registry), no `version` (the API has no
-        // optimistic-concurrency layer). Pre-fix the modal posted `dataset`
-        // + `version` and the API silently dropped them, so the operator's
-        // dataset edit looked saved but never persisted.
-        var payload = {
-            sync_strategy: document.getElementById('editStrategy').value,
-            primary_key: primaryKey,
-            description: document.getElementById('editDescription').value.trim() || null,
-            folder: document.getElementById('editDataset').value.trim() || null,
-        };
+        if (sourceType === 'bigquery') {
+            var entityType = document.getElementById('editBqEntityType').value;
+            payload = {
+                description: document.getElementById('editDescription').value.trim() || null,
+                folder: document.getElementById('editFolder').value.trim() || null,
+                source_type: 'bigquery',
+                sync_schedule:
+                    document.getElementById('editBqSyncSchedule').value.trim() || null,
+            };
+            if (entityType === 'query') {
+                payload.query_mode = 'materialized';
+                payload.source_query =
+                    document.getElementById('editBqSourceQuery').value.trim();
+                // Server validator clears bucket/source_table when mode is
+                // materialized (UpdateTableRequest), but be explicit so the
+                // PATCH semantics don't carry stale fields forward.
+                payload.bucket = null;
+                payload.source_table = null;
+            } else {
+                payload.query_mode = 'remote';
+                payload.bucket =
+                    document.getElementById('editBqDataset').value.trim() || null;
+                payload.source_table =
+                    document.getElementById('editBqSourceTable').value.trim() || null;
+                payload.source_query = null;
+            }
+        } else {
+            // Keboola path — keeps the existing field set.
+            var pk = document.getElementById('editPrimaryKey').value.trim();
+            var primaryKey = pk
+                ? pk.split(',').map(function(s) { return s.trim(); }).filter(Boolean)
+                : [];
+            payload = {
+                sync_strategy: document.getElementById('editStrategy').value,
+                primary_key: primaryKey,
+                description:
+                    document.getElementById('editDescription').value.trim() || null,
+                folder: document.getElementById('editFolder').value.trim() || null,
+            };
+        }
 
         fetch('/api/admin/registry/' + encodeURIComponent(currentEditTableId), {
             method: 'PUT',

--- a/app/web/templates/admin_tables.html
+++ b/app/web/templates/admin_tables.html
@@ -947,9 +947,16 @@
                     </label>
                     <input type="text" class="form-input" id="bqSourceTable" list="bqTableList" placeholder="e.g. orders">
                     <datalist id="bqTableList"></datalist>
-                    <div class="form-hint">Table or view name within the dataset. Agnes auto-detects whether
-                        it's a BASE TABLE or a VIEW and routes the query path accordingly. Click
-                        <strong>List tables</strong> after filling Dataset to populate the autocomplete.</div>
+                    <div class="form-hint">Table or view name within the dataset. Click
+                        <strong>List tables</strong> after filling Dataset to populate autocomplete.
+                        <br><strong>Live access:</strong> BASE TABLEs are queryable directly via
+                        <code>da query --remote</code>; VIEWs are registered but analysts must run
+                        <code>da fetch</code> to materialize a local snapshot (or the admin can flip
+                        <code>data_source.bigquery.legacy_wrap_views=true</code> to wrap views via the
+                        BQ jobs API).
+                        <br><strong>Synced access:</strong> handles both table and view transparently
+                        — the scheduler runs <code>SELECT *</code> through the jobs API and writes a
+                        parquet.</div>
                 </div>
                 <div class="form-group bq-source-custom" style="display:none;">
                     <label class="form-label" for="bqSourceQuery">
@@ -1146,7 +1153,14 @@
                     <input type="text" class="form-input" id="editBqSourceTable"
                            list="editBqTableList" placeholder="e.g. orders">
                     <datalist id="editBqTableList"></datalist>
-                    <div class="form-hint">Agnes auto-detects whether this is a table or a view.</div>
+                    <div class="form-hint">Table or view name within the dataset.
+                        <br><strong>Live access:</strong> BASE TABLEs are queryable directly via
+                        <code>da query --remote</code>; VIEWs are registered but analysts must run
+                        <code>da fetch</code> to materialize a local snapshot (or admin can flip
+                        <code>data_source.bigquery.legacy_wrap_views=true</code>).
+                        <br><strong>Synced access:</strong> handles both transparently — the
+                        scheduler runs <code>SELECT *</code> through the jobs API and writes a
+                        parquet.</div>
                 </div>
                 <div class="form-group bq-edit-only bq-edit-source-custom" style="display:none;">
                     <label class="form-label" for="editBqSourceQuery">

--- a/app/web/templates/admin_tables.html
+++ b/app/web/templates/admin_tables.html
@@ -1122,16 +1122,42 @@
                     </div>
                 </div>
                 <div class="form-group bq-edit-only bq-edit-source-table" style="display:none;">
-                    <label class="form-label" for="editBqDataset">Dataset</label>
-                    <input type="text" class="form-input" id="editBqDataset" placeholder="e.g. analytics">
+                    <label class="form-label" for="editBqDataset">
+                        Dataset
+                        <button type="button" class="btn btn-secondary btn-sm"
+                                onclick="discoverBqDatasets('editBqDatasetList')"
+                                style="float:right; margin-top:-3px;">
+                            Discover
+                        </button>
+                    </label>
+                    <input type="text" class="form-input" id="editBqDataset"
+                           list="editBqDatasetList" placeholder="e.g. analytics">
+                    <datalist id="editBqDatasetList"></datalist>
                 </div>
                 <div class="form-group bq-edit-only bq-edit-source-table" style="display:none;">
-                    <label class="form-label" for="editBqSourceTable">Source Table / View</label>
-                    <input type="text" class="form-input" id="editBqSourceTable" placeholder="e.g. orders">
+                    <label class="form-label" for="editBqSourceTable">
+                        Source Table / View
+                        <button type="button" class="btn btn-secondary btn-sm"
+                                onclick="discoverBqTables('editBqDataset', 'editBqTableList')"
+                                style="float:right; margin-top:-3px;">
+                            List tables
+                        </button>
+                    </label>
+                    <input type="text" class="form-input" id="editBqSourceTable"
+                           list="editBqTableList" placeholder="e.g. orders">
+                    <datalist id="editBqTableList"></datalist>
                     <div class="form-hint">Agnes auto-detects whether this is a table or a view.</div>
                 </div>
                 <div class="form-group bq-edit-only bq-edit-source-custom" style="display:none;">
-                    <label class="form-label" for="editBqSourceQuery">SQL</label>
+                    <label class="form-label" for="editBqSourceQuery">
+                        SQL
+                        <button type="button" class="btn btn-secondary btn-sm"
+                                onclick="prefillFromTable('editBqSourceQuery')"
+                                style="float:right; margin-top:-3px;"
+                                title="Prefill SELECT * FROM `project.dataset.table` so you only edit the WHERE / projection">
+                            Use table as base
+                        </button>
+                    </label>
                     <textarea class="form-textarea" id="editBqSourceQuery" rows="8"></textarea>
                     <div class="form-hint">SELECT statement, no trailing semicolon. Native BQ
                         identifiers recommended for the cost guardrail to engage.</div>
@@ -1593,12 +1619,19 @@
         });
     }
 
-    function discoverBqDatasets() {
+    // The discover / list-tables / prefill helpers are shared between the
+    // Register and Edit modals. The default datalist + input ids match the
+    // Register modal; Edit-modal callers pass their own ids so the
+    // autocomplete populates the right datalist and reads from the right
+    // dataset input.
+
+    function discoverBqDatasets(datalistId) {
         // GET /api/admin/discover-tables (no `dataset`) → list datasets in
-        // the configured BQ project. Populate the bqDatasetList <datalist>
-        // so the input shows them as autocomplete suggestions. The endpoint
+        // the configured BQ project. Populate the named <datalist> so the
+        // dataset input shows them as autocomplete suggestions. Endpoint
         // routes through BqAccess so config / auth errors come back as the
         // standard {error, kind, details} shape.
+        var dlId = datalistId || 'bqDatasetList';
         fetch('/api/admin/discover-tables')
             .then(function(r) {
                 if (!r.ok) return r.json().then(function(d) {
@@ -1608,7 +1641,7 @@
                 return r.json();
             })
             .then(function(data) {
-                var dl = document.getElementById('bqDatasetList');
+                var dl = document.getElementById(dlId);
                 dl.innerHTML = '';
                 (data.datasets || []).forEach(function(ds) {
                     var opt = document.createElement('option');
@@ -1623,11 +1656,13 @@
             });
     }
 
-    function discoverBqTables() {
+    function discoverBqTables(datasetInputId, tablesDatalistId) {
         // GET /api/admin/discover-tables?dataset=NAME → list tables + views
         // in the dataset. Two-step (dataset → tables) avoids paying the
         // per-dataset list_tables() cost up front on big projects.
-        var dataset = document.getElementById('bqDataset').value.trim();
+        var inId = datasetInputId || 'bqDataset';
+        var dlId = tablesDatalistId || 'bqTableList';
+        var dataset = document.getElementById(inId).value.trim();
         if (!dataset) {
             showToast('Fill Dataset first', 'error');
             return;
@@ -1641,14 +1676,14 @@
                 return r.json();
             })
             .then(function(data) {
-                var dl = document.getElementById('bqTableList');
+                var dl = document.getElementById(dlId);
                 dl.innerHTML = '';
                 (data.tables || []).forEach(function(t) {
                     var opt = document.createElement('option');
                     opt.value = t.table_id;
                     // BQ entity types: TABLE, VIEW, MATERIALIZED_VIEW,
                     // EXTERNAL, SNAPSHOT — surface so the operator can
-                    // pick the right Type selector option.
+                    // pick the right entity option.
                     opt.label = t.table_id + (t.table_type ? '  (' + t.table_type + ')' : '');
                     dl.appendChild(opt);
                 });
@@ -1659,13 +1694,15 @@
             });
     }
 
-    function prefillFromTable() {
+    function prefillFromTable(textareaId) {
         // Convenience for the Custom SQL path: prompt for project.dataset.table
         // and prefill `SELECT * FROM \`...\`` so the operator only edits the
         // WHERE / projection. We can't know the project from the form (it's
         // server-side config), so the prompt accepts both `dataset.table` and
         // `project.dataset.table`. Empty / cancel → no change.
-        var existing = document.getElementById('bqSourceQuery').value.trim();
+        var taId = textareaId || 'bqSourceQuery';
+        var ta = document.getElementById(taId);
+        var existing = ta.value.trim();
         if (existing && !confirm('SQL field is not empty — overwrite with prefill?')) {
             return;
         }
@@ -1681,7 +1718,7 @@
             + 'FROM `' + ref + '`\n'
             + 'WHERE -- TODO: filter or aggregate before the COPY runs (10 GiB cap)\n'
             + 'LIMIT 1000';
-        document.getElementById('bqSourceQuery').value = stub;
+        ta.value = stub;
     }
 
     function registerTable() {

--- a/cli/commands/admin.py
+++ b/cli/commands/admin.py
@@ -63,11 +63,19 @@ def register_table(
     source_type: str = typer.Option("keboola", help="Source type: keboola | bigquery | jira | local"),
     bucket: str = typer.Option("", help="Source bucket (Keboola) or dataset (BigQuery)"),
     source_table: str = typer.Option("", help="Source table name in the bucket/dataset"),
-    query_mode: str = typer.Option("local", help="Query mode: local or remote (forced to 'remote' for bigquery)"),
+    query_mode: str = typer.Option("local", help="Query mode: local | remote | materialized"),
+    query: str = typer.Option(
+        "",
+        "--query",
+        help=(
+            "SQL body for query_mode='materialized' (BigQuery only). "
+            "Inline SQL or `@path/to.sql` to read from disk."
+        ),
+    ),
     description: str = typer.Option("", help="Table description"),
     sync_schedule: str = typer.Option(
         "",
-        help="Cron schedule (BigQuery only — note: scheduler not yet wired, see #79 / M3 of #108)",
+        help="Cron schedule (e.g. 'every 6h' / 'daily 03:00'); honored by materialized BQ rows",
     ),
     dry_run: bool = typer.Option(
         False,
@@ -77,11 +85,38 @@ def register_table(
 ):
     """Register a single table.
 
-    For BigQuery: dataset goes in --bucket, the BQ table/view name in
-    --source-table, the DuckDB view name in NAME. The server forces
-    query_mode=remote and profile_after_sync=False; --dry-run goes
-    through /precheck and prints rows + size + columns without writing.
+    Modes:
+    - **local** (Keboola): batch pull, parquet on disk.
+    - **remote** (BigQuery): view only, queries go to BQ. Requires
+      `--bucket` + `--source-table`.
+    - **materialized** (BigQuery): server-side scheduled SQL → parquet.
+      Requires `--query` (inline or `@file.sql`); `--bucket` /
+      `--source-table` ignored.
+
+    `--dry-run` goes through /precheck (BQ remote only — for materialized
+    rows, dry-run is a no-op since the SQL itself is the contract).
     """
+    from pathlib import Path
+
+    # Resolve --query @file.sql shorthand.
+    source_query = ""
+    if query:
+        if query.startswith("@"):
+            sql_path = Path(query[1:])
+            if not sql_path.exists():
+                typer.echo(f"Error: SQL file not found: {sql_path}", err=True)
+                raise typer.Exit(2)
+            source_query = sql_path.read_text(encoding="utf-8").strip()
+        else:
+            source_query = query.strip()
+
+    if query_mode == "materialized" and not source_query:
+        typer.echo(
+            "Error: --query-mode materialized requires --query (literal SQL or @path.sql)",
+            err=True,
+        )
+        raise typer.Exit(2)
+
     payload = {
         "name": name,
         "source_type": source_type,
@@ -90,6 +125,11 @@ def register_table(
         "query_mode": query_mode,
         "description": description,
     }
+    # Omit empty optional fields so the server-side validator doesn't see
+    # `source_query=""` on a remote/local row (which would trigger the
+    # "source_query forbidden" branch).
+    if source_query:
+        payload["source_query"] = source_query
     if sync_schedule:
         payload["sync_schedule"] = sync_schedule
 

--- a/cli/commands/analyst.py
+++ b/cli/commands/analyst.py
@@ -275,6 +275,45 @@ def _get_instance_name(server_url: str, token: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Helper: install SessionStart/End hooks into a Claude settings file
+# ---------------------------------------------------------------------------
+
+def _install_claude_hooks(settings_path: Path) -> None:
+    """Add SessionStart/SessionEnd hooks calling `da sync` to a Claude settings file.
+
+    Idempotent: replaces our prior `da sync` entries (matched by command substring
+    `da sync`) but preserves anyone else's hooks. Creates the file when missing.
+
+    The settings file is workspace-level (`<workspace>/.claude/settings.json`) so
+    the hooks only fire in this analyst workspace, not in unrelated Claude Code
+    sessions on the same machine.
+    """
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if settings_path.exists():
+        cfg = json.loads(settings_path.read_text(encoding="utf-8"))
+    else:
+        cfg = {}
+
+    hooks = cfg.setdefault("hooks", {})
+
+    def _replace_or_add(event: str, command: str) -> None:
+        existing = hooks.setdefault(event, [])
+        # Drop any prior entry whose every command is a `da sync` invocation.
+        # Third-party entries (PreToolUse: echo hi) and mixed entries are left alone.
+        for entry in list(existing):
+            entry_cmds = [h.get("command", "") for h in entry.get("hooks", [])]
+            if entry_cmds and all("da sync" in c for c in entry_cmds):
+                existing.remove(entry)
+        existing.append({"hooks": [{"type": "command", "command": command}]})
+
+    _replace_or_add("SessionStart", "da sync --quiet 2>/dev/null || true")
+    _replace_or_add("SessionEnd",   "da sync --upload-only --quiet 2>/dev/null || true")
+
+    settings_path.write_text(json.dumps(cfg, indent=2) + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
 # Helper: generate CLAUDE.md from template
 # ---------------------------------------------------------------------------
 
@@ -319,8 +358,12 @@ def _generate_claude_md(
 
     settings_path = workspace / ".claude" / "settings.json"
     if not settings_path.exists():
+        # First-run defaults: model + permissions. _install_claude_hooks below
+        # will merge in the SessionStart/End hooks on top of these.
         settings = {"model": "sonnet", "permissions": {"allow": ["Read", "Bash", "Grep", "Glob"]}}
         settings_path.write_text(json.dumps(settings, indent=2))
+
+    _install_claude_hooks(settings_path)
 
 
 # ---------------------------------------------------------------------------
@@ -400,6 +443,7 @@ def setup(
     typer.echo(f"  Server   : {server_url}")
     typer.echo(f"  Tables   : {n_downloaded} downloaded, {total_rows} total rows")
     typer.echo(f"  Workspace: {workspace}")
+    typer.echo(f"  Hooks    : SessionStart/End installed in {workspace}/.claude/settings.json")
     typer.echo("")
     typer.echo("Next steps:")
     typer.echo("  da sync          — refresh data")

--- a/cli/commands/analyst.py
+++ b/cli/commands/analyst.py
@@ -291,7 +291,14 @@ def _install_claude_hooks(settings_path: Path) -> None:
     settings_path.parent.mkdir(parents=True, exist_ok=True)
 
     if settings_path.exists():
-        cfg = json.loads(settings_path.read_text(encoding="utf-8"))
+        try:
+            cfg = json.loads(settings_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            typer.echo(
+                f"Warning: {settings_path} is not valid JSON; skipping hook install.",
+                err=True,
+            )
+            return
     else:
         cfg = {}
 

--- a/cli/commands/sync.py
+++ b/cli/commands/sync.py
@@ -513,6 +513,15 @@ def _sync_quiet(table, docs_only, as_json, dry_run):
                  "skipped_remote": skipped_remote},
                 indent=2,
             ))
+        else:
+            # Single stderr line keeps stdout clean for hooks while still
+            # giving an interactive operator running `da sync --quiet
+            # --dry-run` a sign that something happened.
+            typer.echo(
+                f"sync (dry-run): would download {len(to_download)} tables, "
+                f"skip {len(skipped_remote)} remote-mode",
+                err=True,
+            )
         return
 
     local_dir = _local_data_dir()

--- a/cli/commands/sync.py
+++ b/cli/commands/sync.py
@@ -31,6 +31,11 @@ def sync(
     upload_only: bool = typer.Option(False, "--upload-only", help="Only upload sessions/artifacts"),
     docs_only: bool = typer.Option(False, "--docs-only", help="Only sync documentation"),
     as_json: bool = typer.Option(False, "--json", help="Output as JSON"),
+    quiet: bool = typer.Option(
+        False,
+        "--quiet",
+        help="Suppress progress output (intended for hooks/cron)",
+    ),
     dry_run: bool = typer.Option(
         False,
         "--dry-run",
@@ -39,7 +44,12 @@ def sync(
 ):
     """Sync data between server and local machine."""
     if upload_only:
-        _upload(as_json, dry_run=dry_run)
+        _upload(as_json, dry_run=dry_run, quiet=quiet)
+        return
+
+    if quiet:
+        # Bypass Rich Progress entirely so hook stdout stays clean.
+        _sync_quiet(table=table, docs_only=docs_only, as_json=as_json, dry_run=dry_run)
         return
 
     with Progress(
@@ -388,11 +398,13 @@ def _is_valid_parquet(path: Path) -> bool:
         return False
 
 
-def _upload(as_json: bool, dry_run: bool = False):
+def _upload(as_json: bool, dry_run: bool = False, quiet: bool = False):
     """Upload sessions and CLAUDE.local.md to server.
 
     When `dry_run=True`, enumerate what would be uploaded without hitting the
-    API or mutating anything on disk.
+    API or mutating anything on disk. When `quiet=True`, suppress the trailing
+    "Uploaded N sessions" stdout line — error paths still surface on stderr
+    via api_post itself.
     """
     local_dir = _local_data_dir()
     sessions_dir = local_dir / "user" / "sessions"
@@ -448,7 +460,108 @@ def _upload(as_json: bool, dry_run: bool = False):
 
     if as_json:
         typer.echo(json.dumps(results, indent=2))
-    else:
+    elif not quiet:
         typer.echo(f"Uploaded {results['sessions']} sessions")
         if results["local_md"]:
             typer.echo("Uploaded CLAUDE.local.md")
+
+
+def _sync_quiet(table, docs_only, as_json, dry_run):
+    """Mirror of the Progress-block flow without any Rich UI.
+
+    Designed for Claude Code SessionStart/SessionEnd hooks and cron callers:
+    stdout stays empty in the no-op case, the terse one-line summary lands
+    on stderr so hook stdout pipes don't see it, and a manifest fetch
+    failure exits non-zero so the `|| true` shell fallback can swallow it
+    cleanly.
+
+    Skips remote-mode tables exactly like the noisy path; runs the
+    `_fetch_and_write_rules` corporate-memory step so analysts' .claude/
+    rules/ stay fresh between sessions.
+    """
+    try:
+        resp = api_get("/api/sync/manifest")
+        resp.raise_for_status()
+        manifest = resp.json()
+    except Exception as e:
+        typer.echo(f"sync: manifest fetch failed: {e}", err=True)
+        raise typer.Exit(1)
+
+    server_tables = manifest.get("tables", {})
+    local_state = get_sync_state()
+    local_tables = local_state.get("tables", {})
+
+    to_download = []
+    skipped_remote = []
+    for tid, info in server_tables.items():
+        if table and tid != table:
+            continue
+        if docs_only:
+            continue
+        if info.get("query_mode") == "remote":
+            skipped_remote.append(tid)
+            continue
+        local_hash = local_tables.get(tid, {}).get("hash", "")
+        server_hash = info.get("hash", "")
+        if server_hash != local_hash or tid not in local_tables or not server_hash:
+            to_download.append(tid)
+
+    if dry_run:
+        if as_json:
+            typer.echo(json.dumps(
+                {"dry_run": True, "would_download": to_download,
+                 "skipped_remote": skipped_remote},
+                indent=2,
+            ))
+        return
+
+    local_dir = _local_data_dir()
+    parquet_dir = local_dir / "server" / "parquet"
+    parquet_dir.mkdir(parents=True, exist_ok=True)
+
+    results = {
+        "downloaded": [], "skipped": [],
+        "skipped_remote": list(skipped_remote), "errors": [],
+    }
+    for tid in to_download:
+        target = parquet_dir / f"{tid}.parquet"
+        expected_hash = server_tables[tid].get("hash", "")
+        try:
+            stream_download(f"/api/data/{tid}/download", str(target))
+            if expected_hash:
+                if _md5_file(target) != expected_hash:
+                    target.unlink(missing_ok=True)
+                    raise ValueError("hash mismatch")
+            elif not _is_valid_parquet(target):
+                target.unlink(missing_ok=True)
+                raise ValueError("not a valid parquet")
+            local_tables[tid] = {
+                "hash": expected_hash,
+                "rows": server_tables[tid].get("rows", 0),
+                "size_bytes": server_tables[tid].get("size_bytes", 0),
+            }
+            results["downloaded"].append(tid)
+        except Exception as e:
+            results["errors"].append({"table": tid, "error": str(e)})
+
+    from datetime import datetime, timezone
+    local_state["tables"] = local_tables
+    local_state["last_sync"] = datetime.now(timezone.utc).isoformat()
+    save_sync_state(local_state)
+
+    if results["downloaded"]:
+        _rebuild_duckdb_views(local_dir, parquet_dir)
+
+    # Same corporate-memory rule fetch as the noisy path — keeps the
+    # `.claude/rules/km_*.md` files fresh between sessions even when the
+    # hook is the only thing invoking sync.
+    _fetch_and_write_rules(local_dir)
+
+    if as_json:
+        typer.echo(json.dumps(results, indent=2))
+    elif results["downloaded"] or results["errors"]:
+        typer.echo(
+            f"sync: {len(results['downloaded'])} tables, "
+            f"{len(results['errors'])} errors",
+            err=True,
+        )

--- a/cli/skills/connectors.md
+++ b/cli/skills/connectors.md
@@ -51,3 +51,28 @@ The `_meta` table must have columns:
 - Instance-level config: `config/instance.yaml` (connection details)
 - Table definitions: DuckDB `table_registry` table
 - Credentials: environment variables
+
+## BigQuery: pick a mode
+
+| Need | Mode | Why |
+|------|------|-----|
+| Latency under 100 ms, table fits on disk | `materialized` | Local parquet, no BQ roundtrip |
+| Table too large for analyst's disk, occasional ad-hoc query | `remote` | DuckDB BQ extension, no download |
+| Table too large for disk AND analyst hits it constantly | `materialized` with aggregation/filter | Scheduled COPY of a slice |
+| One-off subquery joined with local data | (no registry row) | Use `da query --register-bq …` for ad-hoc |
+
+Cost: `materialized` runs once per `sync_schedule` regardless of how many analysts query it; `remote` runs once per analyst-query. The break-even is roughly query frequency × bytes scanned vs. one COPY × bytes scanned.
+
+Guardrail: `data_source.bigquery.max_bytes_per_materialize` (default 10 GiB) blocks the COPY when BQ's dry-run estimate exceeds the cap. Set it explicitly per environment in `instance.yaml`.
+
+Register a materialized table:
+
+```bash
+da admin register-table orders_90d \
+    --source-type bigquery \
+    --query-mode materialized \
+    --query @docs/queries/orders_90d.sql \
+    --schedule "every 6h"
+```
+
+`--query` also accepts inline SQL.

--- a/connectors/bigquery/extractor.py
+++ b/connectors/bigquery/extractor.py
@@ -397,14 +397,22 @@ def materialize_query(
 
     # COPY through a BqAccess-managed session.
     with bq.duckdb_session() as conn:
-        # ATTACH the data project. Tolerated-fail when the session already
-        # has `bq` attached (test stubs may pre-populate; rare in production).
+        # ATTACH the data project. Test stubs pre-populate `bq` as an
+        # in-memory schema; production uses the real BQ extension. The
+        # only tolerated failure is "alias already in use" — anything else
+        # (auth, permission, malformed project_id) must surface so the
+        # caller's per-row try/except can record it. Devil's-advocate
+        # review found that swallowing the error blindly hid
+        # cross-project permission errors behind a confusing
+        # "bq is not attached" downstream message.
         try:
             conn.execute(
                 f"ATTACH 'project={bq.projects.data}' AS bq (TYPE bigquery, READ_ONLY)"
             )
-        except duckdb.Error:
-            pass
+        except duckdb.Error as e:
+            msg = str(e).lower()
+            if "already" not in msg and "in use" not in msg:
+                raise
 
         try:
             safe_path = str(tmp_path).replace("'", "''")
@@ -417,10 +425,40 @@ def materialize_query(
                 tmp_path.unlink()
             raise
 
+    # Compute the parquet hash inline before the atomic swap. The caller used
+    # to re-read the file in `_run_materialized_pass` to hash it via
+    # `_file_hash`, but that's a synchronous full-read on the FastAPI worker
+    # thread — a 10 GiB parquet means 50+ seconds of disk I/O blocking other
+    # requests. Hashing here keeps the open-file handle hot from the COPY
+    # round and removes the second read. Devil's-advocate review item.
+    import hashlib
+    h = hashlib.md5()
+    with open(tmp_path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    parquet_hash = h.hexdigest()
+
     size_bytes = tmp_path.stat().st_size
     os.replace(tmp_path, parquet_path)
 
-    return {"rows": int(rows), "size_bytes": size_bytes, "query_mode": "materialized"}
+    rows = int(rows)
+    if rows == 0:
+        # 0 rows is indistinguishable from "the SQL is wrong and nobody
+        # noticed" — surface it loudly so operators see it in the scheduler
+        # log line and the per-row error aggregation. Caller decides whether
+        # to alert.
+        logger.warning(
+            "Materialized %s produced 0 rows — verify the SQL filter is "
+            "intentional. Parquet written: %s",
+            table_id, parquet_path,
+        )
+
+    return {
+        "rows": rows,
+        "size_bytes": size_bytes,
+        "query_mode": "materialized",
+        "hash": parquet_hash,
+    }
 
 
 def _resolve_bq_project_id() -> str:

--- a/connectors/bigquery/extractor.py
+++ b/connectors/bigquery/extractor.py
@@ -9,7 +9,7 @@ import shutil
 import threading
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 import duckdb
 
@@ -182,6 +182,14 @@ def _init_extract_locked(
         _create_remote_attach_table(conn, project_id)
 
         for tc in table_configs:
+            # Materialized rows are written by the sync trigger pass via
+            # `materialize_query()` — they live as parquets in
+            # /data/extracts/bigquery/data/, picked up by the orchestrator's
+            # standard local-parquet discovery. Don't create a remote view
+            # here (would shadow the parquet via name collision).
+            if tc.get("query_mode") == "materialized":
+                continue
+
             table_name = tc["name"]
             dataset = tc.get("bucket", "")
             source_table = tc.get("source_table", table_name)
@@ -277,6 +285,142 @@ def _init_extract_locked(
         tmp_wal.unlink()
 
     return stats
+
+
+class MaterializeBudgetError(RuntimeError):
+    """Raised when a `materialize_query` BQ dry-run estimate exceeds the
+    configured `data_source.bigquery.max_bytes_per_materialize` cap.
+
+    The materialize trigger pass logs this and skips the row; the next
+    scheduled tick re-tries (in case the underlying table size dropped
+    or the operator raised the cap). Shape mirrors `BqAccessError` —
+    `current` and `limit` for operator triage.
+    """
+
+    def __init__(self, message: str, *, table_id: str, current: int, limit: int):
+        self.table_id = table_id
+        self.current = current
+        self.limit = limit
+        super().__init__(message)
+
+
+def materialize_query(
+    table_id: str,
+    sql: str,
+    *,
+    bq,  # connectors.bigquery.access.BqAccess (untyped here to avoid circular import at type-check)
+    output_dir: str,
+    max_bytes: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Run `sql` through the DuckDB BigQuery extension and write the result
+    to `<output_dir>/data/<table_id>.parquet` atomically.
+
+    Designed for `query_mode='materialized'` table_registry rows. The SQL
+    is admin-registered (validated upstream) and may reference DuckDB
+    three-part identifiers (`bq."dataset"."table"`) resolved by the
+    in-session ATTACH, OR native BQ identifiers via the `bigquery_query()`
+    table function — both work because the session has the bigquery
+    extension loaded with a SECRET token.
+
+    Cost guardrail: when `max_bytes` is a positive int, run a BQ dry-run
+    via `bq.client()` first; raise `MaterializeBudgetError` if the
+    estimate exceeds the cap. `max_bytes=None` or `max_bytes <= 0`
+    disables the guardrail (config sentinel, see
+    `data_source.bigquery.max_bytes_per_materialize`).
+
+    Dry-run is best-effort and fail-open: if the SQL uses DuckDB syntax
+    that the native BQ client can't parse (e.g. `bq."ds"."t"`), the
+    dry-run raises and we log a warning; the COPY still runs. This
+    matches the BqAccess facade's "client is for native BQ SQL only"
+    contract — operators who need the cap to engage write the registered
+    SQL using native BQ identifiers (`\\`project.ds.t\\``).
+
+    Atomic write: result lands in `<id>.parquet.tmp` first, then
+    `os.replace` swaps it in. A failed COPY leaves no partial file behind.
+
+    Args:
+        table_id: Logical id from table_registry; becomes the parquet
+            filename. Must pass `validate_identifier()` so it can't
+            inject path traversal.
+        sql: SELECT statement, no trailing semicolon.
+        bq: A `BqAccess` instance — provides `duckdb_session()` for the
+            COPY and `client()` for the dry-run.
+        output_dir: Connector root, e.g. `/data/extracts/bigquery`.
+            Parquet lands in `<output_dir>/data/<table_id>.parquet`.
+        max_bytes: Optional cap on BQ bytes scanned. None or <= 0 disables.
+
+    Returns:
+        {"rows": int, "size_bytes": int, "query_mode": "materialized"}
+
+    Raises:
+        ValueError: if `table_id` is unsafe.
+        MaterializeBudgetError: if `max_bytes > 0` and dry-run estimate exceeds it.
+        BqAccessError: from `bq.duckdb_session()` (auth_failed / bq_lib_missing /
+            not_configured) — caller catches and aggregates into the trigger
+            pass summary.
+        duckdb.Error: if the COPY itself fails (e.g. bad SQL, missing table).
+    """
+    if not validate_identifier(table_id, "materialize table_id"):
+        raise ValueError(f"unsafe table_id: {table_id!r}")
+
+    out_path = Path(output_dir)
+    data_dir = out_path / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    parquet_path = data_dir / f"{table_id}.parquet"
+    tmp_path = data_dir / f"{table_id}.parquet.tmp"
+    if tmp_path.exists():
+        tmp_path.unlink()
+
+    # Cost guardrail (best-effort — fail-open if dry-run can't parse the SQL).
+    if max_bytes is not None and max_bytes > 0:
+        try:
+            from app.api.v2_scan import _bq_dry_run_bytes  # reuse main's impl
+            estimated = _bq_dry_run_bytes(bq, sql)
+        except Exception as e:
+            logger.warning(
+                "BQ dry-run failed for materialize cost guardrail (fail-open): %s. "
+                "If the SQL uses DuckDB three-part names like bq.\"ds\".\"t\", "
+                "rewrite to native BQ identifiers (`project.ds.t`) for the "
+                "guardrail to engage. Proceeding with COPY.",
+                e,
+            )
+            estimated = 0
+        if estimated > max_bytes:
+            raise MaterializeBudgetError(
+                f"dry-run estimate {estimated:,} bytes exceeds cap "
+                f"{max_bytes:,} for table {table_id!r}",
+                table_id=table_id,
+                current=estimated,
+                limit=max_bytes,
+            )
+
+    # COPY through a BqAccess-managed session.
+    with bq.duckdb_session() as conn:
+        # ATTACH the data project. Tolerated-fail when the session already
+        # has `bq` attached (test stubs may pre-populate; rare in production).
+        try:
+            conn.execute(
+                f"ATTACH 'project={bq.projects.data}' AS bq (TYPE bigquery, READ_ONLY)"
+            )
+        except duckdb.Error:
+            pass
+
+        try:
+            safe_path = str(tmp_path).replace("'", "''")
+            conn.execute(f"COPY ({sql}) TO '{safe_path}' (FORMAT PARQUET)")
+            rows = conn.execute(
+                f"SELECT count(*) FROM read_parquet('{safe_path}')"
+            ).fetchone()[0]
+        except Exception:
+            if tmp_path.exists():
+                tmp_path.unlink()
+            raise
+
+    size_bytes = tmp_path.stat().st_size
+    os.replace(tmp_path, parquet_path)
+
+    return {"rows": int(rows), "size_bytes": size_bytes, "query_mode": "materialized"}
 
 
 def _resolve_bq_project_id() -> str:

--- a/connectors/bigquery/extractor.py
+++ b/connectors/bigquery/extractor.py
@@ -397,22 +397,25 @@ def materialize_query(
 
     # COPY through a BqAccess-managed session.
     with bq.duckdb_session() as conn:
-        # ATTACH the data project. Test stubs pre-populate `bq` as an
-        # in-memory schema; production uses the real BQ extension. The
-        # only tolerated failure is "alias already in use" — anything else
-        # (auth, permission, malformed project_id) must surface so the
-        # caller's per-row try/except can record it. Devil's-advocate
-        # review found that swallowing the error blindly hid
-        # cross-project permission errors behind a confusing
-        # "bq is not attached" downstream message.
-        try:
+        # ATTACH the data project — but only when no `bq` catalog is
+        # already attached. Production sessions (real BqAccess) come with
+        # only `:memory:` and need the ATTACH; test sessions pre-populate
+        # `bq` as a fixture catalog and would error on a redundant ATTACH
+        # (alias already in use) AND on the bigquery extension load when
+        # the test runner has no cached extension. Detecting via
+        # `duckdb_databases()` keeps the ATTACH path idempotent without
+        # swallowing real errors (auth, cross-project permission,
+        # malformed project_id) — those still propagate from the actual
+        # ATTACH call.
+        attached = {
+            r[0] for r in conn.execute(
+                "SELECT database_name FROM duckdb_databases()"
+            ).fetchall()
+        }
+        if "bq" not in attached:
             conn.execute(
                 f"ATTACH 'project={bq.projects.data}' AS bq (TYPE bigquery, READ_ONLY)"
             )
-        except duckdb.Error as e:
-            msg = str(e).lower()
-            if "already" not in msg and "in use" not in msg:
-                raise
 
         try:
             safe_path = str(tmp_path).replace("'", "''")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -173,10 +173,19 @@ POST /api/sync/trigger (admin)
 
 `connectors/bigquery/extractor.py`
 
-- Uses the DuckDB BigQuery community extension.
+- Uses the DuckDB BigQuery community extension via the `BqAccess` facade in `connectors/bigquery/access.py`.
 - No data download — views proxy all queries directly to BigQuery.
 - Auth via `GOOGLE_APPLICATION_CREDENTIALS` (service account JSON) or ADC.
 - Populates `_remote_attach` with `extension='bigquery'` and no `token_env` (env-based auth).
+
+### BigQuery — Materialized SQL
+
+`connectors/bigquery/extractor.py::materialize_query` (added in v0.25.0)
+
+- Runs admin-registered SQL through the DuckDB BigQuery extension via `BqAccess.duckdb_session()` and writes the result to `/data/extracts/bigquery/data/<id>.parquet` atomically (`<id>.parquet.tmp` → `os.replace`).
+- Triggered by `_run_materialized_pass` in `app/api/sync.py` between custom-connectors and orchestrator rebuild on every `/api/sync/trigger`. Per-table `sync_schedule` honored via `is_table_due()`.
+- Cost guardrail: BQ dry-run via `app.api.v2_scan._bq_dry_run_bytes` (single source of truth for cost-estimate logic). `data_source.bigquery.max_bytes_per_materialize` (default 10 GiB; `0` disables). Fail-open when dry-run errors (DuckDB three-part syntax the native BQ client can't parse) — log warning + proceed.
+- Distribution: result parquet rides the same manifest + `da sync` flow as Keboola tables. Per-user RBAC unchanged (`resource_grants(group, ResourceType.TABLE, table_id)`).
 
 ### Jira — Real-Time Push
 

--- a/docs/setup/claude_settings.json
+++ b/docs/setup/claude_settings.json
@@ -1,11 +1,21 @@
 {
     "hooks": {
+        "SessionStart": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "da sync --quiet 2>/dev/null || true"
+                    }
+                ]
+            }
+        ],
         "SessionEnd": [
             {
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "python server/scripts/collect_session.py 2>/dev/null || true"
+                        "command": "da sync --upload-only --quiet 2>/dev/null || true"
                     }
                 ]
             }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.24.0"
+version = "0.25.0"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/scripts/smoke-test-materialized-bq.sh
+++ b/scripts/smoke-test-materialized-bq.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# Smoke test — query_mode='materialized' for BigQuery.
+#
+# Runs the full happy-path + 3 adversarial scenarios against a live Agnes
+# instance that has BigQuery configured. Cheap (uses bigquery-public-data
+# samples; ~36 rows, < 1 KB scan) — safe to run against staging.
+#
+# Usage:
+#   ./scripts/smoke-test-materialized-bq.sh [host:port]
+#
+# Required environment:
+#   AGNES_PAT       — admin PAT for the target instance
+#   BQ_TEST_BIG     — (optional) name of a BQ table > 10 GiB to test the
+#                     cost guardrail. Defaults to a public dataset that
+#                     scans ~50 GB on full SELECT.
+#
+# Defaults: AGNES_HOST=http://localhost:8000.
+#
+# Cleans up the test rows on exit (trap), even on SIGINT.
+
+set -euo pipefail
+
+HOST="${1:-${AGNES_HOST:-http://localhost:8000}}"
+PAT="${AGNES_PAT:?AGNES_PAT must be set (admin token)}"
+BIG_TABLE="${BQ_TEST_BIG:-bigquery-public-data.github_repos.commits}"
+
+PASS=0
+FAIL=0
+
+# Test rows we'll create — captured for cleanup.
+CREATED_IDS=()
+
+cleanup() {
+    echo
+    echo "--- Cleanup ---"
+    for tid in "${CREATED_IDS[@]}"; do
+        curl -sS -X DELETE "$HOST/api/admin/registry/$tid" \
+            -H "Authorization: Bearer $PAT" -o /dev/null -w "  DELETE %{http_code} $tid\n" || true
+    done
+}
+trap cleanup EXIT INT TERM
+
+check() {
+    local name="$1" ok="$2"
+    if [ "$ok" = "true" ]; then
+        echo "  PASS $name"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+http() {
+    # POST/PUT/DELETE helper that returns the HTTP status + body separately.
+    local method="$1" path="$2" body="${3:-}"
+    if [ -n "$body" ]; then
+        curl -sS -o /tmp/smoke-mat-body -w "%{http_code}" \
+            -X "$method" "$HOST$path" \
+            -H "Authorization: Bearer $PAT" \
+            -H "Content-Type: application/json" \
+            -d "$body"
+    else
+        curl -sS -o /tmp/smoke-mat-body -w "%{http_code}" \
+            -X "$method" "$HOST$path" \
+            -H "Authorization: Bearer $PAT"
+    fi
+}
+
+echo "Materialized BQ smoke: $HOST"
+echo "Big table for cost-guardrail test: $BIG_TABLE"
+echo "---"
+
+# ---------------------------------------------------------------------------
+# Scenario A — Happy path: register tiny materialized table, trigger,
+#              verify parquet on disk + manifest carries hash.
+# ---------------------------------------------------------------------------
+echo
+echo "[A] Happy path (Shakespeare sample, ~36 rows)"
+SQL_A='SELECT corpus, COUNT(*) AS c FROM `bigquery-public-data.samples.shakespeare` GROUP BY 1 ORDER BY 1'
+TID_A="smoke_mat_shakespeare_$(date +%s)"
+CREATED_IDS+=("$TID_A")
+
+STATUS=$(http POST /api/admin/register-table "{
+    \"name\": \"$TID_A\",
+    \"source_type\": \"bigquery\",
+    \"query_mode\": \"materialized\",
+    \"source_query\": $(printf '%s' "$SQL_A" | python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))"),
+    \"sync_schedule\": \"every 1m\"
+}")
+[ "$STATUS" = "201" ] && check "register 201" true || { check "register 201 (got $STATUS)" false; cat /tmp/smoke-mat-body; }
+
+echo "    triggering sync..."
+http POST /api/sync/trigger '{}' >/dev/null
+sleep 5  # background task
+
+# Manifest must list the row with query_mode + non-empty hash.
+http GET /api/sync/manifest >/dev/null
+HASH=$(python3 -c "
+import json
+m = json.load(open('/tmp/smoke-mat-body'))
+t = m.get('tables', {}).get('$TID_A')
+print(t.get('hash', '') if t else '')
+")
+[ -n "$HASH" ] && [ "$HASH" != "null" ] && check "manifest hash present" true || check "manifest hash present (got '$HASH')" false
+
+# Parquet on disk (assumes co-located filesystem, e.g. local docker compose).
+PARQUET="${DATA_DIR:-./data}/extracts/bigquery/data/$TID_A.parquet"
+if [ -f "$PARQUET" ]; then
+    ROWS=$(python3 -c "import duckdb; print(duckdb.connect().execute(\"SELECT count(*) FROM read_parquet('$PARQUET')\").fetchone()[0])" 2>/dev/null || echo "0")
+    [ "$ROWS" -gt 0 ] && check "parquet has $ROWS rows" true || check "parquet rows ($ROWS)" false
+else
+    echo "    note: parquet at $PARQUET not visible from this host (skip if Agnes is remote)"
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario B — Cost guardrail: register a large-scan materialized SQL,
+#              trigger, expect MaterializeBudgetError logged + row skipped.
+# ---------------------------------------------------------------------------
+echo
+echo "[B] Cost guardrail (\`$BIG_TABLE\` full SELECT)"
+TID_B="smoke_mat_huge_$(date +%s)"
+CREATED_IDS+=("$TID_B")
+SQL_B="SELECT * FROM \`$BIG_TABLE\`"
+
+STATUS=$(http POST /api/admin/register-table "{
+    \"name\": \"$TID_B\",
+    \"source_type\": \"bigquery\",
+    \"query_mode\": \"materialized\",
+    \"source_query\": $(printf '%s' "$SQL_B" | python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))"),
+    \"sync_schedule\": \"every 1m\"
+}")
+[ "$STATUS" = "201" ] && check "register 201" true || check "register 201 (got $STATUS)" false
+
+echo "    triggering sync (expect cap to fire)..."
+http POST /api/sync/trigger '{}' >/dev/null
+sleep 5
+
+# Manifest should NOT have a hash for the huge row (materialize was skipped).
+http GET /api/sync/manifest >/dev/null
+HUGE_HASH=$(python3 -c "
+import json
+m = json.load(open('/tmp/smoke-mat-body'))
+t = m.get('tables', {}).get('$TID_B')
+print(t.get('hash', '') if t else 'absent')
+")
+if [ "$HUGE_HASH" = "absent" ] || [ -z "$HUGE_HASH" ] || [ "$HUGE_HASH" = "null" ]; then
+    check "huge row skipped (no hash in manifest)" true
+else
+    check "huge row skipped (got hash '$HUGE_HASH' — guardrail did not fire)" false
+fi
+echo "    grep server logs for: 'MaterializeBudgetError' or 'Materialize cap exceeded'"
+
+# ---------------------------------------------------------------------------
+# Scenario C — 0-row warning: SQL with always-false WHERE.
+# ---------------------------------------------------------------------------
+echo
+echo "[C] 0-row WARNING (filter to empty result)"
+TID_C="smoke_mat_empty_$(date +%s)"
+CREATED_IDS+=("$TID_C")
+SQL_C='SELECT corpus FROM `bigquery-public-data.samples.shakespeare` WHERE 1=0'
+
+STATUS=$(http POST /api/admin/register-table "{
+    \"name\": \"$TID_C\",
+    \"source_type\": \"bigquery\",
+    \"query_mode\": \"materialized\",
+    \"source_query\": $(printf '%s' "$SQL_C" | python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))"),
+    \"sync_schedule\": \"every 1m\"
+}")
+[ "$STATUS" = "201" ] && check "register 201" true || check "register 201 (got $STATUS)" false
+
+http POST /api/sync/trigger '{}' >/dev/null
+sleep 5
+
+http GET /api/sync/manifest >/dev/null
+EMPTY_ROWS=$(python3 -c "
+import json
+m = json.load(open('/tmp/smoke-mat-body'))
+t = m.get('tables', {}).get('$TID_C')
+print(t.get('rows', 'absent') if t else 'absent')
+")
+[ "$EMPTY_ROWS" = "0" ] && check "empty-result rows=0 in manifest" true || check "empty-result rows ($EMPTY_ROWS)" false
+echo "    grep server logs for: 'produced 0 rows'"
+
+# ---------------------------------------------------------------------------
+# Scenario D — Mode-switch transition clears stale source_query.
+# ---------------------------------------------------------------------------
+echo
+echo "[D] Mode-switch materialized → remote clears source_query"
+TID_D="smoke_mat_switch_$(date +%s)"
+CREATED_IDS+=("$TID_D")
+
+STATUS=$(http POST /api/admin/register-table "{
+    \"name\": \"$TID_D\",
+    \"source_type\": \"bigquery\",
+    \"query_mode\": \"materialized\",
+    \"source_query\": \"SELECT 1\"
+}")
+[ "$STATUS" = "201" ] && check "register materialized" true || check "register materialized (got $STATUS)" false
+
+# Switch to remote, providing required bucket+source_table.
+STATUS=$(http PUT "/api/admin/registry/$TID_D" "{
+    \"query_mode\": \"remote\",
+    \"bucket\": \"samples\",
+    \"source_table\": \"shakespeare\"
+}")
+[ "$STATUS" = "200" ] && check "switch to remote 200" true || check "switch to remote (got $STATUS)" false
+
+http GET /api/admin/registry >/dev/null
+SWITCHED_SQ=$(python3 -c "
+import json
+r = json.load(open('/tmp/smoke-mat-body'))
+row = next((t for t in r.get('tables', []) if t['id'] == '$TID_D'), None)
+print(row.get('source_query') if row else 'NOT_FOUND')
+")
+[ "$SWITCHED_SQ" = "None" ] || [ -z "$SWITCHED_SQ" ] || [ "$SWITCHED_SQ" = "null" ] \
+    && check "source_query cleared on switch" true \
+    || check "source_query cleared (got '$SWITCHED_SQ')" false
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+echo "---"
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/src/db.py
+++ b/src/db.py
@@ -39,7 +39,7 @@ def _maybe_instrument(con, db_tag: str):
 
 _SAFE_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,63}$")
 
-SCHEMA_VERSION = 18
+SCHEMA_VERSION = 19
 
 _SYSTEM_SCHEMA = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -259,6 +259,7 @@ CREATE TABLE IF NOT EXISTS table_registry (
     source_type VARCHAR,
     bucket VARCHAR,
     source_table VARCHAR,
+    source_query TEXT,
     sync_strategy VARCHAR DEFAULT 'full_refresh',
     query_mode VARCHAR DEFAULT 'local',
     sync_schedule VARCHAR,
@@ -932,6 +933,16 @@ _V16_TO_V17_MIGRATIONS = [
 
 # v17 -> v18: see _v17_to_v18_finalize. Env-conditional, so kept as a Python
 # helper rather than a flat SQL list (the migrate-ladder calls it directly).
+
+
+# v18 -> v19: source_query column backs query_mode='materialized' for BigQuery.
+# Admin-registered SQL stored verbatim; scheduler runs it through the DuckDB BQ
+# extension (via BqAccess) and writes the result to
+# /data/extracts/bigquery/data/<id>.parquet so the existing manifest + da sync
+# flow distributes it to analysts. NULL on existing rows.
+_V18_TO_V19_MIGRATIONS = [
+    "ALTER TABLE table_registry ADD COLUMN IF NOT EXISTS source_query TEXT",
+]
 
 
 # Core role seed data — single source of truth. Used by both _seed_core_roles
@@ -1630,6 +1641,9 @@ def _ensure_schema(conn: duckdb.DuckDBPyConnection) -> None:
                     conn.execute(sql)
             if current < 18:
                 _v17_to_v18_finalize(conn)
+            if current < 19:
+                for sql in _V18_TO_V19_MIGRATIONS:
+                    conn.execute(sql)
             conn.execute(
                 "UPDATE schema_version SET version = ?, applied_at = current_timestamp",
                 [SCHEMA_VERSION],

--- a/src/repositories/table_registry.py
+++ b/src/repositories/table_registry.py
@@ -72,7 +72,9 @@ class TableRegistryRepository:
         primary_key: Union[None, str, List[str]] = None,
         description: Optional[str] = None, registered_by: Optional[str] = None,
         source_type: Optional[str] = None, bucket: Optional[str] = None,
-        source_table: Optional[str] = None, query_mode: str = "local",
+        source_table: Optional[str] = None,
+        source_query: Optional[str] = None,
+        query_mode: str = "local",
         sync_schedule: Optional[str] = None, profile_after_sync: bool = True,
         is_public: bool = True,
         registered_at: Optional[datetime] = None,
@@ -86,19 +88,21 @@ class TableRegistryRepository:
         self.conn.execute(
             """INSERT INTO table_registry (id, name, folder, sync_strategy,
                 primary_key, description, registered_by, registered_at,
-                source_type, bucket, source_table, query_mode,
+                source_type, bucket, source_table, source_query, query_mode,
                 sync_schedule, profile_after_sync, is_public)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT (id) DO UPDATE SET
                 name = excluded.name, folder = excluded.folder,
                 sync_strategy = excluded.sync_strategy, primary_key = excluded.primary_key,
                 description = excluded.description, registered_at = excluded.registered_at,
                 source_type = excluded.source_type, bucket = excluded.bucket,
-                source_table = excluded.source_table, query_mode = excluded.query_mode,
+                source_table = excluded.source_table, source_query = excluded.source_query,
+                query_mode = excluded.query_mode,
                 sync_schedule = excluded.sync_schedule, profile_after_sync = excluded.profile_after_sync,
                 is_public = excluded.is_public""",
             [id, name, folder, sync_strategy, encoded_pk, description, registered_by, ts,
-             source_type, bucket, source_table, query_mode, sync_schedule, profile_after_sync, is_public],
+             source_type, bucket, source_table, source_query, query_mode,
+             sync_schedule, profile_after_sync, is_public],
         )
 
     @staticmethod

--- a/tests/test_admin_bq_register.py
+++ b/tests/test_admin_bq_register.py
@@ -705,9 +705,10 @@ class TestAdminTablesUI:
         assert 'id="bqSourceTable"' in body
         assert 'id="bqViewName"' in body
         assert 'id="bqSyncSchedule"' in body
-        # Inline hint about scheduler-not-yet-wired (Decision 3).
-        assert "scheduler" in body.lower()
-        # BQ-specific panel (no discovery for BQ in M1).
+        # Cron-style schedule examples are surfaced near the field
+        # (operator-facing copy explains the syntax).
+        assert "every 6h" in body or "daily 03:00" in body
+        # BQ-specific panel (Keboola-style discovery panel must not appear).
         assert 'data-test="bq-register-panel"' in body
         # Keboola-only inputs must NOT be present.
         assert 'id="regTableId"' not in body

--- a/tests/test_admin_discover_bigquery.py
+++ b/tests/test_admin_discover_bigquery.py
@@ -120,7 +120,16 @@ def test_discover_returns_table_list_for_dataset(seeded_app, bq_instance, monkey
 
 
 def test_discover_keboola_branch_unchanged(seeded_app, monkeypatch):
-    """Negative — when source_type is keboola, BQ logic isn't reached."""
+    """Negative — when source_type is keboola, BQ logic isn't reached.
+
+    Skipped when the Keboola SDK (`kbcstorage`) is not installed: CI
+    runners don't ship it because the dev container only needs it for
+    instances that actually configure source_type=keboola, and the
+    route's lazy import would fail before the test stub gets a chance
+    to fire. The branch-unchanged contract is tested separately by the
+    Keboola integration suite when the package is present.
+    """
+    pytest.importorskip("kbcstorage")
     fake_cfg = {"data_source": {"type": "keboola", "keboola": {}}}
     monkeypatch.setattr(
         "app.instance_config.load_instance_config",

--- a/tests/test_admin_discover_bigquery.py
+++ b/tests/test_admin_discover_bigquery.py
@@ -1,0 +1,196 @@
+"""GET /api/admin/discover-tables — BigQuery branch.
+
+Two-step shape: dataset list (no `dataset` query param) → table list (with
+`dataset=name`). The UI populates the dataset autocomplete first, then
+fetches tables only after the operator picks a dataset, avoiding the
+per-dataset `list_tables()` cost on projects with hundreds of datasets.
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+
+from connectors.bigquery.access import BqAccess, BqProjects
+
+
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def bq_instance(monkeypatch):
+    """Force `data_source.type='bigquery'` so the endpoint routes to the
+    BQ branch."""
+    fake_cfg = {
+        "data_source": {
+            "type": "bigquery",
+            "bigquery": {"project": "my-test-project", "location": "us"},
+        },
+    }
+    monkeypatch.setattr(
+        "app.instance_config.load_instance_config",
+        lambda: fake_cfg,
+        raising=False,
+    )
+    from app.instance_config import reset_cache
+    reset_cache()
+    yield fake_cfg
+    reset_cache()
+
+
+def _stub_bq_with_client(client_mock):
+    """Build a BqAccess wired to return `client_mock` from .client(). The
+    duckdb_session_factory is unused by the discover endpoint — supply a
+    no-op."""
+    from contextlib import contextmanager
+    @contextmanager
+    def _noop(_p):
+        yield None
+    return BqAccess(
+        BqProjects(billing="my-test-project", data="my-test-project"),
+        client_factory=lambda _p: client_mock,
+        duckdb_session_factory=_noop,
+    )
+
+
+def test_discover_returns_dataset_list(seeded_app, bq_instance, monkeypatch):
+    """Without `dataset` param: list datasets in the configured project."""
+    client = MagicMock()
+    ds_a = MagicMock()
+    ds_a.dataset_id = "analytics"
+    ds_a.project = "my-test-project"
+    ds_b = MagicMock()
+    ds_b.dataset_id = "raw"
+    ds_b.project = "my-test-project"
+    client.list_datasets.return_value = [ds_a, ds_b]
+
+    monkeypatch.setattr(
+        "connectors.bigquery.access.get_bq_access",
+        lambda: _stub_bq_with_client(client),
+    )
+
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.get("/api/admin/discover-tables", headers=_auth(token))
+    assert r.status_code == 200, r.json()
+    body = r.json()
+    assert body["source"] == "bigquery"
+    assert body["count"] == 2
+    # Sorted alphabetically by dataset_id.
+    assert [d["dataset_id"] for d in body["datasets"]] == ["analytics", "raw"]
+    assert body["datasets"][0]["full_id"] == "my-test-project.analytics"
+
+
+def test_discover_returns_table_list_for_dataset(seeded_app, bq_instance, monkeypatch):
+    """With `?dataset=analytics`: list tables + views in that dataset."""
+    client = MagicMock()
+    t_orders = MagicMock()
+    t_orders.table_id = "orders"
+    t_orders.table_type = "TABLE"
+    t_orders.project = "my-test-project"
+    t_orders.dataset_id = "analytics"
+    t_view = MagicMock()
+    t_view.table_id = "orders_active"
+    t_view.table_type = "VIEW"
+    t_view.project = "my-test-project"
+    t_view.dataset_id = "analytics"
+    client.list_tables.return_value = [t_view, t_orders]  # unsorted
+
+    monkeypatch.setattr(
+        "connectors.bigquery.access.get_bq_access",
+        lambda: _stub_bq_with_client(client),
+    )
+
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.get(
+        "/api/admin/discover-tables?dataset=analytics",
+        headers=_auth(token),
+    )
+    assert r.status_code == 200, r.json()
+    body = r.json()
+    assert body["source"] == "bigquery"
+    assert body["dataset"] == "analytics"
+    assert body["count"] == 2
+    # Sorted by table_id.
+    assert [t["table_id"] for t in body["tables"]] == ["orders", "orders_active"]
+    by_id = {t["table_id"]: t for t in body["tables"]}
+    assert by_id["orders"]["table_type"] == "TABLE"
+    assert by_id["orders_active"]["table_type"] == "VIEW"
+    # Verify dataset filter was passed through.
+    client.list_tables.assert_called_once_with("analytics")
+
+
+def test_discover_keboola_branch_unchanged(seeded_app, monkeypatch):
+    """Negative — when source_type is keboola, BQ logic isn't reached."""
+    fake_cfg = {"data_source": {"type": "keboola", "keboola": {}}}
+    monkeypatch.setattr(
+        "app.instance_config.load_instance_config",
+        lambda: fake_cfg,
+        raising=False,
+    )
+    from app.instance_config import reset_cache
+    reset_cache()
+
+    # Stub the Keboola client so the test doesn't reach the network.
+    fake_client = MagicMock()
+    fake_client.discover_all_tables.return_value = [{"id": "in.c-foo.bar"}]
+    monkeypatch.setattr(
+        "connectors.keboola.client.KeboolaClient",
+        lambda *a, **kw: fake_client,
+    )
+
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    try:
+        r = c.get("/api/admin/discover-tables", headers=_auth(token))
+        assert r.status_code == 200, r.json()
+        body = r.json()
+        assert body["source"] == "keboola"
+        assert body["count"] == 1
+    finally:
+        reset_cache()
+
+
+def test_discover_bq_not_configured_returns_500(seeded_app, monkeypatch):
+    """When data_source.bigquery.project is missing, BqAccess returns its
+    not_configured sentinel — endpoint surfaces the structured error."""
+    fake_cfg = {
+        "data_source": {
+            "type": "bigquery",
+            "bigquery": {},  # no project
+        },
+    }
+    monkeypatch.setattr(
+        "app.instance_config.load_instance_config",
+        lambda: fake_cfg,
+        raising=False,
+    )
+    from app.instance_config import reset_cache
+    reset_cache()
+
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    try:
+        r = c.get("/api/admin/discover-tables", headers=_auth(token))
+        # not_configured is mapped to 500 in BqAccessError.HTTP_STATUS.
+        assert r.status_code == 500, r.json()
+        detail = r.json().get("detail", {})
+        assert detail.get("kind") == "not_configured"
+    finally:
+        reset_cache()
+
+
+def test_admin_tables_html_wires_discover_buttons(seeded_app, bq_instance):
+    """Structural — the BQ register modal in the rendered HTML now has the
+    Discover (datasets) and List tables buttons + datalists wired to the
+    endpoint."""
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.get("/admin/tables", headers=_auth(token))
+    assert r.status_code == 200, r.text
+    html = r.text
+    assert "discoverBqDatasets" in html
+    assert "discoverBqTables" in html
+    assert 'id="bqDatasetList"' in html
+    assert 'id="bqTableList"' in html
+    assert "list=\"bqDatasetList\"" in html
+    assert "list=\"bqTableList\"" in html

--- a/tests/test_admin_tables_ui_materialized.py
+++ b/tests/test_admin_tables_ui_materialized.py
@@ -69,6 +69,40 @@ def test_admin_tables_renders_bq_type_selector(seeded_app, bq_instance):
     assert "issue #108" not in html
 
 
+def test_edit_modal_has_bq_parity_fields(seeded_app, bq_instance):
+    """Edit modal must expose the same BQ controls as Register so an
+    operator can change the source/SQL/schedule without dropping & re-adding
+    the row. Pre-fix, Edit only had sync_strategy + primary_key + description
+    + folder — missing query_mode, bucket, source_table, source_query,
+    sync_schedule. Tested against the rendered template (the JS branch on
+    `source_type` is structural, not server-side)."""
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+
+    r = c.get("/admin/tables", headers=_auth(token))
+    assert r.status_code == 200, r.text
+    html = r.text
+
+    # Edit modal Type selector mirrors Register's three-way (Table/View/Query).
+    assert 'id="editBqEntityType"' in html
+    assert "onEditBqTypeChange" in html
+    # BQ-specific edit fields.
+    assert 'id="editBqDataset"' in html
+    assert 'id="editBqSourceTable"' in html
+    assert 'id="editBqSourceQuery"' in html
+    assert 'id="editBqSyncSchedule"' in html
+    # Visibility classes for adaptive show/hide on type switch.
+    assert "bq-edit-type-table" in html
+    assert "bq-edit-type-view" in html
+    assert "bq-edit-type-query" in html
+    # Mode-switch warning surface (filled by JS when operator flips
+    # query_mode mid-edit).
+    assert 'id="editBqModeWarning"' in html
+    # Source-type badge so the JS branch knows whether to render BQ vs
+    # Keboola fields without a second round-trip.
+    assert 'id="editSourceTypeBadge"' in html
+
+
 def test_admin_tables_keboola_branch_unchanged(seeded_app, monkeypatch):
     """Negative — when `data_source.type` is NOT bigquery, the BQ form
     fields don't appear at all (the Jinja `{% if %}` block guards them)."""

--- a/tests/test_admin_tables_ui_materialized.py
+++ b/tests/test_admin_tables_ui_materialized.py
@@ -1,17 +1,15 @@
-"""`/admin/tables` register modal exposes the materialized BQ controls.
+"""`/admin/tables` register modal exposes the BQ Type selector + Custom SQL.
 
-The backend supports `query_mode='materialized'` since v0.25.0 (PR #148).
-The Jinja template at `app/web/templates/admin_tables.html` was updated to
-add a `Mode` dropdown plus a `source_query` textarea so operators can
-register materialized BQ tables from the UI without reaching for the CLI.
+The backend supports `query_mode='materialized'` since v0.25.0. The Jinja
+template at `app/web/templates/admin_tables.html` exposes it via an
+operator-facing **Type** selector (Table / View / Custom SQL Query) that
+maps to query_mode in the payload (Table+View → remote, Query → materialized).
 
-This test is structural-only (no headless browser): it loads the template
-through the running app and asserts the expected element ids + attributes
-are present in the rendered HTML for a `data_source_type='bigquery'`
-deployment.
+Structural-only test (no headless browser): loads the template through the
+running app and asserts the expected element ids + attributes are present
+in the rendered HTML for a `data_source_type='bigquery'` deployment.
 """
 import pytest
-from unittest.mock import MagicMock
 
 
 def _auth(token):
@@ -39,7 +37,7 @@ def bq_instance(monkeypatch):
     reset_cache()
 
 
-def test_admin_tables_renders_bq_mode_selector(seeded_app, bq_instance):
+def test_admin_tables_renders_bq_type_selector(seeded_app, bq_instance):
     c = seeded_app["client"]
     token = seeded_app["admin_token"]
 
@@ -47,20 +45,28 @@ def test_admin_tables_renders_bq_mode_selector(seeded_app, bq_instance):
     assert r.status_code == 200, r.text
     html = r.text
 
-    # Mode dropdown with both options.
-    assert 'id="bqQueryMode"' in html
-    assert 'value="remote"' in html and 'value="materialized"' in html
-    assert "onBqModeChange" in html
+    # Type selector with three operator-facing options. Backend payload
+    # maps these onto query_mode (table+view → remote, query → materialized).
+    assert 'id="bqEntityType"' in html
+    assert 'value="table"' in html
+    assert 'value="view"' in html
+    assert 'value="query"' in html
+    assert "onBqTypeChange" in html
 
-    # Materialized-only field (textarea).
+    # Custom-SQL field + the "Use table as base" prefill button.
     assert 'id="bqSourceQuery"' in html
-    # Visibility class so the JS toggle can show/hide it as a group.
-    assert "bq-mode-materialized" in html
+    assert "prefillFromTable" in html
+    assert "bq-type-query" in html
 
-    # Remote-mode fields kept under their own visibility class.
+    # Table/View shared inputs.
     assert 'id="bqDataset"' in html
     assert 'id="bqSourceTable"' in html
-    assert "bq-mode-remote" in html
+    assert "bq-type-table" in html
+    assert "bq-type-view" in html
+
+    # Vendor-agnostic — no internal issue refs in operator-facing UI text.
+    assert "Milestone 2" not in html
+    assert "issue #108" not in html
 
 
 def test_admin_tables_keboola_branch_unchanged(seeded_app, monkeypatch):
@@ -81,7 +87,7 @@ def test_admin_tables_keboola_branch_unchanged(seeded_app, monkeypatch):
         r = c.get("/admin/tables", headers=_auth(token))
         assert r.status_code == 200, r.text
         html = r.text
-        assert 'id="bqQueryMode"' not in html
+        assert 'id="bqEntityType"' not in html
         assert 'id="bqSourceQuery"' not in html
         # Keboola form's regBucket / regTableId still there.
         assert 'id="regTableId"' in html

--- a/tests/test_admin_tables_ui_materialized.py
+++ b/tests/test_admin_tables_ui_materialized.py
@@ -1,0 +1,90 @@
+"""`/admin/tables` register modal exposes the materialized BQ controls.
+
+The backend supports `query_mode='materialized'` since v0.25.0 (PR #148).
+The Jinja template at `app/web/templates/admin_tables.html` was updated to
+add a `Mode` dropdown plus a `source_query` textarea so operators can
+register materialized BQ tables from the UI without reaching for the CLI.
+
+This test is structural-only (no headless browser): it loads the template
+through the running app and asserts the expected element ids + attributes
+are present in the rendered HTML for a `data_source_type='bigquery'`
+deployment.
+"""
+import pytest
+from unittest.mock import MagicMock
+
+
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def bq_instance(monkeypatch):
+    """Force `data_source.type='bigquery'` so /admin/tables renders the BQ
+    branch of the register modal."""
+    fake_cfg = {
+        "data_source": {
+            "type": "bigquery",
+            "bigquery": {"project": "my-test-project", "location": "us"},
+        },
+    }
+    monkeypatch.setattr(
+        "app.instance_config.load_instance_config",
+        lambda: fake_cfg,
+        raising=False,
+    )
+    from app.instance_config import reset_cache
+    reset_cache()
+    yield fake_cfg
+    reset_cache()
+
+
+def test_admin_tables_renders_bq_mode_selector(seeded_app, bq_instance):
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+
+    r = c.get("/admin/tables", headers=_auth(token))
+    assert r.status_code == 200, r.text
+    html = r.text
+
+    # Mode dropdown with both options.
+    assert 'id="bqQueryMode"' in html
+    assert 'value="remote"' in html and 'value="materialized"' in html
+    assert "onBqModeChange" in html
+
+    # Materialized-only field (textarea).
+    assert 'id="bqSourceQuery"' in html
+    # Visibility class so the JS toggle can show/hide it as a group.
+    assert "bq-mode-materialized" in html
+
+    # Remote-mode fields kept under their own visibility class.
+    assert 'id="bqDataset"' in html
+    assert 'id="bqSourceTable"' in html
+    assert "bq-mode-remote" in html
+
+
+def test_admin_tables_keboola_branch_unchanged(seeded_app, monkeypatch):
+    """Negative — when `data_source.type` is NOT bigquery, the BQ form
+    fields don't appear at all (the Jinja `{% if %}` block guards them)."""
+    fake_cfg = {"data_source": {"type": "keboola", "keboola": {}}}
+    monkeypatch.setattr(
+        "app.instance_config.load_instance_config",
+        lambda: fake_cfg,
+        raising=False,
+    )
+    from app.instance_config import reset_cache
+    reset_cache()
+
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    try:
+        r = c.get("/admin/tables", headers=_auth(token))
+        assert r.status_code == 200, r.text
+        html = r.text
+        assert 'id="bqQueryMode"' not in html
+        assert 'id="bqSourceQuery"' not in html
+        # Keboola form's regBucket / regTableId still there.
+        assert 'id="regTableId"' in html
+        assert 'id="regBucket"' in html
+    finally:
+        reset_cache()

--- a/tests/test_admin_tables_ui_materialized.py
+++ b/tests/test_admin_tables_ui_materialized.py
@@ -37,7 +37,12 @@ def bq_instance(monkeypatch):
     reset_cache()
 
 
-def test_admin_tables_renders_bq_type_selector(seeded_app, bq_instance):
+def test_admin_tables_renders_two_question_radio_form(seeded_app, bq_instance):
+    """Q1 = how should analysts access this data? (live / synced).
+    Q2 = (only when synced) what to sync? (whole / custom).
+    Replaces the earlier flat 4-option dropdown that mixed source-kind +
+    distribution-mode into one selector — both UX reviewers (info-arch +
+    analyst persona) flagged the conflation as the core confusion."""
     c = seeded_app["client"]
     token = seeded_app["admin_token"]
 
@@ -45,24 +50,36 @@ def test_admin_tables_renders_bq_type_selector(seeded_app, bq_instance):
     assert r.status_code == 200, r.text
     html = r.text
 
-    # Type selector with three operator-facing options. Backend payload
-    # maps these onto query_mode (table+view → remote, query → materialized).
-    assert 'id="bqEntityType"' in html
-    assert 'value="table"' in html
-    assert 'value="view"' in html
-    assert 'value="query"' in html
-    assert "onBqTypeChange" in html
+    # Q1 radio group.
+    assert 'name="bqAccessMode"' in html
+    assert 'value="live"' in html
+    assert 'value="synced"' in html
+    assert "onBqAccessModeChange" in html
 
-    # Custom-SQL field + the "Use table as base" prefill button.
+    # Q2 radio group (conditional on Q1).
+    assert 'name="bqSyncMode"' in html
+    assert 'value="whole"' in html
+    assert 'value="custom"' in html
+    assert "onBqSyncModeChange" in html
+
+    # Custom-SQL textarea + "Use table as base" prefill button.
     assert 'id="bqSourceQuery"' in html
     assert "prefillFromTable" in html
-    assert "bq-type-query" in html
+    assert "bq-source-custom" in html
 
-    # Table/View shared inputs.
+    # Table/dataset inputs reused across live + synced/whole.
     assert 'id="bqDataset"' in html
     assert 'id="bqSourceTable"' in html
-    assert "bq-type-table" in html
-    assert "bq-type-view" in html
+    assert "bq-source-table" in html
+    assert "bq-access-synced" in html
+
+    # Discover + List tables buttons.
+    assert "discoverBqDatasets" in html
+    assert "discoverBqTables" in html
+
+    # No leftover jargon labels from the prior Type-selector iterations.
+    assert "Direct query" not in html
+    assert "Sync to parquet" not in html
 
     # Vendor-agnostic — no internal issue refs in operator-facing UI text.
     assert "Milestone 2" not in html
@@ -70,12 +87,11 @@ def test_admin_tables_renders_bq_type_selector(seeded_app, bq_instance):
 
 
 def test_edit_modal_has_bq_parity_fields(seeded_app, bq_instance):
-    """Edit modal must expose the same BQ controls as Register so an
-    operator can change the source/SQL/schedule without dropping & re-adding
-    the row. Pre-fix, Edit only had sync_strategy + primary_key + description
-    + folder — missing query_mode, bucket, source_table, source_query,
-    sync_schedule. Tested against the rendered template (the JS branch on
-    `source_type` is structural, not server-side)."""
+    """Edit modal mirrors Register's two-question radio model (Q1 access
+    mode: live/synced; Q2 sync mode: whole/custom). Pre-fix Edit had only
+    sync_strategy+primary_key+description+folder — missing all BQ-specific
+    edit surface. Operator now can flip access mode, change dataset/table,
+    rewrite SQL, and tweak the schedule without dropping & re-adding."""
     c = seeded_app["client"]
     token = seeded_app["admin_token"]
 
@@ -83,24 +99,34 @@ def test_edit_modal_has_bq_parity_fields(seeded_app, bq_instance):
     assert r.status_code == 200, r.text
     html = r.text
 
-    # Edit modal Type selector mirrors Register's three-way (Table/View/Query).
-    assert 'id="editBqEntityType"' in html
-    assert "onEditBqTypeChange" in html
+    # Edit Q1 + Q2 radios.
+    assert 'name="editBqAccessMode"' in html
+    assert 'name="editBqSyncMode"' in html
+    assert "onEditBqAccessModeChange" in html
+    assert "onEditBqSyncModeChange" in html
+
     # BQ-specific edit fields.
     assert 'id="editBqDataset"' in html
     assert 'id="editBqSourceTable"' in html
     assert 'id="editBqSourceQuery"' in html
     assert 'id="editBqSyncSchedule"' in html
-    # Visibility classes for adaptive show/hide on type switch.
-    assert "bq-edit-type-table" in html
-    assert "bq-edit-type-view" in html
-    assert "bq-edit-type-query" in html
-    # Mode-switch warning surface (filled by JS when operator flips
-    # query_mode mid-edit).
+
+    # Visibility classes for adaptive show/hide on access/sync mode switch.
+    assert "bq-edit-access-synced" in html
+    assert "bq-edit-source-table" in html
+    assert "bq-edit-source-custom" in html
+
+    # Mode-switch warning surface (filled by JS when operator flips access
+    # mode mid-edit).
     assert 'id="editBqModeWarning"' in html
+
     # Source-type badge so the JS branch knows whether to render BQ vs
     # Keboola fields without a second round-trip.
     assert 'id="editSourceTypeBadge"' in html
+
+    # No leftover Type-selector remnants.
+    assert 'id="editBqEntityType"' not in html
+    assert "onEditBqTypeChange" not in html
 
 
 def test_admin_tables_keboola_branch_unchanged(seeded_app, monkeypatch):

--- a/tests/test_admin_tables_ui_materialized.py
+++ b/tests/test_admin_tables_ui_materialized.py
@@ -128,6 +128,17 @@ def test_edit_modal_has_bq_parity_fields(seeded_app, bq_instance):
     assert 'id="editBqEntityType"' not in html
     assert "onEditBqTypeChange" not in html
 
+    # Edit modal has the same Discover / List tables / Use-as-base buttons
+    # as Register so the operator can re-pick the source from autocomplete
+    # without dropping the row.
+    assert "discoverBqDatasets('editBqDatasetList')" in html
+    assert "discoverBqTables('editBqDataset', 'editBqTableList')" in html
+    assert "prefillFromTable('editBqSourceQuery')" in html
+    assert 'id="editBqDatasetList"' in html
+    assert 'id="editBqTableList"' in html
+    assert 'list="editBqDatasetList"' in html
+    assert 'list="editBqTableList"' in html
+
 
 def test_admin_tables_keboola_branch_unchanged(seeded_app, monkeypatch):
     """Negative — when `data_source.type` is NOT bigquery, the BQ form

--- a/tests/test_api_admin_materialized.py
+++ b/tests/test_api_admin_materialized.py
@@ -1,6 +1,11 @@
 """Admin API accepts source_query when query_mode='materialized', rejects
 mismatches between mode and query field.
 
+Tests that hit the remote-mode register path require `stub_bq_extractor`
+to bypass the post-register rebuild's real-BQ traffic. Materialized-only
+tests skip the BG path (the 201 fast-path returns before any rebuild
+fires) so they don't need the stub.
+
 Covers PR #145 (re-implementation against 0.24.0 base):
 - RegisterTableRequest + UpdateTableRequest model_validators
 - _validate_bigquery_register_payload materialized branch (skips bucket/
@@ -20,6 +25,26 @@ import pytest
 
 def _auth(token):
     return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def stub_bq_extractor(monkeypatch):
+    """Mirror tests/test_admin_bq_register.py — bypasses real-BQ traffic
+    in the post-register rebuild path so the test stays offline. Required
+    whenever the test seeds a remote-mode BQ row via the HTTP API."""
+    rebuild_mock = MagicMock(return_value={
+        "project_id": "my-test-project",
+        "tables_registered": 1, "errors": [], "skipped": False,
+    })
+    monkeypatch.setattr(
+        "connectors.bigquery.extractor.rebuild_from_registry",
+        rebuild_mock,
+    )
+    monkeypatch.setattr(
+        "src.orchestrator.SyncOrchestrator",
+        lambda *a, **kw: MagicMock(),
+    )
+    return rebuild_mock
 
 
 @pytest.fixture
@@ -135,7 +160,7 @@ def test_register_materialized_with_empty_source_query_rejected(seeded_app, bq_i
     assert 400 <= r.status_code < 500, r.json()
 
 
-def test_update_source_query_alone_requires_query_mode(seeded_app, bq_instance):
+def test_update_source_query_alone_requires_query_mode(seeded_app, bq_instance, stub_bq_extractor):
     """PUT body with source_query but no query_mode is incoherent — reject
     so non-materialized rows can't carry an orphan source_query."""
     c = seeded_app["client"]
@@ -164,7 +189,9 @@ def test_update_source_query_alone_requires_query_mode(seeded_app, bq_instance):
     assert 400 <= r2.status_code < 500, r2.json()
 
 
-def test_update_materialized_to_remote_clears_source_query(seeded_app, bq_instance):
+def test_update_materialized_to_remote_clears_source_query(
+    seeded_app, bq_instance, stub_bq_extractor,
+):
     """When admin switches a materialized table to remote/local, the stale
     source_query must be cleared in the DB — otherwise the registry shows
     a non-materialized row carrying an orphan SQL body."""

--- a/tests/test_api_admin_materialized.py
+++ b/tests/test_api_admin_materialized.py
@@ -1,0 +1,223 @@
+"""Admin API accepts source_query when query_mode='materialized', rejects
+mismatches between mode and query field.
+
+Covers PR #145 (re-implementation against 0.24.0 base):
+- RegisterTableRequest + UpdateTableRequest model_validators
+- _validate_bigquery_register_payload materialized branch (skips bucket/
+  source_table checks, requires source_query)
+- register_table 201 response for materialized BQ rows (no synchronous
+  materialize — cron tick or manual /api/sync/trigger picks them up)
+- update_table clears stale source_query when switching mode away from
+  materialized
+
+Shares the seeded_app + bq_instance fixtures from conftest /
+test_admin_bq_register.py for parity with the existing BQ test surface.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def bq_instance(monkeypatch):
+    """Force instance.yaml to look like a BigQuery deployment.
+
+    Mirrors tests/test_admin_bq_register.py::bq_instance so the
+    project_id read inside _validate_bigquery_register_payload succeeds.
+    """
+    fake_cfg = {
+        "data_source": {
+            "type": "bigquery",
+            "bigquery": {"project": "my-test-project", "location": "us"},
+        },
+    }
+    monkeypatch.setattr(
+        "app.instance_config.load_instance_config",
+        lambda: fake_cfg,
+        raising=False,
+    )
+    from app.instance_config import reset_cache
+    reset_cache()
+    yield fake_cfg
+    reset_cache()
+
+
+def _materialized_payload(**overrides):
+    p = {
+        "name": "orders_90d",
+        "source_type": "bigquery",
+        "query_mode": "materialized",
+        "source_query": "SELECT date FROM `prj.ds.orders`",
+        "sync_schedule": "every 6h",
+    }
+    p.update(overrides)
+    return p
+
+
+def test_register_materialized_requires_source_query(seeded_app, bq_instance):
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.post(
+        "/api/admin/register-table",
+        json={
+            "name": "missing_query",
+            "source_type": "bigquery",
+            "query_mode": "materialized",
+            # source_query missing
+        },
+        headers=_auth(token),
+    )
+    assert 400 <= r.status_code < 500, r.json()
+    detail = str(r.json().get("detail", "")).lower()
+    assert "source_query" in detail or "materialized" in detail
+
+
+def test_register_materialized_accepts_source_query(seeded_app, bq_instance):
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.post(
+        "/api/admin/register-table",
+        json=_materialized_payload(name="orders_90d_a"),
+        headers=_auth(token),
+    )
+    assert r.status_code == 201, r.json()
+    body = r.json()
+    assert body["status"] == "registered"
+    assert "Materialized" in body.get("message", "")
+
+
+def test_register_remote_rejects_source_query(seeded_app, bq_instance):
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.post(
+        "/api/admin/register-table",
+        json={
+            "name": "live_orders",
+            "source_type": "bigquery",
+            "bucket": "analytics",
+            "source_table": "orders",
+            "query_mode": "remote",
+            "source_query": "SELECT 1",
+        },
+        headers=_auth(token),
+    )
+    assert 400 <= r.status_code < 500, r.json()
+
+
+def test_register_local_rejects_source_query(seeded_app):
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.post(
+        "/api/admin/register-table",
+        json={
+            "name": "kbc_orders",
+            "source_type": "keboola",
+            "query_mode": "local",
+            "source_query": "SELECT 1",
+        },
+        headers=_auth(token),
+    )
+    assert 400 <= r.status_code < 500, r.json()
+
+
+def test_register_materialized_with_empty_source_query_rejected(seeded_app, bq_instance):
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.post(
+        "/api/admin/register-table",
+        json=_materialized_payload(name="empty_q", source_query=""),
+        headers=_auth(token),
+    )
+    assert 400 <= r.status_code < 500, r.json()
+
+
+def test_update_source_query_alone_requires_query_mode(seeded_app, bq_instance):
+    """PUT body with source_query but no query_mode is incoherent — reject
+    so non-materialized rows can't carry an orphan source_query."""
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+
+    # Seed a remote-mode row.
+    r = c.post(
+        "/api/admin/register-table",
+        json={
+            "name": "live_orphan",
+            "source_type": "bigquery",
+            "bucket": "analytics",
+            "source_table": "orders",
+            "query_mode": "remote",
+        },
+        headers=_auth(token),
+    )
+    assert r.status_code in (200, 202), r.json()  # synchronous or async
+    table_id = r.json()["id"]
+
+    r2 = c.put(
+        f"/api/admin/registry/{table_id}",
+        json={"source_query": "SELECT 1"},
+        headers=_auth(token),
+    )
+    assert 400 <= r2.status_code < 500, r2.json()
+
+
+def test_update_materialized_to_remote_clears_source_query(seeded_app, bq_instance):
+    """When admin switches a materialized table to remote/local, the stale
+    source_query must be cleared in the DB — otherwise the registry shows
+    a non-materialized row carrying an orphan SQL body."""
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+
+    # Seed a materialized table with a source_query.
+    r = c.post(
+        "/api/admin/register-table",
+        json=_materialized_payload(name="switcher"),
+        headers=_auth(token),
+    )
+    assert r.status_code == 201, r.json()
+    table_id = r.json()["id"]
+
+    # Switch to remote — must include bucket+source_table for the new mode
+    # (the merged validator runs the BQ payload check on the merged record).
+    r2 = c.put(
+        f"/api/admin/registry/{table_id}",
+        json={
+            "query_mode": "remote",
+            "bucket": "analytics",
+            "source_table": "orders_90d",
+        },
+        headers=_auth(token),
+    )
+    assert r2.status_code == 200, r2.json()
+
+    # Verify in the registry: query_mode flipped, source_query cleared.
+    r3 = c.get("/api/admin/registry", headers=_auth(token))
+    assert r3.status_code == 200, r3.json()
+    row = next((t for t in r3.json()["tables"] if t["id"] == table_id), None)
+    assert row is not None, f"Table {table_id} not found in registry"
+    assert row["query_mode"] == "remote"
+    assert row["source_query"] in (None, "")
+
+
+def test_register_materialized_persists_source_query_in_registry(seeded_app, bq_instance):
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.post(
+        "/api/admin/register-table",
+        json=_materialized_payload(
+            name="persist_q",
+            source_query="SELECT col FROM `prj.ds.t` WHERE x = 1",
+        ),
+        headers=_auth(token),
+    )
+    assert r.status_code == 201, r.json()
+    table_id = r.json()["id"]
+
+    r2 = c.get("/api/admin/registry", headers=_auth(token))
+    row = next((t for t in r2.json()["tables"] if t["id"] == table_id), None)
+    assert row is not None
+    assert row["query_mode"] == "materialized"
+    assert "WHERE x = 1" in row["source_query"]

--- a/tests/test_api_admin_materialized.py
+++ b/tests/test_api_admin_materialized.py
@@ -189,6 +189,78 @@ def test_update_source_query_alone_requires_query_mode(seeded_app, bq_instance, 
     assert 400 <= r2.status_code < 500, r2.json()
 
 
+def test_update_schedule_only_on_materialized_row_succeeds(
+    seeded_app, bq_instance, stub_bq_extractor,
+):
+    """REGRESSION (Devin BUG_0002 on 2219255): an admin editing only the
+    sync_schedule of a materialized row sends `{query_mode: 'materialized',
+    sync_schedule: '...'}` (the Edit modal always sends query_mode for BQ
+    rows). Pre-fix the UpdateTableRequest validator rejected this with 422
+    because source_query wasn't in the body — even though the existing row
+    already had one.
+
+    The PUT semantics overlay the body on the existing row, so omitted
+    source_query keeps the stored value. The synthetic RegisterTableRequest
+    constructed against the merged record at the handler still runs the
+    strict cross-field check, so the truly-broken case (materialized
+    without ANY source_query, even on existing) is still caught."""
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+
+    # Seed a materialized row with a real source_query.
+    r = c.post("/api/admin/register-table", json={
+        "name": "schedule_edit_target",
+        "source_type": "bigquery",
+        "query_mode": "materialized",
+        "source_query": "SELECT 1",
+        "sync_schedule": "every 1h",
+    }, headers=_auth(token))
+    assert r.status_code == 201, r.json()
+    table_id = r.json()["id"]
+
+    # Edit ONLY the schedule. UI's saveTableEdit sends query_mode for BQ
+    # rows even when the operator didn't change it.
+    r2 = c.put(f"/api/admin/registry/{table_id}", json={
+        "query_mode": "materialized",
+        "sync_schedule": "every 12h",
+    }, headers=_auth(token))
+    assert r2.status_code == 200, r2.json()
+
+    # Verify the schedule changed and source_query survived.
+    r3 = c.get("/api/admin/registry", headers=_auth(token))
+    row = next((t for t in r3.json()["tables"] if t["id"] == table_id), None)
+    assert row is not None
+    assert row["sync_schedule"] == "every 12h"
+    assert row["source_query"] == "SELECT 1"  # preserved across edit
+    assert row["query_mode"] == "materialized"
+
+
+def test_update_materialized_with_explicit_empty_source_query_rejected(
+    seeded_app, bq_instance, stub_bq_extractor,
+):
+    """The fix above relaxes the validator for OMITTED source_query, but
+    explicitly setting it to an empty / whitespace string while claiming
+    materialized is still a typo and must be rejected (not silently
+    persisted as NULL)."""
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+
+    r = c.post("/api/admin/register-table", json={
+        "name": "explicit_empty",
+        "source_type": "bigquery",
+        "query_mode": "materialized",
+        "source_query": "SELECT 1",
+    }, headers=_auth(token))
+    assert r.status_code == 201, r.json()
+    table_id = r.json()["id"]
+
+    r2 = c.put(f"/api/admin/registry/{table_id}", json={
+        "query_mode": "materialized",
+        "source_query": "",  # explicitly empty
+    }, headers=_auth(token))
+    assert 400 <= r2.status_code < 500, r2.json()
+
+
 def test_update_materialized_to_remote_clears_source_query(
     seeded_app, bq_instance, stub_bq_extractor,
 ):

--- a/tests/test_bq_cost_guardrail.py
+++ b/tests/test_bq_cost_guardrail.py
@@ -1,0 +1,137 @@
+"""materialize_query refuses to run when dry-run estimate exceeds the cap.
+
+The cap is wired through `data_source.bigquery.max_bytes_per_materialize`
+(read by the trigger pass; default 10 GiB; set 0 to disable). The dry-run
+itself reuses `app.api.v2_scan._bq_dry_run_bytes` so cost-estimate logic
+lives in exactly one place. Fail-open behaviour (DuckDB-syntax SQL the
+native BQ client can't parse → estimate=0 → COPY proceeds with a warning)
+is documented and exercised here too.
+"""
+import duckdb
+import pytest
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+from connectors.bigquery.access import BqAccess, BqProjects
+from connectors.bigquery.extractor import materialize_query, MaterializeBudgetError
+
+
+def _bq_with_seed(tables: dict[str, str] | None = None) -> BqAccess:
+    """Stub BqAccess seeded with in-memory tables (same recipe as
+    test_bq_materialize)."""
+    tables = tables or {}
+
+    @contextmanager
+    def _session(_projects):
+        conn = duckdb.connect(":memory:")
+        try:
+            conn.execute("ATTACH ':memory:' AS bq")
+            for s in {ref.rsplit(".", 1)[0] for ref in tables}:
+                conn.execute(f"CREATE SCHEMA IF NOT EXISTS {s}")
+            for ref, body in tables.items():
+                conn.execute(f"CREATE OR REPLACE TABLE {ref} AS {body}")
+            yield conn
+        finally:
+            conn.close()
+
+    return BqAccess(
+        BqProjects(billing="test-billing", data="test-data"),
+        client_factory=lambda _p: MagicMock(),
+        duckdb_session_factory=_session,
+    )
+
+
+def test_refuses_when_estimate_exceeds_cap(tmp_path):
+    out = tmp_path / "extracts" / "bigquery"
+    out.mkdir(parents=True)
+
+    bq = _bq_with_seed({"bq.test.tiny": "SELECT 1 AS n"})
+
+    with patch(
+        "app.api.v2_scan._bq_dry_run_bytes", return_value=100 * 2**30
+    ):
+        with pytest.raises(MaterializeBudgetError) as exc:
+            materialize_query(
+                table_id="huge",
+                sql="SELECT * FROM bq.test.tiny",
+                bq=bq,
+                output_dir=str(out),
+                max_bytes=10 * 2**30,
+            )
+    err = exc.value
+    assert err.table_id == "huge"
+    assert err.current == 100 * 2**30
+    assert err.limit == 10 * 2**30
+
+
+def test_proceeds_when_estimate_under_cap(tmp_path):
+    out = tmp_path / "extracts" / "bigquery"
+    out.mkdir(parents=True)
+
+    bq = _bq_with_seed({"bq.test.tiny": "SELECT 1 AS n"})
+
+    with patch("app.api.v2_scan._bq_dry_run_bytes", return_value=1024):
+        stats = materialize_query(
+            table_id="tiny",
+            sql="SELECT * FROM bq.test.tiny",
+            bq=bq,
+            output_dir=str(out),
+            max_bytes=10 * 2**30,
+        )
+    assert stats["rows"] == 1
+
+
+def test_no_cap_skips_dry_run(tmp_path):
+    """When max_bytes=None (default), no dry-run is performed."""
+    out = tmp_path / "extracts" / "bigquery"
+    out.mkdir(parents=True)
+    bq = _bq_with_seed({"bq.test.tiny": "SELECT 1 AS n"})
+
+    with patch("app.api.v2_scan._bq_dry_run_bytes") as mock_dry:
+        stats = materialize_query(
+            table_id="t1",
+            sql="SELECT * FROM bq.test.tiny",
+            bq=bq,
+            output_dir=str(out),
+        )
+    mock_dry.assert_not_called()
+    assert stats["rows"] == 1
+
+
+def test_zero_max_bytes_skips_dry_run(tmp_path):
+    """Sentinel: max_bytes=0 disables the guardrail (config docs)."""
+    out = tmp_path / "extracts" / "bigquery"
+    out.mkdir(parents=True)
+    bq = _bq_with_seed({"bq.test.tiny": "SELECT 1 AS n"})
+
+    with patch("app.api.v2_scan._bq_dry_run_bytes") as mock_dry:
+        stats = materialize_query(
+            table_id="t1",
+            sql="SELECT * FROM bq.test.tiny",
+            bq=bq,
+            output_dir=str(out),
+            max_bytes=0,
+        )
+    mock_dry.assert_not_called()
+    assert stats["rows"] == 1
+
+
+def test_dry_run_failure_is_fail_open(tmp_path):
+    """If the dry-run errors (DuckDB syntax, missing google lib, transient
+    upstream failure) we don't block — log + proceed with COPY. Operators
+    who need hard-fail watch logs for the warning."""
+    out = tmp_path / "extracts" / "bigquery"
+    out.mkdir(parents=True)
+    bq = _bq_with_seed({"bq.test.tiny": "SELECT 1 AS n"})
+
+    with patch(
+        "app.api.v2_scan._bq_dry_run_bytes", side_effect=RuntimeError("boom")
+    ):
+        stats = materialize_query(
+            table_id="t1",
+            sql="SELECT * FROM bq.test.tiny",
+            bq=bq,
+            output_dir=str(out),
+            max_bytes=10 * 2**30,
+        )
+    assert stats["rows"] == 1

--- a/tests/test_bq_init_extract_skips.py
+++ b/tests/test_bq_init_extract_skips.py
@@ -1,0 +1,98 @@
+"""init_extract skips rows with query_mode='materialized'.
+
+Materialized rows are written by the sync trigger pass via
+`materialize_query()`; they live as parquets in /data/extracts/bigquery/data/
+and surface via the orchestrator's standard local-parquet discovery.
+Creating a remote view in extract.duckdb for the same name would shadow
+the parquet via cross-source name collision.
+
+Pattern matches `tests/test_bigquery_extractor.py::TestViewVsTableTemplates`
+(uses `_CapturingProxy` to wrap a real DuckDB conn and stub BQ-specific calls).
+"""
+import duckdb
+from unittest.mock import MagicMock
+
+
+class _CapturingProxy:
+    """Wraps a real DuckDB connection, captures SQL, stubs BQ-specific calls.
+
+    DuckDBPyConnection.execute is C-level read-only, so we wrap rather than
+    monkey-patch. Shape lifted directly from tests/test_bigquery_extractor.py
+    to keep stub behavior consistent across the BQ test suite.
+    """
+
+    def __init__(self, real_conn, captured: list):
+        self._real = real_conn
+        self._captured = captured
+
+    def execute(self, sql, *args, **kwargs):
+        self._captured.append(sql)
+        stripped_u = sql.strip().upper()
+        if stripped_u.startswith(("INSTALL ", "LOAD ", "CREATE SECRET")):
+            return MagicMock()
+        if stripped_u.startswith("ATTACH ") and "BIGQUERY" in stripped_u:
+            return MagicMock()
+        if stripped_u.startswith("DETACH "):
+            return MagicMock()
+        if 'FROM bq.' in sql or 'FROM bigquery_query' in sql:
+            return MagicMock()
+        return self._real.execute(sql, *args, **kwargs)
+
+    def close(self):
+        return self._real.close()
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+def test_init_extract_skips_materialized_rows(tmp_path, monkeypatch):
+    """A registry mix of remote + materialized rows: only the remote row
+    gets a `_meta` entry; the materialized row is silently skipped."""
+    from connectors.bigquery.extractor import init_extract
+
+    monkeypatch.setattr(
+        "connectors.bigquery.extractor.get_metadata_token",
+        lambda: "test-token",
+    )
+    monkeypatch.setattr(
+        "connectors.bigquery.extractor._detect_table_type",
+        lambda *a, **kw: "BASE TABLE",
+    )
+
+    captured: list[str] = []
+    real_connect = duckdb.connect
+
+    def spy_connect(*a, **kw):
+        return _CapturingProxy(real_connect(*a, **kw), captured)
+
+    monkeypatch.setattr(
+        "connectors.bigquery.extractor.duckdb.connect", spy_connect
+    )
+
+    configs = [
+        {
+            "name": "live_orders", "bucket": "dset", "source_table": "live",
+            "query_mode": "remote", "description": "",
+        },
+        {
+            "name": "agg_90d", "bucket": "dset", "source_table": "live",
+            "query_mode": "materialized",
+            "source_query": "SELECT 1",
+            "description": "",
+        },
+    ]
+    stats = init_extract(str(tmp_path), "test-project", configs)
+
+    db_path = tmp_path / "extract.duckdb"
+    assert db_path.exists(), "extract.duckdb should be written"
+
+    db = duckdb.connect(str(db_path))
+    meta = db.execute(
+        "SELECT table_name, query_mode FROM _meta ORDER BY table_name"
+    ).fetchall()
+    db.close()
+
+    assert meta == [("live_orders", "remote")]
+    assert stats["tables_registered"] == 1
+    # No CREATE VIEW for the materialized row
+    assert not any("agg_90d" in s for s in captured if "CREATE" in s.upper())

--- a/tests/test_bq_materialize.py
+++ b/tests/test_bq_materialize.py
@@ -1,0 +1,139 @@
+"""BigQuery `materialize_query` writes parquet via BqAccess + DuckDB COPY.
+
+The function takes a `BqAccess` instance so the BQ extension session and
+SECRET token live in one place across the codebase (cf. `v2_scan` / `v2_sample`
+/ `v2_schema`). Tests inject a stub BqAccess whose `duckdb_session()` yields
+an in-memory connection with a pre-attached `bq` catalog containing fixture
+tables, exercising the COPY path end-to-end without any GCP traffic.
+"""
+import duckdb
+import pytest
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from connectors.bigquery.access import BqAccess, BqProjects
+from connectors.bigquery.extractor import materialize_query, MaterializeBudgetError
+
+
+def _make_stub_bq(tables: dict[str, str] | None = None) -> BqAccess:
+    """Return a BqAccess wired to factories that yield an in-memory DuckDB
+    with a pretend `bq` catalog containing test tables. `tables` maps
+    DuckDB-three-part references like `'bq.test.orders'` to a SELECT
+    expression to seed them with.
+    """
+    tables = tables or {}
+
+    @contextmanager
+    def _session(_projects):
+        conn = duckdb.connect(":memory:")
+        try:
+            conn.execute("ATTACH ':memory:' AS bq")
+            schemas = {ref.rsplit(".", 1)[0] for ref in tables}
+            for s in schemas:
+                conn.execute(f"CREATE SCHEMA IF NOT EXISTS {s}")
+            for ref, body in tables.items():
+                conn.execute(f"CREATE OR REPLACE TABLE {ref} AS {body}")
+            yield conn
+        finally:
+            conn.close()
+
+    # client_factory returns a stub whose .query(sql, job_config=...) yields
+    # a job whose .total_bytes_processed defaults to 0 (fail-open).
+    def _client(_projects):
+        client = MagicMock()
+        job = MagicMock()
+        job.total_bytes_processed = 0
+        client.query.return_value = job
+        return client
+
+    return BqAccess(
+        BqProjects(billing="test-billing", data="test-data"),
+        client_factory=_client,
+        duckdb_session_factory=_session,
+    )
+
+
+def test_materialize_writes_parquet_and_returns_stats(tmp_path):
+    out = tmp_path / "extracts" / "bigquery"
+    out.mkdir(parents=True)
+
+    bq = _make_stub_bq({
+        "bq.test.orders": (
+            "SELECT 'EU' AS region, 100 AS revenue UNION ALL "
+            "SELECT 'US' AS region, 250 AS revenue"
+        )
+    })
+
+    stats = materialize_query(
+        table_id="orders_summary",
+        sql="SELECT region, SUM(revenue) AS revenue FROM bq.test.orders GROUP BY 1",
+        bq=bq,
+        output_dir=str(out),
+    )
+
+    parquet_path = out / "data" / "orders_summary.parquet"
+    assert parquet_path.exists()
+    assert stats["rows"] == 2
+    assert stats["size_bytes"] > 0
+    assert stats["query_mode"] == "materialized"
+
+    # Parquet readable end-to-end
+    rows = duckdb.connect().execute(
+        f"SELECT region, revenue FROM read_parquet('{parquet_path}') ORDER BY region"
+    ).fetchall()
+    assert rows == [("EU", 100), ("US", 250)]
+
+
+def test_materialize_atomic_on_failure(tmp_path):
+    """Bad SQL must not leave a half-written parquet behind."""
+    out = tmp_path / "extracts" / "bigquery"
+    out.mkdir(parents=True)
+    parquet_path = out / "data" / "broken.parquet"
+
+    bq = _make_stub_bq({"bq.test.orders": "SELECT 1 AS n"})
+
+    with pytest.raises(Exception):
+        materialize_query(
+            table_id="broken",
+            sql="SELECT * FROM bq.test.does_not_exist",
+            bq=bq,
+            output_dir=str(out),
+        )
+    assert not parquet_path.exists()
+    # Tmp also cleaned
+    assert not (out / "data" / "broken.parquet.tmp").exists()
+
+
+def test_materialize_rejects_unsafe_table_id(tmp_path):
+    """table_id becomes the parquet filename — block path traversal up front."""
+    out = tmp_path / "extracts" / "bigquery"
+    out.mkdir(parents=True)
+    bq = _make_stub_bq()
+
+    with pytest.raises(ValueError, match="unsafe"):
+        materialize_query(
+            table_id="../etc/passwd",
+            sql="SELECT 1",
+            bq=bq,
+            output_dir=str(out),
+        )
+
+
+def test_materialize_overwrites_existing_parquet(tmp_path):
+    out = tmp_path / "extracts" / "bigquery"
+    out.mkdir(parents=True)
+    bq = _make_stub_bq({"bq.test.tiny": "SELECT 1 AS n"})
+
+    materialize_query(
+        table_id="t1", sql="SELECT 1 AS n",
+        bq=bq, output_dir=str(out),
+    )
+    materialize_query(
+        table_id="t1", sql="SELECT 2 AS n",
+        bq=bq, output_dir=str(out),
+    )
+    rows = duckdb.connect().execute(
+        f"SELECT n FROM read_parquet('{out}/data/t1.parquet')"
+    ).fetchall()
+    assert rows == [(2,)]

--- a/tests/test_cli_admin_materialized.py
+++ b/tests/test_cli_admin_materialized.py
@@ -1,0 +1,157 @@
+"""`da admin register-table --query-mode materialized --query @file.sql`
+sends source_query in the payload; existing local/remote paths still work
+unchanged."""
+from typer.testing import CliRunner
+from unittest.mock import MagicMock
+
+from cli.main import app
+
+
+def _fake_resp(status_code, body=None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json = lambda: body or {"id": "x", "name": "x", "status": "registered"}
+    return resp
+
+
+def test_register_materialized_with_inline_query(monkeypatch):
+    captured = {}
+
+    def fake_post(path, json):
+        captured["path"] = path
+        captured["json"] = json
+        return _fake_resp(201)
+
+    monkeypatch.setattr("cli.commands.admin.api_post", fake_post)
+
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "admin", "register-table", "orders_90d",
+        "--source-type", "bigquery",
+        "--query-mode", "materialized",
+        "--query", "SELECT date FROM `prj.ds.orders`",
+        "--sync-schedule", "every 6h",
+    ])
+
+    assert result.exit_code == 0, result.stdout
+    assert captured["path"] == "/api/admin/register-table"
+    assert captured["json"]["query_mode"] == "materialized"
+    assert captured["json"]["source_query"] == "SELECT date FROM `prj.ds.orders`"
+    assert captured["json"]["sync_schedule"] == "every 6h"
+
+
+def test_register_materialized_reads_query_from_file(tmp_path, monkeypatch):
+    sql_file = tmp_path / "orders.sql"
+    sql_file.write_text(
+        "SELECT date, SUM(revenue) FROM `prj.ds.orders` GROUP BY 1\n"
+    )
+
+    captured = {}
+
+    def fake_post(path, json):
+        captured["json"] = json
+        return _fake_resp(201)
+
+    monkeypatch.setattr("cli.commands.admin.api_post", fake_post)
+
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "admin", "register-table", "orders_90d",
+        "--source-type", "bigquery",
+        "--query-mode", "materialized",
+        "--query", f"@{sql_file}",
+        "--sync-schedule", "daily 03:00",
+    ])
+
+    assert result.exit_code == 0, result.stdout
+    assert "SELECT date, SUM(revenue)" in captured["json"]["source_query"]
+    assert not captured["json"]["source_query"].endswith("\n")
+
+
+def test_register_materialized_without_query_fails(monkeypatch):
+    """--query-mode materialized without --query is a client-side error,
+    no API call made."""
+    called = {"count": 0}
+
+    def fake_post(*args, **kwargs):
+        called["count"] += 1
+        return _fake_resp(201)
+
+    monkeypatch.setattr("cli.commands.admin.api_post", fake_post)
+
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "admin", "register-table", "orders_90d",
+        "--source-type", "bigquery",
+        "--query-mode", "materialized",
+    ])
+
+    assert result.exit_code != 0
+    assert called["count"] == 0
+    combined = result.stdout + (result.stderr or "")
+    assert "--query" in combined
+
+
+def test_register_local_mode_does_not_send_source_query(monkeypatch):
+    """Default local mode shouldn't send source_query — server-side
+    validator forbids it on local."""
+    captured = {}
+
+    def fake_post(path, json):
+        captured["json"] = json
+        return _fake_resp(201)
+
+    monkeypatch.setattr("cli.commands.admin.api_post", fake_post)
+
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "admin", "register-table", "kbc_orders",
+        "--source-type", "keboola",
+        "--bucket", "in.c-crm",
+    ])
+
+    assert result.exit_code == 0
+    assert "source_query" not in captured["json"]
+    assert "sync_schedule" not in captured["json"]
+
+
+def test_register_query_at_path_missing_file_fails(monkeypatch):
+    """@file.sql where the file doesn't exist surfaces a clear error."""
+    monkeypatch.setattr(
+        "cli.commands.admin.api_post", lambda *a, **kw: _fake_resp(201),
+    )
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "admin", "register-table", "x",
+        "--source-type", "bigquery",
+        "--query-mode", "materialized",
+        "--query", "@/tmp/definitely-does-not-exist-9b4f7e2c.sql",
+    ])
+    assert result.exit_code != 0
+
+
+def test_register_remote_path_unchanged(monkeypatch):
+    """The pre-existing --bucket / --source-table / --query-mode remote
+    flow still works without --query."""
+    captured = {}
+
+    def fake_post(path, json):
+        captured["json"] = json
+        return _fake_resp(200)
+
+    monkeypatch.setattr("cli.commands.admin.api_post", fake_post)
+
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "admin", "register-table", "live_orders",
+        "--source-type", "bigquery",
+        "--bucket", "analytics",
+        "--source-table", "orders",
+        "--query-mode", "remote",
+    ])
+
+    assert result.exit_code == 0
+    assert captured["json"]["query_mode"] == "remote"
+    assert "source_query" not in captured["json"]
+    assert captured["json"]["bucket"] == "analytics"
+    assert captured["json"]["source_table"] == "orders"

--- a/tests/test_cli_analyst_setup_hooks.py
+++ b/tests/test_cli_analyst_setup_hooks.py
@@ -1,0 +1,82 @@
+"""`_install_claude_hooks` writes SessionStart/End hooks idempotently into
+a Claude settings file (workspace-level for analyst workspaces)."""
+import json
+from pathlib import Path
+
+from cli.commands.analyst import _install_claude_hooks
+
+
+def test_install_creates_settings_when_missing(tmp_path):
+    settings = tmp_path / ".claude" / "settings.json"
+    _install_claude_hooks(settings)
+
+    cfg = json.loads(settings.read_text())
+    starts = cfg["hooks"]["SessionStart"]
+    cmds = [h["command"] for e in starts for h in e["hooks"]]
+    assert any("da sync --quiet" in c and "--upload-only" not in c for c in cmds), cmds
+
+    ends = cfg["hooks"]["SessionEnd"]
+    end_cmds = [h["command"] for e in ends for h in e["hooks"]]
+    assert any("da sync --upload-only" in c for c in end_cmds), end_cmds
+
+
+def test_install_preserves_existing_unrelated_hooks(tmp_path):
+    settings = tmp_path / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True)
+    settings.write_text(json.dumps({
+        "hooks": {
+            "PreToolUse": [{"hooks": [{"type": "command", "command": "echo hi"}]}],
+        },
+        "permissions": {"allow": ["Bash(git status:*)"]},
+        "model": "sonnet",
+    }))
+
+    _install_claude_hooks(settings)
+
+    cfg = json.loads(settings.read_text())
+    # Unrelated hook event preserved
+    assert cfg["hooks"]["PreToolUse"][0]["hooks"][0]["command"] == "echo hi"
+    # Unrelated top-level keys preserved
+    assert cfg["permissions"]["allow"] == ["Bash(git status:*)"]
+    assert cfg["model"] == "sonnet"
+    # Our new hooks added
+    assert "SessionStart" in cfg["hooks"]
+    assert "SessionEnd" in cfg["hooks"]
+
+
+def test_install_is_idempotent(tmp_path):
+    settings = tmp_path / ".claude" / "settings.json"
+    _install_claude_hooks(settings)
+    first = json.loads(settings.read_text())
+    _install_claude_hooks(settings)
+    second = json.loads(settings.read_text())
+    # No duplicate entries
+    assert first["hooks"]["SessionStart"] == second["hooks"]["SessionStart"]
+    assert first["hooks"]["SessionEnd"] == second["hooks"]["SessionEnd"]
+    assert len(second["hooks"]["SessionStart"]) == 1
+    assert len(second["hooks"]["SessionEnd"]) == 1
+
+
+def test_install_replaces_old_da_sync_entry_without_duplicating(tmp_path):
+    """If the user already has a `da sync` entry from a prior version, our
+    install replaces it cleanly rather than appending a second copy."""
+    settings = tmp_path / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True)
+    settings.write_text(json.dumps({
+        "hooks": {
+            "SessionStart": [
+                {"hooks": [{"type": "command", "command": "da sync"}]},  # old shape
+                {"hooks": [{"type": "command", "command": "echo not-ours"}]},
+            ]
+        }
+    }))
+
+    _install_claude_hooks(settings)
+
+    cfg = json.loads(settings.read_text())
+    starts = cfg["hooks"]["SessionStart"]
+    assert len(starts) == 2  # one ours, one third-party
+    cmds = [h["command"] for e in starts for h in e["hooks"]]
+    assert "da sync --quiet 2>/dev/null || true" in cmds
+    assert "echo not-ours" in cmds
+    assert all(c == "echo not-ours" or "da sync --quiet" in c for c in cmds), cmds

--- a/tests/test_cli_analyst_setup_hooks.py
+++ b/tests/test_cli_analyst_setup_hooks.py
@@ -80,3 +80,18 @@ def test_install_replaces_old_da_sync_entry_without_duplicating(tmp_path):
     assert "da sync --quiet 2>/dev/null || true" in cmds
     assert "echo not-ours" in cmds
     assert all(c == "echo not-ours" or "da sync --quiet" in c for c in cmds), cmds
+
+
+def test_install_skips_malformed_existing_settings(tmp_path, capsys):
+    """If the settings file is corrupted JSON, warn on stderr and bail —
+    don't crash the surrounding `da analyst setup` flow."""
+    settings = tmp_path / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True)
+    settings.write_text("{not valid json")
+
+    _install_claude_hooks(settings)  # must not raise
+
+    captured = capsys.readouterr()
+    assert "not valid JSON" in captured.err
+    # File untouched
+    assert settings.read_text() == "{not valid json"

--- a/tests/test_cli_sync_quiet.py
+++ b/tests/test_cli_sync_quiet.py
@@ -1,0 +1,138 @@
+"""`da sync --quiet` truly suppresses stdout chatter, including the download
+loop and final summary.
+
+Without --quiet, the same fixture prints "Downloading", "Downloaded:", etc.;
+with --quiet, stdout stays empty and the terse one-liner lands on stderr.
+The first test forces the download loop to run so the contrast between
+noisy/quiet stdout is observable (mutation-tests the flag — see PR #145
+for the original empty-manifest test that passed even without --quiet).
+"""
+import json
+from typer.testing import CliRunner
+from unittest.mock import patch, MagicMock
+
+from cli.main import app
+
+
+def _fake_manifest_one_table():
+    resp = MagicMock()
+    resp.json.return_value = {
+        "tables": {
+            "orders": {
+                "hash": "abc123",
+                "rows": 5,
+                "size_bytes": 100,
+                "query_mode": "local",
+                "source_type": "keboola",
+            }
+        },
+        "assets": {},
+        "server_time": "2026-04-30T00:00:00Z",
+    }
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _stub_download(_url, target_path):
+    from pathlib import Path
+    Path(target_path).write_bytes(b"PAR1" + b"\x00" * 16 + b"PAR1")
+
+
+def test_quiet_suppresses_stdout_when_downloading(tmp_path, monkeypatch):
+    """Manifest has tables that actually trigger downloads. Without --quiet
+    stdout would contain 'Downloading' / 'Downloaded:'. With --quiet stdout
+    stays empty and the terse summary lands on stderr."""
+    monkeypatch.setenv("DA_LOCAL_DIR", str(tmp_path))
+    monkeypatch.setenv("DA_CONFIG_DIR", str(tmp_path / "_cfg"))
+    runner = CliRunner()
+
+    with patch("cli.commands.sync.api_get", return_value=_fake_manifest_one_table()), \
+         patch("cli.commands.sync.stream_download", side_effect=_stub_download), \
+         patch("cli.commands.sync._md5_file", return_value="abc123"), \
+         patch("cli.commands.sync._rebuild_duckdb_views"), \
+         patch("cli.commands.sync._fetch_and_write_rules"):
+        result = runner.invoke(app, ["sync", "--quiet"])
+
+    assert result.exit_code == 0, result.stdout
+    assert result.stdout == "", f"expected empty stdout, got: {result.stdout!r}"
+    assert "sync: 1 tables" in result.stderr
+
+
+def test_noisy_mode_prints_to_stdout(tmp_path, monkeypatch):
+    """Anchor: the noisy path DOES print download chatter to stdout, so the
+    contrast in the quiet test above is meaningful."""
+    monkeypatch.setenv("DA_LOCAL_DIR", str(tmp_path))
+    monkeypatch.setenv("DA_CONFIG_DIR", str(tmp_path / "_cfg"))
+    runner = CliRunner()
+
+    with patch("cli.commands.sync.api_get", return_value=_fake_manifest_one_table()), \
+         patch("cli.commands.sync.stream_download", side_effect=_stub_download), \
+         patch("cli.commands.sync._md5_file", return_value="abc123"), \
+         patch("cli.commands.sync._rebuild_duckdb_views"), \
+         patch("cli.commands.sync._fetch_and_write_rules"):
+        result = runner.invoke(app, ["sync"])
+
+    assert result.exit_code == 0, result.stdout
+    assert "Downloaded:" in result.stdout
+
+
+def test_quiet_manifest_failure_exits_nonzero(tmp_path, monkeypatch):
+    """SessionStart hook contract: server unreachable → non-zero exit (so
+    `|| true` swallows it cleanly), error message on stderr."""
+    monkeypatch.setenv("DA_LOCAL_DIR", str(tmp_path))
+    monkeypatch.setenv("DA_CONFIG_DIR", str(tmp_path / "_cfg"))
+    runner = CliRunner()
+
+    fake_resp = MagicMock()
+    fake_resp.raise_for_status.side_effect = RuntimeError("boom")
+
+    with patch("cli.commands.sync.api_get", return_value=fake_resp):
+        result = runner.invoke(app, ["sync", "--quiet"])
+
+    assert result.exit_code == 1
+    assert "manifest fetch failed" in result.stderr
+
+
+def test_quiet_skips_remote_mode_tables(tmp_path, monkeypatch):
+    """Materialized rows go through the download path; remote rows do not.
+    Locks in the contract that --quiet honors the same skipped_remote
+    filter as the noisy path."""
+    monkeypatch.setenv("DA_LOCAL_DIR", str(tmp_path))
+    monkeypatch.setenv("DA_CONFIG_DIR", str(tmp_path / "_cfg"))
+
+    resp = MagicMock()
+    resp.json.return_value = {
+        "tables": {
+            "live_orders": {
+                "hash": "x", "rows": 0, "size_bytes": 0,
+                "query_mode": "remote", "source_type": "bigquery",
+            },
+            "agg_90d": {
+                "hash": "abc", "rows": 5, "size_bytes": 100,
+                "query_mode": "materialized", "source_type": "bigquery",
+            },
+        },
+        "assets": {},
+        "server_time": "2026-04-30T00:00:00Z",
+    }
+    resp.raise_for_status = MagicMock()
+
+    runner = CliRunner()
+    download_calls = []
+
+    def _spy_download(url, target):
+        download_calls.append(url)
+        from pathlib import Path
+        Path(target).write_bytes(b"PAR1" + b"\x00" * 16 + b"PAR1")
+
+    with patch("cli.commands.sync.api_get", return_value=resp), \
+         patch("cli.commands.sync.stream_download", side_effect=_spy_download), \
+         patch("cli.commands.sync._md5_file", return_value="abc"), \
+         patch("cli.commands.sync._rebuild_duckdb_views"), \
+         patch("cli.commands.sync._fetch_and_write_rules"):
+        result = runner.invoke(app, ["sync", "--quiet"])
+
+    assert result.exit_code == 0, result.stdout
+    # Remote table never downloaded; materialized table downloaded.
+    assert any("agg_90d" in u for u in download_calls)
+    assert not any("live_orders" in u for u in download_calls)

--- a/tests/test_db_migration_v19.py
+++ b/tests/test_db_migration_v19.py
@@ -1,0 +1,71 @@
+"""v19 adds source_query column to table_registry.
+
+Backs query_mode='materialized' for BigQuery: admin registers a SQL body
+that the scheduler runs through the DuckDB BQ extension and writes as a
+parquet to /data/extracts/bigquery/data/<id>.parquet.
+"""
+import duckdb
+
+from src.db import SCHEMA_VERSION, _ensure_schema, get_schema_version
+
+
+def test_schema_version_is_19():
+    assert SCHEMA_VERSION == 19
+
+
+def test_v19_adds_source_query(tmp_path):
+    db_path = tmp_path / "system.duckdb"
+    conn = duckdb.connect(str(db_path))
+    _ensure_schema(conn)
+
+    cols = {
+        r[0] for r in conn.execute(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_name = 'table_registry'"
+        ).fetchall()
+    }
+    assert "source_query" in cols, f"source_query missing from {cols}"
+    assert get_schema_version(conn) == 19
+    conn.close()
+
+
+def test_v18_db_migrates_to_v19(tmp_path):
+    """Pre-existing v18 DB without source_query upgrades cleanly without losing data."""
+    db_path = tmp_path / "system.duckdb"
+    conn = duckdb.connect(str(db_path))
+
+    # Simulate a v18 DB at minimal but realistic shape: just the schema_version
+    # row + a table_registry row whose existing columns must survive the v19 ALTER.
+    conn.execute(
+        "CREATE TABLE schema_version (version INTEGER, "
+        "applied_at TIMESTAMP DEFAULT current_timestamp)"
+    )
+    conn.execute("INSERT INTO schema_version (version) VALUES (18)")
+    conn.execute("""CREATE TABLE table_registry (
+        id VARCHAR PRIMARY KEY, name VARCHAR NOT NULL,
+        source_type VARCHAR, bucket VARCHAR, source_table VARCHAR,
+        sync_strategy VARCHAR DEFAULT 'full_refresh',
+        query_mode VARCHAR DEFAULT 'local',
+        sync_schedule VARCHAR, profile_after_sync BOOLEAN DEFAULT true,
+        primary_key VARCHAR, folder VARCHAR, description TEXT,
+        registered_by VARCHAR, is_public BOOLEAN DEFAULT true,
+        registered_at TIMESTAMP DEFAULT current_timestamp
+    )""")
+    conn.execute("INSERT INTO table_registry (id, name) VALUES ('foo', 'foo')")
+
+    _ensure_schema(conn)
+
+    assert get_schema_version(conn) == 19
+    cols = {
+        r[0] for r in conn.execute(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_name = 'table_registry'"
+        ).fetchall()
+    }
+    assert "source_query" in cols
+    # Existing row preserved, new column NULL
+    row = conn.execute(
+        "SELECT id, source_query FROM table_registry WHERE id='foo'"
+    ).fetchone()
+    assert row == ("foo", None)
+    conn.close()

--- a/tests/test_materialized_e2e.py
+++ b/tests/test_materialized_e2e.py
@@ -1,0 +1,321 @@
+"""End-to-end integration coverage for query_mode='materialized'.
+
+Unit tests verify each piece in isolation; this file glues them together:
+
+1. Admin POST /api/admin/register-table (materialized) → registry row written
+2. _run_materialized_pass writes parquet + sync_state with correct hash
+3. GET /api/sync/manifest (per-user) returns the row with query_mode +
+   the parquet hash, filtered by RBAC
+4. Mode-switch transitions (remote → materialized, materialized → SQL edit
+   preserves registered_at) maintain registry invariants.
+
+Devil's-advocate review found these were the gaps the unit tests left
+open. Each piece passes in isolation; this file proves they compose.
+"""
+import duckdb
+import hashlib
+import pytest
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from connectors.bigquery.access import BqAccess, BqProjects
+from src.repositories.table_registry import TableRegistryRepository
+from src.repositories.sync_state import SyncStateRepository
+
+
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def bq_instance(monkeypatch):
+    """Force instance.yaml to look like a BigQuery deployment so the BQ
+    register validator's project_id check passes."""
+    fake_cfg = {
+        "data_source": {
+            "type": "bigquery",
+            "bigquery": {"project": "my-test-project", "location": "us"},
+        },
+    }
+    monkeypatch.setattr(
+        "app.instance_config.load_instance_config",
+        lambda: fake_cfg,
+        raising=False,
+    )
+    from app.instance_config import reset_cache
+    reset_cache()
+    yield fake_cfg
+    reset_cache()
+
+
+@pytest.fixture
+def stub_bq_extractor(monkeypatch):
+    """Mirror tests/test_admin_bq_register.py::stub_bq_extractor — replaces
+    rebuild_from_registry + SyncOrchestrator so the API's post-register
+    materialize doesn't hit real BQ during HTTP-driven tests."""
+    rebuild_mock = MagicMock(return_value={
+        "project_id": "my-test-project",
+        "tables_registered": 1,
+        "errors": [],
+        "skipped": False,
+    })
+    monkeypatch.setattr(
+        "connectors.bigquery.extractor.rebuild_from_registry",
+        rebuild_mock,
+    )
+    orch_mock = MagicMock()
+    monkeypatch.setattr(
+        "src.orchestrator.SyncOrchestrator",
+        lambda *a, **kw: orch_mock,
+    )
+    return {"rebuild": rebuild_mock, "orchestrator": orch_mock}
+
+
+@pytest.fixture
+def stub_bq():
+    """Real-shape BqAccess wired to in-memory DuckDB factories so the
+    materialize_query path can run end-to-end without GCP."""
+    @contextmanager
+    def _session(_p):
+        conn = duckdb.connect(":memory:")
+        try:
+            conn.execute("ATTACH ':memory:' AS bq")
+            conn.execute("CREATE SCHEMA bq.test")
+            conn.execute(
+                "CREATE OR REPLACE TABLE bq.test.orders AS "
+                "SELECT 'EU' AS region, 100 AS revenue UNION ALL "
+                "SELECT 'US' AS region, 250 AS revenue"
+            )
+            yield conn
+        finally:
+            conn.close()
+    return BqAccess(
+        BqProjects(billing="my-test-project", data="my-test-project"),
+        client_factory=lambda _p: MagicMock(),
+        duckdb_session_factory=_session,
+    )
+
+
+def test_e2e_register_then_materialize_then_manifest_via_repo(
+    bq_instance, stub_bq, tmp_path, monkeypatch,
+):
+    """Glue test: register row at the repository layer (skips HTTP/auth),
+    run the materialized pass, verify sync_state, then exercise the
+    `_build_manifest_for_user` admin path. Catches integration breakage
+    that unit tests miss because each only sees one layer."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    db_path = tmp_path / "system.duckdb"
+    conn = duckdb.connect(str(db_path))
+    from src.db import _ensure_schema
+    _ensure_schema(conn)
+
+    table_id = "orders_summary_e2e"
+    repo = TableRegistryRepository(conn)
+    repo.register(
+        id=table_id, name=table_id, source_type="bigquery",
+        query_mode="materialized",
+        source_query="SELECT region, SUM(revenue) AS revenue "
+                     "FROM bq.test.orders GROUP BY 1",
+        sync_schedule="every 1m",
+    )
+
+    # Run the materialized pass.
+    from app.api import sync as sync_mod
+    summary = sync_mod._run_materialized_pass(conn, stub_bq)
+    assert table_id in summary["materialized"], summary
+    assert not summary["errors"]
+
+    # Parquet on disk.
+    parquet_path = (
+        tmp_path / "data" / "extracts" / "bigquery" / "data"
+        / f"{table_id}.parquet"
+    )
+    assert parquet_path.exists(), f"Expected {parquet_path} to exist"
+
+    # sync_state hash matches the file's MD5.
+    expected_hash = hashlib.md5(parquet_path.read_bytes()).hexdigest()
+    state = SyncStateRepository(conn)
+    row = state.get_table_state(table_id)
+    assert row is not None
+    assert row["hash"] == expected_hash
+    assert row["rows"] == 2
+
+    # Manifest builder exposes query_mode + hash to admin (no RBAC filter).
+    admin_user = {"id": "u-admin", "email": "admin@test", "role": "admin"}
+    manifest = sync_mod._build_manifest_for_user(conn, admin_user)
+    assert table_id in manifest["tables"]
+    entry = manifest["tables"][table_id]
+    assert entry["query_mode"] == "materialized"
+    assert entry["hash"] == expected_hash
+    assert entry["rows"] == 2
+
+    conn.close()
+
+
+def test_remote_to_materialized_transition_clears_bucket_table(
+    seeded_app, bq_instance, stub_bq_extractor,
+):
+    """Switching a remote BQ row to materialized must accept source_query
+    and the merged validator must not trip on the now-irrelevant
+    bucket/source_table fields."""
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+
+    # Seed a remote row.
+    r = c.post("/api/admin/register-table", json={
+        "name": "live_to_mat",
+        "source_type": "bigquery",
+        "bucket": "analytics",
+        "source_table": "orders",
+        "query_mode": "remote",
+    }, headers=_auth(token))
+    assert r.status_code in (200, 202), r.json()
+    table_id = r.json()["id"]
+
+    # Switch to materialized — must include source_query for the validator.
+    r2 = c.put(f"/api/admin/registry/{table_id}", json={
+        "query_mode": "materialized",
+        "source_query": "SELECT 1 AS n",
+    }, headers=_auth(token))
+    assert r2.status_code == 200, r2.json()
+
+    # Verify the merged record reflects the switch.
+    r3 = c.get("/api/admin/registry", headers=_auth(token))
+    row = next((t for t in r3.json()["tables"] if t["id"] == table_id), None)
+    assert row is not None
+    assert row["query_mode"] == "materialized"
+    assert row["source_query"] == "SELECT 1 AS n"
+
+
+def test_materialized_sql_edit_preserves_registered_at(
+    seeded_app, bq_instance, stub_bq_extractor, monkeypatch,
+):
+    """Editing source_query on an existing materialized row must not
+    reset registered_at — the row's registration history is preserved
+    across SQL edits (issue #130 invariant)."""
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+
+    # Seed a materialized row.
+    r = c.post("/api/admin/register-table", json={
+        "name": "sql_edit_target",
+        "source_type": "bigquery",
+        "query_mode": "materialized",
+        "source_query": "SELECT 1 AS n",
+    }, headers=_auth(token))
+    assert r.status_code == 201, r.json()
+    table_id = r.json()["id"]
+
+    # Capture the original registered_at.
+    r2 = c.get("/api/admin/registry", headers=_auth(token))
+    row = next((t for t in r2.json()["tables"] if t["id"] == table_id), None)
+    original_ts = row["registered_at"]
+    assert original_ts is not None
+
+    # Edit the SQL.
+    import time
+    time.sleep(0.01)  # ensure a clock tick elapses so a fresh stamp would differ
+    r3 = c.put(f"/api/admin/registry/{table_id}", json={
+        "query_mode": "materialized",
+        "source_query": "SELECT 2 AS n",
+    }, headers=_auth(token))
+    assert r3.status_code == 200, r3.json()
+
+    r4 = c.get("/api/admin/registry", headers=_auth(token))
+    row = next((t for t in r4.json()["tables"] if t["id"] == table_id), None)
+    assert row["source_query"] == "SELECT 2 AS n"
+    # registered_at preserved across edit
+    assert row["registered_at"] == original_ts, (
+        f"Expected registered_at preserved (issue #130 contract). "
+        f"Original: {original_ts}, after edit: {row['registered_at']}"
+    )
+
+
+def test_materialized_zero_rows_logs_warning(stub_bq, tmp_path, caplog):
+    """Devil's-advocate item: an SQL filter that returns 0 rows is
+    indistinguishable from 'SQL is wrong'. Confirm we log a WARNING so
+    operators can grep on it."""
+    import logging
+    from connectors.bigquery.extractor import materialize_query
+
+    out = tmp_path / "extracts" / "bigquery"
+    out.mkdir(parents=True)
+
+    # Add an empty BQ table to the stub for this test.
+    @contextmanager
+    def _session_empty(_p):
+        conn = duckdb.connect(":memory:")
+        try:
+            conn.execute("ATTACH ':memory:' AS bq")
+            conn.execute("CREATE SCHEMA bq.test")
+            conn.execute("CREATE OR REPLACE TABLE bq.test.empty AS "
+                         "SELECT 1 AS n WHERE FALSE")
+            yield conn
+        finally:
+            conn.close()
+
+    bq_empty = BqAccess(
+        BqProjects(billing="t", data="t"),
+        client_factory=lambda _p: MagicMock(),
+        duckdb_session_factory=_session_empty,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="connectors.bigquery.extractor"):
+        stats = materialize_query(
+            table_id="empty_t",
+            sql="SELECT * FROM bq.test.empty",
+            bq=bq_empty,
+            output_dir=str(out),
+        )
+
+    assert stats["rows"] == 0
+    assert any("0 rows" in rec.message for rec in caplog.records), (
+        f"Expected '0 rows' WARNING; got: {[r.message for r in caplog.records]}"
+    )
+
+
+def test_attach_real_error_propagates(stub_bq, tmp_path):
+    """ATTACH 'project=...' that fails for a real reason (not the
+    'already attached' tolerated case) must propagate so callers see
+    the actual error instead of a confusing downstream 'bq is not
+    attached' message."""
+    from connectors.bigquery.extractor import materialize_query
+
+    out = tmp_path / "extracts" / "bigquery"
+    out.mkdir(parents=True)
+
+    @contextmanager
+    def _session_attach_fails(_p):
+        conn = duckdb.connect(":memory:")
+        try:
+            # Force ATTACH 'project=...' to raise something other than
+            # "already attached" by intercepting via execute wrapper —
+            # since DuckDB's real connection doesn't accept attribute
+            # patches, we use a thin proxy for this test.
+            class _Proxy:
+                def __init__(self, real):
+                    self._real = real
+                def execute(self, sql, *a, **kw):
+                    if sql.startswith("ATTACH 'project="):
+                        raise duckdb.Error("fake permission denied: missing serviceusage.services.use")
+                    return self._real.execute(sql, *a, **kw)
+                def __getattr__(self, name):
+                    return getattr(self._real, name)
+                def close(self):
+                    return self._real.close()
+            yield _Proxy(conn)
+        finally:
+            conn.close()
+
+    bq_bad = BqAccess(
+        BqProjects(billing="t", data="t"),
+        client_factory=lambda _p: MagicMock(),
+        duckdb_session_factory=_session_attach_fails,
+    )
+
+    with pytest.raises(duckdb.Error, match="permission denied"):
+        materialize_query(
+            table_id="x", sql="SELECT 1",
+            bq=bq_bad, output_dir=str(out),
+        )

--- a/tests/test_setup_hooks_template.py
+++ b/tests/test_setup_hooks_template.py
@@ -1,0 +1,33 @@
+"""The shipped Claude settings template must point hooks at `da sync`, not the deleted server/scripts."""
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = REPO_ROOT / "docs" / "setup" / "claude_settings.json"
+
+
+def test_template_has_session_start_da_sync():
+    cfg = json.loads(TEMPLATE.read_text())
+    starts = cfg.get("hooks", {}).get("SessionStart", [])
+    assert starts, "SessionStart hook missing"
+    cmds = [h["command"] for entry in starts for h in entry.get("hooks", [])]
+    assert any("da sync" in c and "--upload-only" not in c for c in cmds), (
+        f"Expected `da sync` in SessionStart, got {cmds}"
+    )
+
+
+def test_template_has_session_end_upload():
+    cfg = json.loads(TEMPLATE.read_text())
+    ends = cfg.get("hooks", {}).get("SessionEnd", [])
+    cmds = [h["command"] for entry in ends for h in entry.get("hooks", [])]
+    assert any("da sync --upload-only" in c for c in cmds), (
+        f"Expected `da sync --upload-only` in SessionEnd, got {cmds}"
+    )
+
+
+def test_template_drops_dead_server_scripts_reference():
+    raw = TEMPLATE.read_text()
+    assert "server/scripts/collect_session.py" not in raw, (
+        "Template still references the deleted server/scripts/collect_session.py — "
+        "the SessionEnd hook would silently fail."
+    )

--- a/tests/test_sync_trigger_materialized.py
+++ b/tests/test_sync_trigger_materialized.py
@@ -185,6 +185,83 @@ def test_materialized_pass_records_parquet_hash(system_db, stub_bq, tmp_path):
     assert row["hash"] == expected
 
 
+def test_run_sync_runs_materialized_pass_on_bq_only_deployment(
+    tmp_path, monkeypatch,
+):
+    """REGRESSION (Devin BUG_0002 on 2fa44f2): on BigQuery-only deployments
+    `list_local('bigquery')` is always empty (BQ rows are remote or
+    materialized, never local). The pre-fix _run_sync early-returned in
+    that case → materialized pass + orchestrator rebuild were dead code.
+    Post-fix: run_extractor_subprocess flag skips just the Keboola
+    subprocess, and the materialized pass still fires."""
+    import duckdb
+    from src.db import _ensure_schema
+
+    db_path = tmp_path / "system.duckdb"
+    conn = duckdb.connect(str(db_path))
+    _ensure_schema(conn)
+
+    repo = TableRegistryRepository(conn)
+    # Materialized BQ row — would be invisible to list_local('bigquery').
+    repo.register(
+        id="m1", name="m1", source_type="bigquery",
+        query_mode="materialized",
+        source_query="SELECT 1",
+        sync_schedule="every 1m",
+    )
+    conn.close()
+
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+
+    # Patch the heavy collaborators so we observe what _run_sync invoked
+    # without actually running BQ / orchestrator.
+    from app.api import sync as sync_mod
+
+    materialized_called = {"count": 0}
+    orchestrator_called = {"count": 0}
+
+    def _spy_materialized_pass(_conn, _bq):
+        materialized_called["count"] += 1
+        return {"materialized": ["m1"], "skipped": [], "errors": []}
+
+    class _OrchStub:
+        def rebuild(self):
+            orchestrator_called["count"] += 1
+            return {}
+
+    monkeypatch.setattr(
+        "app.api.sync._run_materialized_pass",
+        _spy_materialized_pass,
+    )
+    monkeypatch.setattr(
+        "src.orchestrator.SyncOrchestrator",
+        lambda *a, **kw: _OrchStub(),
+    )
+    # Pretend instance.yaml says data_source.type=bigquery
+    monkeypatch.setattr(
+        "app.instance_config.get_data_source_type",
+        lambda: "bigquery",
+    )
+    # bq_project must be truthy so the materialized pass branch fires.
+    real_get_value = sync_mod.__dict__.get("get_value")
+    monkeypatch.setattr(
+        "app.instance_config.get_value",
+        lambda *args, **kw: (
+            "my-bq-proj" if (args and args[-1] == "project")
+            else kw.get("default", "")
+        ),
+    )
+
+    sync_mod._run_sync()
+
+    assert materialized_called["count"] == 1, (
+        "materialized pass must run on BQ-only deployment (no local rows)"
+    )
+    assert orchestrator_called["count"] == 1, (
+        "orchestrator rebuild must run so materialized parquets are picked up"
+    )
+
+
 @pytest.mark.parametrize("yaml_value, expected_max", [
     (10737418240, 10737418240),       # int — canonical
     (10737418240.0, 10737418240),     # float — YAML often parses as float

--- a/tests/test_sync_trigger_materialized.py
+++ b/tests/test_sync_trigger_materialized.py
@@ -185,6 +185,53 @@ def test_materialized_pass_records_parquet_hash(system_db, stub_bq, tmp_path):
     assert row["hash"] == expected
 
 
+@pytest.mark.parametrize("yaml_value, expected_max", [
+    (10737418240, 10737418240),       # int — canonical
+    (10737418240.0, 10737418240),     # float — YAML often parses as float
+    (1e10, 10000000000),              # scientific notation
+    ("10737418240", 10737418240),     # string — coerced
+    (0, None),                        # explicit disable sentinel
+    (None, None),                     # missing key
+    ("not-a-number", None),           # malformed → fail-open + warn
+])
+def test_materialized_pass_max_bytes_yaml_coercion(
+    system_db, stub_bq, tmp_path, monkeypatch, yaml_value, expected_max,
+):
+    """`max_bytes_per_materialize` YAML value is coerced to int regardless of
+    the YAML scalar type (int / float / scientific / string). Devin found
+    that an `isinstance(raw, int)` guard silently disabled the guardrail
+    on float values."""
+    repo = TableRegistryRepository(system_db)
+    repo.register(
+        id="t", name="t", source_type="bigquery",
+        query_mode="materialized", source_query="SELECT 1",
+        sync_schedule="every 1m",
+    )
+
+    parquet_dir = tmp_path / "data" / "extracts" / "bigquery" / "data"
+    parquet_dir.mkdir(parents=True, exist_ok=True)
+    (parquet_dir / "t.parquet").write_bytes(b"PAR1" + b"\x00" * 16 + b"PAR1")
+
+    captured = {}
+
+    def _spy(table_id, sql, bq, output_dir, max_bytes):
+        captured["max_bytes"] = max_bytes
+        return {"rows": 1, "size_bytes": 100, "query_mode": "materialized"}
+
+    from app.api import sync as sync_mod
+
+    with patch(
+        "app.instance_config.get_value",
+        side_effect=lambda *a, **kw: (
+            yaml_value if a[-1] == "max_bytes_per_materialize"
+            else kw.get("default", "")
+        ),
+    ), patch("app.api.sync._materialize_table", side_effect=_spy):
+        sync_mod._run_materialized_pass(system_db, stub_bq)
+
+    assert captured["max_bytes"] == expected_max
+
+
 def test_materialized_pass_keys_sync_state_by_name_not_id(
     system_db, stub_bq, tmp_path,
 ):

--- a/tests/test_sync_trigger_materialized.py
+++ b/tests/test_sync_trigger_materialized.py
@@ -185,6 +185,87 @@ def test_materialized_pass_records_parquet_hash(system_db, stub_bq, tmp_path):
     assert row["hash"] == expected
 
 
+def test_run_sync_keboola_timeout_does_not_skip_materialized(tmp_path, monkeypatch):
+    """REGRESSION (Devin BUG_0001 on 2219255): when the Keboola extractor
+    subprocess raises TimeoutExpired, the materialized BQ pass and the
+    orchestrator rebuild must still fire. Pre-fix the timeout propagated
+    to the outer except handler and skipped the rest of _run_sync — on
+    a dual-source deployment a slow Keboola extractor would silently
+    block all materialized parquets and the master-view rebuild until
+    the next trigger."""
+    import duckdb
+    import subprocess as _sp
+    from src.db import _ensure_schema
+
+    db_path = tmp_path / "system.duckdb"
+    conn = duckdb.connect(str(db_path))
+    _ensure_schema(conn)
+
+    repo = TableRegistryRepository(conn)
+    # One Keboola row (drives the extractor subprocess) + one materialized
+    # BQ row (must still run after the Keboola timeout).
+    repo.register(
+        id="kbc_a", name="kbc_a", source_type="keboola",
+        query_mode="local", bucket="in.c-foo", source_table="a",
+    )
+    repo.register(
+        id="m1", name="m1", source_type="bigquery",
+        query_mode="materialized",
+        source_query="SELECT 1",
+        sync_schedule="every 1m",
+    )
+    conn.close()
+
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("KEBOOLA_STACK_URL", "https://example.invalid")
+    monkeypatch.setenv("KEBOOLA_STORAGE_TOKEN", "fake")
+
+    from app.api import sync as sync_mod
+
+    # Subprocess raises TimeoutExpired the moment _run_sync calls it.
+    def _timeout(*a, **kw):
+        raise _sp.TimeoutExpired(cmd=["fake"], timeout=1)
+
+    monkeypatch.setattr(sync_mod.subprocess, "run", _timeout)
+
+    materialized_called = {"count": 0}
+    orchestrator_called = {"count": 0}
+
+    def _spy_materialized(_conn, _bq):
+        materialized_called["count"] += 1
+        return {"materialized": ["m1"], "skipped": [], "errors": []}
+
+    class _OrchStub:
+        def rebuild(self):
+            orchestrator_called["count"] += 1
+            return {}
+
+    monkeypatch.setattr("app.api.sync._run_materialized_pass", _spy_materialized)
+    monkeypatch.setattr(
+        "src.orchestrator.SyncOrchestrator", lambda *a, **kw: _OrchStub(),
+    )
+    monkeypatch.setattr(
+        "app.instance_config.get_data_source_type", lambda: "keboola",
+    )
+    monkeypatch.setattr(
+        "app.instance_config.get_value",
+        lambda *args, **kw: (
+            "my-bq-proj" if (args and args[-1] == "project")
+            else kw.get("default", "")
+        ),
+    )
+
+    sync_mod._run_sync()
+
+    assert materialized_called["count"] == 1, (
+        "materialized pass must run even when Keboola subprocess timed out"
+    )
+    assert orchestrator_called["count"] == 1, (
+        "orchestrator rebuild must run after Keboola timeout to publish "
+        "any partial / materialized parquets that did land"
+    )
+
+
 def test_run_sync_runs_materialized_pass_on_bq_only_deployment(
     tmp_path, monkeypatch,
 ):

--- a/tests/test_sync_trigger_materialized.py
+++ b/tests/test_sync_trigger_materialized.py
@@ -1,0 +1,231 @@
+"""_run_materialized_pass walks table_registry for materialized BQ rows
+and runs each that is due via _materialize_table.
+
+Tests inject a stub BqAccess (factories never called by these tests since
+_materialize_table is patched) and assert that scheduling, error
+aggregation, sync_state hash, and the disable-sentinel all behave
+correctly.
+"""
+import duckdb
+import pytest
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from src.db import _ensure_schema
+from src.repositories.table_registry import TableRegistryRepository
+from src.repositories.sync_state import SyncStateRepository
+from connectors.bigquery.access import BqAccess, BqProjects
+
+
+@pytest.fixture
+def system_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "system.duckdb"
+    conn = duckdb.connect(str(db_path))
+    _ensure_schema(conn)
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def stub_bq():
+    """A BqAccess instance that the tests don't actually exercise (the test
+    patches `_materialize_table`); just needs to be a valid BqAccess so the
+    type contract doesn't break."""
+    @contextmanager
+    def _session(_p):
+        conn = duckdb.connect(":memory:")
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    return BqAccess(
+        BqProjects(billing="t", data="t"),
+        client_factory=lambda _p: MagicMock(),
+        duckdb_session_factory=_session,
+    )
+
+
+def test_materialized_pass_calls_materialize_for_due_rows(system_db, stub_bq, tmp_path):
+    repo = TableRegistryRepository(system_db)
+    repo.register(
+        id="orders_90d", name="orders_90d",
+        source_type="bigquery", query_mode="materialized",
+        source_query="SELECT 1 AS n",
+        sync_schedule="every 1m",  # always due in tests (no prior sync)
+    )
+
+    # Pre-create the parquet so _file_hash returns non-empty
+    parquet_dir = tmp_path / "data" / "extracts" / "bigquery" / "data"
+    parquet_dir.mkdir(parents=True, exist_ok=True)
+    (parquet_dir / "orders_90d.parquet").write_bytes(
+        b"PAR1" + b"\x00" * 16 + b"PAR1"
+    )
+
+    from app.api import sync as sync_mod
+
+    with patch("app.api.sync._materialize_table") as mock_mat:
+        mock_mat.return_value = {
+            "rows": 1, "size_bytes": 100, "query_mode": "materialized",
+        }
+        summary = sync_mod._run_materialized_pass(system_db, stub_bq)
+
+    mock_mat.assert_called_once()
+    call_kwargs = mock_mat.call_args.kwargs
+    assert call_kwargs["table_id"] == "orders_90d"
+    assert "SELECT 1 AS n" in call_kwargs["sql"]
+    assert call_kwargs["bq"] is stub_bq
+    # Default cap (10 GiB) flows through when no instance.yaml override
+    assert call_kwargs["max_bytes"] == 10 * 2**30
+    assert "orders_90d" in summary["materialized"]
+    assert not summary["errors"]
+
+
+def test_materialized_pass_skips_undue_rows(system_db, stub_bq):
+    repo = TableRegistryRepository(system_db)
+    repo.register(
+        id="orders_daily", name="orders_daily",
+        source_type="bigquery", query_mode="materialized",
+        source_query="SELECT 1",
+        sync_schedule="daily 03:00",
+    )
+    state = SyncStateRepository(system_db)
+    state.update_sync(
+        table_id="orders_daily", rows=1, file_size_bytes=10, hash="x",
+    )
+
+    from app.api import sync as sync_mod
+
+    with patch("app.api.sync._materialize_table") as mock_mat:
+        summary = sync_mod._run_materialized_pass(system_db, stub_bq)
+
+    mock_mat.assert_not_called()
+    assert "orders_daily" in summary["skipped"]
+
+
+def test_materialized_pass_skips_non_materialized_rows(system_db, stub_bq):
+    repo = TableRegistryRepository(system_db)
+    repo.register(id="t1", name="t1", source_type="keboola", query_mode="local")
+    repo.register(id="t2", name="t2", source_type="bigquery", query_mode="remote")
+
+    from app.api import sync as sync_mod
+
+    with patch("app.api.sync._materialize_table") as mock_mat:
+        summary = sync_mod._run_materialized_pass(system_db, stub_bq)
+
+    mock_mat.assert_not_called()
+    assert summary == {"materialized": [], "skipped": [], "errors": []}
+
+
+def test_materialized_pass_collects_errors_per_row(system_db, stub_bq, tmp_path):
+    """One row failing must not stop a healthy sibling."""
+    repo = TableRegistryRepository(system_db)
+    repo.register(
+        id="ok", name="ok", source_type="bigquery",
+        query_mode="materialized", source_query="SELECT 1",
+        sync_schedule="every 1m",
+    )
+    repo.register(
+        id="bad", name="bad", source_type="bigquery",
+        query_mode="materialized", source_query="SELECT broken",
+        sync_schedule="every 1m",
+    )
+
+    parquet_dir = tmp_path / "data" / "extracts" / "bigquery" / "data"
+    parquet_dir.mkdir(parents=True, exist_ok=True)
+    (parquet_dir / "ok.parquet").write_bytes(b"PAR1" + b"\x00" * 16 + b"PAR1")
+
+    from app.api import sync as sync_mod
+
+    def _fake(table_id, sql, bq, output_dir, max_bytes):
+        if table_id == "bad":
+            raise RuntimeError("simulated COPY failure")
+        return {"rows": 1, "size_bytes": 100, "query_mode": "materialized"}
+
+    with patch("app.api.sync._materialize_table", side_effect=_fake):
+        summary = sync_mod._run_materialized_pass(system_db, stub_bq)
+
+    assert summary["materialized"] == ["ok"]
+    assert len(summary["errors"]) == 1
+    assert summary["errors"][0]["table"] == "bad"
+    assert "simulated" in summary["errors"][0]["error"]
+
+
+def test_materialized_pass_records_parquet_hash(system_db, stub_bq, tmp_path):
+    """sync_state.hash must be the MD5 of the parquet file — otherwise the
+    manifest reports an empty hash and every da sync re-downloads."""
+    repo = TableRegistryRepository(system_db)
+    repo.register(
+        id="hashed", name="hashed",
+        source_type="bigquery", query_mode="materialized",
+        source_query="SELECT 1",
+        sync_schedule="every 1m",
+    )
+
+    parquet_dir = tmp_path / "data" / "extracts" / "bigquery" / "data"
+    parquet_dir.mkdir(parents=True, exist_ok=True)
+    parquet_path = parquet_dir / "hashed.parquet"
+
+    def _fake(**kwargs):
+        parquet_path.write_bytes(b"PAR1" + b"\x00" * 16 + b"PAR1")
+        return {"rows": 1, "size_bytes": 24, "query_mode": "materialized"}
+
+    from app.api import sync as sync_mod
+
+    with patch("app.api.sync._materialize_table", side_effect=_fake):
+        sync_mod._run_materialized_pass(system_db, stub_bq)
+
+    state = SyncStateRepository(system_db)
+    row = state.get_table_state("hashed")
+    assert row is not None
+    import hashlib
+    expected = hashlib.md5(b"PAR1" + b"\x00" * 16 + b"PAR1").hexdigest()
+    assert row["hash"] == expected
+
+
+def test_materialized_pass_zero_max_bytes_disables_guardrail(
+    system_db, stub_bq, tmp_path, monkeypatch
+):
+    """`max_bytes_per_materialize: 0` in instance.yaml → None passed downstream
+    so materialize_query skips the dry-run entirely."""
+    repo = TableRegistryRepository(system_db)
+    repo.register(
+        id="big", name="big", source_type="bigquery",
+        query_mode="materialized", source_query="SELECT 1",
+        sync_schedule="every 1m",
+    )
+
+    parquet_dir = tmp_path / "data" / "extracts" / "bigquery" / "data"
+    parquet_dir.mkdir(parents=True, exist_ok=True)
+    (parquet_dir / "big.parquet").write_bytes(
+        b"PAR1" + b"\x00" * 16 + b"PAR1"
+    )
+
+    monkeypatch.setattr(
+        "app.api.sync.get_value",
+        lambda *args, **kwargs: 0 if args[-1] == "max_bytes_per_materialize" else "",
+        raising=False,
+    )
+
+    from app.api import sync as sync_mod
+
+    captured = {}
+
+    def _spy(**kwargs):
+        captured.update(kwargs)
+        return {"rows": 1, "size_bytes": 100, "query_mode": "materialized"}
+
+    # The function reads `get_value` via a local import in the body — patch
+    # the import target instead.
+    with patch(
+        "app.instance_config.get_value",
+        side_effect=lambda *args, **kw: (
+            0 if args[-1] == "max_bytes_per_materialize"
+            else kw.get("default", "")
+        ),
+    ), patch("app.api.sync._materialize_table", side_effect=_spy):
+        sync_mod._run_materialized_pass(system_db, stub_bq)
+
+    assert captured["max_bytes"] is None

--- a/tests/test_sync_trigger_materialized.py
+++ b/tests/test_sync_trigger_materialized.py
@@ -185,6 +185,54 @@ def test_materialized_pass_records_parquet_hash(system_db, stub_bq, tmp_path):
     assert row["hash"] == expected
 
 
+def test_materialized_pass_keys_sync_state_by_name_not_id(
+    system_db, stub_bq, tmp_path,
+):
+    """Devin review: when admin registers a name with mixed case (e.g.
+    "Orders_90d") the slug-derived id ("orders_90d") differs from name.
+    sync_state must be keyed by `name` so the manifest's `registry_by_name`
+    lookup resolves and `query_mode='materialized'` flows through to the
+    client. Otherwise CLI sees `query_mode='local'` and downloads the
+    wrong file or skips the row."""
+    repo = TableRegistryRepository(system_db)
+    # Mixed-case name — id will be slugified to lowercase by the API path,
+    # but at the repo level we control both directly.
+    repo.register(
+        id="orders_90d", name="Orders_90d",
+        source_type="bigquery", query_mode="materialized",
+        source_query="SELECT 1",
+        sync_schedule="every 1m",
+    )
+
+    # Pre-create the parquet at the NAME-keyed path.
+    parquet_dir = tmp_path / "data" / "extracts" / "bigquery" / "data"
+    parquet_dir.mkdir(parents=True, exist_ok=True)
+    (parquet_dir / "Orders_90d.parquet").write_bytes(
+        b"PAR1" + b"\x00" * 16 + b"PAR1"
+    )
+
+    from app.api import sync as sync_mod
+
+    captured = {}
+
+    def _spy(table_id, sql, bq, output_dir, max_bytes):
+        captured["table_id"] = table_id
+        return {"rows": 1, "size_bytes": 100, "query_mode": "materialized"}
+
+    with patch("app.api.sync._materialize_table", side_effect=_spy):
+        sync_mod._run_materialized_pass(system_db, stub_bq)
+
+    # materialize_query was called with the NAME, not the id.
+    assert captured["table_id"] == "Orders_90d"
+
+    # sync_state row keyed by name.
+    state = SyncStateRepository(system_db)
+    name_row = state.get_table_state("Orders_90d")
+    id_row = state.get_table_state("orders_90d")
+    assert name_row is not None, "sync_state should be keyed by name"
+    assert id_row is None, "sync_state should NOT be keyed by id"
+
+
 def test_materialized_pass_zero_max_bytes_disables_guardrail(
     system_db, stub_bq, tmp_path, monkeypatch
 ):

--- a/tests/test_table_registry_source_query.py
+++ b/tests/test_table_registry_source_query.py
@@ -1,0 +1,93 @@
+"""Repository round-trips source_query column for query_mode='materialized'.
+
+Lives alongside the schema-v19 migration: register() now accepts source_query
+as an Optional[str] kwarg, and the column flows through SELECT * via list/get.
+"""
+import duckdb
+import pytest
+
+from src.db import _ensure_schema
+from src.repositories.table_registry import TableRegistryRepository
+
+
+@pytest.fixture
+def repo(tmp_path):
+    conn = duckdb.connect(str(tmp_path / "system.duckdb"))
+    _ensure_schema(conn)
+    return TableRegistryRepository(conn)
+
+
+def test_register_persists_source_query(repo):
+    repo.register(
+        id="orders_90d",
+        name="orders_90d",
+        source_type="bigquery",
+        query_mode="materialized",
+        source_query=(
+            "SELECT date, SUM(revenue) FROM `prj.ds.orders` "
+            "WHERE date >= DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY) GROUP BY 1"
+        ),
+        sync_schedule="every 6h",
+    )
+    row = repo.get("orders_90d")
+    assert row is not None
+    assert row["query_mode"] == "materialized"
+    assert "INTERVAL 90 DAY" in row["source_query"]
+    assert row["sync_schedule"] == "every 6h"
+
+
+def test_register_omitted_source_query_stays_null(repo):
+    """Default registrations (Keboola local) must not stamp an empty string."""
+    repo.register(id="t1", name="t1", source_type="keboola", query_mode="local")
+    row = repo.get("t1")
+    assert row is not None
+    assert row["source_query"] is None
+
+
+def test_list_all_includes_source_query(repo):
+    repo.register(
+        id="m1", name="m1", source_type="bigquery",
+        query_mode="materialized", source_query="SELECT 1",
+    )
+    rows = repo.list_all()
+    assert len(rows) == 1
+    assert rows[0]["source_query"] == "SELECT 1"
+
+
+def test_register_updates_source_query_on_conflict(repo):
+    """Re-registering the same id must overwrite source_query (admin edit)."""
+    repo.register(
+        id="m1", name="m1", source_type="bigquery",
+        query_mode="materialized", source_query="SELECT 1",
+    )
+    repo.register(
+        id="m1", name="m1", source_type="bigquery",
+        query_mode="materialized", source_query="SELECT 2",
+    )
+    row = repo.get("m1")
+    assert row["source_query"] == "SELECT 2"
+
+
+def test_register_preserves_registered_at_when_supplied(repo):
+    """source_query addition must not break the existing registered_at
+    preservation contract (admin edits keep the original timestamp)."""
+    from datetime import datetime, timezone
+
+    original = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    repo.register(
+        id="t", name="t", source_type="bigquery",
+        query_mode="materialized", source_query="SELECT 1",
+        registered_at=original,
+    )
+    repo.register(
+        id="t", name="t", source_type="bigquery",
+        query_mode="materialized", source_query="SELECT 2",
+        registered_at=original,
+    )
+    row = repo.get("t")
+    assert row["source_query"] == "SELECT 2"
+    # Don't assert exact equality on naive vs aware (DuckDB strips tz);
+    # just confirm the year+month+day didn't slide forward to 'now'.
+    assert row["registered_at"].year == 2026
+    assert row["registered_at"].month == 1
+    assert row["registered_at"].day == 1


### PR DESCRIPTION
## Summary

End-to-end smart local sync for AI analysts. **Reimplemented from PR #145** against the 0.24.0 base because main advanced 26 commits (schema v14-v18, `BqAccess` facade, register-table flow rework) and a merge would have hidden the architectural decisions inside conflict resolution.

**Phase A — Auto-sync hooks**
- `da sync --quiet` for hook/cron use (clean stdout, terse stderr summary, non-zero exit on failure)
- `da analyst setup` installs `SessionStart` (pull) + `SessionEnd` (upload) hooks idempotently into `<workspace>/.claude/settings.json` — workspace-level, not user-home
- Replaces broken `SessionEnd` reference in `docs/setup/claude_settings.json` (`server/scripts/collect_session.py` was deleted in the v1→v2 server purge)
- `_install_claude_hooks` handles malformed existing settings.json gracefully

**Phase B — BigQuery `query_mode='materialized'`**
- Schema v19: new `source_query TEXT` column on `table_registry`
- `materialize_query()` routes through the **`BqAccess` facade** (`connectors/bigquery/access.py`) so cost-estimate logic and DuckDB-extension session setup live in one place. Reuses `app.api.v2_scan._bq_dry_run_bytes` for cost guardrail.
- Cost guardrail: configurable cap via `data_source.bigquery.max_bytes_per_materialize` (default 10 GiB; **explicit 0 disables** — YAML `null` falls through to default)
- `/api/sync/trigger` walks materialized rows via `is_table_due()`, computes parquet MD5 inline (so manifest serves it immediately and `da sync` honors delta-skip)
- Admin API: `RegisterTableRequest` + `UpdateTableRequest` accept `source_query` with `model_validator` enforcing mode/query coherence; `_validate_bigquery_register_payload` branches on `query_mode='materialized'`
- `da admin register-table --query <SQL>` accepts inline SQL or `@path/to.sql` shorthand. Reuses main's existing `--sync-schedule` flag.

**Phase C — Documentation**
- README mode-first source table + new "Local sync & auto-update" section
- CLAUDE.md schema chain → v19, four source modes (Materialized SQL added), new "Local sync & Claude Code hooks" subsection
- `cli/skills/connectors.md` "BigQuery: pick a mode" decision table
- `docs/architecture.md` "BigQuery — Materialized SQL" subsection

## RBAC story (no new code)

Auto-sync set per analyst is the intersection of:
1. Tables with `query_mode IN ('local', 'materialized')` (manifest scope)
2. Tables granted to one of the analyst's groups via `resource_grants(group, ResourceType.TABLE, table_id)`

`/api/sync/manifest` already filters per user via `can_access_table` → `resource_grants`. Admins curate auto-sync membership via `query_mode` + the existing RBAC layer; no new endpoints.

## Devil's advocate review

A pre-PR adversarial review surfaced 7 production failure modes; the fixes are baked in:

| # | Issue | Status |
|---|---|---|
| 1 | `null`-disable trap on guardrail | **Fixed** — `0` sentinel; `null` documented as falls-through |
| 2 | Empty hash → every `da sync` re-downloads materialized parquet | **Fixed** — hash recorded inline in `materialize_query` |
| 3 | Stale `source_query` on PUT mode-switch | **Fixed** — `merged` dict cleared when `query_mode != 'materialized'` |
| 4 | 0-row materialization silent | **Fixed** — `WARNING` log per row |
| 5 | ATTACH `except duckdb.Error: pass` swallows real errors | **Fixed** — narrowed to "already attached" case |
| 6 | `_file_hash` blocks request thread on multi-GB parquets | **Fixed** — hash inline (no second read) |
| 7 | DuckDB BQ ext can't dry-run `bq."ds"."t"` syntax (cosmetic guardrail) | **Documented** — operators write native BQ identifiers if cap matters |

Known limitations (CHANGELOG `### Internal`): GCE token expiry mid-COPY for very long scans, unpinned community extension, schema drift on SQL edit, no concurrency lock on `materialize_query`.

## Plan reference

`docs/superpowers/plans/2026-04-30-local-sync-and-materialized-bq.md` (the original plan; details may differ from the implementation post-rebase, kept on the old branch for audit).

## Audit trail

- **Tag `pr145-final`** (commit `91b5cf7`) preserves the previous PR's working state. `git checkout pr145-final` retrieves it; the original `plan/local-sync-and-materialized-bq` branch on origin remains untouched.
- **PR #145** stays open as an audit reference (Devin findings + review thread); will be closed with a "superseded by this PR" comment after merge here.

## Test plan

- [x] **168 cílených testů procházejí** — full sweep across schema v19, repo, BQ extractor (materialize/cost/skip), sync trigger, admin API, CLI register-table, CLI sync --quiet, hooks, and end-to-end integration. `pytest tests/test_db_migration_v19.py tests/test_table_registry_source_query.py tests/test_bq_materialize.py tests/test_bq_cost_guardrail.py tests/test_bq_init_extract_skips.py tests/test_sync_trigger_materialized.py tests/test_api_admin_materialized.py tests/test_cli_admin_materialized.py tests/test_cli_sync_quiet.py tests/test_setup_hooks_template.py tests/test_cli_analyst_setup_hooks.py tests/test_materialized_e2e.py tests/test_admin_bq_register.py tests/test_cli_sync.py` — 168 passed.
- [ ] Manual: register a small materialized BQ table against a real BQ project, trigger sync, confirm parquet appears at `/data/extracts/bigquery/data/<id>.parquet` and is downloaded by `da sync`.
- [ ] Manual: open Claude Code in `da analyst setup`-bootstrapped workspace; confirm SessionStart pulls fresh parquets and SessionEnd uploads jsonl.
- [ ] Manual: register a materialized SQL exceeding `max_bytes_per_materialize`; confirm trigger logs structured `MaterializeBudgetError` with `current` / `limit` and skips the row.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

