### PR TITLE
host-mount: replace named-volume driver_opts with direct service binds

### DIFF
--- a/docker-compose.host-mount.yml
+++ b/docker-compose.host-mount.yml
@@ -1,14 +1,41 @@
-# Bind-mount overlay — replaces the `data` named volume with a bind mount
-# to /data on the host.
+# Bind-mount overlay — replaces the `data` named volume with a direct
+# host bind mount per service.
 #
-# Use this when /data is a persistent disk mounted by the VM startup script,
-# so Agnes data lives on the PD (not on the boot disk's Docker volume).
+# Why direct service-level bind, not driver_opts on the named volume
+# ------------------------------------------------------------------
+# The previous version of this file modified the `data` named volume's
+# `driver_opts` to point at /data with `o: bind,rbind`. Docker named
+# volumes have an immutability footgun: once a volume is created, its
+# driver options are fixed for the life of the volume. Editing this
+# file and re-running `docker compose up -d` does NOT propagate the
+# new options to existing volumes — they keep whatever options were
+# in effect at create time.
 #
-# `bind,rbind` (recursive bind) is required when the host nests a second
-# disk under /data — e.g. the dual-disk layout where sdb is mounted on /data
-# and sdc on /data/state. A plain `bind` captures only the top-level mount
-# and silently shadows the sub-mount with an empty subdirectory inside the
-# container, causing the app to write to the wrong disk.
+# This bit a deployer (Groupon FoundryAI) on 2026-05-05: the volume
+# was created before this overlay had `bind,rbind`, kept the old
+# `bind` (non-recursive) propagation, and containers wrote to a
+# shadowed subdirectory of the parent disk instead of the nested
+# child mount. DuckDB went FATAL on a root-owned WAL during a
+# routine container recreate; sign-in broke.
+#
+# Direct service-level bind mounts (`/host/path:/container/path`)
+# don't go through Docker's volume layer at all. They re-evaluate
+# the mount options every container start, and modern Docker Engine
+# (20.10+) defaults to recursive bind for these. No options to
+# forget, no immutable state to migrate, no shadow-mount class.
+#
+# What this overlay does
+# ----------------------
+# `volumes: !override` on each service replaces the base
+# `data:/data` named-volume mount with a direct `/data:/data` host
+# bind. The named volume `data:` declared at the bottom of
+# docker-compose.yml is left intact (still useful for local-dev
+# `compose up` without this overlay) but is no longer referenced
+# by any service when the overlay is active.
+#
+# When the operator's host has a nested mount under /data (e.g. a
+# separate state disk mounted at /data/state), the recursive bind
+# carries that nested mount into every container automatically.
 #
 # Usage (combined with docker-compose.prod.yml):
 #   docker compose \
@@ -17,11 +44,34 @@
 #     -f docker-compose.host-mount.yml \
 #     up -d
 #
-# Do NOT use this overlay in CI — /data does not exist on GitHub runners.
-volumes:
-  data:
-    driver: local
-    driver_opts:
-      type: none
-      o: bind,rbind
-      device: /data
+# Do NOT use this overlay in CI — /data does not exist on GitHub
+# runners.
+#
+# Compose-spec version requirement: !override merge tag is part of
+# the Compose Specification supported by Docker Compose v2.20+ and
+# the compose-go library used by Compose v5+. If you need to support
+# older clients, fork this overlay into per-service files.
+
+services:
+  app:
+    volumes: !override
+      - /data:/data
+      - ./config:/app/config:ro
+
+  extract:
+    volumes: !override
+      - /data:/data
+      - ./config:/app/config:ro
+
+  scheduler:
+    volumes: !override
+      - /data:/data
+      - ./config:/app/config:ro
+
+  telegram-bot:
+    volumes: !override
+      - /data:/data
+
+  ws-gateway:
+    volumes: !override
+      - /data:/data


### PR DESCRIPTION
## Summary

