### PR TITLE
fix(cli): setup summary reflects actual CLAUDE.md outcome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 - `/install` page renamed to `/setup` ("Setup local agent" nav label) with 302 redirect from `/install`.
 - Dashboard "What Claude Code will receive" inline preview replaced with a link to `/setup` for the canonical view.
 
+### Fixed
+
+- `da analyst setup` summary now accurately reflects whether `CLAUDE.md` was written, skipped (`--no-claude-md`), or skipped due to a server error — previously it always claimed "written from server template" even when the fetch failed (404, 401/403, network), contradicting its own stderr warning.
+
 ## [0.30.1] — 2026-05-02
 
 ### Security

--- a/cli/commands/analyst.py
+++ b/cli/commands/analyst.py
@@ -301,11 +301,15 @@ def _init_claude_workspace(
     workspace: Path,
     server_url: str = "",
     token: str = "",
-) -> None:
+) -> bool:
     """Initialise the .claude/ directory with placeholder files and hooks.
 
     Writes CLAUDE.md from the server (GET /api/welcome) unless ``server_url``
     or ``token`` are empty, or the request fails (graceful degradation).
+
+    Returns True if CLAUDE.md was written from the server, False otherwise
+    (skipped because caller passed empty server_url/token, or fetch failed —
+    in the latter case a warning was already printed to stderr).
     """
     local_md = workspace / ".claude" / "CLAUDE.local.md"
     if not local_md.exists():
@@ -326,15 +330,19 @@ def _init_claude_workspace(
 
     # Write CLAUDE.md from the server
     if server_url and token:
-        _write_claude_md(workspace, server_url, token)
+        return _write_claude_md(workspace, server_url, token)
+    return False
 
 
-def _write_claude_md(workspace: Path, server_url: str, token: str) -> None:
+def _write_claude_md(workspace: Path, server_url: str, token: str) -> bool:
     """Fetch the rendered CLAUDE.md from the server and write it to the workspace.
 
     Gracefully handles:
     - 404: older server without the endpoint — skip with warning.
     - Other HTTP errors / network errors — skip with warning.
+
+    Returns True iff a non-empty CLAUDE.md was successfully written; False on
+    any skipped or failed path (the caller already saw a stderr warning).
     """
     from urllib.parse import urlencode
     import httpx
@@ -353,27 +361,30 @@ def _write_claude_md(workspace: Path, server_url: str, token: str) -> None:
                 "Warning: server does not support CLAUDE.md generation (older version). Skipping.",
                 err=True,
             )
-            return
+            return False
         if resp.status_code == 401 or resp.status_code == 403:
             typer.echo(
                 f"Warning: CLAUDE.md fetch failed ({resp.status_code} {resp.reason_phrase}). Skipping.",
                 err=True,
             )
-            return
+            return False
         resp.raise_for_status()
         data = resp.json()
         content = data.get("content", "")
         if content:
             (workspace / "CLAUDE.md").write_text(content, encoding="utf-8")
-        else:
-            typer.echo("Warning: server returned empty CLAUDE.md content. Skipping.", err=True)
+            return True
+        typer.echo("Warning: server returned empty CLAUDE.md content. Skipping.", err=True)
+        return False
     except httpx.HTTPStatusError as e:
         typer.echo(
             f"Warning: CLAUDE.md fetch failed (HTTP {e.response.status_code}). Skipping.",
             err=True,
         )
