### PR TITLE
fix: #160 da query --remote works for BQ VIEW/MATERIALIZED_VIEW entities + cost guardrail + closing pre-existing RBAC bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   to the data_source Save button; on failure the inline result uses the
   same structured shape as the CLI renderer so operators see the same
   hint format admins do.
-- **`api.query.bq_max_scan_bytes` server-config knob** (default 5 GiB):
+- **`data_source.bigquery.bq_max_scan_bytes` server-config knob** (default 5 GiB):
   caps the BigQuery scan that `da query --remote` will issue against
   `query_mode='remote'` BQ rows. Exceeded queries are rejected with a
   structured `400 remote_scan_too_large` detail naming the bytes,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.32.0] — 2026-05-04
+
+Closes #160. Headline fix: `da query --remote` now resolves
+`query_mode='remote'` BigQuery rows whose underlying entity is a `VIEW`
+or `MATERIALIZED_VIEW`. Plus four reinforcing fixes that surfaced during
+the work — server-side cost guardrail, registry-gating of direct `bq.*`
+paths, function-call backdoor closed, structured CLI error rendering —
+and one operator-side admin convenience (BQ test-connection endpoint +
+billing_project placeholder UI). 14 issues caught + fixed across 6
+iterations of Devin Review.
+
 ### Added
 - **`/admin/server-config` BQ test connection**: admin-only `POST
   /api/admin/bigquery/test-connection` runs a 10s-timeout `SELECT 1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,80 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Added
+- **`/admin/server-config` BQ test connection**: admin-only `POST
+  /api/admin/bigquery/test-connection` runs a 10s-timeout `SELECT 1`
+  against BigQuery via the saved `data_source.bigquery` config and
+  returns typed structured feedback (`200 ok` / `400 not_configured` /
+  `502 cross_project_forbidden` / `504 timeout`). The
+  /admin/server-config UI gets a "Test BigQuery connection" button next
+  to the data_source Save button; on failure the inline result uses the
+  same structured shape as the CLI renderer so operators see the same
+  hint format admins do.
+- **`api.query.bq_max_scan_bytes` server-config knob** (default 5 GiB):
+  caps the BigQuery scan that `da query --remote` will issue against
+  `query_mode='remote'` BQ rows. Exceeded queries are rejected with a
+  structured `400 remote_scan_too_large` detail naming the bytes,
+  tables, and a `da fetch` suggestion. Quota usage is recorded against
+  the same daily byte cap as `/api/v2/scan`.
+- **`data_source.bigquery.billing_project` placeholder UI**: the admin
+  form now shows `(defaults to <project>)` greyed under an empty
+  billing_project input, surfacing the access.py:339-340 fallback rule
+  directly in the UI.
+
+### Fixed
+- **`da query --remote` against `query_mode='remote'` BigQuery rows
+  whose underlying entity is a `VIEW` or `MATERIALIZED_VIEW`** now
+  resolves correctly (issue #160). The BQ extractor creates a master
+  view via the catalog path (`bq."<dataset>"."<source_table>"`) for
+  `BASE TABLE` (Storage Read API; predicate pushdown) and via
+  `bigquery_query()` for `VIEW`/`MATERIALIZED_VIEW` (jobs API). Other
+  BQ entity types (`EXTERNAL`, `SNAPSHOT`, `CLONE`) are logged + skipped
+  at extraction with no `_meta` row, so the orchestrator doesn't strand
+  a registered name with a non-existent inner view.
+- **Direct `bq."<dataset>"."<source_table>"` references in `/api/query`
+  are now registry-gated**: unregistered paths return 403
+  `bq_path_not_registered`; registered paths are subject to the same
+  per-name grant check as registered names. Closes a pre-existing RBAC
+  bypass where direct catalog-path syntax skipped the master-view
+  forbidden-table check entirely. Quoted catalog tokens
+  (`"bq"."ds"."tbl"`) are caught by the same regex.
+- **`bigquery_query()` direct calls in user SQL are now blocked** by the
+  `/api/query` keyword blocklist. Closes a pre-existing function-call
+  bypass that ran arbitrary BQ jobs API calls against any reachable
+  dataset, ignoring the registry. Wrap views internal to the BQ
+  extractor still use `bigquery_query()` inside their `CREATE VIEW`
+  body — those run via DuckDB's view resolution at query time, never
+  via user-submitted SQL, so the blocklist doesn't break them.
+- **CLI commands (`da query --remote`, `da query --register-bq`,
+  `da fetch`, `da schema`, etc.) pretty-print structured BigQuery
+  errors** — `cross_project_forbidden`, `bq_forbidden`, `auth_failed`,
+  `not_configured`, `remote_scan_too_large`, `bq_path_not_registered`,
+  etc. — instead of dumping the truncated JSON body. The hint that
+  explains how to fix `USER_PROJECT_DENIED` (set
+  `data_source.bigquery.billing_project` in /admin/server-config) is
+  now actually visible to the operator.
+- **`/api/query/hybrid` now returns dict `detail`** for typed errors
+  (was flattening to `f"BQ '{alias}': {error_type}: {message}"`), so
+  the new CLI renderer surfaces the structured shape consistently
+  across both endpoints.
+
+### Changed
+- **BREAKING (config-only): `data_source.bigquery.legacy_wrap_views`
+  removed**. The flag was opt-in for the wrap-view behavior that is now
+  the default. Keys still present in operator overlays are silently
+  ignored — no action required. Operators who previously set
+  `legacy_wrap_views: false` (the prior default) get the new behavior
+  for VIEW / MATERIALIZED_VIEW rows: a master view is created (via the
+  BQ jobs API), and `da query --remote` works against the registered
+  name. The cost concern that motivated the prior default is now
+  addressed by the server-side guardrail (see Added).
+- **Quota tracker relocated**: `_build_quota_tracker` and
+  `_quota_singleton` moved from `app/api/v2_scan.py` to
+  `app/api/v2_quota.py` (their natural home). `v2_scan.py` re-exports
+  the function for backwards compat; existing test sites that call
+  `v2_scan._build_quota_tracker()` keep working.
+
 ## [0.31.0] — 2026-05-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,13 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 ### Added
 - **`/admin/server-config` BQ test connection**: admin-only `POST
   /api/admin/bigquery/test-connection` runs a 10s-timeout `SELECT 1`
-  against BigQuery via the saved `data_source.bigquery` config and
-  returns typed structured feedback (`200 ok` / `400 not_configured` /
-  `502 cross_project_forbidden` / `504 timeout`). The
+  against BigQuery via the **process-cached** `BqAccess`
+  (`@functools.cache` on `get_bq_access`) and returns typed structured
+  feedback (`200 ok` / `400 not_configured` / `502 cross_project_forbidden`
+  / `504 timeout`). Tests the config active in the running process —
+  after a `data_source.bigquery` save the response shape includes
+  `restart_required: True`; click "Test connection" AFTER restart to
+  validate the freshly-saved values. The
   /admin/server-config UI gets a "Test BigQuery connection" button next
   to the data_source Save button; on failure the inline result uses the
   same structured shape as the CLI renderer so operators see the same

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,7 +203,13 @@ Tables in `da catalog` have a `query_mode`:
 - **`remote`** (typically BigQuery): the parquet does NOT exist on the laptop.
   You MUST either:
   1. **`da fetch`** a filtered subset → query the local snapshot, OR
-  2. **`da query --remote`** for one-shot server-side execution, OR
+  2. **`da query --remote`** for one-shot server-side execution. Works on
+     all `query_mode='remote'` rows regardless of upstream BQ entity type
+     (BASE TABLE → Storage Read API with predicate pushdown; VIEW /
+     MATERIALIZED_VIEW → BQ jobs API, no pushdown). Cost-guarded by a
+     5 GiB scan cap (configurable in /admin/server-config). Direct
+     `bq."<dataset>"."<table>"` paths are registry-gated — unregistered
+     paths return 403 `bq_path_not_registered`.
   3. **`da query --register-bq`** for hybrid joins (rarely needed).
 
 ### `da fetch` workflow (preferred for remote tables)
@@ -257,10 +263,17 @@ in your `da query` calls — there's no `--where` on local since fetch is implic
 
 ### When NOT to use `da fetch`
 
-- Single aggregate on remote table (`SELECT COUNT(*) FROM remote`):
+- Single aggregate on remote BASE TABLE (`SELECT COUNT(*) FROM remote`):
   use `da query --remote "SELECT COUNT(*) FROM web_sessions_example"`.
-  No materialization needed; cheap.
-- Throwaway exploration with raw BQ syntax: `da query --remote`.
+  Storage Read API pushes the COUNT into BQ — cheap, no materialization.
+- Single aggregate on remote VIEW/MATERIALIZED_VIEW: same syntax works
+  (#160), but the BQ jobs API can't push WHERE/COUNT into the view body.
+  Cost guardrail (default 5 GiB) catches expensive scans → 400
+  `remote_scan_too_large` with `da fetch` suggestion. Pivot to
+  `da fetch <id> --where '<predicate>'` if the cap is hit.
+- Throwaway exploration: `da query --remote "SELECT … FROM <registered_id>"`.
+  Direct `bq."<dataset>"."<table>"` paths are now registry-gated — register
+  first or use the catalog id.
 - Cross-table JOIN with both tables remote: combine `da fetch` for one
   side + `da query --remote` for the other; full cross-remote JOIN
   requires more thought (see #101 for design space).

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -225,6 +225,13 @@ _KNOWN_FIELDS: dict[str, dict[str, dict]] = {
                         "data project). Defaults to data_source.bigquery.project. "
                         "Mismatch → 403 USER_PROJECT_DENIED on every BQ call."
                     ),
+                    # Issue #160 §4.7.5: when this field is empty in the
+                    # admin form, the JS template shows "(defaults to <project>)"
+                    # as placeholder text — surfacing the access.py:339-340
+                    # fallback rule directly in the UI without the operator
+                    # having to read source. Path is walked against the
+                    # `original` config payload from GET /api/admin/server-config.
+                    "placeholder_from": ["data_source", "bigquery", "project"],
                 },
                 "max_bytes_per_materialize": {
                     "kind": "int",

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -226,18 +226,6 @@ _KNOWN_FIELDS: dict[str, dict[str, dict]] = {
                         "Mismatch → 403 USER_PROJECT_DENIED on every BQ call."
                     ),
                 },
-                "legacy_wrap_views": {
-                    "kind": "bool",
-                    "default": False,
-                    "hint": (
-                        "When true, registered VIEWs and MATERIALIZED_VIEWs get a DuckDB "
-                        "master view via bigquery_query() (jobs API) so analysts can "
-                        "SELECT * FROM viewname directly. When false (default), views are "
-                        "catalog-only — analysts use `da fetch` or `da query --remote`. "
-                        "ON for view-heavy deployments where most views are small enough "
-                        "to materialize without 'Response too large' (issue #101)."
-                    ),
-                },
                 "max_bytes_per_materialize": {
                     "kind": "int",
                     "default": 10737418240,
@@ -795,13 +783,10 @@ class ServerConfigUpdateRequest(BaseModel):
 #
 #   - billing_project: defaults to data project; explicit value needed when
 #     the SA can read the data project but not bill against it.
-#   - legacy_wrap_views: default False; toggling ON wraps BQ views via
-#     `bigquery_query()` so analysts can `SELECT *` directly.
 #   - max_bytes_per_materialize: cost guardrail for `query_mode='materialized'`
 #     (default 10 GiB; 0 disables; null falls through to the default).
 _BQ_OPTIONAL_FIELD_DEFAULTS: Dict[str, Any] = {
     "billing_project": "",
-    "legacy_wrap_views": False,
     "max_bytes_per_materialize": 10737418240,
 }
 

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -242,6 +242,16 @@ _KNOWN_FIELDS: dict[str, dict[str, dict]] = {
                         "or sync rejected. 0 disables the gate. Default 10737418240 = 10 GiB."
                     ),
                 },
+                "bq_max_scan_bytes": {
+                    "kind": "int",
+                    "default": 5368709120,
+                    "hint": (
+                        "Cost guardrail for `da query --remote` against query_mode='remote' "
+                        "BQ rows (dry-run check on the underlying SELECT before execute). "
+                        "Bytes processed; exceeds → 400 remote_scan_too_large with a "
+                        "`da fetch` suggestion. 0 disables the gate. Default 5368709120 = 5 GiB."
+                    ),
+                },
             },
         },
         "keboola": {
@@ -795,6 +805,7 @@ class ServerConfigUpdateRequest(BaseModel):
 _BQ_OPTIONAL_FIELD_DEFAULTS: Dict[str, Any] = {
     "billing_project": "",
     "max_bytes_per_materialize": 10737418240,
+    "bq_max_scan_bytes": 5368709120,
 }
 
 

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -803,7 +803,13 @@ class ServerConfigUpdateRequest(BaseModel):
 #   - max_bytes_per_materialize: cost guardrail for `query_mode='materialized'`
 #     (default 10 GiB; 0 disables; null falls through to the default).
 _BQ_OPTIONAL_FIELD_DEFAULTS: Dict[str, Any] = {
-    "billing_project": "",
+    # `billing_project` intentionally NOT seeded here. The empty-string
+    # default would inject `billing_project: ""` into every GET payload,
+    # which makes the JS `isUnset = (value === undefined)` check evaluate
+    # False — and the `(defaults to <project>)` placeholder feature
+    # (#160 §4.7.5) would never render. Leaving it absent keeps the
+    # field in the unset rendering path so placeholder_from fires.
+    # Devin Review iter #3 on PR #168.
     "max_bytes_per_materialize": 10737418240,
     "bq_max_scan_bytes": 5368709120,
 }

--- a/app/api/admin_bigquery_test.py
+++ b/app/api/admin_bigquery_test.py
@@ -1,0 +1,124 @@
+"""POST /api/admin/bigquery/test-connection — admin-only health probe.
+
+Closes the operator-side half of #160. The reporter saw
+USER_PROJECT_DENIED raw in the analyst CLI (now fixed via the structured
+renderer in cli/error_render.py); this endpoint lets an admin verify the
+saved BQ config from /admin/server-config WITHOUT having to wait for an
+analyst to hit a query failure first.
+
+Implementation runs a minimal `SELECT 1` via the existing BqAccess
+plumbing with a 10s polling timeout. On `concurrent.futures.TimeoutError`
+the BQ job is best-effort cancelled (job continues running on BQ side
+until BQ-side timeout if the cancel itself fails — documented caveat).
+"""
+from __future__ import annotations
+
+import concurrent.futures
+import logging
+import time
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.auth.access import require_admin
+from connectors.bigquery.access import get_bq_access, BqAccessError
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/admin/bigquery", tags=["admin"])
+
+_QUERY_TIMEOUT_SECONDS = 10.0
+
+
+@router.post("/test-connection")
+async def test_connection(_user: dict = Depends(require_admin)):
+    """Run `SELECT 1 AS ok` against BigQuery via the configured BqAccess.
+
+    Returns 200 with `{ok, billing_project, data_project, elapsed_ms}` on
+    success. Maps known failure modes:
+
+    - `BqAccessError(not_configured)` → 400 with the typed detail
+    - `BqAccessError` (other kinds) → 502 with the typed detail
+    - `concurrent.futures.TimeoutError` → 504 with `kind="timeout"` and
+      best-effort `cancel_job` invoked
+    """
+    try:
+        bq = get_bq_access()
+    except BqAccessError as exc:
+        # not_configured is a 400 (operator config issue, not server fault).
+        status = 400 if exc.kind == "not_configured" else 502
+        raise HTTPException(status_code=status, detail={
+            "kind": exc.kind,
+            "message": exc.message,
+            **(exc.details or {}),
+        })
+
+    try:
+        client = bq.client()
+    except BqAccessError as exc:
+        status = 400 if exc.kind == "not_configured" else 502
+        raise HTTPException(status_code=status, detail={
+            "kind": exc.kind,
+            "message": exc.message,
+            **(exc.details or {}),
+        })
+
+    started = time.monotonic()
+    try:
+        job = client.query("SELECT 1 AS ok")
+    except BqAccessError as exc:
+        status = 400 if exc.kind == "not_configured" else 502
+        raise HTTPException(status_code=status, detail={
+            "kind": exc.kind,
+            "message": exc.message,
+            **(exc.details or {}),
+        })
+    except Exception as exc:
+        # Fall through to upstream error — covers unexpected exception
+        # types from the BQ client library.
+        raise HTTPException(status_code=502, detail={
+            "kind": "bq_upstream_error",
+            "message": str(exc),
+        })
+
+    try:
+        job.result(timeout=_QUERY_TIMEOUT_SECONDS)
+    except concurrent.futures.TimeoutError:
+        # Best-effort cancel — the BQ job keeps running on BQ side until
+        # it sees the cancel or hits BQ's own timeout. Swallow any cancel
+        # failure (we already failed; layering a cancel error is noise).
+        try:
+            client.cancel_job(
+                job.job_id,
+                location=getattr(job, "location", None),
+            )
+        except Exception:
+            logger.warning("BQ cancel_job failed for job_id=%s", job.job_id)
+        raise HTTPException(status_code=504, detail={
+            "kind": "timeout",
+            "elapsed_ms": int(_QUERY_TIMEOUT_SECONDS * 1000),
+            "hint": (
+                "BigQuery did not respond in 10s. Check network and SA "
+                "permissions. The job was best-effort cancelled."
+            ),
+        })
+    except BqAccessError as exc:
+        # Rare: BqAccessError surfacing from the polling loop (e.g.
+        # auth_failed mid-flight).
+        raise HTTPException(status_code=502, detail={
+            "kind": exc.kind,
+            "message": exc.message,
+            **(exc.details or {}),
+        })
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail={
+            "kind": "bq_upstream_error",
+            "message": str(exc),
+        })
+
+    elapsed_ms = int((time.monotonic() - started) * 1000)
+    return {
+        "ok": True,
+        "billing_project": bq.projects.billing,
+        "data_project": bq.projects.data,
+        "elapsed_ms": elapsed_ms,
+    }

--- a/app/api/query.py
+++ b/app/api/query.py
@@ -31,12 +31,16 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/query", tags=["query"])
 
 # Issue #160 §4.3.1 — direct `bq.<dataset>.<source_table>` references in user
-# SQL. Matches all 16 cases verified empirically (fully-quoted, unquoted,
-# mixed quoting, case-insensitive, inside CTE bodies, multiple in one stmt).
+# SQL. Catalog token accepts both `bq` (the unquoted DuckDB-style name) and
+# `"bq"` (quoted identifier). DuckDB resolves both to the same ATTACHed
+# catalog, so the security-boundary regex must accept both — Phase 3 review
+# caught the quoted variant as an RBAC + cost-cap bypass.
 # Lookahead `(?=\W|$)` works where `\b` doesn't (after a closing quote).
-# Negative lookbehind `(?<![\w.])` rejects `other_bq.x.y` and `x.bq.y.z`.
+# Negative lookbehind `(?<![\w.])` rejects `other_bq.x.y`, `my_bq.ds.tbl`,
+# and `x.bq.y.z` so the regex doesn't fire on column qualifiers or
+# look-alike-prefixed identifiers.
 BQ_PATH = re.compile(
-    r'(?<![\w.])bq\s*\.\s*("[^"]+"|\w+)\s*\.\s*("[^"]+"|\w+)(?=\W|$)',
+    r'(?<![\w.])(?:"bq"|bq)\s*\.\s*("[^"]+"|\w+)\s*\.\s*("[^"]+"|\w+)(?=\W|$)',
     re.IGNORECASE,
 )
 

--- a/app/api/query.py
+++ b/app/api/query.py
@@ -1,5 +1,6 @@
 """Query endpoint — execute SQL against server DuckDB."""
 
+import logging
 import os
 import re
 from pathlib import Path
@@ -9,12 +10,46 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 import duckdb
 
+from app.auth.access import is_user_admin
 from app.auth.dependencies import get_current_user, _get_db
+from app.instance_config import get_value
 from src.db import get_analytics_db_readonly
 from src.rbac import get_accessible_tables
 from src.repositories.table_registry import TableRegistryRepository
 
+# Imported at module level so tests can monkeypatch via
+# `app.api.query._bq_dry_run_bytes` without resolving lazy imports inside
+# the handler (reaches the patched attribute on each call). Same for
+# get_bq_access — sibling module, dep direction doesn't matter (both are
+# leaves under app.api).
+from app.api.v2_quota import _build_quota_tracker, QuotaExceededError
+from app.api.v2_scan import _bq_dry_run_bytes
+from connectors.bigquery.access import get_bq_access, BqAccessError
+
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/api/query", tags=["query"])
+
+# Issue #160 §4.3.1 — direct `bq.<dataset>.<source_table>` references in user
+# SQL. Matches all 16 cases verified empirically (fully-quoted, unquoted,
+# mixed quoting, case-insensitive, inside CTE bodies, multiple in one stmt).
+# Lookahead `(?=\W|$)` works where `\b` doesn't (after a closing quote).
+# Negative lookbehind `(?<![\w.])` rejects `other_bq.x.y` and `x.bq.y.z`.
+BQ_PATH = re.compile(
+    r'(?<![\w.])bq\s*\.\s*("[^"]+"|\w+)\s*\.\s*("[^"]+"|\w+)(?=\W|$)',
+    re.IGNORECASE,
+)
+
+
+def _default_remote_query_cap_bytes() -> int:
+    """5 GiB default cap on /api/query BQ-touching scans. Configurable via
+    `api.query.bq_max_scan_bytes` in /admin/server-config.
+    """
+    raw = get_value("api", "query", "bq_max_scan_bytes", default=5_368_709_120)
+    try:
+        return int(raw) if raw is not None else 5_368_709_120
+    except (TypeError, ValueError):
+        return 5_368_709_120
 
 
 class QueryRequest(BaseModel):
@@ -49,6 +84,12 @@ async def execute_query(
         "parquet_scan", "parquet_metadata", "parquet_schema",
         "json_scan", "csv_scan",
         "query_table", "iceberg_scan", "delta_scan",
+        # #160: bigquery_query() bypasses the registry / RBAC entirely
+        # (it runs an arbitrary BQ jobs API call against any reachable
+        # dataset). Wrap views created by the BQ extractor use it inside
+        # CREATE VIEW bodies, but those run via DuckDB's view resolution at
+        # query time — user-submitted SQL never contains the function name.
+        "bigquery_query",
         "glob(", "list_files",
         "'/", '"/','http://', 'https://', 's3://', 'gcs://',
         # DuckDB metadata (leaks schema info regardless of RBAC)
@@ -88,11 +129,39 @@ async def execute_query(
                 if re.search(pattern, sql_lower):
                     raise HTTPException(status_code=403, detail=f"Access denied to table '{table}'")
 
+        # ---- #160 BQ remote-row guardrail + RBAC patch -------------------
+        dry_run_set, blocked_bq_path = _bq_guardrail_inputs(
+            request.sql, sql_lower, conn, user, allowed,
+        )
+        if blocked_bq_path is not None:
+            raise HTTPException(status_code=403, detail=blocked_bq_path)
+
+        if dry_run_set:
+            _enforce_remote_bq_quota_and_cap(
+                user_id=user.get("id") or user.get("email") or "anon",
+                dry_run_set=dry_run_set,
+                sql=request.sql,
+            )
+
         # Open in read-only mode for extra safety
         result = analytics.execute(request.sql).fetchmany(request.limit + 1)
         columns = [desc[0] for desc in analytics.description] if analytics.description else []
         truncated = len(result) > request.limit
         rows = result[:request.limit]
+
+        # Post-flight: bill the dry-run estimate against the user's daily
+        # quota. Do this AFTER execute so a downstream failure (e.g. BQ
+        # outage) doesn't strand the user with charged-but-unrun bytes.
+        if dry_run_set:
+            user_id = user.get("id") or user.get("email") or "anon"
+            try:
+                _build_quota_tracker().record_bytes(
+                    user_id, sum(b for _, _, b in dry_run_set),
+                )
+            except Exception:
+                # record_bytes is documented as never-raising; defensive guard.
+                logger.warning("quota record_bytes failed for user=%s", user_id)
+
         # Convert to serializable types
         serializable_rows = []
         for row in rows:
@@ -198,3 +267,155 @@ def _build_materialized_hint(row: dict) -> str:
         f"/api/sync/trigger) to materialize the parquet"
         f"{direct_hint}."
     )
+
+
+def _bq_guardrail_inputs(
+    sql: str,
+    sql_lower: str,
+    sys_conn: duckdb.DuckDBPyConnection,
+    user: dict,
+    allowed: Optional[list],
+):
+    """Two-pass scan over user SQL for the upcoming BQ guardrail + RBAC patch.
+
+    Returns a tuple `(dry_run_set, blocked_bq_path)`:
+
+    - `dry_run_set` is a list of `(bucket, source_table, est_bytes)` triples
+      identifying every BigQuery row the request will scan. The caller dry-runs
+      each and bills the sum against the user's daily quota.
+
+    - `blocked_bq_path` is a structured-detail dict for the caller to raise
+      HTTPException(403) with, when user SQL contains a direct
+      `bq."<ds>"."<tbl>"` reference that either points at an unregistered
+      path (`bq_path_not_registered`) or registered but the caller has no
+      grant on the registered name (`bq_path_access_denied`). None when the
+      RBAC check passes.
+    """
+    repo = TableRegistryRepository(sys_conn)
+
+    # 1. Bare-name pass: look up registered remote-BQ names that appear in
+    # the user SQL as word-boundary tokens. Reuses the same regex shape as
+    # the existing forbidden-table loop above.
+    dry_run: list = []
+    seen_paths: set = set()
+    accessible_set = set(allowed) if allowed is not None else None
+    for r in repo.list_by_source("bigquery"):
+        if (r.get("query_mode") or "") != "remote":
+            continue
+        bucket = r.get("bucket")
+        source_table = r.get("source_table")
+        name = r.get("name")
+        if not (bucket and source_table and name):
+            continue
+        if accessible_set is not None and name not in accessible_set:
+            # Forbidden-table loop above will have rejected the request
+            # before we get here. Defensive skip.
+            continue
+        pattern = r'\b' + re.escape(str(name).lower()) + r'\b'
+        if re.search(pattern, sql_lower):
+            key = (bucket.lower(), source_table.lower())
+            if key not in seen_paths:
+                seen_paths.add(key)
+                dry_run.append((bucket, source_table, 0))  # bytes filled at dry-run
+
+    # 2. Direct bq.<ds>.<tbl> pass: every match must point at a registered
+    # row. Run BEFORE adding to dry_run so unregistered paths fail-fast.
+    is_admin = is_user_admin(user.get("id") or user.get("email") or "", sys_conn)
+    for m in BQ_PATH.finditer(sql):
+        bucket_raw = m.group(1).strip('"')
+        source_table_raw = m.group(2).strip('"')
+        row = repo.find_by_bq_path(bucket_raw, source_table_raw)
+        if row is None:
+            return [], {
+                "reason": "bq_path_not_registered",
+                "path": f'bq."{bucket_raw}"."{source_table_raw}"',
+                "hint": (
+                    "Direct bq.* references must point to a registered table. "
+                    "Register via `da admin register-table` or use the "
+                    "registered name from `da catalog`."
+                ),
+            }
+        # Row exists. Per-name grant check (non-admin only).
+        if not is_admin:
+            if accessible_set is None or row["name"] not in accessible_set:
+                return [], {
+                    "reason": "bq_path_access_denied",
+                    "path": f'bq."{bucket_raw}"."{source_table_raw}"',
+                    "registered_as": row["name"],
+                }
+        # Add to dry-run set if not already covered by bare-name pass.
+        bucket = row["bucket"]
+        source_table = row["source_table"]
+        if bucket and source_table:
+            key = (bucket.lower(), source_table.lower())
+            if key not in seen_paths:
+                seen_paths.add(key)
+                dry_run.append((bucket, source_table, 0))
+
+    return dry_run, None
+
+
+def _enforce_remote_bq_quota_and_cap(*, user_id: str, dry_run_set: list, sql: str) -> None:
+    """Pre-flight check + dry-run + cap enforcement for /api/query BQ paths.
+
+    1. `check_daily_budget` — over-cap users get 429 BEFORE any BQ work.
+    2. `with quota.acquire(user_id)` — concurrent slot guard.
+    3. Dry-run each `(bucket, source_table)` via the existing
+       `_bq_dry_run_bytes` helper. Sum bytes.
+    4. If sum > cap → 400 `remote_scan_too_large` with structured detail.
+
+    Mutates `dry_run_set` in place: the third tuple element (bytes) is
+    populated with the per-path dry-run result so the caller can sum and
+    record the bytes against the user's quota post-flight.
+    """
+    quota = _build_quota_tracker()
+    try:
+        quota.check_daily_budget(user_id)
+    except QuotaExceededError as exc:
+        raise HTTPException(status_code=429, detail={
+            "reason": "daily_byte_cap_exceeded",
+            "kind": exc.kind,
+            "current": exc.current,
+            "limit": exc.limit,
+            "retry_after_seconds": exc.retry_after_seconds,
+        })
+
+    try:
+        bq = get_bq_access()
+    except BqAccessError as exc:
+        raise HTTPException(status_code=502, detail={
+            "kind": exc.kind,
+            "message": exc.message,
+            **(exc.details or {}),
+        })
+
+    cap_bytes = _default_remote_query_cap_bytes()
+
+    with quota.acquire(user_id):
+        total_bytes = 0
+        for i, (bucket, source_table, _) in enumerate(dry_run_set):
+            bq_sql = f"SELECT * FROM `{bq.projects.data}.{bucket}.{source_table}`"
+            try:
+                est = _bq_dry_run_bytes(bq, bq_sql)
+            except BqAccessError as exc:
+                raise HTTPException(status_code=502, detail={
+                    "kind": exc.kind,
+                    "message": exc.message,
+                    **(exc.details or {}),
+                })
+            dry_run_set[i] = (bucket, source_table, est)
+            total_bytes += est
+
+        if cap_bytes > 0 and total_bytes > cap_bytes:
+            tables = [f"{b}.{t}" for b, t, _ in dry_run_set]
+            raise HTTPException(status_code=400, detail={
+                "reason": "remote_scan_too_large",
+                "scan_bytes": total_bytes,
+                "limit_bytes": cap_bytes,
+                "tables": tables,
+                "suggestion": (
+                    "Use `da fetch <id> --select <cols> --where <predicate> "
+                    "--estimate` to materialize a filtered subset, then query "
+                    "the snapshot locally."
+                ),
+            })

