### PR TITLE
fix(tests): align docker-e2e health asserts with current /api/health shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,13 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   concrete next step. Falls back to DuckDB's raw error for non-materialized
   unknowns.
 
+### Internal
+- **tests**: refresh `docker-e2e` health asserts to match the current
+  `/api/health` shape (auth-free, returns `status` + `db_schema` only).
+  `version` moved to `/api/version` in 0.10-era refactor; richer
+  `services.duckdb_state` lives in `/api/health/detailed` (auth-gated).
+  Tests had drifted and broke nightly e2e on main.
+
 ## [0.30.0] — 2026-05-01
 
 ### Added

--- a/tests/test_docker_full.py
+++ b/tests/test_docker_full.py
@@ -40,12 +40,17 @@ def require_docker():
 
 
 def test_app_health():
-    """Health endpoint returns 200 with status and version fields."""
+    """/api/health is the auth-free LB probe — status + db_schema only.
+    Version metadata moved to /api/version (see app/api/health.py)."""
     resp = httpx.get(f"{DOCKER_BASE_URL}/api/health", timeout=10)
     assert resp.status_code == 200
     data = resp.json()
-    assert "status" in data
-    assert "version" in data
+    assert data.get("status") == "ok"
+    assert data.get("db_schema") == "ok"
+
+    ver = httpx.get(f"{DOCKER_BASE_URL}/api/version", timeout=10)
+    assert ver.status_code == 200
+    assert "version" in ver.json()
 
 
 def test_app_returns_html_on_root():

--- a/tests/test_e2e_docker.py
+++ b/tests/test_e2e_docker.py
@@ -75,12 +75,13 @@ class TestDockerHealth:
         assert data.get("status") in ("ok", "healthy")
 
     def test_health_has_duckdb(self, docker_env):
+        # /api/health touches system.duckdb to read schema_version, so
+        # db_schema='ok' implies DuckDB is reachable. The richer
+        # services.duckdb_state lives in /api/health/detailed (auth-gated).
         import httpx
         resp = httpx.get(f"{docker_env}/api/health")
         data = resp.json()
-        services = data.get("services", {})
-        assert "duckdb_state" in services
-        assert services["duckdb_state"]["status"] == "ok"
+        assert data.get("db_schema") == "ok"
 
 
 class TestDockerFullFlow:

--- a/tests/test_e2e_docker.py
+++ b/tests/test_e2e_docker.py
@@ -68,11 +68,13 @@ def docker_env():
 
 class TestDockerHealth:
     def test_health_endpoint(self, docker_env):
+        # /api/health returns 'ok' or 'unhealthy' (never 'healthy' — that's
+        # the detailed endpoint's vocabulary). See app/api/health.py:111-118.
         import httpx
         resp = httpx.get(f"{docker_env}/api/health")
         assert resp.status_code == 200
         data = resp.json()
-        assert data.get("status") in ("ok", "healthy")
+        assert data.get("status") == "ok"
 
     def test_health_has_duckdb(self, docker_env):
         # /api/health touches system.duckdb to read schema_version, so


### PR DESCRIPTION
## Summary
- `/api/health` is the auth-free LB probe — returns only `status` + `db_schema`. `version` was moved to `/api/version` (commit b091cf70) and the richer `services.duckdb_state` lives in `/api/health/detailed` (auth-gated).
- The nightly `docker-e2e` job has been red on main because two e2e asserts still expected the old shape: [run 25269716125](https://github.com/keboola/agnes-the-ai-analyst/actions/runs/25269716125/job/74089997396).
- Updates `tests/test_docker_full.py::test_app_health` to assert the auth-free shape and verify `version` via the dedicated `/api/version` endpoint.
- Replaces `tests/test_e2e_docker.py::TestDockerHealth::test_health_has_duckdb` with a `db_schema == 'ok'` check — `/api/health` already touches `system.duckdb` to read schema_version, so a green check implies DuckDB is reachable.

## Test plan
- [ ] `docker-e2e` job passes on this PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->