+        return False
     except Exception as e:
         typer.echo(f"Warning: CLAUDE.md fetch failed: {e}. Skipping.", err=True)
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -443,7 +454,7 @@ def setup(
 
     # 7. Initialise Claude workspace (.claude/ hooks + placeholder + CLAUDE.md)
     typer.echo("Initializing Claude workspace...")
-    _init_claude_workspace(
+    claude_md_written = _init_claude_workspace(
         workspace,
         server_url=server_url if not no_claude_md else "",
         token=token if not no_claude_md else "",
@@ -456,8 +467,12 @@ def setup(
     typer.echo(f"  Tables   : {n_downloaded} downloaded, {total_rows} total rows")
     typer.echo(f"  Workspace: {workspace}")
     typer.echo(f"  Hooks    : SessionStart/End installed in {workspace}/.claude/settings.json")
-    if not no_claude_md:
+    if no_claude_md:
+        typer.echo(f"  CLAUDE.md: skipped (--no-claude-md)")
+    elif claude_md_written:
         typer.echo(f"  CLAUDE.md: written from server template")
+    else:
+        typer.echo(f"  CLAUDE.md: skipped (see warnings above)")
     typer.echo("")
     typer.echo("Next steps:")
     typer.echo("  da sync          — refresh data")

--- a/tests/test_analyst_bootstrap.py
+++ b/tests/test_analyst_bootstrap.py
@@ -153,7 +153,8 @@ class TestInitClaudeWorkspace:
         )
 
     def test_writes_claude_md_when_server_returns_200(self, tmp_workspace):
-        """When /api/welcome returns 200, CLAUDE.md is written."""
+        """When /api/welcome returns 200, CLAUDE.md is written and the helper
+        returns True so the caller can label its summary line accurately."""
         from cli.commands.analyst import _create_workspace, _init_claude_workspace
         from unittest.mock import MagicMock, patch
 
@@ -165,11 +166,45 @@ class TestInitClaudeWorkspace:
         mock_resp.raise_for_status = MagicMock()
 
         with patch("cli.commands.analyst.httpx.get", return_value=mock_resp):
-            _init_claude_workspace(tmp_workspace, server_url="https://example.com", token="tok")
+            written = _init_claude_workspace(
+                tmp_workspace, server_url="https://example.com", token="tok"
+            )
 
+        assert written is True
         claude_md = tmp_workspace / "CLAUDE.md"
         assert claude_md.exists()
         assert "My CLAUDE.md" in claude_md.read_text(encoding="utf-8")
+
+    def test_returns_false_when_server_returns_404(self, tmp_workspace):
+        """When the server is too old for /api/welcome (404), the helper
+        returns False so the caller can render the summary as 'skipped' instead
+        of contradicting its own stderr warning."""
+        from cli.commands.analyst import _create_workspace, _init_claude_workspace
+        from unittest.mock import MagicMock, patch
+
+        _create_workspace(tmp_workspace)
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch("cli.commands.analyst.httpx.get", return_value=mock_resp):
+            written = _init_claude_workspace(
+                tmp_workspace, server_url="https://example.com", token="tok"
+            )
+
+        assert written is False
+        assert not (tmp_workspace / "CLAUDE.md").exists()
+
+    def test_returns_false_when_no_server_url(self, tmp_workspace):
+        """Caller passing empty server_url/token (e.g. --no-claude-md) gets False back."""
+        from cli.commands.analyst import _create_workspace, _init_claude_workspace
+
+        _create_workspace(tmp_workspace)
+        written = _init_claude_workspace(tmp_workspace, server_url="", token="")
+
+        assert written is False
+        assert not (tmp_workspace / "CLAUDE.md").exists()
 
     def test_does_not_write_claude_md_when_no_claude_md_flag(self, tmp_workspace):
         """When server_url/token are empty (--no-claude-md path), CLAUDE.md is not written."""


### PR DESCRIPTION
## Summary

Hotfix on top of #169 (still un-released — v0.31.0 tag deleted, this rolls into it).

`da analyst setup` printed the contradictory pair when `/api/welcome` failed:
- stderr: \`Warning: server does not support CLAUDE.md generation (older version). Skipping.\`
- stdout: \`CLAUDE.md: written from server template\`

\`_write_claude_md\` was returning \`None\` on every path (success and skip) so the caller couldn't tell whether it actually wrote anything. Fixed: \`_write_claude_md\` now returns \`bool\` (True on successful non-empty write, False on skip/error). \`_init_claude_workspace\` propagates the bool. The setup summary now branches:

- \`--no-claude-md\` → \`CLAUDE.md: skipped (--no-claude-md)\`
- 200 with content → \`CLAUDE.md: written from server template\`
- 404 / 401 / 5xx / network / empty → \`CLAUDE.md: skipped (see warnings above)\`

## Test plan

- [ ] \`da analyst setup\` against a server that supports \`/api/welcome\` shows "written from server template".
- [ ] \`da analyst setup\` against an older server (404) shows the warning and "skipped" — no contradictory message.
- [ ] \`da analyst setup --no-claude-md\` shows "skipped (--no-claude-md)".
- [ ] Auth failure (401/403) shows the auth warning and "skipped".
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->