### PR TITLE
feat(workspace-prompt): decision tree + size-hint so analyst Claude gets it right first try

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Added
+- **Workspace prompt: decision tree, common-mistakes callout, failure-mode dictionary** in `config/claude_md_template.txt` (the template `agnes init` writes to `<workspace>/CLAUDE.md`). Surfaces every catalog-row field analyst Claude should read before deciding which command to use (`query_mode`, `sql_flavor`, `where_examples`, `fetch_via`, `rough_size_hint`); explicitly binds `--estimate` to `agnes snapshot create` ONLY (was the most-failed first-try misuse — fails with `No such option: --estimate` on `agnes query`); calls out the `agnes fetch` → `agnes snapshot create` rename so stale-doc analysts don't run a non-command; documents the BQ permission model (server SA, not personal Google identity) and a 6-row failure-mode table mapping each common error wording to its cause + the right next step.
+- **`rough_size_hint` populated for `local` + `materialized` catalog rows** in `GET /api/v2/catalog` (was hardcoded `null` with a "Task 8" TODO). Reads the parquet file size at `${DATA_DIR}/extracts/<source_type>/data/<table_id>.parquet` and buckets into `small` (≤100 MiB), `medium` (≤1 GiB), `large` (≤10 GiB), `very_large` (>10 GiB). `remote` rows stay `null` for now (size requires a BQ INFORMATION_SCHEMA call; tracked separately). Lets analyst Claude pick `agnes snapshot create` over `agnes query --remote` by inspecting `agnes catalog --json` rather than discovering size empirically via a failed `--remote` round-trip.
+
+### Changed
+- **CLI update-banner now says `agnes` instead of `da`** (`cli/update_check.py:format_outdated_notice`). The string `[update] da X is out of date` had survived the `da` → `agnes` CLI rename and was the most-visible stale identifier in the analyst-facing surface — every CLI command printed it on stderr when a newer wheel was available.
+
 ### Fixed
 
 - Keboola sync now falls back to the legacy Storage-API client when the DuckDB Keboola extension's per-table scan fails, not just when the initial `ATTACH` fails. Two changes:

--- a/app/api/v2_catalog.py
+++ b/app/api/v2_catalog.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 from datetime import datetime, timezone
+from pathlib import Path
 from fastapi import APIRouter, Depends
 import duckdb
 
 from app.auth.dependencies import get_current_user, _get_db
+from app.utils import get_data_dir as _get_data_dir
 from src.rbac import can_access_table
 from src.repositories.table_registry import TableRegistryRepository
 from app.api.v2_cache import TTLCache
@@ -43,6 +45,52 @@ def _fetch_hint(table_id: str, source_type: str) -> str:
     return "already local — query directly via `agnes query`"
 
 
+# Coarse size buckets for `rough_size_hint`. Boundaries chosen so an analyst
+# Claude can decide tool by inspection: anything `large` or worse implies
+# `agnes snapshot create` over `agnes query --remote`. Numbers reflect the
+# default `bq_max_scan_bytes` 5 GiB ceiling — at "large" you're already at
+# half the per-query gate and a naive `--remote` is likely to refuse.
+_SIZE_BUCKETS = (
+    (10 * 2**20, "small"),     # ≤10 MiB
+    (100 * 2**20, "small"),    # ≤100 MiB still small (analyst-laptop scale)
+    (1 * 2**30, "medium"),     # ≤1 GiB
+    (10 * 2**30, "large"),     # ≤10 GiB
+)
+
+
+def _bucket_size(byte_count: int) -> str:
+    for cap, label in _SIZE_BUCKETS:
+        if byte_count <= cap:
+            return label
+    return "very_large"
+
+
+def _materialized_size_hint(table_id: str, source_type: str, query_mode: str) -> str | None:
+    """Return a rough size bucket for a row whose data is on the server's
+    local filesystem (any `query_mode` that produces a parquet — `local` and
+    `materialized`). Returns ``None`` for `remote` (size requires a BQ
+    INFORMATION_SCHEMA round-trip; tracked separately) and for tables whose
+    parquet hasn't been materialised yet so the AI gets ``null`` not a
+    misleading "small".
+
+    Layout matches the v2 extract.duckdb contract:
+      ${DATA_DIR}/extracts/<source_type>/data/<table_id>.parquet
+    """
+    if query_mode == "remote":
+        return None
+    if not source_type:
+        return None
+    try:
+        path = Path(_get_data_dir()) / "extracts" / source_type / "data" / f"{table_id}.parquet"
+        if not path.exists():
+            return None
+        return _bucket_size(path.stat().st_size)
+    except Exception:
+        # Filesystem stat() race / permissions / weird DATA_DIR — fall back
+        # to null rather than crash the whole catalog response.
+        return None
+
+
 def build_catalog(conn: duckdb.DuckDBPyConnection, user: dict) -> dict:
     rows = _table_rows_cache.get(_TABLE_ROWS_KEY)
     if rows is None:
@@ -66,7 +114,10 @@ def build_catalog(conn: duckdb.DuckDBPyConnection, user: dict) -> dict:
             "sql_flavor": _flavor_for(r.get("source_type") or ""),
             "where_examples": _examples_for(r.get("source_type") or ""),
             "fetch_via": _fetch_hint(r["id"], r.get("source_type") or ""),
-            "rough_size_hint": None,  # populated by Task 8 schema endpoint when called
+            "rough_size_hint": _materialized_size_hint(
+                r["id"], r.get("source_type") or "",
+                r.get("query_mode") or "local",
+            ),
         })
 
     return {

--- a/cli/update_check.py
+++ b/cli/update_check.py
@@ -184,7 +184,7 @@ def format_outdated_notice(info: UpdateInfo) -> str:
     literal string "None" into a copy-pasteable command — drop the upgrade
     snippet in that case.
     """
-    msg = f"[update] da {info.installed} is out of date — latest on this server is {info.latest}."
+    msg = f"[update] agnes {info.installed} is out of date — latest on this server is {info.latest}."
     if info.download_url:
         msg += f" Upgrade: uv tool install --force {info.download_url}"
     return msg

--- a/config/claude_md_template.txt
+++ b/config/claude_md_template.txt
@@ -58,15 +58,43 @@ Not every table is synced. Tables registered with `query_mode: "remote"` live in
 BigQuery, accessed server-side via DuckDB's BQ extension — no parquet on disk.
 Tables you don't see in `server/parquet/` may still be queryable.
 
-### Discovery first
+### Discovery first — read `agnes catalog --json` BEFORE every cross-table decision
+
+`agnes catalog --json` returns one row per table with these fields. Use them; don't guess:
+
+| Field | What it tells you | How to use it |
+|---|---|---|
+| `query_mode` | `local` (parquet on laptop) / `remote` (BQ on demand) / `materialized` (synced parquet of a BQ result) | Picks the tool — see decision tree below |
+| `source_type` | `keboola` / `bigquery` / `jira` | Determines SQL dialect |
+| `sql_flavor` | `duckdb` for local sources, `bigquery` for `--remote` queries on BQ rows | What syntax `--where` expects |
+| `where_examples` | 1–3 example WHERE predicates that are valid for this table's dialect | Copy as starting point for `--where` |
+| `fetch_via` | Pre-formatted `agnes snapshot create …` template for this table | The canonical "how do I get a slice of this table" command |
+| `rough_size_hint` | Coarse size hint (`small` / `medium` / `large` or null when unknown) | Bigger than `medium` → never `agnes query --remote` without a tight `--where`; use `agnes snapshot create` |
 
 ```
-agnes catalog --json | jq '.[] | {name, source_type, query_mode}'   # see all tables + their modes
-agnes schema <table>                                                # columns + types
-agnes describe <table> -n 5                                         # sample rows
+agnes catalog --json                              # full structured view (use this in scripts)
+agnes catalog                                     # human-readable summary
+agnes schema <table>                              # columns + types (BIGQUERY/DUCKDB dialect printed in header)
+agnes describe <table> -n 5                       # sample rows (works on local & materialized only)
 ```
 
-For local-mode tables, query directly with `agnes query "SELECT … FROM <table>"`.
+### Decision tree — pick the right tool BEFORE writing SQL
+
+```
+                       ┌─ local        → agnes query "SELECT ..."
+agnes catalog →   ─────┤
+query_mode of <table>  ├─ materialized → agnes query (parquet was synced by agnes pull)
+                       │                 (if missing locally, run `agnes pull` first)
+                       │
+                       └─ remote       → choose by table size + query shape:
+                                          - one cheap probe (COUNT, schema-confirm, single agg ≤200s)
+                                              → agnes query --remote "..."
+                                          - repeated questions on same slice / large scan
+                                              → agnes snapshot create <table> --select ... --where ... --as <name>
+                                                then agnes query "SELECT ... FROM <name>"
+                                          - join with a local table
+                                              → agnes query --register-bq "alias=BQ_SQL" --sql "..."
+```
 
 ### Three patterns for `query_mode: "remote"` tables
 
@@ -76,13 +104,30 @@ For local-mode tables, query directly with `agnes query "SELECT … FROM <table>
 | **`agnes query --remote`** | one-shot, server-side execution against BigQuery (works for BASE TABLE rows directly + VIEW/MATERIALIZED_VIEW rows via the BQ jobs API; cost-guarded by a 5 GiB scan cap configurable in /admin/server-config) | single aggregate / cheap probe |
 | **`agnes query --register-bq`** | hybrid joins between local snapshots and ad-hoc BQ subqueries | crossing local + remote |
 
-### Permission model + cost — important
+### Common mistakes — avoid on first try
 
-- BQ access goes through the **agnes server's GCE service account**, not your personal Google credentials. If a query fails with a permission error, the table is in a project the server SA cannot read — escalate to admin, do NOT try to authenticate yourself.
-- Every BQ query bills the SA's GCP project for **bytes scanned**. A naive `SELECT * FROM <large_table>` can cost real money. ALWAYS:
-  - filter via `--where` on the partition column (typically a date)
-  - list specific columns in `--select` — column-store BQ skips the rest, cheaper
-  - run `--estimate` first when unsure of the table size or partitioning
+- **`--estimate` is on `agnes snapshot create` ONLY.** Do NOT pass it to `agnes query` — fails with `No such option: --estimate`. The estimate flow is a snapshot-creation cost gate, not a query primitive.
+- **Old `agnes fetch` / `da fetch` / `da query` references in stale docs** — the CLI is `agnes`; `agnes fetch` was renamed to `agnes snapshot create`. If you see those names, translate before running.
+- **Don't attempt personal GCP auth** if a BQ query fails with permission errors. BQ access uses the **server's service account**, not your Google identity — escalate to admin instead.
+- **Don't `agnes query --remote "SELECT * FROM <large_table>"`** without a `--where`. Even if the scan-byte gate refuses, you've wasted the round-trip; gate yourself first by reading `rough_size_hint` and `where_examples` from `agnes catalog --json`.
+
+### Failure-mode dictionary — what each error means + the right response
+
+| Error wording (substring) | Cause | Response |
+|---|---|---|
+| `Binder Error: Query execution exceeded the timeout. Job ID: ...` | BQ-side query took >~200 s wall-clock; the DuckDB BQ extension's `bq_query_timeout_ms` (default 90 s, server may bump to 600 s) elapsed | Narrow `--where` (especially partition column), drop unused columns from `--select`, or switch to `agnes snapshot create` to materialise once + query locally |
+| `HTTP 400: remote_scan_too_large` | Server's `bq_max_scan_bytes` cost gate refused the query (default 5 GiB) | Tighten `--where`; consider `agnes snapshot create` so the cost is paid once, then local queries are free |
+| `HTTP 401: ... unauthorized` | PAT expired or wrong | `agnes init --server-url ... --token <new-PAT>`; re-mint via the dashboard's "Personal Access Tokens" page |
+| `HTTP 403: cross_project_forbidden` (with `serviceusage` mention) | Server SA lacks `serviceusage.services.use` on the BQ data project | Escalate to admin to set `data_source.bigquery.billing_project`; do NOT try personal auth |
+| `ReadTimeout` (client-side) on `agnes query --remote` | CLI is older than 0.35.1 (had 30 s default) | `agnes --version`; if <0.35.1, upgrade with `uv tool install --force <wheel-from-server>` (the URL is in the `[update]` banner that prints on every command). Then retry. |
+| `unknown columns: [...]` from `agnes snapshot create` | `--select` lists columns that don't exist | Run `agnes schema <table>` and copy column names verbatim |
+
+### Cost discipline — every BQ query bills bytes scanned
+
+A naive `SELECT * FROM <large_table>` can cost real money. ALWAYS:
+- filter via `--where` on the partition column (typically a date) — read `where_examples` in `agnes catalog --json`
+- list specific columns in `--select` — column-store BQ skips the rest
+- run `--estimate` first (only valid on `agnes snapshot create`) when the table is partitioned/clustered or when `rough_size_hint` is unknown
 
 ### `agnes snapshot create` discipline
 


### PR DESCRIPTION
## Why

A real analyst Claude session in another window misused the CLI on first try and reported five concrete failures, all of which trace back to ambiguities in the analyst-facing workspace prompt + missing structured signals on the `agnes catalog` payload:

- `agnes query --remote --estimate` → `No such option: --estimate Did you mean --remote?` — `--estimate` is on `agnes snapshot create`, not `agnes query`. The template said "ALWAYS run `--estimate` first" inside the snapshot section but a few lines above mentioned `--estimate` without binding to a specific command — easy to misread.
- `agnes fetch` was attempted because stale docs/training data still references it. The command was renamed to `agnes snapshot create` per the 0.34.0 bootstrap PR; the template doesn't acknowledge the rename.
- Repeated guesswork on "how big is this table" — the catalog row carries `rough_size_hint` but it's hardcoded `null` with a TODO; analysts only discover size empirically via a failed `--remote` round-trip.
- `[update] da X is out of date` printed on every command (CLI banner survived the `da → agnes` rename) — trains analysts to associate the binary with the old name.

## What changes

| File | Change |
|---|---|
| `config/claude_md_template.txt` | Discovery section gets a field-by-field table of `agnes catalog --json` columns (each with "what it tells you" + "how to use it"). Adds an explicit decision tree by `query_mode`. Adds a "Common mistakes" callout that explicitly scopes `--estimate` to `agnes snapshot create` and the `agnes fetch` → `agnes snapshot create` rename. Adds a 6-row failure-mode dictionary mapping each common error wording to cause + right next step (timeout, scan-too-large, 401, cross_project_forbidden, ReadTimeout, unknown columns). |
| `app/api/v2_catalog.py` | Populates `rough_size_hint` for `local` + `materialized` rows from the on-disk parquet size at `${DATA_DIR}/extracts/<source_type>/data/<table_id>.parquet`, bucketed `small` (≤100 MiB) / `medium` (≤1 GiB) / `large` (≤10 GiB) / `very_large` (>10 GiB). `remote` stays `null` until a separate BQ INFORMATION_SCHEMA path lands. Fail-soft on filesystem errors. |
| `cli/update_check.py` | `[update] da X is out of date` → `[update] agnes X is out of date`. |
| `CHANGELOG.md` | Entries under `[Unreleased]` → Added / Changed. |

## Decision tree (preview)

The template now spells this out so the AI can pick its tool BEFORE writing any SQL:

```
                       ┌─ local        → agnes query "SELECT ..."
agnes catalog →   ─────┤
query_mode of <table>  ├─ materialized → agnes query (parquet was synced by agnes pull)
                       │                 (if missing locally, run `agnes pull` first)
                       │
                       └─ remote       → choose by table size + query shape:
                                          - one cheap probe (COUNT, schema-confirm, single agg ≤200s)
                                              → agnes query --remote "..."
                                          - repeated questions on same slice / large scan
                                              → agnes snapshot create <table> --select ... --where ... --as <name>
                                                then agnes query "SELECT ... FROM <name>"
                                          - join with a local table
                                              → agnes query --register-bq "alias=BQ_SQL" --sql "..."
```

## Failure-mode dictionary (preview)

Every error wording an analyst will see, mapped to cause + next step:

| Error wording (substring) | Cause | Response |
|---|---|---|
| `Binder Error: Query execution exceeded the timeout. Job ID: ...` | BQ-side query took >~200 s wall-clock; the DuckDB BQ extension's `bq_query_timeout_ms` elapsed | Narrow `--where`, drop columns, or `agnes snapshot create` |
| `HTTP 400: remote_scan_too_large` | Server's `bq_max_scan_bytes` cost gate refused | Tighten `--where`; `agnes snapshot create` so cost is paid once |
| `HTTP 401: ... unauthorized` | PAT expired | `agnes init --token <new>` |
| `HTTP 403: cross_project_forbidden` | Server SA lacks BQ access | Escalate to admin; do NOT try personal auth |
| `ReadTimeout` (client-side) | CLI <0.35.1 (had 30 s default) | `uv tool install --force <wheel-from-update-banner>` |
| `unknown columns: [...]` from `agnes snapshot create` | `--select` lists columns that don't exist | `agnes schema <table>` and copy column names verbatim |

## Test plan

- [x] `pytest tests/test_claude_md_renderer.py tests/test_claude_md_api.py` — 33/33 pass; renderer doesn't choke on the new content
- [x] Full template render against representative `data_source: bigquery` and `data_source: keboola` contexts — output is valid markdown, jinja `StrictUndefined` doesn't trip
- [x] Empirical reproduction of all 5 use-cases from the original analyst screenshot via real CLI against a dev VM (issue #5 reproduced; #3 fixed by separate PR #181; #2 Windows-only; #1 already fixed by 0.35.1)
- [x] Vendor-token sweep — no foundryai/groupon/prj-grp leakage

## Out of scope (separate PRs / follow-ups)

- BQ INFORMATION_SCHEMA lookup for `remote` row size (would let `rough_size_hint` work for `--remote`-only tables too)
- Server-side cache of `rough_size_hint` so the catalog response doesn't `stat()` on every call (currently no significant cost — the catalog endpoint is already cached for 5 min via `_table_rows_cache`)
- Translating the existing `docs/CLAUDE.md`'s "Querying Agnes data — agent rails" section to current `agnes` CLI (separate doc cleanup)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->