### PR TITLE
fix(sync): make POST /api/sync/trigger singleton per process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,13 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Changed
+
+- `POST /api/sync/trigger` is now singleton per process. A second trigger that arrives while the previous sync is still running returns **HTTP 409** (`detail: sync_already_in_progress`) instead of scheduling a parallel `_run_sync`. The scheduler container's `data-refresh` job logs the 409 as a normal warning and waits for its next tick — no retry loop. Operator-visible: clients that hand-roll their own polling on `/api/sync/trigger` now need to handle 409. Why it matters: two concurrent extractor subprocesses both write `extract.duckdb`, fight for its file lock, starve uvicorn's worker pool, and Docker flips `agnes-app` to `unhealthy` long enough for `reverse_proxy`-fronted deploys to return 503 to external traffic until contention drains.
+
 ### Fixed
 
+- Latent `NameError: name '_sys' is not defined` in `app/api/sync.py:_run_sync` when the function fell into its outer `except Exception` before reaching the inner `import sys as _sys`. Hoisted the import to the top of the body so the error path stays loggable instead of trading the original failure for a misleading stack trace.
 - Keboola sync now falls back to the legacy Storage-API client when the DuckDB Keboola extension's per-table scan fails, not just when the initial `ATTACH` fails. Two changes:
   - `kbcstorage>=0.9.0` is promoted from optional to core dependency. The legacy fallback path in `connectors/keboola/extractor.py:_extract_via_legacy` has been there since the extension landed, but until now the bare `from kbcstorage.client import Client` would crash any default install with `ModuleNotFoundError`.
   - `connectors/keboola/extractor.py:run` now wraps `_extract_via_extension` in a per-table try/except — on any per-table scan failure it retries via the legacy client. Previously, when `ATTACH` succeeded but the table-level `COPY (SELECT * FROM kbc."<bucket>"."<table>")` failed, the table was just marked failed with no retry.

--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -4,6 +4,7 @@ import hashlib
 import logging
 import os
 import subprocess
+import threading
 import traceback
 from datetime import datetime, timezone
 from pathlib import Path
@@ -24,6 +25,17 @@ from src.scheduler import filter_due_tables, is_table_due
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/sync", tags=["sync"])
+
+# Process-wide guard against overlapping `_run_sync` invocations. Two
+# concurrent extractor subprocesses both write `extract.duckdb` and fight
+# for its file lock — the first sync stalls, the second crashes, and the
+# `/api/health` check times out long enough that Docker flips the
+# container to `unhealthy`, which (behind a `reverse_proxy` upstream)
+# bricks external traffic until contention drains. The singleton-ness is
+# enforced both in the trigger handler (return 409 fast, before the work
+# is scheduled) and in `_run_sync` itself (defense in depth, in case
+# something bypasses the handler).
+_sync_lock = threading.Lock()
 
 
 def _file_hash(path: Path) -> str:
@@ -258,9 +270,20 @@ def _run_sync(tables: Optional[List[str]] = None):
     Reads table configs from DuckDB (in main process which has the shared
     connection), passes them as JSON via stdin to the extractor subprocess.
     This avoids DuckDB lock conflicts — subprocess never opens system.duckdb.
