### PR TITLE
fix(cli): Windows console crashes on da skills list / da sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Fixed
+- **Windows: `da skills list` and `da sync` no longer crash on cp1250 consoles.**
+  On a Czech-locale Windows console (default codepage `cp1250`), Rich's
+  Braille spinner glyphs and skill markdown's UTF-8 chars (em-dash, accents)
+  triggered `UnicodeEncodeError` / `UnicodeDecodeError` before any
+  command-level code ran. Two fixes: (1) `cli/main.py` reconfigures
+  stdout/stderr to UTF-8 with `errors="replace"` at import time on
+  `sys.platform == "win32"`, so Rich's legacy-Windows render path emits
+  decodable bytes; (2) all `Path.read_text()` / `Path.write_text()` in `cli/`
+  now pass `encoding="utf-8"` explicitly — defensive coverage for the
+  `cli/config.py`, `cli/update_check.py`, `cli/snapshot_meta.py`,
+  `cli/commands/skills.py`, `cli/commands/analyst.py`, `cli/commands/setup.py`
+  call sites that were previously relying on the locale default.
+
 ## [0.32.0] — 2026-05-04
 
 Closes #160. Headline fix: `da query --remote` now resolves

--- a/cli/commands/analyst.py
+++ b/cli/commands/analyst.py
@@ -324,7 +324,7 @@ def _init_claude_workspace(
         # First-run defaults: model + permissions. _install_claude_hooks below
         # will merge in the SessionStart/End hooks on top of these.
         settings = {"model": "sonnet", "permissions": {"allow": ["Read", "Bash", "Grep", "Glob"]}}
-        settings_path.write_text(json.dumps(settings, indent=2))
+        settings_path.write_text(json.dumps(settings, indent=2), encoding="utf-8")
 
     _install_claude_hooks(settings_path)
 

--- a/cli/commands/setup.py
+++ b/cli/commands/setup.py
@@ -23,7 +23,7 @@ def setup_init(
 
     import yaml
     config = {"server": server}
-    config_file.write_text(yaml.dump(config))
+    config_file.write_text(yaml.dump(config), encoding="utf-8")
     typer.echo(f"Config saved to {config_file}")
     os.environ["DA_SERVER"] = server
     typer.echo("\nNext: da setup bootstrap --email admin@company.com")

--- a/cli/commands/skills.py
+++ b/cli/commands/skills.py
@@ -18,7 +18,7 @@ def list_skills():
     for f in sorted(SKILLS_DIR.glob("*.md")):
         name = f.stem
         # Read first line as description
-        first_line = f.read_text().split("\n")[0].strip("# ").strip()
+        first_line = f.read_text(encoding="utf-8").split("\n")[0].strip("# ").strip()
         typer.echo(f"  {name:25s} {first_line}")
 
 
@@ -29,4 +29,4 @@ def show_skill(name: str = typer.Argument(..., help="Skill name to display")):
     if not skill_file.exists():
         typer.echo(f"Skill '{name}' not found. Run: da skills list", err=True)
         raise typer.Exit(1)
-    typer.echo(skill_file.read_text())
+    typer.echo(skill_file.read_text(encoding="utf-8"))

--- a/cli/config.py
+++ b/cli/config.py
@@ -20,7 +20,7 @@ def get_server_url() -> str:
 def get_token() -> Optional[str]:
     token_file = _config_dir() / "token.json"
     if token_file.exists():
-        data = json.loads(token_file.read_text())
+        data = json.loads(token_file.read_text(encoding="utf-8"))
         return data.get("access_token")
     return os.environ.get("DA_TOKEN")
 
@@ -37,7 +37,7 @@ def save_token(token: str, email: str, role: Optional[str] = None):
     token_file.write_text(json.dumps({
         "access_token": token,
         "email": email,
-    }, indent=2))
+    }, indent=2), encoding="utf-8")
 
 
 def clear_token():
@@ -50,20 +50,20 @@ def load_config() -> dict:
     config_file = _config_dir() / "config.yaml"
     if config_file.exists():
         import yaml
-        return yaml.safe_load(config_file.read_text()) or {}
+        return yaml.safe_load(config_file.read_text(encoding="utf-8")) or {}
     return {}
 
 
 def get_sync_state() -> dict:
     state_file = _config_dir() / "sync_state.json"
     if state_file.exists():
-        return json.loads(state_file.read_text())
+        return json.loads(state_file.read_text(encoding="utf-8"))
     return {}
 
 
 def save_sync_state(state: dict):
     state_file = _config_dir() / "sync_state.json"