Eliminates a class of silent data-corruption bug from the bind-mount overlay by switching from "named volume with driver_opts" to "direct service-level bind mounts."

## The bug class

Docker named volumes are immutable in their driver options after creation. Once `agnes_data` is created with whatever options were in effect at `compose up` time, future edits to `driver_opts` in this file are silently ignored on existing volumes.

## How it bit us

Groupon FoundryAI deployment, 2026-05-05:

1. **2026-04-22**: VMs bootstrapped with this overlay, which at the time had `o: bind` (non-recursive). Volume `agnes_data` created with that option.
2. **2026-04-24**: Disk migration adds a second persistent disk for irreplaceable state, mounted under the data disk at `/data/state`.
3. **A later commit** updates this file to `o: bind,rbind` so the new nested mount propagates into containers.
4. **The existing `agnes_data` volume keeps the old `bind` option** because Docker doesn't migrate driver_opts on existing volumes.
5. **Containers write to a shadowed subdirectory of the parent disk** instead of the nested child mount. SQLite/DuckDB files diverge between what the host sees (correct disk) and what the app actually writes (shadow).
6. **2026-05-05**: a routine `tls_reconcile` recreates the agnes-app container. The new container can't open `/data/state/system.duckdb.wal` (root-owned, on the shadow). DuckDB enters FATAL state. Every authed request 500s. Google sign-in broken for ~30 minutes until manual recovery.

Recovery required `docker volume rm agnes_data` + selective data migration on every affected VM (5 of 9 in the deployment).

## The fix

Replace the named-volume `driver_opts` approach with direct service-level bind mounts via `volumes: !override` per service:

```yaml
services:
  app:
    volumes: !override
      - /data:/data           # direct host bind, recursive by default
      - ./config:/app/config:ro
```

**Why this fixes it permanently**:
- Direct bind mounts don't go through Docker's volume layer.
- Mount options re-evaluate every container start.
- Modern Docker Engine (20.10+) defaults to **recursive bind** for service-level binds, so any nested mount on the host (`/data/state`, etc.) propagates into containers automatically.
- No volume to migrate, no `driver_opts` to forget, no immutability footgun.

The `data:` named volume declaration in `docker-compose.yml` is left intact — it's still the path used by local-dev `compose up` without this overlay (where there's no host `/data` directory).

## Validation

```bash
$ docker compose -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.host-mount.yml config | head
services:
  app:
    volumes:
    - type: bind
      source: /data
      target: /data
      bind:
        create_host_path: true
    - type: bind
      source: ./config
      target: /app/config
      read_only: true
```

Each of `app`, `extract`, `scheduler`, `telegram-bot`, `ws-gateway` now bind `/data:/data` directly. The named volume `data:` no longer appears under any service's `volumes:`.

The 2026-05-05 incident root-cause analysis (with full inode comparison, mount tables, and the deployer-side recovery script) is captured in [Groupon's infra repo](https://github.groupondev.com/FoundryAI/agnes-the-ai-analyst-infra) PRs #78 + #79 + #80. The recovery script writes this same direct-bind config inline as a fallback when the deployed image lacks it — so this PR retroactively makes that fallback unnecessary for new deployments.

## Compose-spec version

`!override` merge tag is part of the Compose Specification supported by Docker Compose v2.20+. Tested against Compose v5.1.3 (Groupon deployment).

## What changes for existing deployers

- Next image rebuild containing this commit ships the new overlay.
- On the operator's VM, next `docker compose up -d` with this overlay starts containers with direct binds. The old `agnes_data` named volume is no longer referenced; can be removed with `docker volume rm agnes_data` (operator's choice — orphaned but harmless if left).
- For deployers who hit the 2026-05-05 shadow class: this PR makes the fix permanent. The recovery scripts can be retired once all VMs are on an image containing this commit.

## Backward compatibility

Local dev (`compose up` without the overlay): unchanged. Named volume `data` still works as before.
CI: unchanged. Overlay isn't loaded in CI per existing comment in the file.