+
+    Singleton: only one invocation runs at a time per process (see
+    `_sync_lock` module-level). The trigger handler also fast-fails with
+    409 when the lock is held, so this branch is defense in depth.
     """
     import json as _json
-    import sys
+    import sys as _sys
+
+    if not _sync_lock.acquire(blocking=False):
+        print(
+            "[SYNC] another sync is already in flight — skipping",
+            file=_sys.stderr, flush=True,
+        )
+        return
 
     try:
         from app.instance_config import get_data_source_type, get_value
@@ -342,7 +365,6 @@ def _run_sync(tables: Optional[List[str]] = None):
             )
 
         env = {**os.environ}
-        import sys as _sys
 
         if run_extractor_subprocess:
             # Serialize configs — strip non-serializable fields
@@ -353,7 +375,7 @@ def _run_sync(tables: Optional[List[str]] = None):
 
             # Run extractor subprocess with table configs via stdin
             # Subprocess does NOT open system.duckdb — no lock conflict
-            cmd = [sys.executable, "-c", """
+            cmd = [_sys.executable, "-c", """
 import json, sys, os, logging
 from pathlib import Path
 
@@ -441,7 +463,7 @@ sys.exit(compute_exit_code(result, len(configs)))
                     logger.info("Running custom connector: %s", connector_dir.name)
                     try:
                         custom_result = subprocess.run(
-                            [sys.executable, str(extractor)],
+                            [_sys.executable, str(extractor)],
                             env=env, capture_output=True, text=True, timeout=600,
                             cwd=str(Path(__file__).parent.parent.parent),
                         )
@@ -535,6 +557,8 @@ sys.exit(compute_exit_code(result, len(configs)))
     except Exception as e:
         print(f"[SYNC] FAILED: {e}", file=_sys.stderr, flush=True)
         traceback.print_exc()
+    finally:
+        _sync_lock.release()
 
 
 # ---- Manifest ----
@@ -625,7 +649,20 @@ async def trigger_sync(
     tables: Optional[List[str]] = None,
     user: dict = Depends(require_admin),
 ):
-    """Trigger data sync from configured source. Admin only. Runs in background."""
+    """Trigger data sync from configured source. Admin only. Runs in background.
+
+    Returns 409 if a previously-triggered sync is still running. Two
+    concurrent extractor subprocesses fight for the same `extract.duckdb`
+    file lock — that contention starves uvicorn, makes `/api/health` time
+    out, flips the container to `unhealthy`, and (behind a `reverse_proxy`
+    upstream like the bundled Caddy overlay) bricks external traffic
+    until contention drains. Fast-fail here keeps that from happening.
+    """
+    if _sync_lock.locked():
+        raise HTTPException(
+            status_code=409,
+            detail="sync_already_in_progress",
+        )
     background_tasks.add_task(_run_sync, tables)
     return {
         "status": "triggered",

--- a/tests/test_sync_trigger_singleton.py
+++ b/tests/test_sync_trigger_singleton.py
@@ -1,0 +1,110 @@
+"""Process-wide singleton guard around POST /api/sync/trigger.
+
+Without it, two near-simultaneous trigger calls each launch their own
+extractor subprocess, both write `extract.duckdb`, fight for the file
+lock, starve uvicorn, and Docker flips the container to `unhealthy`.
+
+These tests cover the trigger handler's 409 fast-fail (the
+operator-visible behavior) and the in-`_run_sync` defense-in-depth
+(if something bypasses the handler).
+"""
+from unittest.mock import patch
+
+import pytest
+
+from app.api import sync as sync_module
+
+
+@pytest.fixture(autouse=True)
+def reset_sync_lock():
+    """Make sure each test starts with a free lock — and never leaves one
+    held even if an assertion fires mid-test."""
+    if sync_module._sync_lock.locked():
+        sync_module._sync_lock.release()
+    yield
+    if sync_module._sync_lock.locked():
+        sync_module._sync_lock.release()
+
+
+def test_run_sync_skips_when_lock_held(capsys):
+    """When `_sync_lock` is already held, `_run_sync` no-ops with a log
+    line instead of starting a second extractor subprocess."""
+    sync_module._sync_lock.acquire()
+
+    # Patch the heavy parts so a successful path would otherwise execute.
+    # Reaching any of them while the lock is held would be the bug.
+    with patch("app.api.sync.subprocess.run") as run_mock, \
+         patch("app.instance_config.get_data_source_type") as src_mock:
+        sync_module._run_sync(tables=None)
+
+    assert not run_mock.called, "extractor subprocess must not run when lock is held"
+    assert not src_mock.called, "_run_sync must short-circuit before reading config"
+
+    captured = capsys.readouterr()
+    assert "another sync is already in flight" in captured.err
+
+
+def test_run_sync_releases_lock_on_exception():
+    """Even if the body throws, the lock must release so the next sync can
+    run. Asserts the `finally:` covers all exit paths.
+
+    `_run_sync` imports `get_data_source_type` lazily inside the body, so
+    we patch the source module rather than the re-export in `app.api.sync`.
+    """
+    with patch(
+        "app.instance_config.get_data_source_type",
+        side_effect=RuntimeError("boom"),
+    ):
+        # Should not raise — `_run_sync` catches and logs
+        sync_module._run_sync(tables=None)
+
+    assert not sync_module._sync_lock.locked()
+
+
+def test_trigger_endpoint_returns_409_when_locked():
+    """Handler-level fast-fail: when a sync is already running, the
+    trigger endpoint returns 409 without scheduling a second background
+    task."""
+    from fastapi.testclient import TestClient
+    from fastapi import FastAPI
+
+    # Stand up a minimal app exposing only the sync router. Bypass auth
+    # by overriding the require_admin dependency.
+    from app.auth.access import require_admin
+
+    app = FastAPI()
+    app.include_router(sync_module.router)
+    app.dependency_overrides[require_admin] = lambda: {"id": "test", "email": "t@e"}
+    client = TestClient(app)
+
+    sync_module._sync_lock.acquire()
+    try:
+        resp = client.post("/api/sync/trigger")
+        assert resp.status_code == 409
+        assert resp.json()["detail"] == "sync_already_in_progress"
+    finally:
+        sync_module._sync_lock.release()
+
+
+def test_trigger_endpoint_succeeds_when_lock_free():
+    """When the lock is free, the trigger endpoint schedules the
+    background task and returns 200. The background task itself doesn't
+    execute synchronously in TestClient — that's how FastAPI background
+    tasks work — so we patch `_run_sync` to a no-op and only assert the
+    handler shape."""
+    from fastapi.testclient import TestClient
+    from fastapi import FastAPI
+    from app.auth.access import require_admin
+
+    app = FastAPI()
+    app.include_router(sync_module.router)
+    app.dependency_overrides[require_admin] = lambda: {"id": "test", "email": "t@e"}
+    client = TestClient(app)
+
+    with patch("app.api.sync._run_sync") as run_mock:
+        resp = client.post("/api/sync/trigger")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "triggered"
+        # BackgroundTasks runs after response; TestClient awaits them
+        run_mock.assert_called_once()


### PR DESCRIPTION
## Summary

Two near-simultaneous \`POST /api/sync/trigger\` calls (scheduler tick + manual retrigger, or two operators clicking at once) each scheduled their own \`_run_sync\`, which forked an extractor subprocess. Both subprocesses then opened the same \`extract.duckdb\` and fought for its file lock — observed live on a dev VM today: three concurrent extractors → DB-lock contention starved uvicorn → \`/api/health\` timed out 3× → Docker flipped \`agnes-app\` to \`unhealthy\` → Caddy \`reverse_proxy\` upstream check failed → external traffic dropped until contention drained.

## Changes

- Module-level \`threading.Lock\` in \`app/api/sync.py\`. The trigger handler returns **409** (\`detail: sync_already_in_progress\`) when held, before scheduling the background task. \`_run_sync\` acquires the lock non-blocking on entry and releases it in \`finally\` — defense in depth in case anything bypasses the handler.
- Hoist \`import sys as _sys\` to the top of \`_run_sync\`. The outer \`except Exception\` block referenced \`_sys\`, but the import sat inside the \`try\` body, so an early failure (e.g. config-loading exception) traded the original error for \`NameError: name '_sys' is not defined\`. Latent — surfaced by a new test that injects an exception before the import line.
- 4 new tests in \`tests/test_sync_trigger_singleton.py\`:
  - lock-held → \`_run_sync\` no-ops with log line, doesn't enter body
  - lock-released-after-exception via \`finally:\`
  - handler returns 409 when locked
  - handler returns 200 + schedules background task when free

## Operator impact

Clients that hand-roll their own polling on \`/api/sync/trigger\` now need to handle 409. The scheduler container's \`data-refresh\` job logs 409 as a normal HTTP warning and waits for its next tick — no retry loop. Documented in CHANGELOG \`### Changed\`.

## Test plan

- [x] \`pytest tests/test_sync_trigger_singleton.py tests/test_sync_trigger_materialized.py tests/test_sync_trigger_keboola_materialized.py tests/test_sync_manifest.py tests/test_sync_filter.py\` — 52 passed
- [ ] CI green
- [ ] On a live dev VM: trigger sync twice within seconds → second call returns 409, only one extractor subprocess in \`/proc\`, app stays healthy throughout
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->