-    state_file.write_text(json.dumps(state, indent=2))
+    state_file.write_text(json.dumps(state, indent=2), encoding="utf-8")
 
 
 def save_config(data: dict):
@@ -73,6 +73,6 @@ def save_config(data: dict):
     config_file = _config_dir() / "config.yaml"
     existing = {}
     if config_file.exists():
-        existing = yaml.safe_load(config_file.read_text()) or {}
+        existing = yaml.safe_load(config_file.read_text(encoding="utf-8")) or {}
     existing.update(data)
-    config_file.write_text(yaml.dump(existing, default_flow_style=False))
+    config_file.write_text(yaml.dump(existing, default_flow_style=False), encoding="utf-8")

--- a/cli/main.py
+++ b/cli/main.py
@@ -3,10 +3,25 @@
 Primary interface for AI agents. Install: uv tool install data-analyst
 """
 
+import sys
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 
 import typer
+
+# Force UTF-8 on Windows stdout/stderr at import time. The default Windows
+# console codepage (cp1250 on cs-CZ, cp1252 on en-US, …) cannot encode the
+# Braille spinner glyphs Rich uses for `da sync` progress, nor the em-dash /
+# accented chars that show up in skill markdown via `da skills list`. Both
+# crash with UnicodeEncode/DecodeError before any command-level code runs.
+# `reconfigure` is a no-op on non-TextIOWrapper streams (pytest capture,
+# pipes wrapped by other tooling) — swallow the AttributeError there.
+if sys.platform == "win32":
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, OSError):
+        pass
 
 from cli.commands.auth import auth_app
 from cli.commands.sync import sync_app

--- a/cli/snapshot_meta.py
+++ b/cli/snapshot_meta.py
@@ -39,7 +39,7 @@ def _meta_path(snap_dir: Path, name: str) -> Path:
 
 def write_meta(snap_dir: Path, meta: SnapshotMeta) -> None:
     snap_dir.mkdir(parents=True, exist_ok=True)
-    with _meta_path(snap_dir, meta.name).open("w") as f:
+    with _meta_path(snap_dir, meta.name).open("w", encoding="utf-8") as f:
         json.dump(asdict(meta), f, indent=2)
 
 
@@ -47,7 +47,7 @@ def read_meta(snap_dir: Path, name: str) -> Optional[SnapshotMeta]:
     p = _meta_path(snap_dir, name)
     if not p.exists():
         return None
-    data = json.loads(p.read_text())
+    data = json.loads(p.read_text(encoding="utf-8"))
     return SnapshotMeta(**data)
 
 
@@ -57,7 +57,7 @@ def list_snapshots(snap_dir: Path) -> list[SnapshotMeta]:
     out = []
     for meta_file in snap_dir.glob("*.meta.json"):
         try:
-            data = json.loads(meta_file.read_text())
+            data = json.loads(meta_file.read_text(encoding="utf-8"))
             out.append(SnapshotMeta(**data))
         except (json.JSONDecodeError, TypeError):
             continue

--- a/cli/update_check.py
+++ b/cli/update_check.py
@@ -88,7 +88,7 @@ def _read_cache() -> Optional[dict]:
     if not p.exists():
         return None
     try:
-        return json.loads(p.read_text())
+        return json.loads(p.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
 
@@ -97,7 +97,7 @@ def _write_cache(entry: dict) -> None:
     p = _cache_path()
     try:
         p.parent.mkdir(parents=True, exist_ok=True)
-        p.write_text(json.dumps(entry))
+        p.write_text(json.dumps(entry), encoding="utf-8")
     except OSError:
         pass  # best-effort — cache failure must not break the flow
 


### PR DESCRIPTION
cp1250 (cs-CZ default) and cp1252 consoles cannot encode the Braille spinner glyphs Rich uses for progress bars, nor decode UTF-8 chars in skill markdown — both crash before any command-level code runs.

- cli/main.py: reconfigure stdout/stderr to UTF-8 with errors="replace" on sys.platform == "win32", at import time so Rich's legacy-Windows render path emits decodable bytes.
- cli/commands/skills.py: pass encoding="utf-8" to read_text() (root cause of `da skills list` UnicodeDecodeError).
- cli/{config,update_check,snapshot_meta}.py and cli/commands/{analyst, setup}.py: defensive encoding="utf-8" on all remaining read_text / write_text / open() calls — these wrote ASCII-only JSON in practice but were one non-ASCII value away from the same failure mode.