--- a/app/api/query.py
+++ b/app/api/query.py
@@ -47,9 +47,10 @@ BQ_PATH = re.compile(
 
 def _default_remote_query_cap_bytes() -> int:
     """5 GiB default cap on /api/query BQ-touching scans. Configurable via
-    `api.query.bq_max_scan_bytes` in /admin/server-config.
+    `data_source.bigquery.bq_max_scan_bytes` in /admin/server-config —
+    sits next to `max_bytes_per_materialize` for visual symmetry.
     """
-    raw = get_value("api", "query", "bq_max_scan_bytes", default=5_368_709_120)
+    raw = get_value("data_source", "bigquery", "bq_max_scan_bytes", default=5_368_709_120)
     try:
         return int(raw) if raw is not None else 5_368_709_120
     except (TypeError, ValueError):

--- a/app/api/query.py
+++ b/app/api/query.py
@@ -1,5 +1,6 @@
 """Query endpoint — execute SQL against server DuckDB."""
 
+import contextlib
 import logging
 import os
 import re
@@ -141,31 +142,41 @@ async def execute_query(
         if blocked_bq_path is not None:
             raise HTTPException(status_code=403, detail=blocked_bq_path)
 
-        if dry_run_set:
-            _enforce_remote_bq_quota_and_cap(
-                user_id=user.get("id") or user.get("email") or "anon",
-                dry_run_set=dry_run_set,
-                sql=request.sql,
+        # Issue #160 §4.3.3 — concurrent-slot guard MUST wrap the actual
+        # `analytics.execute(request.sql)` call (which is what triggers the
+        # BQ scan when DuckDB resolves the master view), not just the
+        # dry-run. Devin Review on PR #168 caught this — earlier
+        # implementation released the slot before execute. Use a context
+        # manager so dry-run + cap check + execute + record_bytes all run
+        # inside the slot.
+        user_id = user.get("id") or user.get("email") or "anon"
+        guard = (
+            _bq_quota_and_cap_guard(
+                user_id=user_id, dry_run_set=dry_run_set, sql=request.sql,
             )
+            if dry_run_set
+            else contextlib.nullcontext()
+        )
+        with guard:
+            # Open in read-only mode for extra safety
+            result = analytics.execute(request.sql).fetchmany(request.limit + 1)
+            columns = [desc[0] for desc in analytics.description] if analytics.description else []
+            truncated = len(result) > request.limit
+            rows = result[:request.limit]
 
-        # Open in read-only mode for extra safety
-        result = analytics.execute(request.sql).fetchmany(request.limit + 1)
-        columns = [desc[0] for desc in analytics.description] if analytics.description else []
-        truncated = len(result) > request.limit
-        rows = result[:request.limit]
-
-        # Post-flight: bill the dry-run estimate against the user's daily
-        # quota. Do this AFTER execute so a downstream failure (e.g. BQ
-        # outage) doesn't strand the user with charged-but-unrun bytes.
-        if dry_run_set:
-            user_id = user.get("id") or user.get("email") or "anon"
-            try:
-                _build_quota_tracker().record_bytes(
-                    user_id, sum(b for _, _, b in dry_run_set),
-                )
-            except Exception:
-                # record_bytes is documented as never-raising; defensive guard.
-                logger.warning("quota record_bytes failed for user=%s", user_id)
+            # Post-flight: bill the dry-run estimate against the user's daily
+            # quota. Do this AFTER execute so a downstream failure (e.g. BQ
+            # outage) doesn't strand the user with charged-but-unrun bytes.
+            # Stays inside the `with quota.acquire(...)` block so the slot
+            # release happens after record_bytes completes.
+            if dry_run_set:
+                try:
+                    _build_quota_tracker().record_bytes(
+                        user_id, sum(b for _, _, b in dry_run_set),
+                    )
+                except Exception:
+                    # record_bytes is documented as never-raising; defensive guard.
+                    logger.warning("quota record_bytes failed for user=%s", user_id)
 
         # Convert to serializable types
         serializable_rows = []
@@ -360,14 +371,27 @@ def _bq_guardrail_inputs(
     return dry_run, None
 
 
-def _enforce_remote_bq_quota_and_cap(*, user_id: str, dry_run_set: list, sql: str) -> None:
+@contextlib.contextmanager
+def _bq_quota_and_cap_guard(*, user_id: str, dry_run_set: list, sql: str):
     """Pre-flight check + dry-run + cap enforcement for /api/query BQ paths.
 
+    Context-manager shape (Devin Review #5 on PR #168). Earlier implementation
+    ran the dry-run + cap check inside `with quota.acquire(user_id):`, then
+    returned — releasing the concurrent slot BEFORE the actual BQ-touching
+    `analytics.execute(...)` ran. Spec §4.3.3 wants execute to be inside the
+    slot so the per-user concurrent cap actually limits BQ scans, not just
+    dry-runs.
+
+    Now: the helper is a context manager that yields after the cap check.
+    The caller's `with` block holds the slot through both dry-run AND the
+    subsequent `analytics.execute(...)` until the body exits.
+
     1. `check_daily_budget` — over-cap users get 429 BEFORE any BQ work.
-    2. `with quota.acquire(user_id)` — concurrent slot guard.
-    3. Dry-run each `(bucket, source_table)` via the existing
-       `_bq_dry_run_bytes` helper. Sum bytes.
-    4. If sum > cap → 400 `remote_scan_too_large` with structured detail.
+    2. `quota.acquire(user_id)` opened — concurrent-slot held throughout.
+    3. Dry-run each `(bucket, source_table)` via `_bq_dry_run_bytes`.
+    4. If sum > cap → 400 `remote_scan_too_large`.
+    5. Yield. Caller runs `analytics.execute(...)` + `record_bytes(...)`.
+    6. On exit, slot released.
 
     Mutates `dry_run_set` in place: the third tuple element (bytes) is
     populated with the per-path dry-run result so the caller can sum and
@@ -424,3 +448,7 @@ def _enforce_remote_bq_quota_and_cap(*, user_id: str, dry_run_set: list, sql: st
                     "the snapshot locally."
                 ),
             })
+
+        # Yield control to the handler — slot stays acquired while the
+        # caller runs analytics.execute() + record_bytes().
+        yield total_bytes

--- a/app/api/query.py
+++ b/app/api/query.py
@@ -318,6 +318,15 @@ def _bq_guardrail_inputs(
     # 1. Bare-name pass: look up registered remote-BQ names that appear in
     # the user SQL as word-boundary tokens. Reuses the same regex shape as
     # the existing forbidden-table loop above.
+    #
+    # `accessible_set` comes from `get_accessible_tables()` which returns
+    # `resource_grants.resource_id` values — i.e. table registry IDs, NOT
+    # display names. Devin Review iter #3 caught the mismatch: when
+    # `id != name` (e.g. id="bq.finance.ue", name="ue"), legitimate
+    # accessible rows were skipped, under-counting dry-run bytes for the
+    # cost cap. The user SQL still references the display `name` (that's
+    # what shows in `da catalog`), so the regex match below uses `name`,
+    # but the access gate uses `id`.
     dry_run: list = []
     seen_paths: set = set()
     accessible_set = set(allowed) if allowed is not None else None
@@ -327,9 +336,10 @@ def _bq_guardrail_inputs(
         bucket = r.get("bucket")
         source_table = r.get("source_table")
         name = r.get("name")
-        if not (bucket and source_table and name):
+        row_id = r.get("id")
+        if not (bucket and source_table and name and row_id):
             continue
-        if accessible_set is not None and name not in accessible_set:
+        if accessible_set is not None and row_id not in accessible_set:
             # Forbidden-table loop above will have rejected the request
             # before we get here. Defensive skip.
             continue
@@ -357,9 +367,12 @@ def _bq_guardrail_inputs(
                     "registered name from `da catalog`."
                 ),
             }
-        # Row exists. Per-name grant check (non-admin only).
+        # Row exists. Per-id grant check (non-admin only).
+        # `accessible_set` is keyed by registry id (resource_grants
+        # resource_id), so use `row["id"]` here, not display name.
+        # Devin Review iter #3.
         if not is_admin:
-            if accessible_set is None or row["name"] not in accessible_set:
+            if accessible_set is None or row["id"] not in accessible_set:
                 return [], {
                     "reason": "bq_path_access_denied",
                     "path": f'bq."{bucket_raw}"."{source_table_raw}"',

--- a/app/api/query.py
+++ b/app/api/query.py
@@ -149,7 +149,13 @@ async def execute_query(
         # implementation released the slot before execute. Use a context
         # manager so dry-run + cap check + execute + record_bytes all run
         # inside the slot.
-        user_id = user.get("id") or user.get("email") or "anon"
+        # Match /api/v2/scan's user_id key shape (`email or "anon"`) so the
+        # shared QuotaTracker singleton sees the SAME key for both endpoints.
+        # Earlier `id or email` ordering keyed BQ bytes on UUID for /api/query
+        # vs email for /api/v2/scan — the per-user daily cap was effectively
+        # doubled because the two paths tracked under different keys.
+        # Devin Review #2 caught this on PR #168.
+        user_id = user.get("email") or user.get("id") or "anon"
         guard = (
             _bq_quota_and_cap_guard(
                 user_id=user_id, dry_run_set=dry_run_set, sql=request.sql,
@@ -420,35 +426,56 @@ def _bq_quota_and_cap_guard(*, user_id: str, dry_run_set: list, sql: str):
 
     cap_bytes = _default_remote_query_cap_bytes()
 
-    with quota.acquire(user_id):
-        total_bytes = 0
-        for i, (bucket, source_table, _) in enumerate(dry_run_set):
-            bq_sql = f"SELECT * FROM `{bq.projects.data}.{bucket}.{source_table}`"
-            try:
-                est = _bq_dry_run_bytes(bq, bq_sql)
-            except BqAccessError as exc:
-                raise HTTPException(status_code=502, detail={
-                    "kind": exc.kind,
-                    "message": exc.message,
-                    **(exc.details or {}),
+    # `quota.acquire(user_id)` raises QuotaExceededError(KIND_CONCURRENT)
+    # via __enter__ when the per-user concurrent-scan slot is at cap.
+    # Catch around the `with` and map to HTTP 429 with the typed detail
+    # shape — same shape as the daily-budget rejection above. Without
+    # this, the exception propagates through @contextlib.contextmanager
+    # and is caught by execute_query's generic `except Exception` →
+    # returns HTTP 400 with a flattened "Query error: concurrent_scans:
+    # N/M" string, dropping the typed retry_after_seconds field.
+    # Devin Review #2 on PR #168.
+    try:
+        with quota.acquire(user_id):
+            total_bytes = 0
+            for i, (bucket, source_table, _) in enumerate(dry_run_set):
+                bq_sql = f"SELECT * FROM `{bq.projects.data}.{bucket}.{source_table}`"
+                try:
+                    est = _bq_dry_run_bytes(bq, bq_sql)
+                except BqAccessError as exc:
+                    raise HTTPException(status_code=502, detail={
+                        "kind": exc.kind,
+                        "message": exc.message,
+                        **(exc.details or {}),
+                    })
+                dry_run_set[i] = (bucket, source_table, est)
+                total_bytes += est
+
+            if cap_bytes > 0 and total_bytes > cap_bytes:
+                tables = [f"{b}.{t}" for b, t, _ in dry_run_set]
+                raise HTTPException(status_code=400, detail={
+                    "reason": "remote_scan_too_large",
+                    "scan_bytes": total_bytes,
+                    "limit_bytes": cap_bytes,
+                    "tables": tables,
+                    "suggestion": (
+                        "Use `da fetch <id> --select <cols> --where <predicate> "
+                        "--estimate` to materialize a filtered subset, then query "
+                        "the snapshot locally."
+                    ),
                 })
-            dry_run_set[i] = (bucket, source_table, est)
-            total_bytes += est
 
-        if cap_bytes > 0 and total_bytes > cap_bytes:
-            tables = [f"{b}.{t}" for b, t, _ in dry_run_set]
-            raise HTTPException(status_code=400, detail={
-                "reason": "remote_scan_too_large",
-                "scan_bytes": total_bytes,
-                "limit_bytes": cap_bytes,
-                "tables": tables,
-                "suggestion": (
-                    "Use `da fetch <id> --select <cols> --where <predicate> "
-                    "--estimate` to materialize a filtered subset, then query "
-                    "the snapshot locally."
-                ),
-            })
-
-        # Yield control to the handler — slot stays acquired while the
-        # caller runs analytics.execute() + record_bytes().
-        yield total_bytes
+            # Yield control to the handler — slot stays acquired while the
+            # caller runs analytics.execute() + record_bytes().
+            yield total_bytes
+    except QuotaExceededError as exc:
+        # Only KIND_CONCURRENT can land here (daily-budget already mapped
+        # above; record_bytes never raises). Map to 429 with structured
+        # detail consistent with the daily-budget shape.
+        raise HTTPException(status_code=429, detail={
+            "reason": "concurrent_slot_exceeded",
+            "kind": exc.kind,
+            "current": exc.current,
+            "limit": exc.limit,
+            "retry_after_seconds": exc.retry_after_seconds,
+        })

--- a/app/api/query.py
+++ b/app/api/query.py
@@ -128,8 +128,22 @@ async def execute_query(
                 "SELECT table_name FROM information_schema.tables WHERE table_type='VIEW'"
             ).fetchall()}
 
+            # `allowed` carries registry IDs (resource_grants.resource_id);
+            # DuckDB master views are named by registry display `name`.
+            # Build a name->id map so the forbidden check compares apples to
+            # apples — when id != name, the prior `all_views - set(allowed)`
+            # over-denied authorized users (Devin Review iter #5 on PR #168;
+            # pre-existing class of name/id mismatch flagged across this
+            # PR's BQ guardrail too).
+            allowed_ids = set(allowed)
+            registry_rows = TableRegistryRepository(conn).list_all()
+            allowed_view_names = {
+                r["name"] for r in registry_rows
+                if r.get("name") and r.get("id") in allowed_ids
+            }
+
             # Check if query references any forbidden tables (word-boundary match)
-            forbidden = all_views - set(allowed)
+            forbidden = all_views - allowed_view_names
             for table in forbidden:
                 pattern = r'\b' + re.escape(table.lower()) + r'\b'
                 if re.search(pattern, sql_lower):

--- a/app/api/v2_quota.py
+++ b/app/api/v2_quota.py
@@ -118,3 +118,45 @@ class QuotaTracker:
     def bytes_used_today(self, user: str) -> int:
         with self._lock:
             return self._ensure_bucket(user)["bytes"]
+
+
+# Module-level singleton (process-local quota state per spec §3.8). FastAPI
+# dispatches sync handlers via a thread pool, so two concurrent first-time
+# requests can both observe `_quota_singleton is None` and each construct a
+# separate tracker; the second assignment wins and the first reference leaks
+# split-brain quota state. Guard with an init lock + double-check.
+#
+# Note: `_quota_singleton` and `_quota_init_lock` are intentionally
+# module-private. Callers MUST go through `_build_quota_tracker()` so the
+# singleton stays single. Re-exporting `_quota_singleton` from another
+# module via `from app.api.v2_quota import _quota_singleton` would copy the
+# initial-None binding at import time and never see subsequent updates —
+# that's a footgun. The function re-export is safe (it always reads the
+# live module-global).
+_quota_init_lock = threading.Lock()
+_quota_singleton: "QuotaTracker | None" = None
+
+
+def _build_quota_tracker() -> QuotaTracker:
+    """Returns or constructs the process-local quota tracker (thread-safe).
+
+    Shared across `/api/v2/scan` (the original caller) and `/api/query`
+    (issue #160 cost guardrail) so the per-user daily byte cap accumulates
+    across both BQ-touching paths.
+    """
+    from app.instance_config import get_value
+    global _quota_singleton
+    if _quota_singleton is not None:
+        return _quota_singleton
+    with _quota_init_lock:
+        if _quota_singleton is None:
+            _quota_singleton = QuotaTracker(
+                max_concurrent_per_user=int(
+                    get_value("api", "scan", "max_concurrent_per_user", default=5) or 5
+                ),
+                max_daily_bytes_per_user=int(
+                    get_value("api", "scan", "max_daily_bytes_per_user", default=53687091200)
+                    or 53687091200
+                ),
+            )
+    return _quota_singleton

--- a/app/api/v2_scan.py
+++ b/app/api/v2_scan.py
@@ -244,28 +244,15 @@ async def scan_estimate_endpoint(
         )
 
 
-# Module-level singleton (process-local quota state per spec §3.8). FastAPI
-# dispatches sync handlers via a thread pool, so two concurrent first-time
-# requests can both observe `_quota_singleton is None` and each construct a
-# separate tracker; the second assignment wins and the first reference leaks
-# split-brain quota state. Guard with an init lock + double-check.
-import threading as _threading
-_quota_init_lock = _threading.Lock()
-_quota_singleton: QuotaTracker | None = None
-
-
-def _build_quota_tracker() -> QuotaTracker:
-    """Returns or constructs the process-local quota tracker (thread-safe)."""
-    global _quota_singleton
-    if _quota_singleton is not None:
-        return _quota_singleton
-    with _quota_init_lock:
-        if _quota_singleton is None:
-            _quota_singleton = QuotaTracker(
-                max_concurrent_per_user=int(get_value("api", "scan", "max_concurrent_per_user", default=5) or 5),
-                max_daily_bytes_per_user=int(get_value("api", "scan", "max_daily_bytes_per_user", default=53687091200) or 53687091200),
-            )
-    return _quota_singleton
+# `_build_quota_tracker` lives in `app.api.v2_quota` so /api/query (issue #160)
+# can share the same singleton without inverting the dep direction
+# (api/query → api/v2/scan would couple a high-level endpoint to a sibling).
+# Re-exported here so existing test sites that call
+# `v2_scan._build_quota_tracker()` (7 in tests/test_v2_scan.py) keep working.
+# Do NOT re-export `_quota_singleton` — `from X import var` copies the
+# binding at import time, so a re-exported singleton would never see the
+# initialized value (#160 review caveat).
+from app.api.v2_quota import _build_quota_tracker  # re-export
 
 
 def _max_result_bytes() -> int:

--- a/app/main.py
+++ b/app/main.py
@@ -110,6 +110,7 @@ from app.api.telegram import router as telegram_router
 from app.api.access import router as access_router, me_router as me_access_router
 from app.api.me_debug import router as me_debug_router
 from app.api.admin import router as admin_router
+from app.api.admin_bigquery_test import router as admin_bigquery_test_router
 from app.api.jira_webhooks import router as jira_webhooks_router
 from app.api.metrics import router as metrics_router
 from app.api.metadata import router as metadata_router
@@ -514,6 +515,7 @@ def create_app() -> FastAPI:
     app.include_router(catalog_router)
     app.include_router(telegram_router)
     app.include_router(admin_router)
+    app.include_router(admin_bigquery_test_router)
     app.include_router(access_router)
     app.include_router(me_access_router)
     app.include_router(me_debug_router)

--- a/app/web/templates/admin_server_config.html
+++ b/app/web/templates/admin_server_config.html
@@ -316,7 +316,21 @@ function renderLeafInput(fieldId, section, pathSegments, kind, value, opts, isUn
   const v = isUnset
     ? (opts && opts.spec && opts.spec.default != null ? String(opts.spec.default) : "")
     : (value == null ? "" : value);
-  return `<input id="${fieldId}" type="text" data-section="${section}" data-key="${escHtml(dottedKey)}" data-path="${dataPath}" value="${escHtml(v)}">`;
+  // Issue #160 §4.7.5: `placeholder_from: ["a","b","c"]` walks the loaded
+  // `original` config dict and shows "(defaults to <resolved>)" greyed in
+  // the empty input. Used by data_source.bigquery.billing_project to
+  // surface the access.py:339-340 billing→data fallback in the UI.
+  let placeholderAttr = "";
+  if (isUnset && opts && opts.spec && Array.isArray(opts.spec.placeholder_from)) {
+    const resolved = opts.spec.placeholder_from.reduce(
+      (cur, k) => (cur && typeof cur === "object" ? cur[k] : undefined),
+      original,
+    );
+    if (resolved !== undefined && resolved !== null && resolved !== "") {
+      placeholderAttr = ` placeholder="(defaults to ${escHtml(String(resolved))})"`;
+    }
+  }
+  return `<input id="${fieldId}" type="text" data-section="${section}" data-key="${escHtml(dottedKey)}" data-path="${dataPath}" value="${escHtml(v)}"${placeholderAttr}>`;
 }
 
 // Cast a string raw value to the JS type implied by an item_kind / value_kind.
@@ -680,6 +694,10 @@ function renderSection(section, payload, knownForSection) {
       </div>
       <div class="section-actions">
         <button class="cfg-btn primary" data-action="save-section" data-section="${section}">Save ${escHtml(meta.title.toLowerCase())}</button>
+        ${section === "data_source" ? `
+        <button class="cfg-btn" data-action="test-bigquery" type="button">Test BigQuery connection</button>
+        <span class="bq-test-result" data-section="${section}" hidden style="margin-left: 1ex;"></span>
+        ` : ""}
       </div>
     </section>`;
 }
@@ -694,6 +712,12 @@ function renderAll(data) {
 
   wrap.querySelectorAll('[data-action="save-section"]').forEach(btn =>
     btn.addEventListener("click", () => onSaveSection(btn.dataset.section)));
+
+  // Issue #160 §4.9: Test BigQuery connection — admin probe to verify the
+  // saved data_source.bigquery config is reachable WITHOUT having to
+  // ssh to the VM or wait for an analyst's failed query.
+  wrap.querySelectorAll('[data-action="test-bigquery"]').forEach(btn =>
+    btn.addEventListener("click", () => onTestBigQuery(btn)));
 
   // Wire array-of-scalars + map-of-scalars add/remove buttons via event
   // delegation on the wrapper. Re-attaching after every renderAll() is
@@ -972,6 +996,39 @@ function collectSection(section) {
     setNested(patch, segments, value);
   }
   return patch;
+}
+
+// ── BigQuery test connection (#160 §4.9) ───────────────────────────────
+async function onTestBigQuery(btn) {
+  const resultEl = btn.parentElement.querySelector(".bq-test-result");
+  resultEl.hidden = false;
+  resultEl.textContent = "Testing…";
+  resultEl.style.color = "";
+  btn.disabled = true;
+  try {
+    const r = await fetch("/api/admin/bigquery/test-connection", {
+      method: "POST",
+      credentials: "include",
+    });
+    if (r.ok) {
+      const body = await r.json();
+      resultEl.textContent = `✓ ok (${body.elapsed_ms} ms; billing=${body.billing_project}, data=${body.data_project})`;
+      resultEl.style.color = "#2a8c4a";
+    } else {
+      let body;
+      try { body = await r.json(); } catch (_) { body = await r.text(); }
+      const detail = body && typeof body === "object" ? body.detail : body;
+      const kind = detail && typeof detail === "object" ? (detail.kind || "error") : "error";
+      const hint = detail && typeof detail === "object" ? (detail.hint || detail.message || "") : String(detail);
+      resultEl.textContent = `✗ ${kind}${hint ? " — " + hint : ""}`;
+      resultEl.style.color = "#c0392b";
+    }
+  } catch (e) {
+    resultEl.textContent = `✗ network error — ${e.message}`;
+    resultEl.style.color = "#c0392b";
+  } finally {
+    btn.disabled = false;
+  }
 }
 
 // ── Save flow ─────────────────────────────────────────────────────────

--- a/app/web/templates/admin_server_config.html
+++ b/app/web/templates/admin_server_config.html
@@ -322,9 +322,13 @@ function renderLeafInput(fieldId, section, pathSegments, kind, value, opts, isUn
   // surface the access.py:339-340 billing→data fallback in the UI.
   let placeholderAttr = "";
   if (isUnset && opts && opts.spec && Array.isArray(opts.spec.placeholder_from)) {
+    // `original` is the full GET /api/admin/server-config response shape:
+    // {sections: {data_source: ...}, editable_sections: [...], ...}.
+    // `placeholder_from` is a section-relative path (e.g. ["data_source",
+    // "bigquery", "project"]) so walk `original.sections` not `original`.
     const resolved = opts.spec.placeholder_from.reduce(
       (cur, k) => (cur && typeof cur === "object" ? cur[k] : undefined),
-      original,
+      original && original.sections ? original.sections : original,
     );
     if (resolved !== undefined && resolved !== null && resolved !== "") {
       placeholderAttr = ` placeholder="(defaults to ${escHtml(String(resolved))})"`;

--- a/app/web/templates/admin_tables.html
+++ b/app/web/templates/admin_tables.html
@@ -891,11 +891,11 @@
                             <datalist id="bqTableList"></datalist>
                             <div class="form-hint">Table or view name within the dataset. Click
                                 <strong>List tables</strong> after filling Dataset to populate autocomplete.
-                                <br><strong>Live access:</strong> BASE TABLEs are queryable directly via
-                                <code>da query --remote</code>; VIEWs are registered but analysts must run
-                                <code>da fetch</code> to materialize a local snapshot (or the admin can flip
-                                <code>data_source.bigquery.legacy_wrap_views=true</code> to wrap views via the
-                                BQ jobs API).
+                                <br><strong>Live access:</strong> BASE TABLEs query via
+                                <code>bq."dataset"."table"</code> (Storage Read API; predicate pushdown).
+                                VIEWs and MATERIALIZED_VIEWs query via the BQ jobs API (full-scan estimate;
+                                cost-guarded by <code>max_bytes_per_remote_query</code>).
+                                <code>da query --remote</code> works for both.
                                 <br><strong>Synced access:</strong> handles both table and view transparently
                                 — the scheduler runs <code>SELECT *</code> through the jobs API and writes a
                                 parquet.</div>
@@ -1048,10 +1048,11 @@
                                    list="editBqTableList" placeholder="e.g. orders">
                             <datalist id="editBqTableList"></datalist>
                             <div class="form-hint">Table or view name within the dataset.
-                                <br><strong>Live access:</strong> BASE TABLEs are queryable directly via
-                                <code>da query --remote</code>; VIEWs are registered but analysts must run
-                                <code>da fetch</code> to materialize a local snapshot (or admin can flip
-                                <code>data_source.bigquery.legacy_wrap_views=true</code>).
+                                <br><strong>Live access:</strong> BASE TABLEs query via
+                                <code>bq."dataset"."table"</code> (Storage Read API; predicate pushdown).
+                                VIEWs and MATERIALIZED_VIEWs query via the BQ jobs API (full-scan estimate;
+                                cost-guarded by <code>max_bytes_per_remote_query</code>).
+                                <code>da query --remote</code> works for both.
                                 <br><strong>Synced access:</strong> handles both transparently — the
                                 scheduler runs <code>SELECT *</code> through the jobs API and writes a
                                 parquet.</div>

--- a/app/web/templates/admin_tables.html
+++ b/app/web/templates/admin_tables.html
@@ -894,7 +894,7 @@
                                 <br><strong>Live access:</strong> BASE TABLEs query via
                                 <code>bq."dataset"."table"</code> (Storage Read API; predicate pushdown).
                                 VIEWs and MATERIALIZED_VIEWs query via the BQ jobs API (full-scan estimate;
-                                cost-guarded by <code>max_bytes_per_remote_query</code>).
+                                cost-guarded by <code>bq_max_scan_bytes</code>).
                                 <code>da query --remote</code> works for both.
                                 <br><strong>Synced access:</strong> handles both table and view transparently
                                 — the scheduler runs <code>SELECT *</code> through the jobs API and writes a
@@ -1051,7 +1051,7 @@
                                 <br><strong>Live access:</strong> BASE TABLEs query via
                                 <code>bq."dataset"."table"</code> (Storage Read API; predicate pushdown).
                                 VIEWs and MATERIALIZED_VIEWs query via the BQ jobs API (full-scan estimate;
-                                cost-guarded by <code>max_bytes_per_remote_query</code>).
+                                cost-guarded by <code>bq_max_scan_bytes</code>).
                                 <code>da query --remote</code> works for both.
                                 <br><strong>Synced access:</strong> handles both transparently — the
                                 scheduler runs <code>SELECT *</code> through the jobs API and writes a

--- a/cli/commands/query.py
+++ b/cli/commands/query.py
@@ -86,10 +86,19 @@ def _query_local(sql: str, fmt: str, limit: int):
 def _query_remote(sql: str, fmt: str, limit: int):
     """Run query against server DuckDB via API."""
     from cli.client import api_post
+    from cli.error_render import render_error
 
     resp = api_post("/api/query", json={"sql": sql, "limit": limit})
     if resp.status_code != 200:
-        typer.echo(f"Query failed: {resp.json().get('detail', resp.text)}", err=True)
+        # Parse JSON body if possible, fall back to text. The shared
+        # renderer pretty-prints typed BQ errors (cross_project_forbidden,
+        # remote_scan_too_large, bq_path_not_registered) instead of
+        # flattening the structured detail to a single truncated line.
+        try:
+            body = resp.json()
+        except Exception:
+            body = resp.text
+        typer.echo(render_error(resp.status_code, body), err=True)
         raise typer.Exit(1)
 
     data = resp.json()
@@ -137,13 +146,29 @@ def _query_hybrid(sql: str, fmt: str, limit: int, register_bq_specs: List[str]):
                     err=True,
                 )
             except RemoteQueryError as exc:
-                typer.echo(f"BQ registration failed for '{alias}': {exc}", err=True)
+                # Use the shared renderer so typed BqAccessError details
+                # (carried via RemoteQueryError.details) surface as a
+                # multi-line block with the operator-facing hint.
+                from cli.error_render import render_error
+                synthetic = {"detail": {
+                    "kind": exc.error_type,
+                    "alias": alias,
+                    "message": str(exc),
+                    **(exc.details or {}),
+                }}
+                typer.echo(render_error(400, synthetic), err=True)
                 raise typer.Exit(1)
 
         try:
             result = engine.execute(sql)
         except RemoteQueryError as exc:
-            typer.echo(f"Query error: {exc}", err=True)
+            from cli.error_render import render_error
+            synthetic = {"detail": {
+                "kind": exc.error_type,
+                "message": str(exc),
+                **(exc.details or {}),
+            }}
+            typer.echo(render_error(400, synthetic), err=True)
             raise typer.Exit(1)
 
         _output(result["columns"], result["rows"], fmt)

--- a/cli/error_render.py
+++ b/cli/error_render.py
@@ -1,0 +1,111 @@
+"""Shared CLI renderer for HTTP error responses.
+
+Three CLI paths surface BigQuery / guardrail / RBAC typed errors today:
+- ``da query --remote`` (POST /api/query)
+- ``da query --register-bq`` (RemoteQueryEngine wrapping BqAccessError)
+- ``da fetch`` / ``da schema`` etc. (cli.v2_client wrappers around v2 endpoints)
+
+All three previously flattened the structured ``detail`` JSON to a
+truncated single-line string, hiding the operator-facing hint that
+explains how to fix ``USER_PROJECT_DENIED`` / cost-cap rejection /
+unregistered ``bq.*`` paths. This module recognizes a few canonical
+shapes and pretty-prints them; falls back to truncated form for
+anything unrecognized so the renderer never makes a worse-than-
+status-quo error message.
+
+Closes #160 §4.7.
+"""
+from __future__ import annotations
+
+import json
+from textwrap import fill
+from typing import Any
+
+
+# Keys that hold long human-readable text — wrap separately so the line
+# break is at a word boundary, not mid-key.
+_WRAP_KEYS = ("hint", "suggestion")
+# Keys to render first in the key/value block (when present); other keys
+# follow in declaration order so a future server-side detail addition
+# surfaces automatically without a renderer change.
+_PRIORITY_KEYS = ("kind", "reason", "path", "registered_as",
+                  "billing_project", "data_project", "scan_bytes",
+                  "limit_bytes", "tables", "current", "limit",
+                  "retry_after_seconds")
+
+
+def render_error(status_code: int, body: Any) -> str:
+    """Format an HTTP error body for stderr.
+
+    Recognized shapes (pretty-printed):
+    - ``{"detail": {"kind": str, ...}}`` — typed BqAccessError
+    - ``{"detail": {"reason": str, ...}}`` — guardrail / RBAC dicts
+    Anything else: fallback ``f"HTTP {status_code}: {str(body)[:500]}"``.
+    """
+    detail = _detail_dict(body)
+    if detail is not None and ("kind" in detail or "reason" in detail):
+        return _format_dict(status_code, detail)
+    if isinstance(body, dict) and isinstance(body.get("detail"), str):
+        return f"HTTP {status_code}: {body['detail']}"
+    text = str(body) if not isinstance(body, str) else body
+    if len(text) > 500:
+        text = text[:497] + "..."
+    return f"HTTP {status_code}: {text}"
+
+
+def _detail_dict(body: Any) -> dict | None:
+    """Return ``body['detail']`` when it's a dict, else None."""
+    if isinstance(body, dict):
+        d = body.get("detail")
+        if isinstance(d, dict):
+            return d
+    return None
+
+
+def _format_dict(status_code: int, detail: dict) -> str:
+    """Multi-line render of a recognized typed-error dict."""
+    label = detail.get("kind") or detail.get("reason") or "error"
+    lines: list[str] = [f"Error: {label} (HTTP {status_code})"]
+
+    seen: set[str] = {"kind", "reason"}  # already in the label line
+    # Priority keys first
+    for key in _PRIORITY_KEYS:
+        if key in seen:
+            continue
+        if key in detail and detail[key] not in (None, ""):
+            lines.append(_kv_line(key, detail[key]))
+            seen.add(key)
+
+    # Anything else not already shown and not a wrap key
+    for key, value in detail.items():
+        if key in seen or key in _WRAP_KEYS:
+            continue
+        if value not in (None, ""):
+            lines.append(_kv_line(key, value))
+            seen.add(key)
+
+    # Wrap keys last — they're the long human-readable explanation
+    for key in _WRAP_KEYS:
+        if key in detail and detail[key]:
+            wrapped = fill(
+                str(detail[key]),
+                width=80,
+                initial_indent=f"  {key}: ",
+                subsequent_indent="    ",
+            )
+            lines.append(wrapped)
+    return "\n".join(lines)
+
+
+def _kv_line(key: str, value: Any) -> str:
+    """Format one ``  key: value`` line. Lists join with comma; dicts
+    json-encode (rare but defensive)."""
+    if isinstance(value, list):
+        rendered = ", ".join(str(v) for v in value) if value else "(empty)"
+    elif isinstance(value, dict):
+        rendered = json.dumps(value, default=str)
+    elif value == "":
+        rendered = "(empty)"
+    else:
+        rendered = str(value)
+    return f"  {key}: {rendered}"

--- a/cli/error_render.py
+++ b/cli/error_render.py
@@ -77,11 +77,15 @@ def _format_dict(status_code: int, detail: dict) -> str:
 
     # Only the key actually used in the label is hidden from the kv block.
     seen: set[str] = {label_key} if label_key else set()
-    # Priority keys first
+    # Priority keys first. Filter only None — `_kv_line` already renders
+    # empty strings as `(empty)`, which is the key diagnostic for
+    # `billing_project: ""` in cross_project_forbidden errors. Earlier
+    # `not in (None, "")` filter dropped exactly the field the operator
+    # needs to see (Devin Review iter #6 on PR #168).
     for key in _PRIORITY_KEYS:
         if key in seen:
             continue
-        if key in detail and detail[key] not in (None, ""):
+        if key in detail and detail[key] is not None:
             lines.append(_kv_line(key, detail[key]))
             seen.add(key)
 
@@ -89,7 +93,7 @@ def _format_dict(status_code: int, detail: dict) -> str:
     for key, value in detail.items():
         if key in seen or key in _WRAP_KEYS:
             continue
-        if value not in (None, ""):
+        if value is not None:
             lines.append(_kv_line(key, value))
             seen.add(key)
 

--- a/cli/error_render.py
+++ b/cli/error_render.py
@@ -63,11 +63,20 @@ def _detail_dict(body: Any) -> dict | None:
 
 
 def _format_dict(status_code: int, detail: dict) -> str:
-    """Multi-line render of a recognized typed-error dict."""
-    label = detail.get("kind") or detail.get("reason") or "error"
+    """Multi-line render of a recognized typed-error dict.
+
+    When both `kind` and `reason` are present (e.g. quota rejections at
+    `app/api/query.py` carry `{reason: "daily_byte_cap_exceeded",
+    kind: "daily_bytes", ...}`), the label line shows only one — the
+    other must still appear in the key/value section so its value isn't
+    silently dropped. Devin Review iter #4 caught this.
+    """
+    label_key = "kind" if detail.get("kind") else ("reason" if detail.get("reason") else None)
+    label = detail.get(label_key) if label_key else "error"
     lines: list[str] = [f"Error: {label} (HTTP {status_code})"]
 
-    seen: set[str] = {"kind", "reason"}  # already in the label line
+    # Only the key actually used in the label is hidden from the kv block.
+    seen: set[str] = {label_key} if label_key else set()
     # Priority keys first
     for key in _PRIORITY_KEYS:
         if key in seen:

--- a/cli/skills/agnes-data-querying.md
+++ b/cli/skills/agnes-data-querying.md
@@ -101,8 +101,9 @@ For `source_type=keboola` / `source_type=jira` (local), use **DuckDB SQL** in yo
 
 | Scenario | Use instead |
 |----------|------------|
-| Single aggregate on remote table (`SELECT COUNT(*)`) | `da query --remote "SELECT COUNT(*) FROM web_sessions_example"` — cheap, no fetch needed |
-| Throwaway exploration with raw BQ syntax | `da query --remote` — one-shot, no snapshot |
+| Single aggregate on remote BASE TABLE (`SELECT COUNT(*)`) | `da query --remote "SELECT COUNT(*) FROM web_sessions_example"` — cheap, no fetch needed (Storage Read API pushes the COUNT into BQ) |
+| Single aggregate on remote VIEW/MATERIALIZED_VIEW | Same syntax works (#160) but the BQ jobs API can't push WHERE/COUNT into the view body. Cost guardrail (default 5 GiB) catches expensive scans → 400 `remote_scan_too_large` with `da fetch` suggestion. Pivot to `da fetch <id> --where '<predicate>'` if rejected. |
+| Throwaway exploration with raw BQ syntax | `da query --remote "SELECT … FROM <registered_id>"` — direct `bq."<dataset>"."<table>"` paths are now registry-gated (403 `bq_path_not_registered` if not registered). Register first or use the catalog id. |
 | Cross-table JOIN with both remote | Use `da fetch` for one side + `da query --remote` for the other; full cross-remote JOIN needs design (see #101) |
 
 ## When the table you need isn't in `da catalog`

--- a/cli/skills/agnes-table-registration.md
+++ b/cli/skills/agnes-table-registration.md
@@ -118,7 +118,7 @@ Returns `204 No Content` on success, `404` if the id doesn't exist. **The underl
 
 ## When NOT to register
 
-- The user wants to inspect a table once, doesn't intend to share it: use `da query --remote "SELECT … FROM \`<project>.<dataset>.<table>\`"` instead.
+- The user wants to inspect a table once, doesn't intend to share it: register the row once with `query_mode='remote'` (admin-only, ~30s) and query it via `da query --remote "SELECT … FROM <registered_id>"`. Direct `bq."<dataset>"."<table>"` syntax is now registry-gated — unregistered paths return 403 `bq_path_not_registered` (closes the pre-existing RBAC + cost-cap bypass).
 - The data lives in a third source not yet supported by a connector: implement the connector first (see `connectors.md` skill), then register.
 - The dataset already has a registered "parent" view that exposes the rows you want: register-table is for distinct catalog entities, not for slicing existing ones — slice with `da fetch --where`.
 

--- a/cli/v2_client.py
+++ b/cli/v2_client.py
@@ -1,7 +1,7 @@
 """HTTP client helpers for /api/v2/* endpoints (CLI side)."""
 
 from __future__ import annotations
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 import io
 
@@ -9,16 +9,24 @@ import httpx
 import pyarrow as pa
 
 from cli.config import get_server_url, get_token
+from cli.error_render import render_error
 
 
 @dataclass
 class V2ClientError(Exception):
     status_code: int
     body: Any
+    # `message` retained for backwards compat with any existing caller
+    # that reads `.message`. Renderer is the canonical str path now.
     message: str = ""
 
     def __str__(self) -> str:
-        return f"HTTP {self.status_code}: {self.message or self.body}"
+        # Prefer the structured renderer — it pretty-prints typed BQ errors
+        # (cross_project_forbidden, remote_scan_too_large, etc.) instead
+        # of the historical truncate-and-flatten form. Falls back to
+        # truncated form for unrecognized bodies, so we never make output
+        # WORSE than the status-quo (#160 §4.7).
+        return render_error(self.status_code, self.body)
 
 
 def _headers() -> dict:
@@ -26,12 +34,20 @@ def _headers() -> dict:
     return {"Authorization": f"Bearer {token}"} if token else {}
 
 
+def _parse_error_body(r: httpx.Response) -> Any:
+    if "json" in r.headers.get("content-type", ""):
+        try:
+            return r.json()
+        except Exception:
+            return r.text
+    return r.text
+
+
 def api_get_json(path: str, **params) -> dict:
     url = f"{get_server_url().rstrip('/')}{path}"
     r = httpx.get(url, headers=_headers(), params=params or None, timeout=30)
     if r.status_code >= 400:
-        body = r.json() if "json" in r.headers.get("content-type", "") else r.text
-        raise V2ClientError(status_code=r.status_code, body=body, message=str(body)[:200])
+        raise V2ClientError(status_code=r.status_code, body=_parse_error_body(r))
     return r.json()
 
 
@@ -39,8 +55,7 @@ def api_post_json(path: str, payload: dict) -> dict:
     url = f"{get_server_url().rstrip('/')}{path}"
     r = httpx.post(url, json=payload, headers=_headers(), timeout=120)
     if r.status_code >= 400:
-        body = r.json() if "json" in r.headers.get("content-type", "") else r.text
-        raise V2ClientError(status_code=r.status_code, body=body, message=str(body)[:200])
+        raise V2ClientError(status_code=r.status_code, body=_parse_error_body(r))
     return r.json()
 
 
@@ -49,7 +64,6 @@ def api_post_arrow(path: str, payload: dict) -> pa.Table:
     url = f"{get_server_url().rstrip('/')}{path}"
     r = httpx.post(url, json=payload, headers=_headers(), timeout=600)
     if r.status_code >= 400:
-        body = r.json() if "json" in r.headers.get("content-type", "") else r.text
-        raise V2ClientError(status_code=r.status_code, body=body, message=str(body)[:200])
+        raise V2ClientError(status_code=r.status_code, body=_parse_error_body(r))
     reader = pa.ipc.open_stream(io.BytesIO(r.content))
     return reader.read_all()

--- a/config/instance.yaml.example
+++ b/config/instance.yaml.example
@@ -122,14 +122,6 @@ data_source:
     #                                    # Mismatch -> every BQ call 403 USER_PROJECT_DENIED.
     #                                    # `da diagnose` warns when this falls back to `project`.
     #                                    # Configurable via /admin/server-config UI.
-    # legacy_wrap_views: false           # When true, registered VIEWs and MATERIALIZED_VIEWs get a DuckDB
-    #                                    # master view via bigquery_query() (jobs API) so analysts can
-    #                                    # `SELECT * FROM viewname` directly. When false (default), views
-    #                                    # are catalog-only -- analysts use `da fetch viewname` or
-    #                                    # `da query --remote`. ON can cause "Response too large" on big
-    #                                    # views; OFF requires analyst-side discipline (CLAUDE.md rails).
-    #                                    # Toggle ON for view-heavy deployments where most views are small.
-    #                                    # Configurable via /admin/server-config UI.
     # max_bytes_per_materialize: 10737418240
     #                                    # Cost guardrail (bytes) for query_mode='materialized' BQ scans.
     #                                    # Dry-run check before running; exceeding -> registration / sync

--- a/connectors/bigquery/extractor.py
+++ b/connectors/bigquery/extractor.py
@@ -222,25 +222,26 @@ def _init_extract_locked(
                         f"BQ entity {project_id}.{dataset}.{source_table} not found"
                     )
 
-                legacy_wrap_views = bool(
-                    get_value("data_source", "bigquery", "legacy_wrap_views", default=False)
-                )
-
+                # Issue #160: always create a master view for query_mode='remote'
+                # rows we have proven runtime support for.
+                #   BASE TABLE → catalog path (Storage Read API, predicate pushdown)
+                #   VIEW / MATERIALIZED_VIEW → bigquery_query() (jobs API, no
+                #   pushdown — cost is bounded by the /api/query guardrail)
+                # Other entity types (EXTERNAL, SNAPSHOT, CLONE, future) are
+                # logged + skipped, with NO _meta row, since orchestrator-side
+                # master-view creation requires a corresponding inner view.
                 if entity_type == "BASE TABLE":
-                    # Storage Read API — fast for full scans
                     view_sql = (
                         f'CREATE OR REPLACE VIEW "{table_name}" AS '
                         f'SELECT * FROM bq."{dataset}"."{source_table}"'
                     )
                     conn.execute(view_sql)
-                elif legacy_wrap_views:
-                    # Backwards compatibility — for one release cycle only.
-                    if entity_type not in ("VIEW", "MATERIALIZED_VIEW"):
-                        logger.warning(
-                            "Unknown BQ entity type %r for %s.%s.%s — using bigquery_query() path",
-                            entity_type, project_id, dataset, source_table,
-                        )
-                    # VIEW or MATERIALIZED_VIEW — use jobs API
+                elif entity_type in ("VIEW", "MATERIALIZED_VIEW"):
+                    # `dataset` and `source_table` are validated above by
+                    # validate_quoted_identifier; project_id is validated at
+                    # the entry boundary of init_extract (lines 152-160).
+                    # The .replace("'", "''") is defense-in-depth on the
+                    # inline literal.
                     bq_inner = f"SELECT * FROM `{project_id}.{dataset}.{source_table}`"
                     bq_inner_escaped = bq_inner.replace("'", "''")
                     view_sql = (
@@ -249,13 +250,17 @@ def _init_extract_locked(
                     )
                     conn.execute(view_sql)
                 else:
-                    # Default: VIEW / MATERIALIZED_VIEW are recorded in _meta but no master
-                    # view created. Analyst must use `da fetch` (v2 primitives) to materialise
-                    # a snapshot locally.
-                    logger.info(
-                        "Skipping wrap view for %s entity %s.%s.%s — use `da fetch`",
+                    # Unverified entity type. Skip both the wrap view and
+                    # the _meta row. The registry row remains; /api/v2/scan
+                    # can still operate from it (builds BQ SQL from
+                    # bucket+source_table), and `da fetch` works.
+                    logger.warning(
+                        "Unverified BQ entity_type %r for %s.%s.%s — master view skipped. "
+                        "Use `da fetch` for this row, or file an issue with a repro to "
+                        "request native support.",
                         entity_type, project_id, dataset, source_table,
                     )
+                    continue  # Do NOT insert _meta — no inner view to point at.
 
                 conn.execute(
                     "INSERT INTO _meta VALUES (?, ?, 0, 0, ?, 'remote')",

--- a/docs/superpowers/specs/2026-05-03-issue-160-da-query-remote-fix-spec.md
+++ b/docs/superpowers/specs/2026-05-03-issue-160-da-query-remote-fix-spec.md
@@ -1,0 +1,823 @@
+# Spec — issue #160: `da query --remote` for `query_mode='remote'` BigQuery rows
+
+**Status:** draft for review
+**Target release:** 0.31.0 (minor — restored capability + new server-config knob)
+**Author:** Zdenek
+**Closes:** #160
+
+---
+
+## 1. Problem statement
+
+The CLI rail `da query --remote "<sql>"` is documented (PR #154 + `cli/skills/agnes-data-querying.md` + root `CLAUDE.md`) as the way to run a one-shot server-side SQL probe against any registered table — including `query_mode='remote'` BigQuery-backed rows. The implementation does not match the docs:
+
+- For `query_mode='remote'` BQ rows whose underlying entity is a `BASE TABLE`, the call works (master view exists, BQ extension's Storage Read API path serves it).
+- For `query_mode='remote'` BQ rows whose underlying entity is `VIEW` or `MATERIALIZED_VIEW`, the call fails with `Catalog Error: Table with name <id> does not exist`. No master view is created on the server. The reporter's `unit_economics` (a curated finance VIEW) hits this path.
+
+Root cause: `connectors/bigquery/extractor.py:225-258` checks `data_source.bigquery.legacy_wrap_views` (default `False`) and skips master-view creation for `VIEW`/`MATERIALIZED_VIEW` entities — directing analysts to `da fetch` instead. This was a v2-fetch-primitives design choice for cost control. PR #154's docs then promised the opposite without touching the implementation. Reporter is the first analyst to hit the gap.
+
+Reporter's hypothesis ("the `--remote` flag is being ignored") is wrong — `cli/commands/query.py:58` does route differently. The diagnostic message Pavel posted is the correct DuckDB error from a missing master view.
+
+## 2. Goals
+
+1. `da query --remote "SELECT … FROM <id>"` resolves any `query_mode='remote'` BigQuery row, regardless of whether the upstream BQ entity is `BASE TABLE`, `VIEW`, or `MATERIALIZED_VIEW`.
+2. Cost is bounded server-side: a query that would scan more than the operator-configured cap is rejected before execution with a clear, actionable error.
+3. RBAC is preserved: callers can only query tables they have grants on; the cap-bypass workaround (`SELECT … FROM bq."ds"."tbl"` directly) is closed by the same enforcement layer.
+4. Daily quota usage is tracked so `/api/query` BQ-touching calls share the budget with `/api/v2/scan`.
+5. Operator can adjust the cap from the `/admin/server-config` UI without editing files or redeploying.
+6. No legacy / opt-out flags. `legacy_wrap_views` is removed.
+
+## 3. Out of scope (clarification, not deferred work)
+
+- Hybrid `--register-bq` flow (`/api/query/hybrid`) algorithm is unchanged. The CLI render fix in §4.7 covers its error UX.
+- `da fetch` (`/api/v2/scan`) flow algorithm is unchanged. Same render fix covers its UX.
+- Per-row cost-cap overrides (different cap per registered table). One global cap is the design — not a deferral.
+
+## 4. Design
+
+### 4.1 Always create a master view for `query_mode='remote'` BQ rows
+
+**File:** `connectors/bigquery/extractor.py`
+
+Replace the entity-type branch at lines 225-258. Two SQL forms, one per BQ entity capability — no flag, no skip, no fallback:
+
+```python
+# Per BQ docs INFORMATION_SCHEMA.TABLES.table_type can return: BASE TABLE,
+# VIEW, MATERIALIZED_VIEW, EXTERNAL, SNAPSHOT, CLONE. We support the three
+# we have empirical evidence for in this codebase:
+#   - BASE TABLE → catalog path (Storage Read API, predicate pushdown).
+#     Proven by current code (legacy_wrap_views=False BASE TABLE branch).
+#   - VIEW / MATERIALIZED_VIEW → bigquery_query() (jobs API, no pushdown).
+#     Proven by current code (legacy_wrap_views=True branch).
+# EXTERNAL / SNAPSHOT / CLONE behavior with the duckdb-bigquery extension
+# is unverified at the time of writing this spec. Conservative: log+skip
+# (same handling as a future unknown type). Operators who hit this can
+# file a follow-up issue with a concrete repro; we add the supported set
+# explicitly when verified.
+
+if entity_type == "BASE TABLE":
+    view_sql = (
+        f'CREATE OR REPLACE VIEW "{table_name}" AS '
+        f'SELECT * FROM bq."{dataset}"."{source_table}"'
+    )
+elif entity_type in ("VIEW", "MATERIALIZED_VIEW"):
+    # `project_id` flows from the `_create_remote_attach_table` call upstream
+    # (extractor.py:182), sourced from `data_source.bigquery.project` config.
+    # Validate at this boundary too — `dataset` and `source_table` are
+    # validated by lines 211-216 below, but project_id wasn't. Add it.
+    if not validate_quoted_identifier(project_id, "BigQuery project_id"):
+        raise RuntimeError(
+            f"unsafe BQ project_id {project_id!r} — refusing to build view"
+        )
+    # The .replace("'", "''") is defense-in-depth; if the validator is ever
+    # relaxed this still keeps the inline literal safe.
+    bq_inner = f"SELECT * FROM `{project_id}.{dataset}.{source_table}`"
+    bq_inner_escaped = bq_inner.replace("'", "''")
+    view_sql = (
+        f'CREATE OR REPLACE VIEW "{table_name}" AS '
+        f"SELECT * FROM bigquery_query('{project_id}', '{bq_inner_escaped}')"
+    )
+else:
+    # Unverified entity type for the duckdb-bigquery extension. Skip
+    # master-view creation and the _meta INSERT. The registry row exists
+    # and /api/v2/scan can still operate from it (it builds BQ SQL from
+    # bucket+source_table, not from the master view).
+    logger.warning(
+        "Unverified BQ entity_type %r for %s.%s.%s — master view skipped. "
+        "Use `da fetch` for this row, or file an issue with a repro to "
+        "request native support.",
+        entity_type, project_id, dataset, source_table,
+    )
+    continue  # next tc, no _meta INSERT (would point at non-existent view)
+conn.execute(view_sql)
+```
+
+**No regression for current operators.** `BASE TABLE` and `VIEW`/`MATERIALIZED_VIEW` are the entity types we have proven paths for. Operators on default `legacy_wrap_views=False` today get NEW behavior for VIEW/MATERIALIZED_VIEW (master view appears where there was none — the headline fix). Operators who had `legacy_wrap_views=True` get IDENTICAL behavior to today for VIEW/MATERIALIZED_VIEW.
+
+Both forms produce an inner view in extract.duckdb. The orchestrator (`src/orchestrator.py:340-355`) then creates a master analytics view from each — `da query --remote "SELECT … FROM <id>"` resolves uniformly, regardless of upstream entity type.
+
+`_detect_table_type` is still called and still errors with `BQ entity {project}.{dataset}.{table} not found` when BQ returns no entity. New `else` branch above catches a future BQ entity type (e.g. `EXTERNAL` if anyone registers one) loud rather than silent.
+
+**Why not let the extension dispatch internally for VIEWs:** The DuckDB BQ extension's catalog enumerates VIEWs (which is why Pavel's error message offered `bq.finance_unit_economics.unit_economics` as a fuzzy-match suggestion), but Storage Read API is a tables-only RPC — `SELECT * FROM bq."ds"."view_name"` raises `INVALID_ARGUMENT: Read sessions cannot be created on logical views`. Going via `bigquery_query()` is the only path that actually runs SELECTs on VIEW entities. The previous codebase already used this exact form behind `legacy_wrap_views=True`; it is a proven path.
+
+### 4.2 Remove `legacy_wrap_views` config knob
+
+The flag is the inverse of the new behavior. With "always wrap" as the only mode, the flag has no semantic meaning.
+
+**Mandatory grep target list (verified per-file counts; merge gate: all but CHANGELOG must hit zero):**
+
+| File | Count | Action |
+|------|-------|--------|
+| `connectors/bigquery/extractor.py` | 3 | rewrite the wrap-view branch per §4.1; remove `legacy_wrap_views` config read |
+| `app/api/admin.py` | 3 | delete `_OPTIONAL_FIELDS` entry (line 229), delete the `_BQ_OPTIONAL_FIELD_DEFAULTS` entry (line 804), delete the comment block (line 798) |
+| `config/instance.yaml.example` | 1 | delete the example line |
+| `tests/test_bigquery_extractor.py` | 6 | rewrite tests per §5.1 (5 entries — BASE TABLE / VIEW / MAT_VIEW / unknown skip / overlay key ignored) |
+| `tests/test_admin_server_config.py` | 10 | rewrite assertions: field NOT in payload; `max_bytes_per_remote_query` IS in payload; `billing_project` carries `placeholder_from` |
+| `tests/test_admin_server_config_known_fields.py` | 3 | delete the `legacy_wrap_views` known-field assertion |
+| `app/web/templates/admin_tables.html` | 2 | rewrite operator copy — master view now always exists for VIEW/MAT_VIEW |
+| `src/orchestrator.py` | 1 | comment update — `_attach_and_create_views` skip branch comment at lines 330-355 references `legacy_wrap_views=False`. The skip BRANCH stays (still needed for any future `_meta`-without-inner-object case), but the comment must reflect that BQ rows now always have an inner view |
+| `CHANGELOG.md` | 4 | leave historical entries; new `### Fixed` bullet cross-refs |
+
+Total: 33 references across 9 files. Verified by per-file `grep -c` (rev3 review).
+
+After all edits: `grep -rn 'legacy_wrap_views' connectors app src tests config cli` must return zero. `docs/` is **excluded** from the gate — `docs/superpowers/plans/2026-04-27-claude-fetch-primitives.md` (8 hits) and `docs/superpowers/specs/2026-04-27-claude-fetch-primitives-design.md` (1 hit) are historical planning artifacts that document the design decision to introduce the flag; rewriting history would be revisionist. CHANGELOG history retained on the same logic.
+
+Verification command in CI / pre-commit: 
+
+```
+test "$(grep -rn 'legacy_wrap_views' connectors app src tests config cli | wc -l)" -eq 0
+```
+
+No DB migration. Operators who explicitly set `legacy_wrap_views: true` in their overlay get the new (equivalent) behavior automatically; the unrecognized key is ignored by the YAML loader. Operators who explicitly set `legacy_wrap_views: false` get the new behavior as a fix, not a regression.
+
+### 4.3 Server-side cost guardrail on `/api/query`
+
+**File:** `app/api/query.py`
+
+Before executing the SQL, identify whether it touches any `query_mode='remote'` + `source_type='bigquery'` registered name. If yes, run a BQ dry-run to estimate scan bytes. If estimate exceeds cap, reject with 400.
+
+#### 4.3.1 Detection of BQ-touching SQL — regex on raw SQL
+
+Reviewer rev3 verified empirically against DuckDB 1.5.1 that the physical plan **inlines view bodies**. So a plan walker would see `SEQ_SCAN bq.<ds>.<tbl>` for every legitimate master-view query — making it impossible to distinguish "user typed `bq.*` directly" (must be RBAC-checked) from "user referenced a master view that resolves to `bq.*`" (already RBAC-checked via `get_accessible_tables`). The plan-walker design has been dropped.
+
+**Use regex on raw user-submitted SQL.** Two narrow tasks, two narrow regexes:
+
+```python
+# 4.3.1a — direct bq.<dataset>.<source_table> references (3-part path).
+# Tested against 16 cases including all quoting/casing variants, prefix
+# false-positives (other_bq.x.y), middle-position bq (x.bq.y.z), 2-part
+# rejection (bq.col), CTE bodies, multiple paths in one statement.
+BQ_PATH = re.compile(
+    r'(?<![\w.])bq\s*\.\s*("[^"]+"|\w+)\s*\.\s*("[^"]+"|\w+)(?=\W|$)',
+    re.IGNORECASE,
+)
+
+# 4.3.1b — registered remote-mode names referenced as bare identifiers.
+# Built per-request from `query_mode='remote' AND source_type='bigquery'`
+# rows the caller can access. Word-boundary match avoids 'unit_economics_v2'
+# matching 'unit_economics'.
+def remote_name_pattern(names: set[str]) -> re.Pattern:
+    if not names:
+        return None
+    alt = "|".join(re.escape(n) for n in sorted(names, key=len, reverse=True))
+    return re.compile(rf'\b({alt})\b', re.IGNORECASE)
+```
+
+Algorithm — runs once per `/api/query` request, only on `query_mode='remote' + source_type='bigquery'` registry rows:
+
+1. **Cost guardrail (§4.3.2 inputs).** Compile `BQ_PATH` and `remote_name_pattern(accessible_remote_bq_names)`. Both regexes scan the raw user SQL. Each match contributes one `(bucket, source_table)` to the dry-run set — for `BQ_PATH` matches, group(1)/group(2) (stripped of quotes); for bare-name matches, the registry lookup gives bucket/source_table.
+
+2. **RBAC patch (§4.3.4).** Same `BQ_PATH` regex. For each match:
+   - Look up `(bucket=group1_unquoted, source_table=group2_unquoted)` in registry, filtered to `source_type='bigquery'`. (RBAC doesn't filter by `query_mode` — direct `bq.*` paths to materialized rows are also gated.)
+   - No row → 403 `bq_path_not_registered`.
+   - Row exists, caller lacks grant → 403 `bq_path_access_denied`.
+
+**Known false-positive: bare-name match in string literal.** `WHERE comment = 'unit_economics is great'` regex-matches `unit_economics`, fires a wasted dry-run, query then executes normally (string literal doesn't actually touch BQ). Cost: one BQ dry-run RPC (~50ms). Acceptable.
+
+**Known false-positive: bare name shadowed by CTE.** `WITH unit_economics AS (SELECT ...) SELECT FROM unit_economics` regex-matches, wasted dry-run, query executes (CTE shadows the registered name). Same cost, same acceptance.
+
+**Known false-positive: CTE named `bq`.** `WITH bq AS (SELECT 1) SELECT * FROM bq.x.y` would have `BQ_PATH` regex match `bq.x.y` and fire RBAC check. The user is referencing a CTE column path inside a name-shadowed scope — but our RBAC check assumes `bq` always means the BigQuery catalog. Result: 403 on this rare query shape. Documented; recommend CTE rename if encountered.
+
+**Known: 4-part path `bq."ds"."tbl"."col"`** (BigQuery struct field access). Regex matches the leading `bq."ds"."tbl"` part, treats it as a 3-part catalog reference. Functionally fine — the lookup uses the (ds, tbl) pair correctly; the trailing `."col"` is an attribute access on the matched table. No false-negative on RBAC; the dry-run also targets the correct underlying table.
+
+**Known: BQ date-partition shard syntax `bq.ds."tbl$20231201"`.** BigQuery allows `$` in table names for date-partition shards. `$` is `\W`, so the lookahead `(?=\W|$)` matches BEFORE the `$`, capturing `tbl` (without the shard). The dry-run then runs against `bq."ds"."tbl"` (the parent partitioned table) instead of the specific shard — over-estimates scan bytes, never under-estimates. RBAC effect: caller is gated on the parent table's registration, which is the conservative choice. Documented; if shard-precision is ever needed, regex can be widened.
+
+**Two registry rows share a `name`** (e.g. `bigquery` source + `keboola` source both named `users`) → orchestrator's `view_ownership` ensures only the canonical owner's master view exists. The bare-name match against `accessible_remote_bq_names` only includes BQ-source rows; the keboola twin doesn't appear in this set, no collision at dry-run time.
+
+**Block `bigquery_query()` direct calls.** Add `"bigquery_query"` to the SQL blocklist at `app/api/query.py:42-65`. The function-call backdoor is a pre-existing hole (verified empirically — current blocklist passes `SELECT * FROM bigquery_query('proj', 'SELECT * FROM ds.tbl')`). Wrap views created at extract time use `bigquery_query()` internally, but those run via DuckDB's view resolution — the user-submitted SQL never contains the function name, so the blocklist doesn't break them.
+
+**Reuse the existing forbidden-table loop.** `app/api/query.py:80-89` already iterates analytics master views and runs `re.search(r'\b' + re.escape(table.lower()) + r'\b', sql_lower)` for each. The new bare-name detection (§4.3.1 step 1) duplicates this exact pattern. **Implementation should weave into the existing loop:** for each master view name that matches AND whose registry row is `query_mode='remote' + source_type='bigquery'`, also collect `(bucket, source_table)` for the dry-run set. One regex pass, two side effects (RBAC + cost). The `BQ_PATH` regex for direct `bq.X.Y` paths runs as a separate pass — different syntax, can't share the loop.
+
+#### 4.3.2 Dry-run
+
+For each matching row:
+1. Build the BQ dry-run SQL: `SELECT * FROM \`{billing_project}.{bucket}.{source_table}\`` — same format as `_build_bq_sql` in `app/api/v2_scan.py:110`. Reuse `_bq_dry_run_bytes` from `v2_scan.py`.
+2. Sum `scan_bytes` across all matched rows.
+
+This **over-estimates** by counting full table scan per referenced name, ignoring DuckDB-side pushdown. That is intentional: the cap is the safety ceiling, not an exact predictor. Analyst who wants accurate estimate uses `da fetch <id> --estimate` (already exists, structured).
+
+#### 4.3.3 Enforcement
+
+QuotaTracker API verified at `app/api/v2_quota.py:49-120`:
+- `with q.acquire(user):` — context manager; raises `QuotaExceededError(KIND_CONCURRENT, ...)` on entry if at concurrent limit, decrements on exit.
+- `q.check_daily_budget(user)` — raises `QuotaExceededError(KIND_DAILY_BYTES, ...)` if at-or-over daily byte cap.
+- `q.record_bytes(user, n)` — never raises; commits cumulative usage post-flight.
+
+**Quota tracker import path.** `_build_quota_tracker()` and the module-level `_quota_singleton` currently live at `app/api/v2_scan.py:254-268`. 7 test sites in `tests/test_v2_scan.py` (lines 77, 118, 143, 160, 186, 208, 250) call `v2_scan._build_quota_tracker()` directly.
+
+Two options — pick one in implementation:
+
+**(a) Move-and-shim (preferred).** Move the function and singleton to `app/api/v2_quota.py`. Add a thin re-export at `app/api/v2_scan.py` — **but only the function, not the singleton variable**:
+
+```python
+# app/api/v2_scan.py — at module top
+from app.api.v2_quota import _build_quota_tracker  # re-export
+# Do NOT re-export _quota_singleton: `from X import var` copies the
+# binding at import time. Once v2_quota._build_quota_tracker() mutates
+# v2_quota._quota_singleton, a re-exported v2_scan._quota_singleton
+# would still hold the initial None — silent state divergence.
+```
+
+The 7 test sites in `tests/test_v2_scan.py` (lines 77, 118, 143, 160, 186, 208, 250) call `v2_scan._build_quota_tracker()` only — they don't touch `_quota_singleton` directly (verified via grep). Re-export of the function alone preserves their behavior. `/api/query` imports from `v2_quota.py` directly. Clean dep direction. ~5 LOC. Test files unchanged.
+
+**(b) Direct import from v2_scan.** `/api/query` imports `from app.api.v2_scan import _build_quota_tracker`. Inverted dep direction (api/query → api/v2_scan), but zero refactor. Acceptable since both modules are siblings under `app.api`, not layered.
+
+Spec recommends (a) for cleanliness; (b) is a fallback if (a) breaks anything unexpected.
+
+Pre-flight order — only fires when there's something to dry-run (regex matches in §4.3.1 produced a non-empty set):
+
+```python
+quota = _build_quota_tracker()
+quota.check_daily_budget(user)            # raises 429 if over daily cap
+with quota.acquire(user):                 # raises 429 if at concurrent limit
+    total_scan_bytes = sum(
+        _bq_dry_run_bytes(bq, build_dry_run_sql(row))
+        for row in matched_rows
+    )
+    if total_scan_bytes > cap:
+        raise HTTPException(400, detail={
+            "reason": "remote_scan_too_large",
+            "scan_bytes": total_scan_bytes,
+            "limit_bytes": cap,
+            "tables": [r["name"] for r in matched_rows],
+            "suggestion": (
+                "Use `da fetch <id> --select <cols> --where <predicate> "
+                "--estimate` to materialize a filtered subset, then query "
+                "the snapshot locally."
+            ),
+        })
+    result = analytics.execute(user_sql).fetchmany(limit + 1)
+    quota.record_bytes(user, total_scan_bytes)  # post-flight
+```
+
+The `with quota.acquire(user)` block guarantees the concurrent slot is released even if dry-run, execute, or `record_bytes` raises. `QuotaExceededError` is mapped to HTTP 429 by the existing v2 handler shape — reuse the same translation in `/api/query` so CLI render in §4.7 prints the same structured shape (`{kind, current, limit, retry_after_seconds}`).
+
+If matched rows is empty (regular non-BQ query): skip the entire block. Zero new latency for non-BQ-touching queries.
+
+The cap is read from `api.query.bq_max_scan_bytes` (server-config UI; see 4.4). Default `5_368_709_120` (5 GiB).
+
+#### 4.3.4 RBAC patch — close direct `bq.*` bypass
+
+Pre-existing hole: the forbidden-table check at `app/api/query.py:80-89` only blocks names that match a master view. `SELECT … FROM bq."ds"."tbl"` (direct catalog path) doesn't match any master view, so it bypasses the existing check entirely.
+
+Use the `BQ_PATH` regex from §4.3.1 (verified 16/16). For each match, before execute:
+
+```python
+from app.auth.access import is_user_admin
+
+is_admin = is_user_admin(user["id"], conn)
+accessible = get_accessible_tables(user, conn)  # None for admins, list[str] otherwise
+
+for m in BQ_PATH.finditer(user_sql):
+    bucket = m.group(1).strip('"')
+    source_table = m.group(2).strip('"')
+    row = registry.find_by_bq_path(bucket, source_table)  # case-insensitive
+    if row is None:
+        raise HTTPException(403, detail={
+            "reason": "bq_path_not_registered",
+            "path": f'bq."{bucket}"."{source_table}"',
+            "hint": (
+                "Direct bq.* references must point to a registered table. "
+                "Register via `da admin register-table` or use the "
+                "registered name from `da catalog`."
+            ),
+        })
+    # Admin short-circuit: accessible is None for admins (sees all). Only
+    # apply per-name grant check for non-admins.
+    if not is_admin and (accessible is None or row["name"] not in accessible):
+        # accessible=None for non-admin would be a bug; fail closed.
+        raise HTTPException(403, detail={
+            "reason": "bq_path_access_denied",
+            "path": f'bq."{bucket}"."{source_table}"',
+            "registered_as": row["name"],
+        })
+```
+
+**Edge case — `bigquery_query()` function-call backdoor.** Closed by adding `"bigquery_query"` to the SQL blocklist (§4.3.1 last paragraph). The blocklist runs before the regex check, so a user who tries to bypass the `bq.*` regex via `SELECT * FROM bigquery_query('proj', 'SELECT * FROM ds.tbl')` gets a 400 from the existing blocklist path.
+
+**Edge case — admin user.** Admin gets `accessible_table_names = None` from `get_accessible_tables`. The bq-path registration check still fires (the path must point to a registered row); the per-name grant check is short-circuited by the `user_id not in admin_ids` guard. Admin can register first, then query — matches v2-fetch design (registry-gated).
+
+**Edge case — bare `bq.col` 2-part reference** (`SELECT bq.col FROM tbl`). Regex requires 3-part — verified empirically does not match.
+
+**Edge case — string literal containing `bq.x.y`** (`WHERE c = 'bq.foo.bar'`). Regex matches; check fires; if registry doesn't have the row, returns 403. Worst case: a comment or string accidentally shaped like `bq.X.Y` triggers a 403 instead of executing. Documented; low rate; user can rephrase. Strict mode is correct here — we'd rather false-positive-deny than false-positive-allow on a security boundary.
+
+**Method needed: `TableRegistryRepository.find_by_bq_path(bucket, source_table)`.** Returns the row where `source_type='bigquery' AND lower(bucket)=lower(?) AND lower(source_table)=lower(?)`.
+
+**Ambiguity handling.** No unique constraint exists on `(source_type, bucket, source_table)` in `src/db.py` — multiple registry rows can in principle point at the same BQ table (e.g. an admin registers it twice with different `name` values). Resolution policy:
+- Query: `SELECT * FROM table_registry WHERE source_type='bigquery' AND bucket IS NOT NULL AND source_table IS NOT NULL AND lower(bucket)=lower(?) AND lower(source_table)=lower(?) ORDER BY registered_at ASC`. The NULL guards defend against rows where bucket or source_table happen to be NULL (some legacy local rows have empty bucket); without them `lower(NULL)=lower('foo')` returns NULL (not false) and the row is excluded by SQL three-valued logic — but the explicit guard makes intent obvious to reviewers.
+- 0 rows → return `None` (handled by 403 `bq_path_not_registered` above).
+- 1 row → return it.
+- 2+ rows → return the **oldest by `registered_at`** (deterministic, prefers the longest-lived registration). Log a warning so an admin can clean up the duplicate.
+
+~15 LOC addition. Test fixture: insert two rows with same path, assert oldest wins.
+
+**Why not add a UNIQUE constraint?** It would require a schema migration that could fail on existing instances with legitimate duplicates. Out of scope for this issue.
+
+#### 4.3.5 Multiple statements / aliases
+
+Existing blocklist already rejects `;` (multi-statement). Aliasing inside a single statement (`SELECT * FROM unit_economics ue`) is fine — the regex matches the bare name once.
+
+### 4.4 New server-config field: `data_source.bigquery.max_bytes_per_remote_query`
+
+Wait — the cost guardrail is for `/api/query`, not `materialize`. Naming it under `data_source.bigquery` keeps it next to `max_bytes_per_materialize` (the precedent).
+
+**File:** `app/api/admin.py:_OPTIONAL_FIELDS["data_source"]["bigquery"]["fields"]`
+
+Add:
+```python
+"max_bytes_per_remote_query": {
+    "kind": "int",
+    "default": 5368709120,
+    "hint": (
+        "Cost guardrail for `da query --remote` against query_mode='remote' "
+        "BigQuery rows. Estimated scan bytes from a BQ dry-run. Exceeds → 400 "
+        "with suggestion to use `da fetch`. 0 disables. Default 5368709120 = 5 GiB."
+    ),
+},
+```
+
+Remove `legacy_wrap_views` entry from same dict (per 4.2).
+
+**Reader:** `app/api/query.py` reads via `from app.instance_config import get_value` → `get_value("data_source", "bigquery", "max_bytes_per_remote_query", default=5368709120)`.
+
+The `/admin/server-config` template (`app/web/templates/admin_server_config.html`) auto-renders the new field from `_OPTIONAL_FIELDS` — no template change needed.
+
+### 4.5 Documentation
+
+Touch four files. Rev3 review caught the missing `agnes-table-registration.md`.
+
+1. **`config/claude_md_template.txt`** (PR #154's analyst CLAUDE.md template). Update the "three query patterns" table:
+   - `da query --remote`: keep as one-shot path. Add: "Server-side cost guardrail caps scans at 5 GiB by default (configurable). Exceeded queries are rejected with a `da fetch` suggestion."
+2. **`cli/skills/agnes-data-querying.md`**: same caveat in the rails table at line 33 + decision matrix at line 104. Add an explicit note: "Cost guardrail kicks in via BQ dry-run; if the cap is hit, the response names the bytes and suggests `da fetch`."
+3. **`cli/skills/agnes-table-registration.md:121`** — currently shows `da query --remote "SELECT … FROM \`<project>.<dataset>.<table>\`"` as a one-off pattern. Under §4.3.4 RBAC patch this exact form is now blocked unless the table is registered. Update the example to the registered-name form: `da query --remote "SELECT … FROM <registered_id>"`. Add note: "raw `bq.<dataset>.<table>` paths require a registered row; admins can register first or use the bare id."
+4. **`CLAUDE.md`** (root, "Querying Agnes data — agent rails" section). Two specific edits:
+
+   **(a)** Under "Choose the right tool" / `remote`: add one bullet explaining the new guardrail — "Server caps the dry-run scan at 5 GiB by default. Cheap aggregates on BASE TABLE rows (Storage Read API pushes WHERE down) typically fit; aggregates on VIEW/MATERIALIZED_VIEW rows estimate as full-scan and may be rejected — pivot to `da fetch <id> --where '<predicate>' --estimate`."
+
+   **(b)** "When NOT to use `da fetch`" decision matrix at the bottom of the section currently lists `SELECT COUNT(*) FROM web_sessions_example` as a "cheap" `--remote` candidate. Append a parenthetical: `"(cheap for BASE TABLE rows; for VIEW/MATERIALIZED_VIEW the dry-run estimates a full scan, so the guardrail rejects unless within the 5 GiB cap. Pivot to da fetch.)"`.
+
+   Pre-deploy verification: §5.3 manual scenario should run `SELECT COUNT(*) FROM <a-VIEW-row>` and check if the dry-run actually estimates full-scan or near-zero (BQ COUNT optimization on metadata) — if BQ returns ~0 bytes for COUNT-on-VIEW, edit (b) is overcautious and the matrix can stay simpler.
+
+Skip `cli/skills/corporate-memory.md` and `cli/skills/security.md` — those use `--remote` against `system.knowledge_items` / `system.audit_log` which are admin-only views, not BQ rows. No change.
+
+**Verification before merge:** `grep -rn 'bq\."\|--remote\|bigquery_query' cli/skills/ docs/ config/` and visually inspect each match still describes a working flow.
+
+### 4.6 Insertion point in `/api/query` handler
+
+Pin the exact placement of new logic in `app/api/query.py:execute_query` (lines 30-130 today):
+
+```
+Line 39  : sql_lower = request.sql.strip().lower()
+Line 64  : blocklist check  ← ADD "bigquery_query" entry here
+Line 70  : SELECT/WITH validator (rejects empty/whitespace SQL)
+Line 74  : get_accessible_tables(user, conn) → allowed
+Line 76  : open analytics
+Line 80-89: master-view enumeration + forbidden-table re.search
+            ← WEAVE: when a matched name is query_mode='remote' AND
+              source_type='bigquery', also append (bucket, source_table)
+              to dry_run_set
+Line 90  : ↓ NEW BLOCK INSERTED HERE ↓
+
+            # 4.3.4 — RBAC patch: BQ_PATH regex on raw SQL, registry-gated
+            for m in BQ_PATH.finditer(request.sql): ...
+
+            # 4.3.3 — cost guardrail + quota
+            if dry_run_set:
+                quota.check_daily_budget(user_id)
+                with quota.acquire(user_id):
+                    total_bytes = sum(_bq_dry_run_bytes(...) for ...)
+                    if total_bytes > cap: raise 400
+                    result = analytics.execute(request.sql).fetchmany(...)
+                    quota.record_bytes(user_id, total_bytes)
+            else:
+                result = analytics.execute(request.sql).fetchmany(...)
+
+Line 92  : (existing) result fetching → REPLACED by the conditional above
+Line 109+: (existing) materialized-hint exception path → unchanged
+```
+
+**Empty/whitespace SQL** is rejected by line 70 BEFORE any new code runs (`^(select|with)\s` regex requires content). The new pre-flight only fires after that gate. Verified: empty input passes blocklist (no keywords), fails SELECT/WITH check at line 70, returns 400.
+
+### 4.7 CLI: structured BQ error rendering (covers reporter's secondary nit)
+
+**The reporter's `USER_PROJECT_DENIED` complaint is a CLI render bug, not a config bug.** The server side already maps BQ Forbidden into a typed `BqAccessError(kind='cross_project_forbidden')` with a `hint` field (`connectors/bigquery/access.py:88-107`). The hint reaches the FastAPI response as `detail.hint`. The CLI side has **multiple non-shared rendering paths**, all of which truncate or hide the structured shape.
+
+#### 4.7.1 Inventory of CLI error-rendering paths
+
+**Scope:** only commands that surface BigQuery typed errors today or after this PR. Other CLI commands (`auth`, `metrics`, `tokens`, `setup`) have their own error-formatting logic that doesn't touch BQ paths and is out of scope.
+
+| Path | File | Current rendering | Fix |
+|------|------|-------------------|-----|
+| `da query --remote` | `cli/commands/query.py:90-92` (`_query_remote`) | `resp.json().get('detail', resp.text)` — flattens dict → `str(dict)` | Replace with shared renderer |
+| `da query --register-bq` | `cli/commands/query.py:139-145` (`_query_hybrid`) | `RemoteQueryError` with own `__str__` | Extract structured detail before raising |
+| `da fetch`, `da schema`, `da explore` (v2 endpoints) | `cli/v2_client.py:21` (`V2ClientError`) | `f"HTTP {status}: {message[:200]}"` | Replace with shared renderer |
+
+**Sync drift caveat (renderer in two languages):** Python `cli/error_render.py` renders for CLI; JS `renderBqError(detail)` in `admin_server_config.html` renders for the Test Connection result inline. They format the SAME structured shape (`{kind, hint, billing_project, data_project, ...}`). Keeping them in sync is a manual responsibility — flag this in the PR description so future maintainers know to update both. Tests assert each formatter independently against fixture inputs.
+
+#### 4.7.2 Shared renderer
+
+**New file:** `cli/error_render.py` — single source of truth for "given a parsed JSON response body, format it for the user".
+
+```python
+def render_error(status_code: int, body: dict | str) -> str:
+    """Format an HTTP error body for stderr.
+
+    Recognized shapes (pretty-printed when matched):
+    - {'detail': {'kind': str, 'hint': str, ...}}                  — typed BqAccessError
+    - {'detail': {'reason': str, 'suggestion': str, ...}}          — guardrail rejections
+    - {'detail': {'reason': str, 'kind': str, ...}}                — RBAC denies
+    Anything else: fallback to truncated str(body)[:500].
+    """
+```
+
+Format:
+```
+Error: <kind-or-reason> (HTTP <code>)
+  <key1>: <value1>
+  <key2>: <value2>
+  ...
+  <hint-or-suggestion-key>: <wrapped to 80 cols, indented under the key>
+```
+
+#### 4.7.3 Wiring all three paths
+
+**`cli/v2_client.py`:**
+- Stop pre-truncating in `V2ClientError.__init__`: store `body` as-is (dict or string). Drop `message` field (or keep for back-compat, populate from renderer at access).
+- `__str__` calls `render_error(self.status_code, self.body)`.
+- Wrappers `api_post_json`/`api_post_arrow` populate `body` from `resp.json()` when content-type is JSON, fall back to `resp.text`.
+
+**`cli/commands/query.py:_query_remote`:**
+- Before: `typer.echo(f"Query failed: {resp.json().get('detail', resp.text)}", err=True)`.
+- After: parse JSON if possible, call `render_error(resp.status_code, parsed)`, echo to stderr, exit 1.
+
+**`cli/commands/query.py:_query_hybrid`:**
+- `RemoteQueryError` at `src/remote_query.py:99-116` already carries `details: Optional[Dict[str, Any]]` — rev3 review verified, my earlier claim "add this field" was wrong. The BqAccessError-wrapping path at lines 425/435 already populates it.
+- **Real gap:** 13 raise sites total in `src/remote_query.py`. Lines 422 and 432 already populate `details` (the BqAccessError-wrap path — done). The remaining **11 sites** at lines 134, 142, 167, 173, 259, 264, 282, 289, 313, 322, 375 raise without `details`. Audit each:
+  - For sites that wrap an external error (BadRequest from BQ etc.): pass through that error's relevant fields as `details={"upstream": str(e), ...}`.
+  - For sites that raise on local validation (e.g. "alias already registered"): `details=None` is correct; the `error_type` + message suffice.
+  - Output of audit: a 11-row table in the PR description listing each raise site and the disposition.
+- `_query_hybrid` catches `RemoteQueryError`, calls `render_error(status_code=400, body={'detail': {'kind': e.error_type, 'message': str(e), **(e.details or {})}})`. Status code 400 is a client-error placeholder for local engine errors; the renderer's signature already accepts arbitrary status codes for label-only display.
+
+#### 4.7.4 Server-side: ensure all BQ paths surface typed `detail`
+
+Audit (verify before merge):
+- `/api/query/hybrid:36, 40` raises `HTTPException(400, detail=f"BQ '{alias}': {e.error_type}: {e}")` — **flattens to string**, loses structured fields. Change to `detail={'kind': e.error_type, 'message': str(e), **(e.details or {})}`.
+- `/api/v2/scan`, `/scan/estimate`, `/sample`, `/schema` already raise typed `BqAccessError` → translated to FastAPI HTTPException with dict detail by their existing handlers (verify via `grep -n translate_bq_error app/api/v2_*.py`).
+- `/api/query` raw DuckDB exceptions go through `_materialized_hint_for_query_error` (existing materialized hint) and the new remote-mode hint (4.3); both must use dict `detail`, not string. Ensure consistency.
+
+#### 4.7.5 Server-config placeholder for `billing_project`
+
+**Two-part change.** `placeholder_from` is a NEW key — the template doesn't understand it today. Both halves required:
+
+**Part 1 — server side, `app/api/admin.py`.** In `_OPTIONAL_FIELDS["data_source"]["bigquery"]["fields"]["billing_project"]` add `"placeholder_from": ["data_source", "bigquery", "project"]`.
+
+**Part 2 — client side, `app/web/templates/admin_server_config.html`.** The renderer at `renderLeafInput` (lines 281-320) returns HTML strings, NOT DOM elements — so the placeholder must be injected into the HTML at construction time, before the string is set as innerHTML. The module-level `original` variable (declared line 246, populated line 1071 from the GET payload) is the loaded config dict — it's in closure scope from `renderLeafInput`.
+
+**Diff inside the default text branch at line 315-319 of `admin_server_config.html`:**
+
+```javascript
+  // Default: text. Use the registry's default when unset, else the value.
+  const v = isUnset
+    ? (opts && opts.spec && opts.spec.default != null ? String(opts.spec.default) : "")
+    : (value == null ? "" : value);
++ // placeholder_from: walk the loaded config dict and show the resolved
++ // fallback as placeholder text when the field has no value of its own.
++ // Used by data_source.bigquery.billing_project to surface its fallback
++ // to data_source.bigquery.project per access.py:339-340.
++ let placeholderAttr = "";
++ if (isUnset && opts && opts.spec && Array.isArray(opts.spec.placeholder_from)) {
++   const resolved = opts.spec.placeholder_from.reduce(
++     (cur, k) => (cur && typeof cur === "object" ? cur[k] : undefined),
++     original,
++   );
++   if (resolved !== undefined && resolved !== null && resolved !== "") {
++     placeholderAttr = ` placeholder="(defaults to ${escHtml(String(resolved))})"`;
++   }
++ }
+- return `<input id="${fieldId}" type="text" data-section="${section}" data-key="${escHtml(dottedKey)}" data-path="${dataPath}" value="${escHtml(v)}">`;
++ return `<input id="${fieldId}" type="text" data-section="${section}" data-key="${escHtml(dottedKey)}" data-path="${dataPath}" value="${escHtml(v)}"${placeholderAttr}>`;
+```
+
+`opts.spec` is the field-spec dict from `_OPTIONAL_FIELDS` (the renderer already passes `spec` through `opts`, see how `opts.spec.options` and `opts.spec.default` are read). Adding `opts.spec.placeholder_from` reuses the same plumbing.
+
+If `placeholder_from` walks to a missing key (operator hasn't set `data_source.bigquery.project` either), `resolved` is `undefined` — `placeholderAttr` stays empty, no `placeholder=` rendered. Correct fallback: nothing to suggest.
+
+`isUnset` already gates the branch — once user types something, the field becomes "set" and the placeholder doesn't render.
+
+**Test:** §5.1 `tests/test_admin_server_config_placeholder.py` covers the server-side payload (asserts `placeholder_from` lands in the GET response). Manual scenario §5.3 item 6 covers the visual rendering — admin opens server-config with `data_source.bigquery.project` set but `billing_project` empty, sees `(defaults to <project>)` in the input.
+
+### 4.8 Coverage check: every BQ error path returns the typed shape
+
+Audit point so the §4.7 renderer never silently falls through:
+
+- `/api/v2/scan`, `/scan/estimate`, `/sample`, `/schema` already use `translate_bq_error` (PR #138). Verify with `grep -n translate_bq_error app/api/v2_*.py`.
+- `/api/query/hybrid` uses `RemoteQueryEngine`, which lazily resolves `BqAccess` and re-raises `BqAccessError` (`src/remote_query.py:418-432`). Already typed.
+- The new `/api/query` cost-guardrail dry-run (4.3.2) calls `_bq_dry_run_bytes` from `v2_scan.py`, which already wraps with `translate_bq_error`. Already typed.
+- The new wrap-view path at query time (4.1) — when DuckDB BQ extension hits a BQ error during `SELECT * FROM bq.…`, the error surfaces as a DuckDB exception, NOT a Google API exception. `translate_bq_error` has a string-match fallback for HTTP 403/400 patterns (`access.py:117-148`). Verify by integration test: revoke SA grant → expect `cross_project_forbidden` (typed), not raw 500.
+
+If a path leaks raw 500, fix it at the source (wrap in `translate_bq_error`) — don't paper over in CLI render.
+
+### 4.9 BQ connection test button on `/admin/server-config`
+
+Closes the loop on Pavel's `USER_PROJECT_DENIED` symptom: admin saves `data_source.bigquery` config, immediately verifies it works, no analyst ever needs to discover the misconfig via a failed query.
+
+**Decision: explicit "Test connection" button, not a probe-on-save.** Probe-on-save adds 1–3s to every save and blocks legitimate saves on transient BQ hiccups. A button is admin-controlled, fast to implement, and matches the pattern used by other config UIs (Slack/Stripe webhooks, etc.).
+
+**New endpoint:** `POST /api/admin/bigquery/test-connection`
+
+- Auth: `Depends(require_admin)`.
+- Body: empty (uses currently-saved config from instance.yaml + overlay; no body needed since admin would have just clicked Save).
+- Behavior:
+  1. Resolve `BqAccess` via existing `get_bq_access()`. If config is incomplete (e.g. `data_source.bigquery.project` empty), return 400 with the existing `not_configured` typed error.
+  2. Run a minimal BQ query: `SELECT 1 AS ok` via `bq.client().query("SELECT 1 AS ok")`, then `.result(timeout=10)`. 10s polling timeout.
+  3. On success: 200 with `{ok: true, billing_project: "<resolved>", data_project: "<resolved>", elapsed_ms: <n>}`.
+  4. On `BqAccessError`: translate via existing path, return 502 with the typed `detail` shape (renderer in §4.7 picks it up).
+  5. On `concurrent.futures.TimeoutError` (10s elapsed): best-effort `client.cancel_job(query_job.job_id, location=query_job.location)` (swallow exceptions from cancel — the test endpoint has already failed, surfacing the cancel failure on top would just confuse). Return 504 with `{kind: "timeout", elapsed_ms: 10000, hint: "BigQuery did not respond in 10s. Check network and SA permissions. The job was best-effort cancelled."}`.
+
+**Caveat:** `result(timeout=...)` is a polling-loop timeout client-side; the BQ job continues running until cancelled or completed. For `SELECT 1` the cost is negligible. Documented in CHANGELOG.
+
+**File:** new `app/api/admin_bigquery_test.py` (~50 LOC), registered in `app/main.py`.
+
+**UI side:** `app/web/templates/admin_server_config.html` — add a button next to the `data_source.bigquery` section's Save button:
+
+```html
+<button class="btn-secondary" data-action="test-bigquery">Test connection</button>
+<span class="bq-test-result" hidden></span>
+```
+
+JS handler: POST to `/api/admin/bigquery/test-connection`, populate `.bq-test-result` with green check + elapsed_ms on success, red X + the typed detail on failure (reuse the renderer logic from §4.7 in JS — extract a small `renderBqError(detail)` helper that handles `error_kind`, `hint`, `billing_project`, `data_project`).
+
+The button is only enabled when at least `data_source.bigquery.project` is saved (otherwise the test would just return `not_configured`).
+
+**Why no dashboard-level health badge:** the button gives admins explicit verification on demand. Continuous health-check would mean a periodic background BQ call (cost, complexity, alerts that page someone). Out of scope.
+
+### 4.10 CHANGELOG
+
+Under `## [Unreleased]`:
+
+```markdown
+### Added
+- `data_source.bigquery.max_bytes_per_remote_query` server-config knob
+  (default 5 GiB). Caps the BigQuery scan that `da query --remote` will
+  issue against `query_mode='remote'` BQ rows. Exceeds → 400 with a
+  `da fetch` suggestion. Configurable via /admin/server-config.
+
+### Fixed
+- `da query --remote` now resolves `query_mode='remote'` BigQuery rows
+  whose underlying entity is a `VIEW` or `MATERIALIZED_VIEW` (issue #160).
+  The BQ extractor creates a master view via Storage Read API path
+  (`bq."<dataset>"."<source_table>"`) for `BASE TABLE`, and via jobs API
+  (`bigquery_query()`) for `VIEW` / `MATERIALIZED_VIEW`. Other BQ entity
+  types (`EXTERNAL`, `SNAPSHOT`, `CLONE`) are not (yet) supported — the
+  extractor logs a warning and skips master-view creation; analysts use
+  `da fetch` for those. Cost is bounded by the new server-side guardrail
+  (see Added).
+- **BREAKING (config-only): `data_source.bigquery.legacy_wrap_views`
+  removed.** Keys in operator overlays are silently ignored — no action
+  required. Replaces the prior CHANGELOG entry that introduced the flag
+  (kept in history for context).
+- `/api/query` now blocks direct `bq."<dataset>"."<table>"` references
+  for callers without a registry grant on the corresponding row (closes
+  RBAC hole that pre-dates this issue).
+- CLI commands (`da query --remote`, `da fetch`, `da query --register-bq`,
+  schema/sample/estimate) now pretty-print structured BigQuery errors —
+  `cross_project_forbidden`, `bq_forbidden`, `auth_failed`, etc. — instead
+  of dumping the truncated JSON body. The hint that explains how to fix
+  `USER_PROJECT_DENIED` (set `data_source.bigquery.billing_project` in
+  `/admin/server-config`) is now actually visible to the operator.
+
+### Changed
+- `/admin/server-config` shows the resolved fallback for empty
+  `data_source.bigquery.billing_project` as placeholder text (e.g.
+  `(defaults to <data_project_value>)`), making the fallback chain
+  visible in the UI.
+- `/admin/server-config` adds a **Test connection** button next to the
+  `data_source.bigquery` section. Hits `POST /api/admin/bigquery/test-connection`
+  (admin-only), runs a 10s-timeout `SELECT 1` against BQ, renders typed
+  success/failure inline using the same renderer that the CLI uses (§4.7).
+  Closes the loop on `USER_PROJECT_DENIED` and `auth_failed` — admin
+  verifies BQ reachability before any analyst hits a query failure.
+```
+
+## 5. Tests
+
+### 5.0 JS-side placeholder rendering (§4.7.5)
+
+The placeholder rendering is JS that lives in `admin_server_config.html` — the project today has **no JS test infrastructure** (no Playwright, no jsdom, no Selenium). Adding either to the dep graph for one ~15-line diff is disproportionate. The JS change is verified by:
+
+- **Server-side test** (§5.1 `tests/test_admin_server_config_placeholder.py`): asserts `placeholder_from: ["data_source", "bigquery", "project"]` lands in the GET `/api/admin/server-config` response payload. This is the contract the JS reads — if the contract holds, the JS has the data it needs.
+- **Manual scenario** §5.3 item 6: admin opens server-config with `data_source.bigquery.project` set but `billing_project` empty, sees `(defaults to <project>)` greyed in the input. One-time visual check pre-deploy.
+
+If the JS sketch in §4.7.5 doesn't render correctly, manual scenario catches it before merge. Documented limitation: future PR could add Playwright if the admin UI grows enough to justify it.
+
+### 5.1 Unit
+
+- `tests/test_bigquery_extractor.py` — **rewrite** the existing `legacy_wrap_views=True/False` tests at lines 319/343/590/612-641. New assertions:
+  - `entity_type='BASE TABLE'` → master view uses `bq."<ds>"."<tbl>"` (Storage Read API path).
+  - `entity_type='VIEW'` → master view uses `bigquery_query('<project>', '<sql>')` (jobs API).
+  - `entity_type='MATERIALIZED_VIEW'` → same as VIEW.
+  - `entity_type='EXTERNAL'` → Storage Read API path (NEW — was previously skipped under default flag).
+  - `entity_type='SNAPSHOT'` / `'CLONE'` → Storage Read API path (NEW).
+  - Unknown `entity_type` → `_meta` row NOT inserted, `logger.warning` emitted, no exception.
+  - `legacy_wrap_views: true` in instance overlay is silently ignored — extractor produces same SQL as without the key.
+  - `legacy_wrap_views: false` in instance overlay is silently ignored — extractor produces same SQL as without the key.
+- `tests/test_admin_server_config.py` — **rewrite** existing assertions at lines 810-944 that expected `legacy_wrap_views` to be in `_OPTIONAL_FIELDS`. New assertions:
+  - GET `/server-config` returns `max_bytes_per_remote_query` with default `5368709120` and `kind='int'`.
+  - GET `/server-config` does NOT return `legacy_wrap_views` under any section.
+  - GET `/server-config`'s `data_source.bigquery.billing_project` carries `placeholder_from: ["data_source", "bigquery", "project"]`.
+- `tests/test_admin_server_config_known_fields.py:179-181` — **delete** the `legacy_wrap_views` known-field assertion.
+- `tests/test_api_query_guardrail.py` (new): SQL referencing a `query_mode='remote'` BQ row with mocked dry-run returning `<cap` bytes → executes; with `>cap` bytes → 400 with structured detail.
+- `tests/test_api_query_guardrail.py`: CTE shadow — `WITH unit_economics AS (SELECT 1) SELECT * FROM unit_economics` does NOT trigger dry-run.
+- `tests/test_api_query_guardrail.py`: query references registered name in string literal → dry-run fires (acceptable false-positive), executes with no BQ touch.
+- `tests/test_api_query_rbac.py` (new or extend): caller without grant on `unit_economics` issuing `SELECT * FROM bq."finance_unit_economics"."unit_economics"` → 403.
+- `tests/test_api_query_quota.py` (new): successful `--remote` BQ query records bytes against the same daily cap as `/api/v2/scan`. Pre-flight check fires too: user already over daily cap → 429 BEFORE dry-run, BEFORE execute. Concurrent slot acquired and released around execute.
+- `tests/test_query_bq_regex.py` (new): tests the §4.3.1 `BQ_PATH` regex against the full 16-case matrix verified empirically (`bq."ds"."tbl"`, `bq.ds.tbl`, mixed quoting, case-insensitive, with WHERE / trailing semicolon / inside CTE body / two paths in one statement; rejection: bare registered name, quoted bare name, 2-part `bq.col`, prefix `other_bq.x.y`, middle `x.bq.y.z`, aggregate on bare; accepted false-positive: string literal containing `bq.foo.bar`).
+- `tests/test_query_bigquery_query_blocked.py` (new): `POST /api/query` with `SELECT * FROM bigquery_query('proj', 'SELECT * FROM ds.tbl')` returns 400. Mixed case `BigQuery_Query` also blocked (existing blocklist lowercases `sql.strip().lower()` at app/api/query.py:39 before matching — verified).
+- `tests/test_v2_client_render.py` (new): `V2ClientError.__str__` for body=`{detail: {error_kind: 'cross_project_forbidden', hint: '…', billing_project: '', data_project: 'foo'}}` produces a multi-line block with `Error:`, key/value pairs, wrapped `hint:`. Body without recognizable shape → falls back to truncated form.
+- `tests/test_v2_client_render.py`: same renderer pretty-prints the new `/api/query` cost-guardrail rejection (`{reason: 'remote_scan_too_large', scan_bytes, limit_bytes, tables, suggestion}`).
+- `tests/test_cli_query_render.py` (new): `da query --remote` against a server returning typed `cross_project_forbidden` produces the structured stderr output (kind line + key/value lines + wrapped hint), exit code 1. `da query --register-bq` (hybrid) same end-to-end via `RemoteQueryError.details`. `da fetch` same.
+- `tests/test_remote_query_error_details.py` (new): `src/remote_query.py:RemoteQueryError` carries `details: dict | None` populated from wrapped `BqAccessError.details`. `_query_hybrid` builds the synthetic `{'detail': {'kind': ..., **details}}` and calls renderer.
+- `tests/test_admin_bigquery_test_connection.py` (new): `POST /api/admin/bigquery/test-connection`. Cases: (a) admin + reachable BQ (mocked client) → 200 with `ok=true` and resolved projects; (b) admin + `BqAccessError(not_configured)` → 400; (c) admin + simulated `cross_project_forbidden` → 502 with typed detail; (d) admin + 10s timeout → 504 with `kind=timeout`; (e) non-admin → 403; (f) unauthenticated → 401.
+- `tests/test_admin_server_config_placeholder.py` (new): GET `/server-config` payload for `data_source.bigquery.billing_project` includes `placeholder_from: ["data_source", "bigquery", "project"]` so the template renderer can resolve the fallback display.
+
+### 5.2 Integration
+
+- `tests/integration/test_query_remote_e2e.py` (new, gated on `BIGQUERY_INTEGRATION_TEST=1`): with a real BQ project + a registered VIEW row, `POST /api/query` with `SELECT COUNT(*) FROM <id>` returns the count, hits jobs API via `bigquery_query()`. Cost guardrail at high cap (TB) does not trigger.
+- Same with cap set to 1 byte → 400.
+- **Wrap-view runtime correctness for VIEW** (rev4 review test plan #1): the registry expects a 3-part `(project, dataset=bucket, source_table)` shape. INFORMATION_SCHEMA is NOT a regular dataset and the `_detect_table_type` query reads `<dataset>.INFORMATION_SCHEMA.TABLES` — meta-views don't appear there, so an INFORMATION_SCHEMA target would fail the entity-detect step. Use a real public-BQ VIEW instead. Implementer should run `bq ls --max_results=1000 bigquery-public-data:utility_us` (or similar dataset) and pick a confirmed VIEW entity; `bigquery-public-data.utility_us.us_states_area` is a known candidate. The test then: register that VIEW row; run extractor; ATTACH the resulting `extract.duckdb`; execute `SELECT COUNT(*) FROM <table_name>` against the master view. Assert: returns a non-negative integer without raising. Cleanup: deregister the test row. Closes the runtime-evidence gap for the `bigquery_query()` path on VIEW entities.
+- **`find_by_bq_path` ambiguity** (rev4 review test plan #2): `tests/test_table_registry_find_by_bq_path.py` (new). Insert two rows with `source_type='bigquery'` and identical `(bucket, source_table)`, different `id`/`name`/`registered_at`. Assert `find_by_bq_path(...)` returns the OLDEST row by `registered_at`. Edge: zero rows → returns `None`.
+
+### 5.3 Manual on dev VM (post-deploy)
+
+**Precondition:** before running these scenarios, regenerate the BQ extract so the new wrap-view code path produces master views for VIEW/MATERIALIZED_VIEW entities. Either wait for the next scheduler tick (~5 min) or trigger explicitly: `curl -X POST -H "Authorization: Bearer $AGNES_PAT" https://<dev-host>/api/sync/trigger?source=bigquery`. Without this step, scenario 1 still returns the OLD catalog error and looks like the fix didn't ship.
+
+1. `da query --remote "SELECT COUNT(*) FROM unit_economics"` → returns count, no error. (BQ optimizes COUNT on VIEW via metadata; dry-run reports near-zero bytes; well under 5 GiB cap.)
+2. `da query --remote "SELECT * FROM unit_economics LIMIT 100"` → 400 (full SELECT * exceeds 5 GiB on a multi-GB view) with `tables: ["unit_economics"]` + `suggestion: "Use 'da fetch ..."`. CLI renders multi-line block, not raw JSON.
+3. `da fetch unit_economics --select cnt --where "date = CURRENT_DATE()"` → unaffected (separate path).
+4. `/admin/server-config` UI shows `max_bytes_per_remote_query` field, can be edited and persists.
+5. `/admin/server-config` UI does NOT show `legacy_wrap_views` field anywhere.
+6. `/admin/server-config` UI shows `(defaults to <project>)` placeholder under empty `billing_project` field.
+7. Caller without grant on `unit_economics` issuing direct `bq."finance_unit_economics"."unit_economics"` → 403.
+8. `/admin/server-config` → click "Test connection" with valid config → green status, elapsed_ms shown.
+9. `/admin/server-config` → unset `billing_project`, click "Test connection" — if SA can't bill on data project, red status with the structured `cross_project_forbidden` rendering (same shape as CLI).
+10. Configure invalid `billing_project` → click "Test connection" → 504 timeout or 502 typed forbidden, depending on which BQ side responds.
+
+## 6. Implementation plan — Test-Driven (RED → GREEN → REFACTOR)
+
+**Iron rule: no production code without a failing test first.** All §5 tests are ENTRY criteria for the corresponding §4 implementation, not a finishing touch. Each unit must be witnessed RED before any implementation lands.
+
+Branch: `zs/fix-160-remote-query-view-entities` in a worktree (per repo convention — `feedback_always_work_in_worktree.md`).
+
+Six phases, each a self-contained RED→GREEN→REFACTOR cycle. PR can be opened in draft after Phase 1 lands; reviewers see incremental commits.
+
+### Phase 1 — Extractor wrap views (§4.1)
+
+**RED tests (4 — must fail before §4.1 implementation):**
+- `entity_type='BASE TABLE'` (no flag set) → asserts SQL is `CREATE OR REPLACE VIEW ... SELECT * FROM bq."<ds>"."<tbl>"`. Today fails: existing default branch creates the same SQL but only for BASE TABLE — actually this WOULD pass today. **Re-check during implementation:** if today's BASE TABLE branch already produces this exact SQL, this test is regression-green and should move to REFACTOR. Implementer verifies during Phase 1.
+- `entity_type='VIEW'` (no flag set) → asserts SQL uses `bigquery_query('<project>', 'SELECT * FROM ...')`. Today fails: default branch logs "Skipping wrap view" and creates no view. ✅ truly RED.
+- `entity_type='MATERIALIZED_VIEW'` (no flag set) → same as VIEW. ✅ truly RED.
+- `entity_type='EXTERNAL'` → log warning, NO `_meta` insert, NO view creation. Today fails: existing default branch silently skips with no log AND DOES insert `_meta` row (current behavior — `_meta` insert at extractor.py:260-263 runs after the entity_type branch unconditionally). ✅ truly RED.
+
+**Regression-green tests (2 — must STAY green through implementation, do NOT count as RED):**
+- `entity_type=None` → existing "BQ entity not found" RuntimeError. Already passes today; assert behavior unchanged. Belongs in REFACTOR phase as a regression guard.
+- overlay sets `legacy_wrap_views: true` → ignored, produces same SQL as without the key. Already passes today (existing flag-on path produces `bigquery_query()` SQL; new code produces same SQL ignoring flag). Forward-compat regression guard for stale operator yamls. Belongs in REFACTOR phase.
+
+Run: `pytest tests/test_bigquery_extractor.py -k wrap_view -v`. Expected RED: 3 of the 4 RED tests fail (VIEW, MATERIALIZED_VIEW, EXTERNAL); BASE TABLE may already pass — confirm by running. Existing `legacy_wrap_views=True/False` toggle-tests still pass.
+
+**GREEN:** rewrite `connectors/bigquery/extractor.py:225-258` per §4.1. Drop `legacy_wrap_views` config read.
+
+Re-run: all 5 NEW tests pass; existing toggle-tests now FAIL (expected — they tested the removed flag).
+
+**REFACTOR:** delete the now-failing existing toggle-tests (legacy_wrap_views=True/False fixtures). Update `app/api/admin.py:229-240, 798-805` per §4.2 (delete `_OPTIONAL_FIELDS` entry + `_BQ_OPTIONAL_FIELD_DEFAULTS` entry + comment block). Re-run full `tests/test_bigquery_extractor.py` and `tests/test_admin_server_config*.py`.
+
+Phase 1 exit: `grep -rn 'legacy_wrap_views' connectors app src tests config cli` returns 0.
+
+### Phase 2 — `find_by_bq_path` repo method (§4.3.4 dependency)
+
+**RED:** `tests/test_table_registry_find_by_bq_path.py` (new):
+- 0 rows matching → returns `None`
+- 1 row matching → returns it
+- 2+ rows matching → returns oldest by `registered_at`
+- bucket=NULL excluded by guard
+- case-insensitive bucket+source_table match
+
+Run: `pytest tests/test_table_registry_find_by_bq_path.py -v`. RED: AttributeError, method doesn't exist.
+
+**GREEN:** add ~15 LOC `find_by_bq_path` to `src/repositories/table_registry.py` per §4.3.4 SQL.
+
+Phase 2 exit: 5/5 new tests green.
+
+### Phase 3 — `/api/query` cost guardrail + RBAC patch + blocklist (§4.3, §4.6)
+
+**Conventions for Phase 3 tests:**
+- Quota helpers imported from `app.api.v2_quota` (NOT `v2_scan`). After GREEN step 1 below, `v2_quota` is the canonical source; `v2_scan` re-export is for backward compat of existing test files only.
+- Shared fixtures live in `tests/conftest.py`: `mocked_bq_access` (provides a `BqAccess` stub with controllable `_bq_dry_run_bytes` returns), `registry_with_remote_bq_row` (inserts a `query_mode='remote'`, `source_type='bigquery'` row with known bucket+source_table). Add these to existing conftest before writing test files.
+- Mocking: prefer real DuckDB analytics + real registry repo + mocked `_bq_dry_run_bytes` only. Don't mock the SQL parser or the regex.
+
+**RED:** add tests:
+- `tests/test_query_bq_regex.py` (new) — 16 case BQ_PATH regex matrix per §4.3.1.
+- `tests/test_query_bigquery_query_blocked.py` (new) — `SELECT * FROM bigquery_query(...)` returns 400.
+- `tests/test_api_query_guardrail.py` (new) — small-cap dry-run rejects 400; large-cap accepts; CTE shadow runs wasted dry-run; string-literal false-positive accepted.
+- `tests/test_api_query_quota.py` (new) — daily-budget pre-flight 429; concurrent slot acquire/release; record_bytes post-flight; quota shared across `/api/query` and `/api/v2/scan`.
+- `tests/test_api_query_rbac_bq_path.py` (new) — direct `SELECT FROM bq."ds"."tbl"` for unregistered → 403 `bq_path_not_registered`; for registered + caller without grant → 403 `bq_path_access_denied`; for admin → bypass per-name check but still requires registration.
+
+Run: `pytest tests/test_query_*.py tests/test_api_query_*.py -v`. RED: all fail (regex unimported, blocklist passes the function, no guardrail/RBAC code exists yet).
+
+**GREEN:** in this order to keep dependency chain clean:
+1. Move `_build_quota_tracker` from `v2_scan.py:254-268` to `app/api/v2_quota.py` + function-only re-export per §4.3.3 option (a). Run `pytest tests/test_v2_scan.py` — must stay green.
+2. Add `bigquery_query` to blocklist at `app/api/query.py:42-65`.
+3. Implement BQ_PATH regex constant + the new pre-flight block at the §4.6 insertion point (after line 89, before line 92).
+4. Wire in `find_by_bq_path` (Phase 2 dep), `is_user_admin`, `_bq_dry_run_bytes` (reuse from v2_scan).
+
+Phase 3 exit: all Phase 3 RED tests now GREEN; existing `tests/test_v2_scan.py` + `tests/test_api_query.py` still GREEN.
+
+### Phase 4 — CLI render shared module (§4.7)
+
+**RED:** add tests:
+- `tests/test_cli_error_render.py` (new) — typed BqAccessError dict → multi-line output; `remote_scan_too_large` dict → multi-line output; unrecognized shape → falls through to truncated form.
+- `tests/test_cli_query_render.py` (new) — `da query --remote` against mocked 502 with typed body produces structured stderr; `da query --register-bq` (hybrid) same end-to-end via `RemoteQueryError.details`; `da fetch` same.
+- `tests/test_remote_query_error_details.py` (new) — `RemoteQueryError.details` populated for the 11 raise sites that wrap external errors.
+
+Run: RED — `cli/error_render.py` doesn't exist.
+
+**GREEN:** create `cli/error_render.py`. Refactor `cli/v2_client.py:V2ClientError` (drop pre-truncate). Update `cli/commands/query.py:_query_remote` and `_query_hybrid` to call shared renderer. Audit 11 `RemoteQueryError` raise sites in `src/remote_query.py` per §4.7.3 (populate `details` where wrapping external errors).
+
+Server side: §4.7.4 audit — fix `/api/query/hybrid:36, 40` flatten-to-string bug to use dict `detail`.
+
+Phase 4 exit: all Phase 4 RED tests GREEN.
+
+### Phase 5 — Admin Test Connection + placeholder UI (§4.7.5, §4.9)
+
+**Depends on Phase 1 having merged.** Phase 5 adds `placeholder_from` to `_OPTIONAL_FIELDS["data_source"]["bigquery"]["fields"]["billing_project"]`. Phase 1 REFACTOR modifies the same `_OPTIONAL_FIELDS` block (deleting `legacy_wrap_views` entry, adding `max_bytes_per_remote_query` per §4.4). Land Phase 1's changes first to avoid merge conflicts on the same dict literal.
+
+**RED:** add tests:
+- `tests/test_admin_bigquery_test_connection.py` (new) — 6 cases per §5.1 (admin success / not_configured / cross_project_forbidden / timeout / non-admin 403 / unauth 401).
+- `tests/test_admin_server_config_placeholder.py` (new) — GET payload includes `placeholder_from`.
+
+Run: RED — endpoint doesn't exist; `placeholder_from` not in payload.
+
+**GREEN:** create `app/api/admin_bigquery_test.py` per §4.9. Add `placeholder_from` to `_OPTIONAL_FIELDS["data_source"]["bigquery"]["fields"]["billing_project"]`. Apply the JS diff to `admin_server_config.html:315-319` per §4.7.5.
+
+Phase 5 exit: server tests GREEN. JS placeholder rendering verified by **manual** §5.3 item 6 (no JS test infra — see §5.0).
+
+### Phase 6 — Documentation + manual verification
+
+No new code. Apply `config/claude_md_template.txt`, `cli/skills/agnes-data-querying.md`, `cli/skills/agnes-table-registration.md:121`, root `CLAUDE.md` edits per §4.5. Update CHANGELOG.md per §4.10.
+
+Run full test suite: `pytest tests/ -v`. All green.
+
+Deploy to dev VM. Run §5.3 manual scenarios 1-10 in order. **Each scenario records the expected output** in the PR description as the closure evidence.
+
+Integration test (gated on `BIGQUERY_INTEGRATION_TEST=1`): use `bigquery-public-data.utility_us.us_states_area` (must be confirmed VIEW via `bq ls` first) per §5.2.
+
+PR opens for review after Phase 6 with all phase checkpoints visible in the commit graph.
+
+### Commit granularity
+
+Each phase splits into multiple commits for reviewability. PR shows the TDD cycle in the commit graph.
+
+**Phase 1** — 2 commits:
+- `1a` GREEN: add new entity-type branches in `extractor.py` (flag still readable but ignored). New tests pass.
+- `1b` REFACTOR: delete `legacy_wrap_views` config knob across 9 files (33 references per §4.2 grep table). Update existing toggle-tests. Forward-compat regression test added.
+
+**Phase 2** — 1 commit. RED + GREEN together (small footprint, ~15 LOC + 5 tests).
+
+**Phase 3** — 3 commits:
+- `3a` Quota relocation: move `_build_quota_tracker` + `_quota_singleton` to `v2_quota.py`; function-only re-export from `v2_scan.py`. Run existing `tests/test_v2_scan.py` — must stay green. Mechanical, easy to revert.
+- `3b` RED: add 5 test files + conftest fixtures. All fail with the expected import / 404 / wrong-shape errors.
+- `3c` GREEN: implement `/api/query` pre-flight (RBAC + guardrail + quota wiring) + add `bigquery_query` to blocklist. All 5 test files green. Existing `test_api_query.py` stays green.
+
+**Phase 4** — 2 commits:
+- `4a` RED: 3 test files fail with ImportError (`cli/error_render.py` missing).
+- `4b` GREEN: create renderer + refactor `V2ClientError` + update `_query_remote`/`_query_hybrid` + audit 11 `RemoteQueryError` raise sites + fix `/api/query/hybrid` flatten-to-string bug.
+
+**Phase 5** — 2 commits:
+- `5a` RED: 2 test files fail (endpoint missing, `placeholder_from` missing from payload).
+- `5b` GREEN: create `app/api/admin_bigquery_test.py`; add `placeholder_from` to `_OPTIONAL_FIELDS`; apply JS diff to `admin_server_config.html`.
+
+**Phase 6** — 1 commit (docs only).
+
+Total: ~11 commits. PR opens for review after Phase 6. Reviewer sees clean RED→GREEN cycles in the commit graph.
+
+### Rollout (post-merge)
+
+1. Cut release 0.31.0.
+2. Existing instances pick up the new code on next deploy. Master views regenerate via the next BQ scheduler tick OR `POST /api/sync/trigger?source=bigquery`.
+3. **No `rm -rf /data/extracts/bigquery/` required.** `init_extract` writes to a tmp file and atomically `shutil.move`s over `extract.duckdb` (`extractor.py:277-285`); next sync produces fresh wrap views. Old views vanish, new views appear. Idempotent.
+4. Verify with §5.3 scenarios on production. Close #160 with the closure-comment per §8.
+
+## 7. Open questions
+
+(none — scoped to closure with reviewer feedback addressed)
+
+## 8. PR description + issue closure messaging
+
+Reporter (`pcernik-grpn`) filed #160 narrowly as a CLI bug. Spec adds collateral fixes (cost guardrail, RBAC patch, render fix). To avoid confusion when Pavel re-tests and hits expected-but-unfamiliar 400/403s, the **PR description** must call out:
+
+1. **First-run requires extract regeneration.** Before re-running the original repro command, hit `POST /api/sync/trigger?source=bigquery` (or wait for the scheduler tick). The wrap-view code only takes effect after the next BQ sync rebuilds extract.duckdb.
+
+2. **`SELECT *` against VIEWs may hit the new 5 GiB cap** — by design. `bigquery_query()` does not push DuckDB-side WHERE/LIMIT down into the BQ view body, so the dry-run estimates a full scan. Cheap aggregates (COUNT, MIN/MAX with metadata pruning) typically fit; broad SELECTs may not. The structured 400 names the bytes and suggests `da fetch` with predicates. **Not a regression** — the prior catalog error meant zero work happened; the new behavior at least runs cheap aggregates and rejects expensive ones with actionable guidance. Document this in the issue closure comment so Pavel doesn't perceive it as a side-grade.
+
+3. **`da fetch` still requires `data_source.bigquery.billing_project`** to be set if the SA can't bill on the data project — that's the operator side of Pavel's "Related" note, scoped out of #160 by Pavel's own framing. The CLI render fix and Test Connection button make discovery easier; they do not auto-fix the misconfig. Closure comment should say: "Closes #160 (the CLI bug). The `USER_PROJECT_DENIED` mentioned in 'Related' remains an operator task — set `billing_project` via /admin/server-config (use the new Test Connection button to verify); separate issue if the operator-side workflow needs more polish."
+
+4. **CHANGELOG bullets** should mention the cost cap as `### Added` with a note that prior queries that returned the catalog error may now return `remote_scan_too_large` — same set of users, different but equally-actionable error.

--- a/docs/superpowers/specs/2026-05-03-issue-160-da-query-remote-fix-spec.md
+++ b/docs/superpowers/specs/2026-05-03-issue-160-da-query-remote-fix-spec.md
@@ -120,12 +120,12 @@ The flag is the inverse of the new behavior. With "always wrap" as the only mode
 
 Total: 33 references across 9 files. Verified by per-file `grep -c` (rev3 review).
 
-After all edits: `grep -rn 'legacy_wrap_views' connectors app src tests config cli` must return zero. `docs/` is **excluded** from the gate — `docs/superpowers/plans/2026-04-27-claude-fetch-primitives.md` (8 hits) and `docs/superpowers/specs/2026-04-27-claude-fetch-primitives-design.md` (1 hit) are historical planning artifacts that document the design decision to introduce the flag; rewriting history would be revisionist. CHANGELOG history retained on the same logic.
+After all edits: `grep -rn 'legacy_wrap_views' connectors app src config cli` (production code only) must return zero. `tests/` is excluded — historical references in `assert "legacy_wrap_views" not in ...` regression guards and "removed in #160" docstring breadcrumbs have anti-regression value (they catch a future contributor who tries to re-add the flag). `docs/` is excluded for the same reason — `docs/superpowers/plans/2026-04-27-claude-fetch-primitives.md` (8 hits) and `docs/superpowers/specs/2026-04-27-claude-fetch-primitives-design.md` (1 hit) are historical planning artifacts; rewriting them would be revisionist. CHANGELOG history retained on the same logic.
 
-Verification command in CI / pre-commit: 
+Verification command in CI / pre-commit:
 
 ```
-test "$(grep -rn 'legacy_wrap_views' connectors app src tests config cli | wc -l)" -eq 0
+test "$(grep -rn 'legacy_wrap_views' connectors app src config cli | wc -l)" -eq 0
 ```
 
 No DB migration. Operators who explicitly set `legacy_wrap_views: true` in their overlay get the new (equivalent) behavior automatically; the unrecognized key is ignored by the YAML loader. Operators who explicitly set `legacy_wrap_views: false` get the new behavior as a fix, not a regression.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.31.0"
+version = "0.32.0"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -328,9 +328,12 @@ class SyncOrchestrator:
             ).fetchall()
 
             # Pre-fetch the set of names that actually exist as views/tables in
-            # the attached extract.duckdb. The BQ connector with
-            # legacy_wrap_views=False inserts _meta rows for VIEW entities
-            # without creating inner views — those need a different code path.
+            # the attached extract.duckdb. Most connectors emit a `_meta` row
+            # alongside an inner view per registered name; the keboola
+            # extractor with `use_extension=False` (and other connectors)
+            # may insert `_meta` rows whose inner view doesn't exist yet —
+            # skip those to avoid creating a master view that would resolve
+            # to nothing.
             inner_objects = {
                 row[0]
                 for row in conn.execute(

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -346,13 +346,15 @@ class SyncOrchestrator:
                 if not _validate_identifier(table_name, "table_name"):
                     continue
                 if table_name not in inner_objects:
-                    # `_meta` row without an inner object — typically a BQ
-                    # VIEW entity in the v2 fetch-primitives flow. Skip the
-                    # master-view creation (use `da fetch` to materialize),
-                    # but still process subsequent rows. No claim, no view.
+                    # `_meta` row without an inner object. Post-#160 the
+                    # BigQuery extractor no longer emits these for unsupported
+                    # entity types (it skips both the view AND the _meta row),
+                    # so this branch fires for the keboola use_extension=False
+                    # path and any future connector that splits writes across
+                    # commits. Skip master-view creation; subsequent rows
+                    # continue normally.
                     logger.info(
-                        "Skipping master view for %s.%s — no inner object "
-                        "(use `da fetch` for BQ views)",
+                        "Skipping master view for %s.%s — no inner object",
                         source_name, table_name,
                     )
                     continue

--- a/src/repositories/table_registry.py
+++ b/src/repositories/table_registry.py
@@ -141,6 +141,41 @@ class TableRegistryRepository:
         columns = [desc[0] for desc in self.conn.description]
         return [self._decode_row(dict(zip(columns, row))) for row in results]
 
+    def find_by_bq_path(
+        self, bucket: str, source_table: str,
+    ) -> Optional[Dict[str, Any]]:
+        """Look up a BigQuery row by `(bucket, source_table)`.
+
+        Used by /api/query's RBAC patch to decide whether a direct
+        `bq."<dataset>"."<source_table>"` reference in user SQL points at a
+        registered row. If no row matches, the caller has bypassed the
+        registry — the request is rejected before execute.
+
+        Match is case-insensitive on `bucket` and `source_table`. NULL values
+        in either column are excluded so a legacy NULL-bucket row never
+        masks a legitimate non-NULL lookup.
+
+        When 2+ rows match (no UNIQUE constraint on the
+        (source_type, bucket, source_table) triple — admins can register a
+        BQ table twice with different ids/names), return the oldest by
+        `registered_at` so callers see deterministic resolution.
+        """
+        result = self.conn.execute(
+            """SELECT * FROM table_registry
+            WHERE source_type = 'bigquery'
+              AND bucket IS NOT NULL
+              AND source_table IS NOT NULL
+              AND lower(bucket) = lower(?)
+              AND lower(source_table) = lower(?)
+            ORDER BY registered_at ASC
+            LIMIT 1""",
+            [bucket, source_table],
+        ).fetchone()
+        if not result:
+            return None
+        columns = [desc[0] for desc in self.conn.description]
+        return self._decode_row(dict(zip(columns, result)))
+
     def list_local(self, source_type: Optional[str] = None) -> List[Dict[str, Any]]:
         """List tables with query_mode='local' (data downloaded to parquet)."""
         if source_type:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,42 @@ def _disable_auth_rate_limit_in_tests():
     limiter.enabled = was_enabled
 
 
+@pytest.fixture(autouse=True)
+def _reset_module_caches():
+    """Reset module-level caches that survive across tests on the same
+    pytest-xdist worker process. Without this, a test that populates
+    `app.instance_config._instance_config` (e.g. via `runpy.run_module`
+    in test_bigquery_extractor's __main__ tests, or via any path that
+    calls `app.instance_config.get_value`) leaves stale config visible
+    to the next test on that worker — including config that points at
+    a different DATA_DIR than the next test's e2e_env set.
+
+    Caches reset:
+    - app.instance_config._instance_config — instance.yaml deep-merge cache
+    - get_bq_access (functools.cache) — BqAccess(BqProjects(...)) lru
+    - app.api.v2_quota._quota_singleton — per-user quota tracker
+
+    Pre-existing flakiness; surfaced by issue #160 PR #168 shifting the
+    test bucket distribution on xdist worker gw2.
+    """
+    try:
+        import app.instance_config as _ic
+        _ic._instance_config = None
+        try:
+            from connectors.bigquery.access import get_bq_access
+            get_bq_access.cache_clear()
+        except (ImportError, AttributeError):
+            pass
+    except ImportError:
+        pass
+    try:
+        import app.api.v2_quota as _q
+        _q._quota_singleton = None
+    except ImportError:
+        pass
+    yield
+
+
 @pytest.fixture
 def e2e_env(tmp_path, monkeypatch):
     """Set up complete E2E environment with DATA_DIR, create dirs."""

--- a/tests/test_admin_bigquery_test_connection.py
+++ b/tests/test_admin_bigquery_test_connection.py
@@ -1,0 +1,183 @@
+"""POST /api/admin/bigquery/test-connection — admin-only health probe.
+
+Lets an admin verify the saved data_source.bigquery config is reachable
+WITHOUT having to hit /api/query or /api/v2/scan and read the failure
+mode out of an analyst's error report. Closes #160 §4.9 (the operator-side
+half of the USER_PROJECT_DENIED loop the reporter hit).
+
+Cases: admin + reachable BQ → 200; admin + not_configured → 400; admin
++ cross_project_forbidden → 502; admin + 10s timeout → 504; non-admin →
+403; unauthenticated → 401.
+"""
+from __future__ import annotations
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_test_connection_success(seeded_app, monkeypatch):
+    """A reachable BQ project returns 200 with resolved projects + elapsed_ms."""
+    class _FakeJob:
+        job_id = "fake-1"
+        location = "US"
+
+        def result(self, timeout=None):
+            return [{"ok": 1}]
+
+    class _FakeClient:
+        def query(self, sql):
+            assert "SELECT 1" in sql.upper()
+            return _FakeJob()
+
+    class _FakeProjects:
+        billing = "prj-billing"
+        data = "prj-data"
+
+    class _FakeBqAccess:
+        projects = _FakeProjects()
+
+        def client(self):
+            return _FakeClient()
+
+    monkeypatch.setattr(
+        "app.api.admin_bigquery_test.get_bq_access",
+        lambda: _FakeBqAccess(),
+        raising=False,
+    )
+
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.post("/api/admin/bigquery/test-connection", headers=_auth(token))
+    assert r.status_code == 200, r.json()
+    body = r.json()
+    assert body.get("ok") is True
+    assert body.get("billing_project") == "prj-billing"
+    assert body.get("data_project") == "prj-data"
+    assert isinstance(body.get("elapsed_ms"), (int, float))
+
+
+def test_test_connection_not_configured(seeded_app, monkeypatch):
+    """When BQ isn't configured (no project), return 400 with the typed
+    not_configured detail surface so the admin sees a clear next step."""
+    from connectors.bigquery.access import BqAccessError
+
+    def fake_get_bq_access():
+        raise BqAccessError(
+            "not_configured",
+            "BigQuery project not configured",
+            details={"hint": "Set data_source.bigquery.project in instance.yaml"},
+        )
+
+    monkeypatch.setattr(
+        "app.api.admin_bigquery_test.get_bq_access",
+        fake_get_bq_access,
+        raising=False,
+    )
+
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.post("/api/admin/bigquery/test-connection", headers=_auth(token))
+    assert r.status_code == 400, r.json()
+    detail = r.json().get("detail", {})
+    if isinstance(detail, dict):
+        assert detail.get("kind") == "not_configured"
+
+
+def test_test_connection_cross_project_forbidden(seeded_app, monkeypatch):
+    """USER_PROJECT_DENIED translates to 502 with cross_project_forbidden
+    detail — same shape as /api/v2/scan returns, so the CLI renderer
+    surfaces it identically across both paths."""
+    from connectors.bigquery.access import BqAccessError
+
+    class _FakeProjects:
+        billing = ""
+        data = "prj-data"
+
+    class _FakeBqAccess:
+        projects = _FakeProjects()
+
+        def client(self):
+            raise BqAccessError(
+                "cross_project_forbidden",
+                "USER_PROJECT_DENIED on bigquery.googleapis.com",
+                details={
+                    "billing_project": "",
+                    "data_project": "prj-data",
+                    "hint": "Set data_source.bigquery.billing_project",
+                },
+            )
+
+    monkeypatch.setattr(
+        "app.api.admin_bigquery_test.get_bq_access",
+        lambda: _FakeBqAccess(),
+        raising=False,
+    )
+
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.post("/api/admin/bigquery/test-connection", headers=_auth(token))
+    assert r.status_code == 502, r.json()
+    detail = r.json().get("detail", {})
+    if isinstance(detail, dict):
+        assert detail.get("kind") == "cross_project_forbidden"
+
+
+def test_test_connection_timeout(seeded_app, monkeypatch):
+    """A query that hangs past the 10s polling timeout returns 504. Best-
+    effort cancel_job is called; surface caveat that the BQ job may keep
+    running until BQ side-cancels it."""
+    import concurrent.futures as _cf
+
+    class _FakeJob:
+        job_id = "slow-1"
+        location = "US"
+
+        def result(self, timeout=None):
+            raise _cf.TimeoutError()
+
+    class _FakeClient:
+        def query(self, sql):
+            return _FakeJob()
+
+        def cancel_job(self, job_id, project=None, location=None):
+            pass  # best-effort no-op
+
+    class _FakeProjects:
+        billing = "prj-billing"
+        data = "prj-data"
+
+    class _FakeBqAccess:
+        projects = _FakeProjects()
+
+        def client(self):
+            return _FakeClient()
+
+    monkeypatch.setattr(
+        "app.api.admin_bigquery_test.get_bq_access",
+        lambda: _FakeBqAccess(),
+        raising=False,
+    )
+
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.post("/api/admin/bigquery/test-connection", headers=_auth(token))
+    assert r.status_code == 504, r.json()
+    detail = r.json().get("detail", {})
+    if isinstance(detail, dict):
+        assert detail.get("kind") == "timeout"
+
+
+def test_test_connection_non_admin_403(seeded_app):
+    """Non-admin users cannot probe BQ from the admin UI."""
+    c = seeded_app["client"]
+    analyst_token = seeded_app["analyst_token"]
+    r = c.post("/api/admin/bigquery/test-connection", headers=_auth(analyst_token))
+    assert r.status_code == 403, r.json()
+
+
+def test_test_connection_unauthenticated_401(seeded_app):
+    """Unauthenticated requests get 401."""
+    c = seeded_app["client"]
+    r = c.post("/api/admin/bigquery/test-connection")
+    assert r.status_code == 401, r.json()

--- a/tests/test_admin_server_config.py
+++ b/tests/test_admin_server_config.py
@@ -807,14 +807,15 @@ class TestRedactionHelpers:
 
 
 class TestServerConfigBigQueryFields:
-    """Phase J — billing_project, legacy_wrap_views, and
-    max_bytes_per_materialize are surfaced in the UI/API so an operator can
-    set them without SSH'ing to the VM. The first two were previously only
-    addressable via direct YAML edits; max_bytes_per_materialize had no UI
-    hint at all."""
+    """Phase J — billing_project and max_bytes_per_materialize are surfaced
+    in the UI/API so an operator can set them without SSH'ing to the VM.
+    They were previously only addressable via direct YAML edits.
+
+    legacy_wrap_views was removed in #160 — VIEW/MAT_VIEW are now always
+    wrapped via bigquery_query() (the previous opt-in path)."""
 
     def test_get_surfaces_bq_fields_even_when_unset(self, seeded_app, tmp_path, monkeypatch):
-        """GET response always includes the three BQ fields under
+        """GET response always includes the BQ optional fields under
         data_source.bigquery so the UI's JSON-textarea rendering shows them
         as editable keys even when YAML omits them. Without this, the
         operator has no UI hint that the knobs exist."""
@@ -822,7 +823,7 @@ class TestServerConfigBigQueryFields:
         state = tmp_path / "state"
         state.mkdir(parents=True, exist_ok=True)
         # Plant a minimal instance.yaml that has data_source.bigquery but
-        # NONE of the three fields set.
+        # none of the optional fields set.
         (state / "instance.yaml").write_text(yaml.dump({
             "data_source": {
                 "type": "bigquery",
@@ -838,9 +839,12 @@ class TestServerConfigBigQueryFields:
         assert resp.status_code == 200, resp.text
         bq = resp.json()["sections"]["data_source"]["bigquery"]
         assert "billing_project" in bq, f"billing_project missing from GET: {bq}"
-        assert "legacy_wrap_views" in bq, f"legacy_wrap_views missing from GET: {bq}"
         assert "max_bytes_per_materialize" in bq, \
             f"max_bytes_per_materialize missing from GET: {bq}"
+        # legacy_wrap_views was removed in #160; UI must NOT surface it any
+        # longer (the wrap behavior is now unconditional).
+        assert "legacy_wrap_views" not in bq, \
+            f"legacy_wrap_views was removed in #160 but still present in GET: {bq}"
 
     def test_get_preserves_existing_bq_field_values(self, seeded_app, tmp_path, monkeypatch):
         """When the operator HAS set the fields, GET must surface their actual
@@ -854,7 +858,6 @@ class TestServerConfigBigQueryFields:
                 "bigquery": {
                     "project": "my-data-prj",
                     "billing_project": "my-billing-prj",
-                    "legacy_wrap_views": True,
                     "max_bytes_per_materialize": 5368709120,  # 5 GiB
                 },
             },
@@ -867,7 +870,6 @@ class TestServerConfigBigQueryFields:
         resp = c.get("/api/admin/server-config", headers=_auth(token))
         bq = resp.json()["sections"]["data_source"]["bigquery"]
         assert bq["billing_project"] == "my-billing-prj"
-        assert bq["legacy_wrap_views"] is True
         assert bq["max_bytes_per_materialize"] == 5368709120
 
     def test_post_persists_billing_project(self, seeded_app, tmp_path, monkeypatch):
@@ -890,23 +892,6 @@ class TestServerConfigBigQueryFields:
         bq = resp.json()["sections"]["data_source"]["bigquery"]
         assert bq["billing_project"] == "my-billing-prj"
 
-    def test_post_persists_legacy_wrap_views(self, seeded_app, tmp_path, monkeypatch):
-        monkeypatch.setenv("DATA_DIR", str(tmp_path))
-        (tmp_path / "state").mkdir(parents=True, exist_ok=True)
-        c = seeded_app["client"]
-        token = seeded_app["admin_token"]
-        resp = c.post(
-            "/api/admin/server-config",
-            json={"sections": {"data_source": {"bigquery": {
-                "legacy_wrap_views": True,
-            }}}},
-            headers=_auth(token),
-        )
-        assert resp.status_code == 200, resp.text
-        resp = c.get("/api/admin/server-config", headers=_auth(token))
-        bq = resp.json()["sections"]["data_source"]["bigquery"]
-        assert bq["legacy_wrap_views"] is True
-
     def test_post_persists_max_bytes_per_materialize(self, seeded_app, tmp_path, monkeypatch):
         monkeypatch.setenv("DATA_DIR", str(tmp_path))
         (tmp_path / "state").mkdir(parents=True, exist_ok=True)
@@ -924,14 +909,14 @@ class TestServerConfigBigQueryFields:
         bq = resp.json()["sections"]["data_source"]["bigquery"]
         assert bq["max_bytes_per_materialize"] == 21474836480
 
-    def test_template_documents_three_new_fields(self, seeded_app):
-        """The three BQ optional fields are now surfaced through the
-        known-fields registry (GET /api/admin/server-config carries them
-        in `known_fields.data_source.bigquery.fields`), not hardcoded into
-        the template text. The renderer reads the registry at runtime and
-        creates a structured form with hints for each leaf — so the test
-        verifies operator-discoverability through the API channel rather
-        than via static HTML inspection.
+    def test_template_documents_bq_optional_fields(self, seeded_app):
+        """BQ optional fields are surfaced through the known-fields registry
+        (GET /api/admin/server-config carries them in
+        `known_fields.data_source.bigquery.fields`), not hardcoded into the
+        template text. The renderer reads the registry at runtime and creates
+        a structured form with hints for each leaf — so the test verifies
+        operator-discoverability through the API channel rather than via
+        static HTML inspection.
         """
         c = seeded_app["client"]
         token = seeded_app["admin_token"]
@@ -940,12 +925,13 @@ class TestServerConfigBigQueryFields:
         bq_fields = resp.json()["known_fields"]["data_source"]["bigquery"]["fields"]
         assert "billing_project" in bq_fields, \
             "registry must expose billing_project as a known field"
-        assert "legacy_wrap_views" in bq_fields, \
-            "registry must expose legacy_wrap_views as a known field"
         assert "max_bytes_per_materialize" in bq_fields, \
             "registry must expose max_bytes_per_materialize as a known field"
-        # Each field must carry a hint so the renderer can show operator-
-        # facing help text — no anonymous knobs.
-        for k in ("billing_project", "legacy_wrap_views", "max_bytes_per_materialize"):
+        # legacy_wrap_views was removed in #160 (VIEW/MAT_VIEW always wrap).
+        assert "legacy_wrap_views" not in bq_fields, \
+            "legacy_wrap_views was removed in #160 but still present in known_fields"
+        # Each surviving field must carry a hint so the renderer can show
+        # operator-facing help text — no anonymous knobs.
+        for k in ("billing_project", "max_bytes_per_materialize"):
             assert "hint" in bq_fields[k] and bq_fields[k]["hint"], \
                 f"{k} must carry a non-empty hint"

--- a/tests/test_admin_server_config.py
+++ b/tests/test_admin_server_config.py
@@ -838,7 +838,13 @@ class TestServerConfigBigQueryFields:
         resp = c.get("/api/admin/server-config", headers=_auth(token))
         assert resp.status_code == 200, resp.text
         bq = resp.json()["sections"]["data_source"]["bigquery"]
-        assert "billing_project" in bq, f"billing_project missing from GET: {bq}"
+        # `billing_project` intentionally NOT auto-seeded into GET payload
+        # — that would inject empty string and break the placeholder_from
+        # render path. The field still appears in `known_fields` (so the
+        # UI knows about it) and renders via the unset path with the
+        # `(defaults to <project>)` placeholder. Devin Review iter #3.
+        assert "billing_project" not in bq, \
+            f"billing_project should not be auto-seeded in sections; got: {bq}"
         assert "max_bytes_per_materialize" in bq, \
             f"max_bytes_per_materialize missing from GET: {bq}"
         # legacy_wrap_views was removed in #160; UI must NOT surface it any

--- a/tests/test_admin_server_config_known_fields.py
+++ b/tests/test_admin_server_config_known_fields.py
@@ -176,10 +176,11 @@ def test_bigquery_subfields_populated(seeded_app):
     assert r.status_code == 200
     fields = r.json()["known_fields"]["data_source"]["bigquery"]["fields"]
     assert "billing_project" in fields
-    assert "legacy_wrap_views" in fields
     assert "max_bytes_per_materialize" in fields
-    assert fields["legacy_wrap_views"]["kind"] == "bool"
-    assert fields["legacy_wrap_views"]["default"] is False
+    # legacy_wrap_views was removed in #160 — VIEW/MATERIALIZED_VIEW are now
+    # always wrapped via bigquery_query() (the previous opt-in path).
+    assert "legacy_wrap_views" not in fields, \
+        "legacy_wrap_views config knob was removed; #160 makes the wrap behavior unconditional"
     assert fields["max_bytes_per_materialize"]["kind"] == "int"
     assert fields["max_bytes_per_materialize"]["default"] == 10737418240
 

--- a/tests/test_admin_server_config_placeholder.py
+++ b/tests/test_admin_server_config_placeholder.py
@@ -1,0 +1,29 @@
+"""GET /api/admin/server-config exposes `placeholder_from` for fields
+whose UI placeholder should resolve to another config value at render
+time. Used by `data_source.bigquery.billing_project` to surface its
+fallback to `data_source.bigquery.project` (see
+connectors/bigquery/access.py:339-340).
+
+Closes part of #160 §4.7.5.
+"""
+from __future__ import annotations
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_billing_project_field_carries_placeholder_from(seeded_app):
+    """The known-fields registry must mark billing_project's
+    placeholder_from path so the JS template can resolve and inject
+    `(defaults to <project>)` at render time."""
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.get("/api/admin/server-config", headers=_auth(token))
+    assert r.status_code == 200, r.json()
+    fields = r.json()["known_fields"]["data_source"]["bigquery"]["fields"]
+    assert "billing_project" in fields
+    spec = fields["billing_project"]
+    assert spec.get("placeholder_from") == [
+        "data_source", "bigquery", "project",
+    ], f"expected placeholder_from path; got {spec.get('placeholder_from')!r}"

--- a/tests/test_api_query_guardrail.py
+++ b/tests/test_api_query_guardrail.py
@@ -1,0 +1,119 @@
+"""POST /api/query cost guardrail for query_mode='remote' BigQuery rows.
+
+When user SQL references a registered remote-BQ name (or a direct
+`bq."<ds>"."<tbl>"` path), run a BQ dry-run before execute. If the
+estimated scan exceeds the configured cap, reject with 400 +
+`remote_scan_too_large` so the operator pivots to `da fetch`.
+
+Default cap: 5 GiB per request. Configurable via
+`api.query.bq_max_scan_bytes` in /admin/server-config (#160 §4.4).
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _register_bq_remote_row(name: str, bucket: str, source_table: str) -> None:
+    from src.db import get_system_db
+    from src.repositories.table_registry import TableRegistryRepository
+    sys_conn = get_system_db()
+    try:
+        TableRegistryRepository(sys_conn).register(
+            id=f"bq.{bucket}.{source_table}",
+            name=name,
+            source_type="bigquery",
+            bucket=bucket,
+            source_table=source_table,
+            query_mode="remote",
+        )
+    finally:
+        sys_conn.close()
+
+
+@pytest.fixture
+def mock_dry_run(monkeypatch):
+    """Replace `_bq_dry_run_bytes` with a controllable stub. Each test sets
+    `mock_dry_run.bytes_to_return` to control what /api/query sees."""
+    state = {"bytes": 0}
+
+    def fake(*args, **kwargs):
+        return state["bytes"]
+
+    monkeypatch.setattr("app.api.query._bq_dry_run_bytes", fake, raising=False)
+    return state
+
+
+def test_query_under_cap_calls_dry_run(seeded_app, mock_dry_run, monkeypatch):
+    """Dry-run is invoked when SQL references a registered remote BQ row.
+    Use a sentinel side-effect to confirm: the mock records call counts."""
+    _register_bq_remote_row("ue", "finance", "ue")
+    state = mock_dry_run
+    state["bytes"] = 1 * 1024 * 1024  # 1 MiB
+    state["call_count"] = 0
+
+    def counting_fake(*args, **kwargs):
+        state["call_count"] += 1
+        return state["bytes"]
+
+    monkeypatch.setattr("app.api.query._bq_dry_run_bytes", counting_fake, raising=False)
+
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    c.post(
+        "/api/query",
+        json={"sql": "SELECT count(*) FROM ue"},
+        headers=_auth(token),
+    )
+    assert state["call_count"] >= 1, \
+        "guardrail must invoke _bq_dry_run_bytes when SQL references a registered remote BQ row"
+
+
+def test_query_over_cap_rejected_400(seeded_app, mock_dry_run, monkeypatch):
+    """Dry-run reports 10 GiB; default cap (5 GiB) is exceeded → 400 with
+    structured detail naming bytes + tables + suggestion."""
+    _register_bq_remote_row("ue", "finance", "ue")
+    mock_dry_run["bytes"] = 10 * 1024 * 1024 * 1024  # 10 GiB
+
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.post(
+        "/api/query",
+        json={"sql": "SELECT * FROM ue"},
+        headers=_auth(token),
+    )
+    assert r.status_code == 400, r.json()
+    detail = r.json().get("detail", {})
+    if isinstance(detail, dict):
+        assert detail.get("reason") == "remote_scan_too_large", detail
+        assert detail.get("scan_bytes") >= 10 * 1024 * 1024 * 1024
+        assert "da fetch" in detail.get("suggestion", "").lower() or \
+               "fetch" in detail.get("suggestion", "").lower()
+        assert "ue" in detail.get("tables", []) or \
+               any("ue" in t for t in detail.get("tables", []))
+
+
+def test_no_bq_row_reference_skips_dry_run(seeded_app, monkeypatch):
+    """A query that doesn't touch any registered BQ remote row must NOT
+    invoke `_bq_dry_run_bytes` — guardrail incurs zero new latency on
+    plain non-BQ queries."""
+    state = {"calls": 0}
+
+    def counting_fake(*args, **kwargs):
+        state["calls"] += 1
+        return 100 * 1024 * 1024 * 1024  # 100 GiB — irrelevant if not called
+
+    monkeypatch.setattr("app.api.query._bq_dry_run_bytes", counting_fake, raising=False)
+
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    c.post(
+        "/api/query",
+        json={"sql": "SELECT 1 AS x"},
+        headers=_auth(token),
+    )
+    assert state["calls"] == 0, \
+        f"guardrail must skip dry-run on non-BQ queries; got {state['calls']} calls"

--- a/tests/test_api_query_guardrail.py
+++ b/tests/test_api_query_guardrail.py
@@ -37,13 +37,30 @@ def _register_bq_remote_row(name: str, bucket: str, source_table: str) -> None:
 @pytest.fixture
 def mock_dry_run(monkeypatch):
     """Replace `_bq_dry_run_bytes` with a controllable stub. Each test sets
-    `mock_dry_run.bytes_to_return` to control what /api/query sees."""
+    `mock_dry_run["bytes"]` to control what /api/query sees. Also stubs
+    `get_bq_access` so the guardrail doesn't require a real BQ connection
+    in the test env."""
     state = {"bytes": 0}
 
-    def fake(*args, **kwargs):
+    def fake_dry_run(*args, **kwargs):
         return state["bytes"]
 
-    monkeypatch.setattr("app.api.query._bq_dry_run_bytes", fake, raising=False)
+    monkeypatch.setattr("app.api.query._bq_dry_run_bytes", fake_dry_run, raising=False)
+
+    # Stub get_bq_access so the guardrail's BqAccess construction doesn't
+    # fail with `not_configured` in tests that don't set up real BQ.
+    class _FakeProjects:
+        data = "test-data-prj"
+        billing = "test-billing-prj"
+
+    class _FakeBqAccess:
+        projects = _FakeProjects()
+
+    monkeypatch.setattr(
+        "app.api.query.get_bq_access",
+        lambda: _FakeBqAccess(),
+        raising=False,
+    )
     return state
 
 

--- a/tests/test_api_query_quota.py
+++ b/tests/test_api_query_quota.py
@@ -68,7 +68,7 @@ def test_query_records_bytes_against_shared_quota(seeded_app, fresh_quota, mock_
 
     # Pre-flight: tracker has zero usage for this user.
     tracker = fresh_quota._build_quota_tracker()
-    user_id = "admin"  # seeded_app's admin user id
+    user_id = "admin1"  # seeded_app's admin user id
     before = tracker.bytes_used_today(user_id)
 
     r = c.post(
@@ -93,7 +93,7 @@ def test_query_pre_flight_rejects_user_over_daily_cap(seeded_app, fresh_quota, m
 
     # Plant the user's daily counter already at the cap by injecting bytes.
     tracker = fresh_quota._build_quota_tracker()
-    user_id = "admin"
+    user_id = "admin1"
     # Push counter past the cap (default 50 GiB).
     tracker.record_bytes(user_id, tracker._max_daily_bytes + 1)
 
@@ -111,7 +111,7 @@ def test_non_bq_query_skips_quota_path(seeded_app, fresh_quota, mock_dry_run):
     """A query that doesn't touch any registered remote BQ row must NOT
     decrement quota. Quota wiring runs only when dry_run_set is non-empty."""
     tracker = fresh_quota._build_quota_tracker()
-    user_id = "admin"
+    user_id = "admin1"
     before = tracker.bytes_used_today(user_id)
 
     c = seeded_app["client"]

--- a/tests/test_api_query_quota.py
+++ b/tests/test_api_query_quota.py
@@ -1,0 +1,126 @@
+"""POST /api/query enforces the same per-user quota as /api/v2/scan.
+
+Daily-byte cap is checked pre-flight (before dry-run); concurrent-slot is
+acquired around dry-run + execute and released on exit; record_bytes is
+called post-flight after the result lands. The quota tracker is the
+process-local singleton in app/api/v2_quota.py — shared with /api/v2/scan
+so both paths bill against the same daily budget.
+
+Closes part of #160 §4.3.3.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _register_bq_remote_row(name: str, bucket: str, source_table: str) -> None:
+    from src.db import get_system_db
+    from src.repositories.table_registry import TableRegistryRepository
+    sys_conn = get_system_db()
+    try:
+        TableRegistryRepository(sys_conn).register(
+            id=f"bq.{bucket}.{source_table}",
+            name=name,
+            source_type="bigquery",
+            bucket=bucket,
+            source_table=source_table,
+            query_mode="remote",
+        )
+    finally:
+        sys_conn.close()
+
+
+@pytest.fixture
+def fresh_quota(monkeypatch):
+    """Reset the process-local quota singleton + return a fresh tracker
+    bound to the v2_quota module so the test owns its state. Without
+    this, prior tests' usage bleeds into the daily-bytes counter."""
+    import app.api.v2_quota as q
+    monkeypatch.setattr(q, "_quota_singleton", None, raising=False)
+    return q
+
+
+@pytest.fixture
+def mock_dry_run(monkeypatch):
+    state = {"bytes": 1024}
+
+    def fake(*args, **kwargs):
+        return state["bytes"]
+
+    monkeypatch.setattr("app.api.query._bq_dry_run_bytes", fake, raising=False)
+    return state
+
+
+def test_query_records_bytes_against_shared_quota(seeded_app, fresh_quota, mock_dry_run):
+    """A successful BQ-touching query bumps the user's daily-byte counter
+    on the SAME singleton tracker that /api/v2/scan uses — so a user who
+    has consumed daily budget via /api/v2/scan can't dodge the cap by
+    routing through /api/query."""
+    _register_bq_remote_row("ue", "finance", "ue")
+    mock_dry_run["bytes"] = 4096  # 4 KiB
+
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+
+    # Pre-flight: tracker has zero usage for this user.
+    tracker = fresh_quota._build_quota_tracker()
+    user_id = "admin"  # seeded_app's admin user id
+    before = tracker.bytes_used_today(user_id)
+
+    r = c.post(
+        "/api/query",
+        json={"sql": "SELECT count(*) FROM ue"},
+        headers=_auth(token),
+    )
+    # The query may fail (no real BQ) but bytes recording should happen
+    # before any post-execute failure. Accept either 200 or 400; what
+    # matters is the byte counter advanced.
+    after = tracker.bytes_used_today(user_id)
+    if r.status_code == 200:
+        assert after - before >= 4096, \
+            f"successful BQ-touching query must record bytes; before={before} after={after}"
+
+
+def test_query_pre_flight_rejects_user_over_daily_cap(seeded_app, fresh_quota, mock_dry_run):
+    """If the user is already over their daily byte cap on the shared
+    tracker, /api/query rejects 429 BEFORE running the dry-run — no free
+    BQ work for over-cap users via this back door."""
+    _register_bq_remote_row("ue", "finance", "ue")
+
+    # Plant the user's daily counter already at the cap by injecting bytes.
+    tracker = fresh_quota._build_quota_tracker()
+    user_id = "admin"
+    # Push counter past the cap (default 50 GiB).
+    tracker.record_bytes(user_id, tracker._max_daily_bytes + 1)
+
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.post(
+        "/api/query",
+        json={"sql": "SELECT count(*) FROM ue"},
+        headers=_auth(token),
+    )
+    assert r.status_code == 429, r.json()
+
+
+def test_non_bq_query_skips_quota_path(seeded_app, fresh_quota, mock_dry_run):
+    """A query that doesn't touch any registered remote BQ row must NOT
+    decrement quota. Quota wiring runs only when dry_run_set is non-empty."""
+    tracker = fresh_quota._build_quota_tracker()
+    user_id = "admin"
+    before = tracker.bytes_used_today(user_id)
+
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.post(
+        "/api/query",
+        json={"sql": "SELECT 1 AS x"},
+        headers=_auth(token),
+    )
+    after = tracker.bytes_used_today(user_id)
+    assert after == before, \
+        f"non-BQ query must not record bytes; before={before} after={after}"

--- a/tests/test_api_query_quota.py
+++ b/tests/test_api_query_quota.py
@@ -68,7 +68,7 @@ def test_query_records_bytes_against_shared_quota(seeded_app, fresh_quota, mock_
 
     # Pre-flight: tracker has zero usage for this user.
     tracker = fresh_quota._build_quota_tracker()
-    user_id = "admin1"  # seeded_app's admin user id
+    user_id = "admin@test.com"  # email-keyed per parity with /api/v2/scan (#168 review)  # seeded_app's admin user id
     before = tracker.bytes_used_today(user_id)
 
     r = c.post(
@@ -93,7 +93,7 @@ def test_query_pre_flight_rejects_user_over_daily_cap(seeded_app, fresh_quota, m
 
     # Plant the user's daily counter already at the cap by injecting bytes.
     tracker = fresh_quota._build_quota_tracker()
-    user_id = "admin1"
+    user_id = "admin@test.com"  # email-keyed per parity with /api/v2/scan (#168 review)
     # Push counter past the cap (default 50 GiB).
     tracker.record_bytes(user_id, tracker._max_daily_bytes + 1)
 
@@ -111,7 +111,7 @@ def test_non_bq_query_skips_quota_path(seeded_app, fresh_quota, mock_dry_run):
     """A query that doesn't touch any registered remote BQ row must NOT
     decrement quota. Quota wiring runs only when dry_run_set is non-empty."""
     tracker = fresh_quota._build_quota_tracker()
-    user_id = "admin1"
+    user_id = "admin@test.com"  # email-keyed per parity with /api/v2/scan (#168 review)
     before = tracker.bytes_used_today(user_id)
 
     c = seeded_app["client"]

--- a/tests/test_api_query_rbac_bq_path.py
+++ b/tests/test_api_query_rbac_bq_path.py
@@ -1,0 +1,123 @@
+"""POST /api/query gates direct `bq."<dataset>"."<source_table>"` references.
+
+Pre-existing RBAC hole: the forbidden-table check at `app/api/query.py`
+only blocks names matching an existing master view. Direct `bq.*` syntax
+doesn't match any master view → bypasses the check entirely. Closed in
+#160 via the BQ_PATH regex + find_by_bq_path lookup: every `bq.*` in user
+SQL must point at a registered query_mode='remote' BigQuery row.
+
+Tests cover: unregistered path → 403; registered + caller has grant →
+allowed (request reaches BQ — we only check that RBAC didn't block it
+before BQ runs); admin → bypasses per-name grant but still requires
+registration.
+"""
+from __future__ import annotations
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _register_bq_remote_row(name: str, bucket: str, source_table: str) -> None:
+    """Insert a query_mode='remote' BQ row directly via the system DB."""
+    from src.db import get_system_db
+    from src.repositories.table_registry import TableRegistryRepository
+    sys_conn = get_system_db()
+    try:
+        TableRegistryRepository(sys_conn).register(
+            id=f"bq.{bucket}.{source_table}",
+            name=name,
+            source_type="bigquery",
+            bucket=bucket,
+            source_table=source_table,
+            query_mode="remote",
+        )
+    finally:
+        sys_conn.close()
+
+
+def test_unregistered_bq_path_rejected_403(seeded_app):
+    """Direct reference to a `bq.<ds>.<tbl>` that no registry row points at:
+    403 with `bq_path_not_registered`. Caller has admin token (no per-name
+    RBAC); the registration check still fires because admin must register
+    first to query a new dataset."""
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.post(
+        "/api/query",
+        json={"sql": 'SELECT * FROM bq."secret_ds"."secret_tbl"'},
+        headers=_auth(token),
+    )
+    assert r.status_code == 403, r.json()
+    detail = r.json().get("detail", {})
+    if isinstance(detail, dict):
+        assert detail.get("reason") == "bq_path_not_registered", detail
+        assert "secret_ds" in detail.get("path", "")
+        assert "secret_tbl" in detail.get("path", "")
+    else:
+        # Fallback: detail must at least mention the unregistered path.
+        assert "bq_path_not_registered" in str(detail) or "secret_ds" in str(detail)
+
+
+def test_registered_bq_path_admin_passes_rbac(seeded_app):
+    """When the path IS registered, an admin caller sails past the RBAC
+    check. The query may still fail downstream (e.g. cost guardrail or
+    actual BQ execution) — but NOT with `bq_path_not_registered` or
+    `bq_path_access_denied`."""
+    _register_bq_remote_row("ue", "finance", "ue")
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.post(
+        "/api/query",
+        json={"sql": 'SELECT * FROM bq."finance"."ue"'},
+        headers=_auth(token),
+    )
+    # Either allowed (200/400/etc on downstream paths) but NOT 403 from RBAC.
+    if r.status_code == 403:
+        detail = r.json().get("detail", {})
+        if isinstance(detail, dict):
+            assert detail.get("reason") not in (
+                "bq_path_not_registered",
+                "bq_path_access_denied",
+            ), f"admin with registered path should not be RBAC-rejected: {detail}"
+
+
+def test_unregistered_bq_path_case_insensitive_match(seeded_app):
+    """`bq."Finance"."UE"` resolves to the registered `(finance, ue)` row
+    via case-insensitive lookup — admin sails through, no 403."""
+    _register_bq_remote_row("ue", "finance", "ue")
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.post(
+        "/api/query",
+        json={"sql": 'SELECT * FROM bq."Finance"."UE"'},
+        headers=_auth(token),
+    )
+    if r.status_code == 403:
+        detail = r.json().get("detail", {})
+        if isinstance(detail, dict):
+            assert detail.get("reason") not in (
+                "bq_path_not_registered",
+                "bq_path_access_denied",
+            ), f"case-insensitive lookup should match: {detail}"
+
+
+def test_string_literal_matching_bq_path_rejected_403(seeded_app):
+    """Documented false-positive: `WHERE c = 'bq.unreg.tbl'` regex-matches
+    the literal. Strict-deny: 403 if the path isn't registered. Operator
+    can rephrase or register the path."""
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.post(
+        "/api/query",
+        json={"sql": "SELECT count(*) FROM ue WHERE c = 'bq.unreg.tbl'"},
+        headers=_auth(token),
+    )
+    # The literal contains a `bq.<unreg>.<tbl>` pattern that the regex
+    # matches; the RBAC patch must reject 403 (strict-deny on a security
+    # boundary) — pre-existing master-view check would only return 400 if
+    # `ue` weren't registered. Test: explicitly verify bq_path_not_registered.
+    assert r.status_code == 403, r.json()
+    detail = r.json().get("detail", {})
+    if isinstance(detail, dict):
+        assert detail.get("reason") == "bq_path_not_registered", detail

--- a/tests/test_api_query_rbac_bq_path.py
+++ b/tests/test_api_query_rbac_bq_path.py
@@ -36,6 +36,24 @@ def _register_bq_remote_row(name: str, bucket: str, source_table: str) -> None:
         sys_conn.close()
 
 
+def test_quoted_bq_catalog_token_rejected_403(seeded_app):
+    """Phase 3 review evasion: `SELECT * FROM "bq"."ds"."tbl"` (catalog
+    token quoted) must be caught by the same RBAC check as the unquoted
+    form. DuckDB resolves `"bq"` to the same ATTACHed BQ catalog, so the
+    quoted variant is a real bypass we have to close."""
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.post(
+        "/api/query",
+        json={"sql": 'SELECT * FROM "bq"."secret_ds"."secret_tbl"'},
+        headers=_auth(token),
+    )
+    assert r.status_code == 403, r.json()
+    detail = r.json().get("detail", {})
+    if isinstance(detail, dict):
+        assert detail.get("reason") == "bq_path_not_registered", detail
+
+
 def test_unregistered_bq_path_rejected_403(seeded_app):
     """Direct reference to a `bq.<ds>.<tbl>` that no registry row points at:
     403 with `bq_path_not_registered`. Caller has admin token (no per-name

--- a/tests/test_bigquery_extractor.py
+++ b/tests/test_bigquery_extractor.py
@@ -316,7 +316,9 @@ class TestViewVsTableTemplates:
             "BASE TABLE should not use bigquery_query() function"
 
     def test_view_uses_bigquery_query_function(self, tmp_path, monkeypatch):
-        """For VIEW with legacy_wrap_views=True, generated DuckDB view wraps bigquery_query() (jobs API path)."""
+        """For VIEW entity, generated DuckDB master view wraps bigquery_query()
+        (jobs API path). Same SQL form as the prior `legacy_wrap_views=True`
+        branch — now unconditional per #160."""
         from connectors.bigquery.extractor import init_extract
 
         monkeypatch.setattr(
@@ -336,12 +338,6 @@ class TestViewVsTableTemplates:
             return _CapturingProxy(real_conn, captured)
 
         monkeypatch.setattr("connectors.bigquery.extractor.duckdb.connect", spy_connect)
-
-        # Enable legacy toggle so this test verifies the old wrap-view path still works.
-        monkeypatch.setattr(
-            "connectors.bigquery.extractor.get_value",
-            lambda *args, default=None, **kw: True if "legacy_wrap_views" in args else default,
-        )
 
         init_extract(
             str(tmp_path),
@@ -575,88 +571,16 @@ class TestExtractorMainModule:
         assert exc_info.value.code == 2
 
 
-class TestDropWrapViewForBQViews:
-    def test_view_entity_does_not_create_master_view_by_default(self, tmp_path, monkeypatch):
-        from connectors.bigquery.extractor import init_extract
-        monkeypatch.setattr("connectors.bigquery.extractor.get_metadata_token", lambda: "tok")
-        monkeypatch.setattr("connectors.bigquery.extractor._detect_table_type", lambda *a, **kw: "VIEW")
-
-        # Stub BQ extension calls to avoid hitting real BQ
-        real_connect = duckdb.connect
-
-        captured = []
-
-        def safe_connect(*a, **kw):
-            return _CapturingProxy(real_connect(*a, **kw), captured)
-        monkeypatch.setattr("connectors.bigquery.extractor.duckdb.connect", safe_connect)
-
-        # legacy toggle is OFF by default → expect no CREATE VIEW for the BQ view
-        monkeypatch.setattr(
-            "connectors.bigquery.extractor.get_value",
-            lambda *args, default=None, **kw: False if "legacy_wrap_views" in args else default,
-            raising=False,
-        )
-
-        init_extract(
-            str(tmp_path),
-            "my-project",
-            [{"name": "myview", "bucket": "ds", "source_table": "myview", "description": ""}],
-        )
-
-        # Confirm extract.duckdb has _meta + _remote_attach but NO master view for myview
-        c = duckdb.connect(str(tmp_path / "extract.duckdb"), read_only=True)
-        try:
-            views = c.execute(
-                "SELECT view_name FROM duckdb_views() WHERE view_name='myview'"
-            ).fetchall()
-            assert views == [], f"expected no wrap view for VIEW entity by default; got {views}"
-            meta = c.execute("SELECT table_name FROM _meta").fetchall()
-            assert ("myview",) in meta, "_meta must still record the view"
-        finally:
-            c.close()
-
-    def test_legacy_wrap_views_toggle_restores_old_behavior(self, tmp_path, monkeypatch):
-        from connectors.bigquery.extractor import init_extract
-        monkeypatch.setattr("connectors.bigquery.extractor.get_metadata_token", lambda: "tok")
-        monkeypatch.setattr("connectors.bigquery.extractor._detect_table_type", lambda *a, **kw: "VIEW")
-
-        real_connect = duckdb.connect
-        captured = []
-
-        def safe_connect(*a, **kw):
-            return _CapturingProxy(real_connect(*a, **kw), captured)
-        monkeypatch.setattr("connectors.bigquery.extractor.duckdb.connect", safe_connect)
-
-        # legacy toggle ON → should still create the wrap view
-        monkeypatch.setattr(
-            "connectors.bigquery.extractor.get_value",
-            lambda *args, default=None, **kw: True if "legacy_wrap_views" in args else default,
-            raising=False,
-        )
-
-        init_extract(
-            str(tmp_path),
-            "my-project",
-            [{"name": "myview", "bucket": "ds", "source_table": "myview", "description": ""}],
-        )
-
-        # With legacy ON the wrap view SQL should have been emitted
-        view_sqls = [s for s in captured if "CREATE OR REPLACE VIEW" in s.upper()]
-        myview_sqls = [s for s in view_sqls if '"myview"' in s]
-        assert myview_sqls != [], \
-            f"expected wrap view SQL for VIEW entity when legacy_wrap_views=True; captured={captured}"
-        assert any("bigquery_query(" in s for s in myview_sqls), \
-            f"legacy wrap view should use bigquery_query(); got: {myview_sqls}"
-
-    # ---- #160 always-wrap tests ------------------------------------------
-    # Issue #160: query_mode='remote' BQ rows whose entity is VIEW or
-    # MATERIALIZED_VIEW must get a master view via bigquery_query() by default.
-    # Today (legacy_wrap_views=False default) they don't — `da query --remote`
-    # against such a table returns DuckDB catalog error. Fix: always wrap.
+class TestWrapViewForBQViews:
+    """Issue #160: query_mode='remote' BQ rows whose entity is VIEW or
+    MATERIALIZED_VIEW must get a master view via bigquery_query() — for any
+    other entity type we don't have proven runtime support for, skip both
+    the master view AND the _meta row."""
 
     def test_view_creates_wrap_view_with_default_config(self, tmp_path, monkeypatch):
-        """VIEW entity must get a bigquery_query() wrap view by default
-        (not just when legacy_wrap_views=True). Closes #160."""
+        """VIEW entity must get a bigquery_query() wrap view (the previous
+        opt-in path under `legacy_wrap_views=True`, now unconditional).
+        Closes #160."""
         from connectors.bigquery.extractor import init_extract
         import app.instance_config as _ic
         monkeypatch.setattr(_ic, "_instance_config", None, raising=False)
@@ -670,7 +594,6 @@ class TestDropWrapViewForBQViews:
             return _CapturingProxy(real_connect(*a, **kw), captured)
         monkeypatch.setattr("connectors.bigquery.extractor.duckdb.connect", safe_connect)
 
-        # Default config — no monkeypatch setting legacy_wrap_views
         init_extract(
             str(tmp_path),
             "my-project",

--- a/tests/test_bigquery_extractor.py
+++ b/tests/test_bigquery_extractor.py
@@ -557,6 +557,12 @@ class TestExtractorMainModule:
 
     def test_main_exits_when_project_missing(self, tmp_path, monkeypatch):
         """__main__ must SystemExit(2) when data_source.bigquery.project is empty/missing."""
+        # Reset the app.instance_config cache — `test_main_reads_data_source_bigquery_project`
+        # above populated it with a config that has the project set, and the
+        # cache survives across tests. Without this reset, `_resolve_bq_project_id`
+        # returns the stale cached value instead of the no-project mock below.
+        from app.instance_config import reset_cache
+        reset_cache()
         monkeypatch.setattr(
             "config.loader.load_instance_config",
             lambda: {"data_source": {"type": "bigquery"}},  # no .bigquery.project
@@ -641,6 +647,115 @@ class TestDropWrapViewForBQViews:
             f"expected wrap view SQL for VIEW entity when legacy_wrap_views=True; captured={captured}"
         assert any("bigquery_query(" in s for s in myview_sqls), \
             f"legacy wrap view should use bigquery_query(); got: {myview_sqls}"
+
+    # ---- #160 always-wrap tests ------------------------------------------
+    # Issue #160: query_mode='remote' BQ rows whose entity is VIEW or
+    # MATERIALIZED_VIEW must get a master view via bigquery_query() by default.
+    # Today (legacy_wrap_views=False default) they don't — `da query --remote`
+    # against such a table returns DuckDB catalog error. Fix: always wrap.
+
+    def test_view_creates_wrap_view_with_default_config(self, tmp_path, monkeypatch):
+        """VIEW entity must get a bigquery_query() wrap view by default
+        (not just when legacy_wrap_views=True). Closes #160."""
+        from connectors.bigquery.extractor import init_extract
+        import app.instance_config as _ic
+        monkeypatch.setattr(_ic, "_instance_config", None, raising=False)
+        monkeypatch.setattr("connectors.bigquery.extractor.get_metadata_token", lambda: "tok")
+        monkeypatch.setattr("connectors.bigquery.extractor._detect_table_type", lambda *a, **kw: "VIEW")
+
+        real_connect = duckdb.connect
+        captured = []
+
+        def safe_connect(*a, **kw):
+            return _CapturingProxy(real_connect(*a, **kw), captured)
+        monkeypatch.setattr("connectors.bigquery.extractor.duckdb.connect", safe_connect)
+
+        # Default config — no monkeypatch setting legacy_wrap_views
+        init_extract(
+            str(tmp_path),
+            "my-project",
+            [{"name": "ue", "bucket": "finance", "source_table": "ue", "description": ""}],
+        )
+
+        view_sqls = [s for s in captured if "CREATE OR REPLACE VIEW" in s.upper() and '"ue"' in s]
+        assert view_sqls != [], \
+            f"VIEW entity must produce a wrap view by default; captured={captured}"
+        assert any("bigquery_query(" in s for s in view_sqls), \
+            f"VIEW wrap view must use bigquery_query(); got: {view_sqls}"
+        assert any("`my-project.finance.ue`" in s for s in view_sqls), \
+            f"wrap view must reference full project.dataset.table path; got: {view_sqls}"
+
+    def test_materialized_view_creates_wrap_view_with_default_config(self, tmp_path, monkeypatch):
+        """MATERIALIZED_VIEW entity must get a bigquery_query() wrap view by default."""
+        from connectors.bigquery.extractor import init_extract
+        import app.instance_config as _ic
+        monkeypatch.setattr(_ic, "_instance_config", None, raising=False)
+        monkeypatch.setattr("connectors.bigquery.extractor.get_metadata_token", lambda: "tok")
+        monkeypatch.setattr(
+            "connectors.bigquery.extractor._detect_table_type",
+            lambda *a, **kw: "MATERIALIZED_VIEW",
+        )
+
+        real_connect = duckdb.connect
+        captured = []
+
+        def safe_connect(*a, **kw):
+            return _CapturingProxy(real_connect(*a, **kw), captured)
+        monkeypatch.setattr("connectors.bigquery.extractor.duckdb.connect", safe_connect)
+
+        init_extract(
+            str(tmp_path),
+            "my-project",
+            [{"name": "mv", "bucket": "ds", "source_table": "mv", "description": ""}],
+        )
+
+        view_sqls = [s for s in captured if "CREATE OR REPLACE VIEW" in s.upper() and '"mv"' in s]
+        assert view_sqls != [], \
+            f"MATERIALIZED_VIEW must produce a wrap view by default; captured={captured}"
+        assert any("bigquery_query(" in s for s in view_sqls)
+
+    def test_unsupported_entity_type_skips_meta_and_view(self, tmp_path, monkeypatch):
+        """For entity_types we don't have proven runtime support for
+        (EXTERNAL, SNAPSHOT, CLONE, future types), skip BOTH the master
+        view AND the _meta row. Today the _meta row is inserted
+        unconditionally → orchestrator sees a `_meta` entry pointing to a
+        non-existent inner view, then skips master-view creation, leaving
+        the operator with a registered-but-unqueryable name."""
+        from connectors.bigquery.extractor import init_extract
+        import app.instance_config as _ic
+        monkeypatch.setattr(_ic, "_instance_config", None, raising=False)
+        monkeypatch.setattr("connectors.bigquery.extractor.get_metadata_token", lambda: "tok")
+        monkeypatch.setattr(
+            "connectors.bigquery.extractor._detect_table_type",
+            lambda *a, **kw: "EXTERNAL",
+        )
+
+        real_connect = duckdb.connect
+        captured = []
+
+        def safe_connect(*a, **kw):
+            return _CapturingProxy(real_connect(*a, **kw), captured)
+        monkeypatch.setattr("connectors.bigquery.extractor.duckdb.connect", safe_connect)
+
+        init_extract(
+            str(tmp_path),
+            "my-project",
+            [{"name": "ext_tbl", "bucket": "ds", "source_table": "ext_tbl", "description": ""}],
+        )
+
+        # No CREATE VIEW for ext_tbl
+        view_sqls = [s for s in captured if "CREATE OR REPLACE VIEW" in s.upper() and '"ext_tbl"' in s]
+        assert view_sqls == [], \
+            f"unsupported entity_type must NOT produce a wrap view; got {view_sqls}"
+
+        # _meta row also skipped — no INSERT INTO _meta for ext_tbl
+        c = duckdb.connect(str(tmp_path / "extract.duckdb"), read_only=True)
+        try:
+            meta = c.execute("SELECT table_name FROM _meta").fetchall()
+            assert ("ext_tbl",) not in meta, \
+                f"unsupported entity_type must NOT insert _meta row; got {meta}"
+        finally:
+            c.close()
 
 
 class TestInitExtractProjectIdValidation:

--- a/tests/test_cli_error_render.py
+++ b/tests/test_cli_error_render.py
@@ -1,0 +1,102 @@
+"""CLI structured error renderer for typed BigQuery error responses.
+
+The server side maps BQ Forbidden/auth/badrequest errors into typed
+BqAccessError dicts that the FastAPI handler returns as `detail` JSON.
+Today the CLI side flattens them via `f"HTTP {code}: {body[:200]}"`,
+truncating the structured shape and hiding the operator-facing hints.
+
+`cli.error_render.render_error` recognizes a few canonical shapes and
+pretty-prints them; falls back to truncated form for anything else.
+
+Closes part of #160 §4.7.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def render_error():
+    from cli.error_render import render_error
+    return render_error
+
+
+def test_renders_typed_bq_access_error(render_error):
+    """`{detail: {kind, hint, billing_project, data_project}}` from
+    BqAccessError surfaces as a multi-line block with the kind line, the
+    key/value pairs, and the hint word-wrapped at 80 cols."""
+    body = {"detail": {
+        "kind": "cross_project_forbidden",
+        "message": "USER_PROJECT_DENIED on bigquery.googleapis.com",
+        "billing_project": "",
+        "data_project": "prj-example-data-001",
+        "hint": (
+            "Set data_source.bigquery.billing_project in /admin/server-config "
+            "to a project where the SA has serviceusage.services.use, or "
+            "grant the SA that role on the data project."
+        ),
+    }}
+    out = render_error(502, body)
+    # Single-line `f"HTTP {code}: ..."` style is the OLD form. The new
+    # renderer must produce multi-line output.
+    assert "\n" in out
+    # Kind appears prominently in the output.
+    assert "cross_project_forbidden" in out
+    # Key/value pairs visible.
+    assert "billing_project" in out
+    assert "prj-example-data-001" in out
+    # Hint text included.
+    assert "serviceusage.services.use" in out
+
+
+def test_renders_remote_scan_too_large(render_error):
+    """`{detail: {reason: 'remote_scan_too_large', scan_bytes, limit_bytes,
+    tables, suggestion}}` from the new /api/query guardrail formats with
+    the bytes + tables + suggestion clearly visible."""
+    body = {"detail": {
+        "reason": "remote_scan_too_large",
+        "scan_bytes": 10737418240,  # 10 GiB
+        "limit_bytes": 5368709120,  # 5 GiB
+        "tables": ["finance.unit_economics"],
+        "suggestion": (
+            "Use `da fetch <id> --select <cols> --where <predicate> "
+            "--estimate` to materialize a filtered subset, then query "
+            "the snapshot locally."
+        ),
+    }}
+    out = render_error(400, body)
+    assert "remote_scan_too_large" in out
+    assert "10737418240" in out or "10 GiB" in out or "10737418240" in str(out)
+    assert "finance.unit_economics" in out
+    assert "da fetch" in out
+
+
+def test_renders_bq_path_not_registered(render_error):
+    """`{detail: {reason: 'bq_path_not_registered', path, hint}}` from the
+    RBAC patch formats path + hint clearly."""
+    body = {"detail": {
+        "reason": "bq_path_not_registered",
+        "path": 'bq."secret_ds"."secret_tbl"',
+        "hint": "Direct bq.* references must point to a registered table.",
+    }}
+    out = render_error(403, body)
+    assert "bq_path_not_registered" in out
+    assert 'secret_ds' in out
+    assert "registered table" in out
+
+
+def test_falls_back_to_truncated_for_unrecognized_shape(render_error):
+    """Body without recognizable typed shape falls back to truncated form."""
+    body = "Internal Server Error: Something went wrong" * 20  # 800+ chars
+    out = render_error(500, body)
+    # Old-style truncation kicks in; output is single-line and short.
+    assert len(out) < 600
+    assert "500" in out
+
+
+def test_falls_back_when_detail_is_string(render_error):
+    """Many old endpoints return `detail: "<string message>"` — render that
+    as-is without trying to walk it as a structured error dict."""
+    body = {"detail": "Only single SELECT queries are allowed"}
+    out = render_error(400, body)
+    assert "Only single SELECT" in out

--- a/tests/test_cli_error_render.py
+++ b/tests/test_cli_error_render.py
@@ -100,3 +100,19 @@ def test_falls_back_when_detail_is_string(render_error):
     body = {"detail": "Only single SELECT queries are allowed"}
     out = render_error(400, body)
     assert "Only single SELECT" in out
+
+
+def test_renders_empty_string_as_empty_marker(render_error):
+    """Devin Review iter #6: `billing_project: ""` in cross_project_forbidden
+    is the key diagnostic showing WHY the operator hits USER_PROJECT_DENIED.
+    The renderer must show empty strings as `(empty)`, not silently drop them."""
+    body = {"detail": {
+        "kind": "cross_project_forbidden",
+        "billing_project": "",            # the key diagnostic
+        "data_project": "prj-example",
+        "hint": "Set data_source.bigquery.billing_project",
+    }}
+    out = render_error(502, body)
+    assert "billing_project: (empty)" in out, \
+        f"empty billing_project must render as (empty); got:\n{out}"
+    assert "data_project: prj-example" in out

--- a/tests/test_cli_query.py
+++ b/tests/test_cli_query.py
@@ -37,11 +37,15 @@ class TestRemoteQuery:
         assert result.exit_code == 0
 
     def test_remote_query_failure(self):
-        """--remote prints error message on API failure."""
+        """--remote prints error message on API failure (#160 §4.7: shared
+        renderer surfaces the detail; the prior `Query failed: ...` prefix
+        was dropped in favor of HTTP-status + structured detail)."""
         with patch("cli.client.api_post", return_value=_resp(400, {"detail": "bad SQL"})):
             result = runner.invoke(app, ["query", "SELECT bad", "--remote"])
         assert result.exit_code == 1
-        assert "Query failed" in result.output
+        # Renderer formats string-detail as `HTTP 400: bad SQL`
+        assert "HTTP 400" in result.output
+        assert "bad SQL" in result.output
 
     def test_remote_query_truncated(self):
         """Truncated result shows warning."""

--- a/tests/test_cli_query_render.py
+++ b/tests/test_cli_query_render.py
@@ -1,0 +1,66 @@
+"""CLI commands route BQ-typed errors through the shared renderer.
+
+Three CLI paths surface BQ errors today:
+- `da query --remote` (cli/commands/query.py:_query_remote → /api/query)
+- `da query --register-bq` (cli/commands/query.py:_query_hybrid via
+  RemoteQueryError, which wraps server-side BqAccessError)
+- `da fetch` / `da schema` / etc. (cli/v2_client.V2ClientError → v2 endpoints)
+
+After the refactor they all call cli.error_render.render_error so analyst
+output is consistent and structured. Closes part of #160 §4.7.3.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def test_v2_client_error_uses_renderer():
+    """`V2ClientError.__str__` calls render_error so any caller of the v2
+    HTTP helpers (api_get_json/api_post_json/api_post_arrow) automatically
+    surfaces typed BQ errors as structured output."""
+    from cli.v2_client import V2ClientError
+
+    body = {"detail": {
+        "kind": "cross_project_forbidden",
+        "message": "USER_PROJECT_DENIED",
+        "hint": "Set data_source.bigquery.billing_project",
+    }}
+    err = V2ClientError(status_code=502, body=body)
+    out = str(err)
+    # Old form: `HTTP 502: {'detail': {'kind': ...}}` (single line).
+    # New form: multi-line structured.
+    assert "\n" in out, f"V2ClientError must use multi-line renderer; got {out!r}"
+    assert "cross_project_forbidden" in out
+    assert "billing_project" in out
+
+
+def test_v2_client_error_drops_truncation_for_dicts():
+    """The OLD `message=str(body)[:200]` truncation hid the structured
+    `hint` field for any reasonably-sized error dict. The new renderer
+    must NOT pre-truncate dict bodies."""
+    from cli.v2_client import V2ClientError
+
+    body = {"detail": {
+        "kind": "bq_forbidden",
+        "billing_project": "x" * 200,  # padding to push past old 200-char limit
+        "data_project": "y" * 200,
+        "hint": "MUST_REACH_THIS_HINT_IN_OUTPUT",
+    }}
+    err = V2ClientError(status_code=502, body=body)
+    out = str(err)
+    assert "MUST_REACH_THIS_HINT_IN_OUTPUT" in out, \
+        "renderer must not pre-truncate dict bodies past the hint field"
+
+
+def test_remote_query_error_carries_details():
+    """`RemoteQueryError` already has a `details` field. Verify the type's
+    surface so cli/commands/query.py:_query_hybrid can rely on it."""
+    from src.remote_query import RemoteQueryError
+
+    err = RemoteQueryError(
+        error_type="cross_project_forbidden",
+        message="USER_PROJECT_DENIED",
+        details={"billing_project": "", "data_project": "prj"},
+    )
+    assert err.details == {"billing_project": "", "data_project": "prj"}
+    assert err.error_type == "cross_project_forbidden"

--- a/tests/test_query_bigquery_query_blocked.py
+++ b/tests/test_query_bigquery_query_blocked.py
@@ -1,0 +1,68 @@
+"""POST /api/query must reject direct `bigquery_query()` function calls.
+
+This is a pre-existing RBAC bypass: `bigquery_query('proj', 'SELECT * FROM
+ds.tbl')` runs a BQ jobs API call against any reachable dataset, ignoring
+the master-view forbidden-table check that gates registered names. Closes
+that hole by adding `bigquery_query` to the SQL keyword blocklist.
+
+Internal wrap views (created by the BQ extractor) use bigquery_query()
+inside their CREATE VIEW body — those run via DuckDB's view resolution at
+query time, NOT via user-submitted SQL, so the blocklist doesn't break
+them. Closes part of #160.
+"""
+from __future__ import annotations
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_bigquery_query_function_call_rejected(seeded_app):
+    """Plain `SELECT * FROM bigquery_query(...)` is blocked at the
+    keyword-blocklist layer with the canonical "Only single SELECT
+    queries are allowed" detail."""
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    sql = "SELECT * FROM bigquery_query('proj', 'SELECT 1 AS x')"
+    r = c.post(
+        "/api/query",
+        json={"sql": sql},
+        headers=_auth(token),
+    )
+    assert r.status_code == 400, f"expected 400; got {r.status_code} body={r.json()}"
+    detail = str(r.json().get("detail", ""))
+    # The canonical blocklist message proves this was rejected by the
+    # blocklist (not by some other path like master-view-forbidden).
+    assert "single SELECT" in detail, \
+        f"expected canonical blocklist message; got detail={detail!r}"
+
+
+def test_bigquery_query_mixed_case_rejected(seeded_app):
+    """Existing blocklist runs `sql.strip().lower()` first, so any case
+    variant is blocked uniformly."""
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.post(
+        "/api/query",
+        json={"sql": "SELECT * FROM BigQuery_Query('proj', 'SELECT 1')"},
+        headers=_auth(token),
+    )
+    assert r.status_code == 400, r.json()
+    detail = str(r.json().get("detail", ""))
+    assert "single SELECT" in detail, \
+        f"expected canonical blocklist message; got detail={detail!r}"
+
+
+def test_bigquery_query_with_whitespace_before_paren_rejected(seeded_app):
+    """Substring match catches `bigquery_query (...)` with space too."""
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.post(
+        "/api/query",
+        json={"sql": "SELECT * FROM bigquery_query   ('proj', 'SELECT 1')"},
+        headers=_auth(token),
+    )
+    assert r.status_code == 400, r.json()
+    detail = str(r.json().get("detail", ""))
+    assert "single SELECT" in detail, \
+        f"expected canonical blocklist message; got detail={detail!r}"

--- a/tests/test_query_bq_regex.py
+++ b/tests/test_query_bq_regex.py
@@ -25,6 +25,9 @@ def regex():
     ('SELECT * FROM bq.finance."ue"', ('finance', '"ue"')),
     # Case-insensitive
     ('select * from BQ.Finance.UE', ('Finance', 'UE')),
+    # Quoted catalog token "bq" — Phase 3 review evasion: must be caught
+    ('SELECT * FROM "bq"."finance"."ue"', ('"finance"', '"ue"')),
+    ('SELECT * FROM "BQ"."ds"."tbl"', ('"ds"', '"tbl"')),
     # With WHERE
     ('SELECT a FROM bq.ds.tbl WHERE x=1', ('ds', 'tbl')),
     # Inside CTE body
@@ -55,6 +58,7 @@ def test_regex_finds_multiple_paths_in_one_statement(regex):
     ('SELECT bq.col FROM tbl', '2-part bq.col is column qualifier, not catalog'),
     ('SELECT count(*) FROM unit_economics', 'aggregate on bare name'),
     ('SELECT * FROM other_bq.ds.tbl', 'prefix that contains bq'),
+    ('SELECT * FROM "my_bq".ds.tbl', 'quoted prefix that contains bq'),
     ('SELECT * FROM x.bq.ds.tbl', 'bq is middle component, not catalog'),
 ])
 def test_regex_rejects_non_bq_paths(regex, sql, reason):

--- a/tests/test_query_bq_regex.py
+++ b/tests/test_query_bq_regex.py
@@ -1,0 +1,75 @@
+"""BQ_PATH regex used by /api/query to detect direct `bq.X.Y` references in
+user SQL. The regex powers both the cost guardrail (matches contribute
+dry-run targets) and the RBAC patch (matches must point at a registered row).
+
+Adversarial cases verified empirically before commit; see #160 spec §4.3.1.
+"""
+import pytest
+
+
+@pytest.fixture
+def regex():
+    from app.api.query import BQ_PATH
+    return BQ_PATH
+
+
+# --- positive: must match (3-part `bq.<dataset>.<source_table>`) -------------
+
+@pytest.mark.parametrize("sql,expected_groups", [
+    # Fully quoted
+    ('SELECT * FROM bq."finance"."ue"', ('"finance"', '"ue"')),
+    # Unquoted
+    ('SELECT * FROM bq.finance.ue', ('finance', 'ue')),
+    # Mixed quoting
+    ('SELECT * FROM bq."finance".ue', ('"finance"', 'ue')),
+    ('SELECT * FROM bq.finance."ue"', ('finance', '"ue"')),
+    # Case-insensitive
+    ('select * from BQ.Finance.UE', ('Finance', 'UE')),
+    # With WHERE
+    ('SELECT a FROM bq.ds.tbl WHERE x=1', ('ds', 'tbl')),
+    # Inside CTE body
+    ('WITH x AS (SELECT * FROM bq.ds.tbl) SELECT * FROM x', ('ds', 'tbl')),
+    # Trailing punctuation
+    ('SELECT * FROM bq.ds.tbl;', ('ds', 'tbl')),
+])
+def test_regex_matches_direct_bq_paths(regex, sql, expected_groups):
+    matches = list(regex.finditer(sql))
+    assert len(matches) >= 1, f"expected at least one match in {sql!r}"
+    assert matches[0].groups() == expected_groups
+
+
+def test_regex_finds_multiple_paths_in_one_statement(regex):
+    """Two-path query: SELECT FROM bq.a.b JOIN bq.c.d — must match both."""
+    sql = "SELECT * FROM bq.ds.tbl, bq.ds2.tbl2"
+    matches = list(regex.finditer(sql))
+    assert len(matches) == 2
+    assert matches[0].groups() == ('ds', 'tbl')
+    assert matches[1].groups() == ('ds2', 'tbl2')
+
+
+# --- negative: must NOT match -------------------------------------------------
+
+@pytest.mark.parametrize("sql,reason", [
+    ('SELECT * FROM unit_economics', 'bare registered name (no bq prefix)'),
+    ('SELECT * FROM "unit_economics"', 'quoted bare name'),
+    ('SELECT bq.col FROM tbl', '2-part bq.col is column qualifier, not catalog'),
+    ('SELECT count(*) FROM unit_economics', 'aggregate on bare name'),
+    ('SELECT * FROM other_bq.ds.tbl', 'prefix that contains bq'),
+    ('SELECT * FROM x.bq.ds.tbl', 'bq is middle component, not catalog'),
+])
+def test_regex_rejects_non_bq_paths(regex, sql, reason):
+    matches = list(regex.finditer(sql))
+    assert matches == [], \
+        f"regex should not match {sql!r} ({reason}); matched {[m.group(0) for m in matches]}"
+
+
+# --- accepted false-positives (documented in §4.3.1) -------------------------
+
+def test_regex_matches_string_literal_containing_bq_path(regex):
+    """Known false-positive: `WHERE c = 'bq.foo.bar'` matches. Cost guardrail
+    runs a wasted dry-run (cheap), RBAC fires 403 if the path isn't
+    registered — strict-deny is the right choice on a security boundary."""
+    sql = "SELECT * FROM x WHERE c = 'bq.foo.bar'"
+    matches = list(regex.finditer(sql))
+    assert len(matches) == 1
+    assert matches[0].groups() == ('foo', 'bar')

--- a/tests/test_remote_query_error_details.py
+++ b/tests/test_remote_query_error_details.py
@@ -25,12 +25,15 @@ def test_blocked_keyword_carries_keyword_in_details():
     try:
         engine.execute("DROP TABLE foo")
     except RemoteQueryError as exc:
-        assert exc.error_type == "blocked_keyword", exc.error_type
-        # 'drop' is the keyword that triggers the block.
+        # Blocked-keyword raise lives at src/remote_query.py:134-138 with
+        # error_type="query_error" (not "blocked_keyword" — that's the
+        # keyword name in details, not the type).
+        assert exc.error_type == "query_error", exc.error_type
         assert exc.details, "blocked_keyword raise must populate details"
         assert "blocked_keyword" in exc.details
+        assert exc.details["blocked_keyword"] == "drop "
     else:
-        raise AssertionError("expected blocked_keyword RemoteQueryError")
+        raise AssertionError("expected RemoteQueryError")
 
 
 def test_query_must_be_select_carries_no_unnecessary_details():

--- a/tests/test_remote_query_error_details.py
+++ b/tests/test_remote_query_error_details.py
@@ -1,0 +1,57 @@
+"""`src/remote_query.py:RemoteQueryError` carries a `details` dict
+(verified to already exist) populated for raise sites that wrap an
+upstream BqAccessError.
+
+Currently only the BqAccessError-wrap path (lines 422 + 432) populates
+it. The other 11 raise sites (lines 134, 142, 167, 173, 259, 264, 282,
+289, 313, 322, 375) need an audit — for sites that wrap an external
+exception, populate `details` so the CLI renderer has the structured
+context it needs.
+
+Closes the audit half of #160 §4.7.3.
+"""
+from __future__ import annotations
+
+
+def test_blocked_keyword_carries_keyword_in_details():
+    """`raise RemoteQueryError("blocked_keyword", ..., details={"blocked_keyword": kw})`
+    already populates the keyword. Lock it in via assertion so a future
+    refactor doesn't drop the field."""
+    from src.remote_query import RemoteQueryEngine, RemoteQueryError
+    import duckdb
+
+    conn = duckdb.connect(":memory:")
+    engine = RemoteQueryEngine(conn)
+    try:
+        engine.execute("DROP TABLE foo")
+    except RemoteQueryError as exc:
+        assert exc.error_type == "blocked_keyword", exc.error_type
+        # 'drop' is the keyword that triggers the block.
+        assert exc.details, "blocked_keyword raise must populate details"
+        assert "blocked_keyword" in exc.details
+    else:
+        raise AssertionError("expected blocked_keyword RemoteQueryError")
+
+
+def test_query_must_be_select_carries_no_unnecessary_details():
+    """A pure local-validation raise (SQL doesn't start with SELECT)
+    has nothing structured to surface. details=None is the right shape;
+    test locks that in so a future contributor doesn't add noise."""
+    from src.remote_query import RemoteQueryEngine, RemoteQueryError
+    import duckdb
+
+    conn = duckdb.connect(":memory:")
+    engine = RemoteQueryEngine(conn)
+    try:
+        engine.execute("WITH x AS (SELECT 1) SELECT * FROM x")
+    except RemoteQueryError as exc:
+        # `WITH ...` is treated as not-starting-with-SELECT today; this is
+        # the shape we want to assert: details may be empty/None for pure
+        # local-validation errors.
+        assert exc.error_type in ("query_must_be_select", "blocked_keyword"), exc.error_type
+        # Either empty dict or dict with explanatory keys is fine.
+        assert isinstance(exc.details, dict)
+    except Exception:
+        # If the engine accepts WITH, that's also fine — this test is
+        # primarily about details shape, not what gets blocked.
+        pass

--- a/tests/test_table_registry_find_by_bq_path.py
+++ b/tests/test_table_registry_find_by_bq_path.py
@@ -1,0 +1,125 @@
+"""Repository lookup of registry rows by their BigQuery dataset+source_table.
+
+Used by /api/query's RBAC patch to gate direct `bq."<dataset>"."<source_table>"`
+references — every such reference must point at a registered row, otherwise
+the caller has bypassed the registry and bypassed RBAC.
+
+Closes part of #160.
+"""
+import time
+
+import duckdb
+import pytest
+
+from src.db import _ensure_schema
+from src.repositories.table_registry import TableRegistryRepository
+
+
+@pytest.fixture
+def repo(tmp_path):
+    conn = duckdb.connect(str(tmp_path / "system.duckdb"))
+    _ensure_schema(conn)
+    return TableRegistryRepository(conn)
+
+
+def test_find_returns_none_when_no_match(repo):
+    """Empty registry → None for any path."""
+    result = repo.find_by_bq_path("finance", "unit_economics")
+    assert result is None
+
+
+def test_find_returns_none_when_not_bigquery(repo):
+    """A keboola row with the same bucket+source_table must NOT be returned —
+    find_by_bq_path is BQ-only by contract."""
+    repo.register(
+        id="kbc.in.c-finance.ue",
+        name="ue_kbc",
+        source_type="keboola",
+        bucket="in.c-finance",
+        source_table="ue",
+        query_mode="local",
+    )
+    # Even with the same path strings, this is a Keboola row — must not match.
+    assert repo.find_by_bq_path("in.c-finance", "ue") is None
+
+
+def test_find_returns_single_match(repo):
+    """One BQ row matching → return it as a dict."""
+    repo.register(
+        id="bq.finance.unit_economics",
+        name="unit_economics",
+        source_type="bigquery",
+        bucket="finance",
+        source_table="unit_economics",
+        query_mode="remote",
+    )
+    row = repo.find_by_bq_path("finance", "unit_economics")
+    assert row is not None
+    assert row["id"] == "bq.finance.unit_economics"
+    assert row["name"] == "unit_economics"
+    assert row["source_type"] == "bigquery"
+
+
+def test_find_oldest_when_multiple_match(repo):
+    """No unique constraint on (source_type, bucket, source_table). When 2+
+    rows match, return the oldest by `registered_at` so the result is
+    deterministic across calls."""
+    from datetime import datetime, timezone, timedelta
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    repo.register(
+        id="bq.finance.ue.v1",
+        name="ue_v1",
+        source_type="bigquery",
+        bucket="finance",
+        source_table="ue",
+        query_mode="remote",
+        registered_at=base,
+    )
+    repo.register(
+        id="bq.finance.ue.v2",
+        name="ue_v2",
+        source_type="bigquery",
+        bucket="finance",
+        source_table="ue",
+        query_mode="remote",
+        registered_at=base + timedelta(days=30),  # newer
+    )
+    row = repo.find_by_bq_path("finance", "ue")
+    assert row is not None
+    assert row["id"] == "bq.finance.ue.v1", \
+        f"expected oldest (ue_v1) to win; got {row['id']}"
+
+
+def test_find_case_insensitive(repo):
+    """BQ identifiers are case-preserving but DuckDB analytics views fold
+    unquoted identifiers to lowercase. The lookup must match regardless of
+    case so user SQL `SELECT FROM bq.Finance.UE` resolves to the registered
+    `(finance, unit_economics)` row."""
+    repo.register(
+        id="bq.finance.unit_economics",
+        name="unit_economics",
+        source_type="bigquery",
+        bucket="finance",
+        source_table="unit_economics",
+        query_mode="remote",
+    )
+    # User SQL might come through with any casing.
+    assert repo.find_by_bq_path("FINANCE", "UNIT_ECONOMICS") is not None
+    assert repo.find_by_bq_path("Finance", "Unit_Economics") is not None
+    assert repo.find_by_bq_path("finance", "unit_economics") is not None
+
+
+def test_find_excludes_null_bucket_or_source_table(repo):
+    """Local rows can have NULL bucket/source_table (e.g. some legacy
+    materialized rows). Defensive guard: NULL must never match a non-NULL
+    query, so the cross-RBAC check doesn't mismatch a NULL registry row."""
+    # Insert a BQ row with NULL bucket via direct SQL since register() defaults
+    # source_table to table_name.
+    repo.conn.execute(
+        """INSERT INTO table_registry (id, name, source_type, bucket, source_table, query_mode, registered_at)
+        VALUES ('bq.weird', 'weird', 'bigquery', NULL, NULL, 'remote', current_timestamp)""",
+    )
+    # Looking up with a real bucket+source_table must NOT match the NULL row
+    # (regardless of what `lower(NULL)=lower('x')` evaluates to in DuckDB).
+    assert repo.find_by_bq_path("foo", "bar") is None


### PR DESCRIPTION
## Summary

Closes #160. Three reinforcing fixes for `da query --remote`:

1. **VIEW/MATERIALIZED_VIEW resolution** (the headline). The BQ extractor now creates a master view via `bigquery_query()` for these entity types (the prior `legacy_wrap_views=True` branch behavior, made unconditional). `legacy_wrap_views` config knob removed. Other entity types (`EXTERNAL`/`SNAPSHOT`/`CLONE`) log+skip with no `_meta` row so the orchestrator doesn't strand a registered name.

2. **Server-side cost guardrail** on `/api/query`: 5 GiB scan cap (configurable), shared `_build_quota_tracker` with `/api/v2/scan`, structured `400 remote_scan_too_large` rejection with `da fetch` suggestion.

3. **Closes pre-existing RBAC bypass**: direct `bq.\"<dataset>\".\"<source_table>\"` paths in user SQL are now registry-gated; `bigquery_query()` direct calls are blocked. Quoted-\`\"bq\"\` variant caught by Phase 3 review fix.

Plus operator-side polish:
- New \`POST /api/admin/bigquery/test-connection\` endpoint + UI button
- \`billing_project\` field shows \`(defaults to <project>)\` placeholder
- CLI shared \`error_render\` module — typed BQ errors render multi-line with the operator-facing hint visible (no more raw \`USER_PROJECT_DENIED\` blob)

Detailed spec in \`docs/superpowers/specs/2026-05-03-issue-160-da-query-remote-fix-spec.md\`.

## Three operator-facing notes (per spec §8)

1. **First-run requires extract regeneration.** Hit \`POST /api/sync/trigger?source=bigquery\` (or wait for the scheduler tick) before re-running the original repro command. The wrap-view code only takes effect after the next BQ sync rebuilds \`extract.duckdb\`.

2. **\`SELECT *\` against VIEWs may hit the new 5 GiB cap** — by design (BQ jobs API can't push WHERE into the view body, dry-run estimates a full scan). Cheap aggregates (COUNT etc., metadata-driven) work. **Not a regression** — prior catalog error meant zero work happened; the new behavior at least runs cheap aggregates and rejects expensive ones with actionable guidance.

3. **\`da fetch\` still requires \`data_source.bigquery.billing_project\`** if the SA can't bill on the data project. Out of scope for #160 by reporter's framing in \"Related\"; the new Test Connection button + placeholder make discovery easier but don't auto-fix the misconfig.

## Commits (15)

- \`118f6ff4\` docs(specs): implementation spec
- \`ffb84a2b\` fix(bq): wrap views via bigquery_query() for VIEW/MATERIALIZED_VIEW
- \`e03a714c\` refactor(bq): remove legacy_wrap_views config knob (always-wrap)
- \`1f2f0b28\` docs(orchestrator): comment polish
- \`2403f77d\` feat(repo): add find_by_bq_path lookup
- \`438a72db\` refactor(quota): relocate _build_quota_tracker to v2_quota.py
- \`aa5dd733\` test(query): RED tests for guardrail+quota+RBAC+blocklist
- \`46828de5\` feat(query): cost guardrail + bq.* RBAC + quota integration on /api/query
- \`9eb3410f\` sec(query): BQ_PATH catches quoted \"bq\" catalog token
- \`e8681619\` test(cli): RED tests for shared BQ error renderer
- \`4db34152\` feat(cli): shared structured error renderer for BQ-typed responses
- \`3e50df3a\` test(admin): RED tests for BQ test-connection + placeholder
- \`757fc815\` feat(admin): BQ test-connection endpoint + billing_project placeholder UI
- \`82032629\` docs(query): align CLAUDE.md/skills/CHANGELOG

## Test plan
- [x] 140 unit/integration tests pass across all #160-affected files
- [x] 6 review iterations on the spec; 2 phase-checkpoint reviews passed
- [ ] Manual on dev VM: 10-scenario checklist per spec §5.3 (after deploy)
- [ ] Issue closure with §8 messaging