### PR TITLE
docs(activity-center): brainstorm + implementation plan

### DIFF
--- a/docs/brainstorms/activity-center-requirements.md
+++ b/docs/brainstorms/activity-center-requirements.md
@@ -1,0 +1,399 @@
+# Activity Center — Requirements
+
+**Date:** 2026-05-05
+**Status:** Draft, brainstorm output (pre-plan)
+**Owner:** vrysanek
+**Phase:** Pre-`/ce:plan`. Implementation decisions are deliberately deferred.
+
+## Problem
+
+Agnes already collects rich behavioral data (Claude Code session JSONLs uploaded via `agnes push`, admin actions in `audit_log`, BigQuery scans via `BqAccess`), but none of it is exposed in a form leadership can interrogate. The CEO has asked for **comprehensive per-user activity visibility** — what each analyst prompts, which tools and plugins they invoke, which queries succeed or fail, and **how good each session is** (scored). Aggregates alone don't satisfy the ask; CEO wants drill-down per user with quantitative scoring of sessions and plugins, and a way to export the full picture.
+
+Today this requires reading raw JSONLs by hand. There is no privacy-mode toggle for analysts who want to keep a session off the wire, no per-department aggregation, no export, no scoring, and no view that distinguishes "user opened a plugin" from "user actually relied on it".
+
+## Goals
+
+**Ship one Activity Center that gives leadership a comprehensive per-user view, scored.** Not three phases of partial visibility — the CEO ask is unambiguous. Phasing here means iteration tracks (parallel work streams), not deferred features.
+
+The single coherent product:
+
+- **Per-user dashboards with chronological session replay.** Drill from "all users" → individual user → session timeline → individual session detail → individual prompt/tool call. The session detail is a step-by-step replay surface: events ordered by `event_ts`, prompt → tool calls → tool results → next prompt, with inputs/outputs visible at each step. Filter by `outcome='error'` or specific `error_class` to jump to the failure points. Cross-session chronology view shows the user's full event timeline across sessions so an admin can trace how a problem evolved (e.g. "user hit `remote_scan_too_large` three times across two sessions before figuring out the workaround"). Goal: the admin can almost replay the conditions a user faced when debugging or coaching, without having to read raw JSONL by hand.
+- **Scored sessions.** Every session gets a composite productivity score (0–100) plus sub-scores (success-rate, error-density, tool-efficiency, output-density, prompt-iteration). Sub-scores are deterministic. A 5% LLM-as-judge sample adds qualitative flavor (top accomplishments / worst stuck-points of the week).
+- **Scored plugins.** Composite adoption score (0–100) + sub-scores (breadth, intensity, success-rate, retention). CEO can rank plugins by actual leverage delivered, not just "how many people clicked install".
+- **Scored users.** Per-user composite (0–100) + sub-scores (productivity-trend, plugin-mastery, query-cost-efficiency). Trend is more important than absolute number — leadership sees who's improving, who's stuck.
+- **Failure intelligence.** Wrong-tool detection, query errors, plugin churn surfaced as a separate tile fed by the same store.
+- **Privacy mode.** Per-session opt-out. Already designed below.
+- **Hardening config.** Per-user prompt-level read is RBAC-gated + rate-limited + dual-approver-configurable from day one, not as a separate phase. Operator can enable instance-wide on day one or hold it back; the gating is config, not a release milestone.
+
+**Sequencing — be honest about what ships when.** Pass 2 review pushed back on the "single coherent release" framing as rhetorical: in practice, Track A ships first (initial release); Track B and C ship as first-iteration follow-ups within weeks, not quarters. Naming this honestly avoids over-committing to a release date that the underlying plan can't honor.
+
+- **Track A — Data + dashboards (initial release, critical path).** Extractor, schema, scoring engine, per-user / per-plugin / per-user dashboards, exports, privacy mode, disclosure flow, baseline RBAC gates. Ships first as the product face leadership opens.
+- **Track B — Failure intelligence (iteration 1).** `wrong_tool` heuristic, plugin-churn dashboard, failure-rate tile. Lands when the heuristic is validated against ≥10 sample sessions; not a release blocker for Track A.
+- **Track C — Hardening hardening (iteration 1, parallel with B).** Dual-approver flow, mutual-visibility digest, bulk-query rejection, compliance setup wizard. Track A ships with baseline RBAC + rate-limit + audit-log on day one; the more advanced abuse controls land alongside or shortly after.
+
+This is the brief the CEO actually asked for. Earlier drafts split the work into three sequential phases with per-user content gated behind works-council sign-off; that framing was rejected in adversarial review as bureaucratic deferral. The defaults the OSS ships are themselves product opinions, not neutral knobs — see *Defaults are product opinions* under Privacy & legal posture for the explicit posture.
+
+## Non-goals
+
+- **Real-time monitoring or alerting** for the dashboard. Daily refresh is sufficient for the leadership-overview use case; expect a worst-case t+24h tail (event happens → SessionEnd → `agnes push` → next nightly extractor → next admin `agnes pull`). BigQuery cost events are the one exception worth calling out: the existing 5 GiB scan cap (`/admin/server-config`) is the cost-prevention layer, not Activity Center. Activity Center does retrospective cost attribution; it does not stop a runaway query mid-flight. If sub-day cost detection is needed later, the synchronous path is `BqAccess` writing directly to `activity_events` at scan time — out of scope for Phase 1.
+- **Forking the JSONL walker.** Two existing pipelines already walk `/data/user_sessions/*.jsonl` and dedup via `session_extraction_state`: `services/corporate_memory` (knowledge extraction → `knowledge_items`) and `services/verification_detector` (verification-evidence extraction). Note: `services/session_collector` is a one-shot file *copier* (`shutil.copy2` from `/home/<user>/user/sessions/` to `/data/user_sessions/`); it does not parse JSONL contents. Activity Center becomes a third *content* consumer of the corpus. Plan-phase decision: either (a) introduce a shared walker abstraction that all three content extractors plug into (corporate_memory + verification_detector + activity_center), or (b) Activity Center runs an independent third scan with its own `activity_extraction_state` table. Option (a) is the better long-term shape but is a larger refactor than Track A alone justifies; Option (b) is the cheaper Track A landing with a refactor task in iteration backlog. Decide in plan-phase, not by accident in implementation.
+- **Tracking activity outside Agnes-managed sessions.** If a user runs Claude Code without `agnes init` hooks, nothing is captured. Acceptable, with the chilling-effect caveat under *Alternatives considered* below.
+- **Surveillance of private sessions.** Privacy mode (below) is a per-session opt-out the user can invoke. It is not a complete right-to-disconnect — admins still see metadata (existence, counts, durations); the session content is the only thing redacted. Documented honestly, not framed as something stronger than it is.
+- **Cross-tenant analytics.** Each instance is self-contained.
+
+## Users & primary outcomes
+
+| User | What they need |
+|------|----------------|
+| **CEO / leadership** | **Comprehensive per-user activity view, scored.** Drill from all-users → individual → session → prompt. Session, plugin, and user scores with trends. Export per user / per department / all. NL prompting for ad-hoc questions, dashboards as the primary surface. |
+| **Admin** | Per-user investigation any time. Plugin lifecycle audit (admin grants from `audit_log` joined to actual usage). Export per scope. RBAC gates + rate-limit + optional dual-approver — configured per instance, not as a release gate. |
+| **Platform team** | Failure patterns (wrong tool used, BQ scan rejected, snapshot too large). Drives roadmap. Same data, different lens. |
+| **Analyst (user)** | Visible privacy toggle they can invoke per session. Self-view of their own activity and scores — same view leadership sees of them, no asymmetry. Disclosure of what's collected, when, how long, who can see it. |
+
+## Decisions reached
+
+### 1. Single-release delivery (not 3 phases)
+- The product ships as one coherent Activity Center. Tracks A/B/C run in parallel; Track A (data + dashboard + scoring) is the critical path, B (failure classification) joins if its heuristic is solid, C (hardening config) is always-on from day one.
+- Per-user prompt-level read, dual-approver, rate-limits — all configurable on day one. Operators decide what to enable per instance; no feature is "deferred to a later phase" as a way of dodging a hard product decision now.
+- Implementation will still ship in iterations (Track A first, then B/C polish) but the user-facing brief and acceptance bar describe the whole product, not a partial first cut.
+
+### 2. Privacy mode: per-session opt-out, metadata-only
+- **Default:** full session activity is extracted (prompts, tool params, results) into the activity store. Subject to retention.
+- **When private:** the session's `agnes push` ships a **metadata manifest** — start/end timestamps, tool names, query target tables, durations, exit status — and the JSONL itself is *not* uploaded. The session's existence and counts are visible to admins ("user X had a 47-minute private session, 23 tool calls, 4 BQ queries"). This is the deliberate balance between trust and accountability — admins can spot anomalies without seeing content.
+- **Trust model — what server enforcement actually means.** The threat model is accidental disclosure (a careless toggle, a sync race, a forgotten setting), not hostile clients. A user determined to hide content can already run Claude Code without `agnes init` hooks (acknowledged in non-goals). The server enforces the model by structurally separating the two upload paths:
+  - **`POST /api/upload/sessions`** (existing) — full-JSONL upload. PAT-authed, 50 MB cap, streams to `${DATA_DIR}/user_sessions/<user_id>/`.
+  - **`POST /api/upload/sessions/manifest`** (new in Phase 1) — structured JSON body validated against a pydantic schema (`session_id`, `started_at`, `ended_at`, `tool_calls: [{name, target, duration_ms, outcome}]`, `query_count`, `bq_bytes_scanned`, `exit_status`). PAT-authed. Stored as JSON sidecar at `${DATA_DIR}/user_sessions/<user_id>/<session_id>.manifest.json`.
+
+  The client picks one endpoint per session based on the privacy toggle. The server cannot receive a "mixed" payload because the routes accept different content types and schemas — there is no third combined endpoint. The activity-center extractor reads `*.jsonl` and `*.manifest.json` from the same directory; a `*.manifest.json` shortcut-circuits any extraction attempts on a same-session JSONL (defense against a client that manages to call both endpoints — it's the manifest that wins).
+- **Toggle mechanism.** `agnes private on|off|status` writes per-session state keyed by Claude Code's `$CLAUDE_SESSION_ID` if the SessionStart hook can read it, otherwise falls back to a workspace-level flag with explicit "stays on until you turn it off" semantics — documented as the actual behavior, not approximated as session-scoped. Plan-phase verification task: confirm whether `$CLAUDE_SESSION_ID` (or equivalent) is exposed to hooks; if not, the docs say "workspace-wide private until `agnes private off`" plainly.
+- **No per-user persistent default in Phase 1.** Decision recorded explicitly: the toggle is per-session, defaults open, and the user re-asserts it each session. The reviewer-flagged dark-pattern risk is acknowledged and addressed by *not* claiming this is more than it is — see the disclosure language below, which describes the actual semantics rather than calling it a "first-class right". A per-user always-private option remains a Phase 3 candidate if works-council consultation or operator feedback shows the per-session friction is hurting trust.
+
+### 3. Plugin lifecycle = grants + adoption (both)
+- **Lifecycle (intent):** Admin grant/revoke events for a plugin (against a `user_group`) are already captured in `audit_log` via `app/api/access.py`. Surface those as the canonical "plugin enabled for this group" timeline. No new instrumentation needed.
+- **Adoption (reality):** Tool calls in session JSONLs carry plugin identity *only when the tool name is plugin-prefixed* (MCP tools like `mcp__plugin_<server>__<tool>`, plugin-defined slash commands resolvable via the cached `marketplace_plugins` table). Built-in Claude Code tools (Read/Edit/Bash/Grep/Glob/Edit/Task), Skill invocations without a plugin manifest, and ambiguous same-named tools across marketplaces produce `plugin_name = NULL`. The "first appearance = adopted" heuristic only applies to plugin-attributable tool calls; below a coverage threshold (target: ≥70% of a plugin's expected tool surface attributable from JSONL), the adoption signal is reported as **unobservable** rather than zero. A Phase 1 implementation task validates the derivation rule against a sample of real JSONLs (≥3 known plugins: one heavily used, one zombie, one ambiguous) before any roadmap decision uses the metric.
+- **Adoption persistence vs retention.** Raw events purge at 90 days, but a plugin granted >90 days ago and used at least once before the window opens would lose its first-adoption marker. To keep the headline "granted vs adopted" ratio meaningful past the retention window, the daily extractor upserts a denormalized aggregate `plugin_adoption(user_id, plugin_name, first_seen_at, last_seen_at)` that is kept past the rolling delete (aggregate-only, no payload).
+- **Abandonment threshold.** "Last appearance + N days of silence = abandoned" — initial value `N = 30 days`, configurable via `instance.yaml`. Validated against ≥3 plugins in plan-phase before publishing the metric on the dashboard (one heavily used, one zombie, one ambiguous).
+- Combined view answers the high-leverage question: "we granted access to plugin X to 50 users; how many actually use it monthly?" Both data sources already exist on disk; the activity-center extractor produces the join-friendly shape.
+
+### 4. Admin UX — surfaces by persona, defaults steered toward synthesis
+
+Five named surfaces, all on the existing `/activity-center` route. Defaults are steered toward synthesis (paragraph narrative, sub-score trends) over composite ranking, because composite-driven workforce decisions are the failure mode the OSS deliberately does not make easy.
+
+- **`/activity-center` (overview, default landing).** Tiles: active users 7d/30d (clickable to user-list), top plugins by composite score (clickable to plugin detail), BQ bytes by department, failure-rate trend, redaction-counter anomaly tile (operator hygiene), and **the weekly leadership digest tile** (see below). The "top users by composite score" tile is *off by default*; operators flip `scoring.show_user_composite_to_admin: true` in the setup wizard to surface it. Each tile has CSV/Parquet export.
+- **`/activity-center/weekly` (leadership digest, P2 review finding addressed).** A paragraph-shaped narrative synthesizing the prior week: top accomplishments by department, top friction points (failure-class trends), plugin highlights (zombies, breakouts), 1–3 recommended actions tied to the named decisions in §7. Generated nightly on Sunday from the deterministic data — *not* via LLM-as-judge (deferred to backlog) but via templated rendering of the rollups (e.g. "department X ran N queries this week, Y% success rate, top friction was `remote_scan_too_large` (Z times)"). When LLM-judge ships, this surface gets richer; until then, templated narrative is materially closer to what leadership actually opens than tile drill-down.
+- **`/activity-center/users` and `/activity-center/users/<user_id>` (per-user dashboard, gated).** Available only when `per_user_audit_enabled: true` (post-wizard). All-users table with sub-scores; click → individual dashboard: session timeline (chronological, scored), plugin usage histogram, BQ cost trend, error-class breakdown, sub-score trend lines, **the disputed-count flag tile** when the analyst has flagged any score, and **a cross-session chronology view** showing the user's full event timeline across sessions (filterable by date range, error class, or plugin) so an admin can trace how a problem evolved across multiple sessions. Click a session → session detail (next bullet). Reads of `payload` trigger audit-log writes + entries in the analyst's "who looked at me" view.
+- **`/activity-center/users/<user_id>/sessions/<session_id>` (session-replay surface, gated).** Step-by-step chronological reconstruction of a single session: events ordered by `event_ts`, prompt → tool calls (with params) → tool results (with outcome/error_class) → next prompt. Each step has a deep-link anchor (`#event-<event_id>`) so an admin can share a specific failure point. Filter affordances: jump-to-next-failure, jump-to-prompt-N, collapse-successful-tool-calls. For private sessions (`privacy_mode=TRUE`), the surface shows the manifest only — tool names, durations, outcomes — with content fields rendered as `<private session — content not collected>` placeholders. Same RBAC stack as per-user-detail (admin + `resource_grants(per_user_audit)` + rate-limit + dual-approver) — every render of a non-private session writes one `audit_log` row.
+- **`/activity-center/plugins` and `/activity-center/plugins/<plugin>` (per-plugin dashboard).** All plugins ranked by composite score. Click → plugin detail: distinct active users trend, granted-vs-adopted ratio, success-rate trend, top users by intensity (only when `show_user_composite_to_admin: true`), abandonment list. Plugin-level data is much lower privacy weight than per-user data and is enabled by default.
+- **`/me/activity` (analyst self-view).** The analyst sees: their own composite + sub-scores, session timeline, plugin usage, BQ cost, **the active composite weights and weight-version**, **a "who looked at me" list (last 30 days)**, **a "dispute this score" action per session**, **the disclosure history (versions accepted, when)**, **and the same session-replay surface for their own sessions** so they can review what they did and use it to debug their own workflow without admin involvement. This is the recourse mechanism that makes scoring legitimate to the people being scored — without it, self-view is a one-way mirror.
+- **NL prompting for ad-hoc.** Activity rollup views exposed in `analytics.duckdb` (`query_mode='local'` parquet, distributed via `agnes pull` per RBAC). Per-user `activity_events.payload` is `query_mode='remote'` (server-only) so admin queries against per-user content land server-side and trigger audit + rate-limit + bulk-query rejection at the API boundary. Reviewer-flagged constraint: rollup tables ship to admin laptops via `agnes pull`, so admin queries against rollups don't generate audit-log rows — that's by design (rollups are the cross-user-aggregate surface, no per-user content involved). Audit-log discipline applies to `payload`-touching queries, not to aggregate analysis.
+- Every admin-side query against per-user detail writes its own row to `audit_log`. The CEO is not exempt.
+
+### 5. Retention: 90 days rolling, configurable
+- **Basis for 90 days.** Product-team default chosen to balance recent-investigation utility with EU/CZ works-council expectations for behavioral telemetry. Not a hard requirement; operators tune to local legal context. Naming the basis here so future maintainers don't treat it as load-bearing when it isn't.
+- **Raw activity events:** 90-day rolling window, then hard-deleted by a daily scheduler job. The job is idempotent and emits a row to `audit_log` on each run (`action='activity_purge'`, `result='ok'|'failed'`, `params={"deleted_rows": N}`); a missed run for >48h triggers the platform health-check warning surface used by `app/api/health.py`.
+- **Daily aggregates** (per-user, per-plugin, per-department, score tables): same 90 days at initial release. Tiered retention (longer for aggregates) is in the iteration backlog — single config-key change, no schema work — `activity_center.aggregate_retention_days` defaulting to `retention_days`.
+- **`plugin_adoption` aggregate** (first/last-seen markers): kept past the rolling delete since it is aggregate-only with no payload. Operators can purge a single user's row via the right-to-forget tool below.
+- **Configuration:** `activity_center.retention_days: 90` in `instance.yaml`. Operators can shorten silently; extending requires re-publishing the disclosure to users (the disclosure text references the configured value at the time of acceptance).
+- **Right-to-forget:** initial release ships `agnes admin activity forget --user <id>` — deletes the user's rows from `activity_events`, all daily rollups, `plugin_adoption`, and the score tables (`session_scores`, `user_scores` rows for that user; `plugin_scores` is plugin-keyed and unaffected). Single transaction. Bounded worst-case (90d) means this is rarely needed, but the tooling exists day one.
+
+### 6. Export
+- CSV and Parquet, both. CSV for spreadsheet hand-off, Parquet for further analysis pipelines.
+- **`activity_export` ResourceType is not a new abstraction.** Adding it follows the established pattern in `app/resource_types.py`: one `ResourceType` enum member, one `ResourceTypeSpec` registration with a `list_blocks` delegate. No DB migration. Roughly 4–10 lines of code.
+- **Export scopes** gated by `resource_grants`:
+  - "all instance" export → admin group only.
+  - "per department" export → group leads, via `resource_grants(resource_type='activity_export', resource_id='<group_id>')`.
+  - "per user — myself" → every user, against their own user_id (no grant needed; checked at the API boundary).
+  - "per user — other" → admin only, audit-logged.
+- **Column inclusion in exports** is scope-dependent: `payload` is included only for "all instance" admin export and "per user — myself"; "per department" exports for group leads strip `payload` (counts, metadata, and scores only). This keeps the per-department surface aggregate-shaped even when a group lead exports raw rows.
+- **Private-session rows** in exports: `privacy_mode=TRUE` rows never include `payload` regardless of scope (the column is NULL by extraction-time contract); admins exporting "all instance" still see the rows' existence and counts, matching the in-app surface.
+- **Grant lifecycle.** Today, `resource_grants` has no expiry; for `activity_export` grants this is acceptable at initial release because group membership churn already revokes via Google Workspace sync. Per-grant expiry (`expires_at`) is in the iteration backlog if we see standing-grant abuse.
+- **Exported file lifetime.** Once a CSV/Parquet file leaves the server, it is outside the retention contract. The export endpoint logs the export with row count + scope; the operator runbook documents that exported files inherit the operator's retention obligations.
+- Every export action logs to `audit_log` with scope, row count, and target user/group (for non-aggregate scopes).
+
+### 7. Scoring (sessions, plugins, users)
+
+**Default visibility posture (P0 review finding addressed).** Composite per-user scores ranked across analysts on a leadership tile create a de facto performance metric — exactly the artifact Czech Labour Code §316 + GDPR Art. 88 treat as systematic monitoring of work performance, regardless of how the OSS frames it. To avoid the OSS shipping a one-click surveillance lever:
+
+- **Per-user composite is hidden from the leadership view by default.** `activity_center.scoring.show_user_composite_to_admin: false` in `instance.yaml`. Leadership sees per-plugin scores, aggregate trends, and the analyst's *own* sub-scores when drilling down — not a ranked all-users-by-composite tile out of the box. Operators who want the ranking flip the flag after explicit acknowledgement in the compliance setup wizard.
+- **Per-user composite is visible on the analyst's own self-view always.** The analyst sees their score; leadership does not by default. This breaks the symmetry-of-data claim earlier drafts made — and that's correct. Symmetry of data without symmetry of consequence is theatre. The new contract: the analyst sees what the system says about them; leadership sees aggregates and per-plugin views, with per-user content gated behind explicit operator opt-in plus per-user RBAC grants.
+- **Sub-scores are the dashboard's lead, not the composite number.** The 0–100 composite is computed and stored; the dashboard tiles surface trends, qualitative narrative, and sub-score breakdowns. This is steered design — operators can change the default tile set, but the OSS doesn't make composite-driven workforce decisions the easy default.
+
+**LLM-as-judge: deferred to iteration backlog (P0 review finding addressed).** Pass 2 surfaced three load-bearing problems: (a) judgeability — Claude scoring its own work biases toward verbose/structured output, not actually-useful work; (b) Art. 28 surface — sending session content to Anthropic creates an undisclosed third-party processor relationship requiring DPA + recipient disclosure under Art. 13/14; (c) cost path — the existing `connectors/llm/anthropic_provider.py:extract_json` does not surface usage metadata, so per-instance budget caps require an extractor-protocol extension. Together this exceeds the value of a 1-line model-written summary on a 5% sample. LLM-as-judge moves to iteration backlog: revisit when there's operator-side evidence the qualitative gap matters, the cost-metering path is built, and the disclosure language is updated. Track A scoring is deterministic-only.
+
+**Score table retention bound (P1 review finding addressed).** Score tables are user_id-keyed behavioral data — personal data under GDPR Art. 4 even without prompt content. Initial release: `activity_center.aggregate_retention_days: 365` (default). After 365 days, score rows older than the window are hard-deleted by the same daily purge job that handles raw events. Aggregate-only framing does not override Art. 5(1)(e) storage limitation when the data is directly user-identified. `plugin_scores` is plugin-keyed and not user-identified — retention applies but the privacy weight is much lower.
+
+**Sub-score gaming defenses (P1/P2 review finding addressed).** Each sub-score has a known game vector; the sub-score definition either includes a cross-validation that defeats the obvious game or the score doesn't ship.
+
+Every score is a composite (0–100) plus its sub-components, both stored. Composite weights live in `instance.yaml` so operators can tune what "good" means without a code release. All deterministic scores are recomputed nightly by the extractor.
+
+**Session score (per session)**
+- *Productivity sub-score* — tool-call density (calls / minute) × success-rate, **capped at the 95th percentile of the operator's historical tool-call rate** so shell-loop gaming (`for i in {1..50}; do ...`) doesn't dominate. The cap is recomputed weekly from the previous 30 days of data.
+- *Success-rate sub-score* — `ok` outcomes / total tool calls. Penalizes thrash.
+- *Error-density sub-score* — inverse of error events / total events. High when sessions don't trip over `BqAccessError`s, snapshot rejections, or tool timeouts. **Errors are tool calls with `outcome='error'`; failures are errors with a populated `error_class` from the taxonomy.** Both terms now have specific meanings; do not interchange.
+- *Output-density sub-score* — artifacts uploaded (`/api/upload/artifacts`) + queries whose returned rows are referenced in a subsequent prompt (cross-validation against the JSONL — uploading a dummy file or running `SELECT 1` doesn't count because no subsequent prompt references the result). Captures "stuff actually got used".
+- *Prompt-iteration sub-score* — **bell-curve weighted, not inverse-linear**. Very low iteration (one-shot vibes-prompt) and very high iteration (50 retries) both score worse than 2–5 thoughtful iterations. Reviewer flag: penalizing all iteration encodes the wrong incentive — careful analysts iterate.
+- *Composite* — weighted geometric mean of sub-scores, normalized 0–100. Default weights ship with the runbook. **Tool-efficiency sub-score (distinct tools / total tool calls) is dropped** — repetitive single-tool query workflows are the dominant correct pattern for an analytics platform; the original definition penalized correct behavior. Reviewer-flagged calibration miss; cut.
+
+**Plugin score (per plugin, refreshed daily)**
+- *Adoption-breadth sub-score* — distinct users in the granted population who used the plugin in the last 30 days.
+- *Adoption-intensity sub-score* — invocations per active user (90th percentile capped to avoid outliers dominating).
+- *Success-rate sub-score* — `ok` outcomes / total invocations of plugin tools.
+- *Retention sub-score* — fraction of users who used the plugin in two consecutive 14-day windows.
+- *Composite* — weighted geometric mean. Headline number on the plugin tile.
+
+**User score (per user, refreshed daily)**
+- *Productivity-trend sub-score* — slope of the user's session-score median over the last 30 days (positive = improving, negative = stuck). **Visible to the analyst on `/me/activity`; visible to leadership only when `show_user_composite_to_admin: true`.**
+- *Plugin-mastery sub-score* — distinct plugins used with success-rate > **`activity_center.scoring.user.plugin_mastery_success_threshold` (default 0.75)** over 30 days. Threshold named explicitly; not left undefined at commit time.
+- *Query-cost-efficiency sub-score* — useful query bytes (queries whose returned rows are referenced in a subsequent prompt within the same session — heuristic computable in deterministic SQL: prompt event within 5 minutes after a successful query event in the same session) / total BQ bytes scanned. Reviewer flagged this as borderline-LLM; the deterministic time-window heuristic is cheaper and explainable.
+- *Composite* — weighted geometric mean.
+
+**Decisions the score drives** (P1 review finding addressed). Without a named decision, scores are decoration consuming political capital. Concrete leadership actions the OSS treats as legitimate uses for the scoring data:
+- Reallocate plugin grants when `plugin_scores.adoption_breadth < threshold` for 30 days (zombie plugin sunset).
+- Flag `/activity-center/plugins/<plugin>` for review when granted-vs-adopted ratio < 20%.
+- Surface aggregate failure-class trends to the platform team for roadmap input.
+- Surface cost-per-active-analyst trend per department to the CEO for quarterly reviews.
+
+The OSS *does not* ship a "rank analysts by composite for performance review" surface. That would be a per-deployment HR-policy decision the operator has to enable explicitly via the compliance setup wizard. Leadership uses of per-user scoring beyond the named decisions are operator policy, not OSS feature.
+
+**Storage shape** (additions to the schema sketch below):
+- `session_scores(session_id, user_id, day, composite, productivity, success_rate, error_density, output_density, prompt_iteration)` — daily rollup, kept up to `aggregate_retention_days` (default 365). LLM-judge columns deferred to iteration backlog.
+- `plugin_scores(plugin_name, day, composite, adoption_breadth, adoption_intensity, success_rate, retention)` — daily.
+- `user_scores(user_id, day, composite, productivity_trend, plugin_mastery, query_cost_efficiency, disputed_session_count, disputed_summary_count)` — daily. The two `disputed_*` columns surface analyst-flagged issues into the leadership view (reviewer-flagged: visibility without recourse is a dark pattern).
+
+**Recourse and dispute (P1/P2 review finding addressed).** The analyst's `/me/activity` view is not read-only; without recourse, "symmetry" is rhetoric.
+- *Weight transparency.* The analyst sees the active composite weights for their score and the weight-version timestamp.
+- *Score dispute.* The analyst can flag a specific session's score as disputed via `/me/activity`. The flag writes to `audit_log` (`action='score_disputed', user_id=<self>, params={session_id, sub_score_disputed, reason}`) and increments `user_scores.disputed_session_count` for that user. Leadership view of the user shows the disputed-count as a flag tile next to the composite.
+- *Symmetric mutual-visibility.* The analyst sees who has queried their `/activity-center/users/<self>` detail page in the prior 30 days (same shape as the admin mutual-visibility digest). If admins can see "who looked at whom" weekly, analysts can see "who looked at me" on their own page. Without this, the digest is a one-way mirror.
+- *Right-to-recompute.* The analyst can request that an LLM-judge summary (when LLM-judge ships in iteration backlog) be regenerated or deleted from their record. Stored as a `audit_log` event; processed in the next nightly run.
+
+These aren't polish — they're the mechanism that makes the scoring legitimate to the people being scored. Without them, the OSS ships a one-way performance-monitoring tool with self-view as window-dressing.
+
+**Tuning vs gaming.** Visibility plus capped sub-scores plus output cross-validation reduces the obvious game vectors. It does not eliminate Goodhart's Law — once a metric is used for decisions, it gets gamed. The mitigation is structural: drop tile-level "rank by composite" surfaces by default, lead with sub-score trends and qualitative narrative when the LLM-judge eventually ships, and treat the composite as one signal among many — not the management lens. Operators who flip the composite-visible flag are explicitly opting into Goodhart territory.
+
+## Adversarial cuts (what was deleted, why)
+
+Adversarial review (Musk-style first-principles + "the best part is no part") removed several scope items that earlier drafts treated as load-bearing. Naming them here so future maintainers don't reintroduce them by accident.
+
+**Cut: 3-phase delivery split.** Earlier drafts staged the work as Phase 1 (cost dashboard) → Phase 2 (failure patterns) → Phase 3 (per-user audit gated by works-council sign-off). The cut: phasing was bureaucracy, not product. CEO asked for the comprehensive view; staging it as a sequence with deferred per-user content was a way of saying "we want to build less than was asked." Replaced with iteration tracks (A: data + dashboard, B: failure classification, C: hardening config) running in parallel. Per-user content is in the initial release with RBAC + rate-limit + dual-approver-configurable from day one. Operators decide what to enable; the OSS doesn't decide for them.
+
+**Cut: "Sharpest wedge" 0.5-phase ROI spike.** Earlier draft proposed answering the CEO's "is this paying off" question with a one-page rollup over existing data before committing to the full pipeline. The cut: CEO ask wasn't "is this paying off" in the narrow ROI sense — it was comprehensive per-user activity with scoring. A spike that answers a smaller question doesn't de-risk the actual ask; it delays it. Plan-phase will still validate corpus-size assumptions before committing to specific extractor topology, but as a 1-day spike inside the planning task, not a separate phase.
+
+**Cut: "ROI tile" framing.** Earlier draft labeled the dashboard tile set as "answering 'is this paying off' not just 'who used what'." Misread of the brief. CEO wants who used what, scored, with drill-down. Reframed to per-user / per-plugin / per-user dashboards with composite scoring tiles.
+
+**Cut: "DEMO" labeling on the admin page.** Pre-emptive lowering of the bar. The dashboard is the product face — ship it as the product face, not as a "we'll iterate on this later" placeholder.
+
+**Kept: privacy mode (per-session opt-out).** Originally requested by the user, retained. Adversarial pressure-tested it against "delete it entirely — if leadership wants comprehensive visibility, why offer an off-switch?" Answer: privacy mode is the trust contract that lets leadership keep visibility everywhere except where the user explicitly objects, in exchange for not driving analysts to bypass `agnes init` entirely. Deleting the off-switch trades away more than it gains.
+
+**Kept: works-council / DPIA / disclosure.** Adversarial cut considered: "operator's problem entirely, no documentation surface in the OSS." Rejected — the operator runbook is part of shipping the OSS responsibly; not documenting the legal surface lets a careless operator believe there isn't one. The runbook is one file; not a phase.
+
+**Kept: schema reservation for future column-level encryption.** Adversarial cut: "premature, just don't ship the column slot." Rejected because it costs zero (one nullable column) and saves a future migration that touches a 90d-retention store. Forward-compat is cheap when it's three lines of DDL.
+
+**Considered, deferred (not cut, just not initial-release):**
+
+- **LLM-as-judge on every session.** Adversarial: "5% sampling is enough; full-corpus LLM scoring is expensive and judgeability concerns are real (Claude scoring its own work)." Sampling is the cap.
+- **Survey-based ROI complement.** Useful, orthogonal, lower priority. Iteration backlog.
+- **Cross-tenant analytics.** Out of scope by architectural design (each instance is self-contained).
+
+### Chilling-effect risk (named, mitigated, not eliminated)
+
+Analysts who know prompts are stored 90 days and leadership-queryable with scoring will self-censor or route around the tool. Mitigations baked into the design: per-session privacy mode is a one-command opt-out; the disclosure is explicit and acceptance-blocking; the self-view tooling is symmetric (analyst sees the same shape leadership sees); scoring is visible to the user being scored, not opaque; per-user content access is RBAC + rate-limited + dual-approver-configurable. Residual risk acknowledged: some analysts will run Claude Code without `agnes init` hooks. The OSS does not solve for that; it makes the in-scope path trustworthy.
+
+## Privacy & legal posture
+
+This is employee-facing telemetry in an EU/CZ context. The brainstorm output makes the following defensible by default; implementation must keep them defensible.
+
+- **Disclosure.** First-run notice in `agnes init` describes collection, retention, scoring, how privacy mode works, and that the operator may have separately enabled per-user prompt-level inspection. Acceptance recorded server-side per user (`users.activity_disclosure_accepted_at` + `users.activity_disclosure_version`); uploads from unaccepted or stale-version users are rejected with `403 disclosure_required`. When the operator updates the disclosure (e.g. enables a new feature), the `activity_disclosure_version` bumps and users re-accept on next session start. The state machine is: `null` → first acceptance → potentially-stale → re-acceptance, with each transition logged.
+- **User access to own data.** `/me/activity` self-view is symmetric in *what data exists about the user* (sessions, scores, plugin usage, BQ cost) plus the recourse mechanisms in §7 (weight transparency, score dispute, mutual-visibility on who looked at me, right-to-recompute). Symmetry of data without symmetry of agency is theatre; the new contract is symmetric data + asymmetric stakes (acknowledged) + symmetric recourse mechanisms.
+- **Privacy Mode framing.** Per-session opt-out, content-only redaction, metadata still visible. Disclosure language: "When you turn private mode on for a session, the prompts and tool parameters from that session are not sent to the server. The fact that you had a session, how long it lasted, which tools you used, and which tables you queried are still recorded and counted toward your scores. The setting resets when the session ends — you turn it on each time."
+- **Admin queries on per-user detail are logged.** Every read of `activity_events.payload` writes an `audit_log` row; the weekly mutual-visibility digest surfaces who looked at whom (symmetric: the analyst is also notified); rate-limit + dual-approver (default ON for ≥2-admin instances) backstop the audit trail.
+- **Retention is bounded.** Raw events: 90 days, hard delete, configurable down. Score tables and `plugin_adoption`: 365 days default, hard delete, configurable down (reviewer flagged that user-keyed score data is personal data even without payload — Art. 5(1)(e) applies).
+- **Operator-side compliance gating, not just documentation.** First-boot operator setup wizard at `/admin/activity-center/setup` forces the operator to acknowledge §316 / Art. 88 / Art. 35 obligations before the per-user-audit features unlock. Without the acknowledgement, the system runs in degraded mode (overview + aggregates only). The wizard records acknowledgement in `audit_log`; refusing or bypassing the wizard does not silently turn on surveillance.
+
+### Defaults are product opinions
+
+The defaults the OSS ships are deliberate bets, not neutral knobs. Stating them explicitly so future maintainers don't change them by accident:
+
+| Knob | Default | Why |
+|---|---|---|
+| `per_user_audit_enabled` | **false** | Must be explicitly enabled via setup wizard; no silent surveillance |
+| `per_user_audit_dual_approver` | **true** (when ≥2 admins) | Strongest abuse control should be opt-out, not opt-in |
+| `per_user_audit.rate_limit_per_hour` | **5** | Caps unilateral corpus traversal at workday-scale, not minute-scale |
+| `per_user_audit.bulk_query_max_distinct_users` | **1** | Single-user reads only on payload; cross-user goes through rollups |
+| `scoring.show_user_composite_to_admin` | **false** | Composite is on the analyst's self-view; leadership sees aggregates by default |
+| `scoring.llm_judge_enabled` | (n/a, deferred to backlog) | Off entirely until Art. 28 + cost-metering + judgeability concerns are addressed |
+| `retention_days` (raw events) | 90 | Behavioral telemetry default, configurable down |
+| `aggregate_retention_days` (score tables) | 365 | Personal data under Art. 4; bounded retention applies |
+| `redaction.high_entropy_pattern_enabled` | **true with UUID exclusion** | UUIDs (8-4-4-4-12 hex) excluded from the high-entropy regex to avoid false-positive payload destruction |
+
+Operators in less-restrictive jurisdictions can flip individual knobs; operators in stricter jurisdictions adopt the `minimum_collection: true` profile (one-line override). The OSS defaults are tuned for EU/CZ context — the most restrictive context the project knows about — not a global average.
+
+These postures are decisions, not implementation. Plan-phase work includes a checklist verifying each is wired up before the release ships.
+
+## Activity event shape (provisional)
+
+Sketched here for shared vocabulary; final schema is a planning concern.
+
+**Storage topology.** Activity Center produces a new extract under `/data/extracts/activity_center/extract.duckdb` matching the existing connector contract (`_meta` table + views, optional `data/` for parquet rollups). The `SyncOrchestrator` picks it up on its next `rebuild()` pass and surfaces the views through `analytics.duckdb` master views — same path as Keboola/BigQuery extracts. This avoids inventing a cross-DB ATTACH between `system.duckdb` and `analytics.duckdb`.
+
+```
+activity_events (90d hot, /data/extracts/activity_center/extract.duckdb)
+  event_id          UUID
+  user_id           VARCHAR
+  session_id        VARCHAR             -- Claude Code session id when exposed to hooks; falls back to JSONL filename hash
+  event_ts          TIMESTAMP
+  event_type        ENUM('prompt', 'tool_call', 'tool_result', 'query', 'plugin_invoke', 'session_start', 'session_end')
+  tool_name         VARCHAR             -- nullable
+  plugin_name       VARCHAR             -- nullable; derived from MCP tool-name prefix or marketplace_plugins lookup. NULL for built-ins / ambiguous.
+  duration_ms       INTEGER             -- nullable
+  outcome           VARCHAR             -- 'ok' | 'error' | 'rejected'
+  error_class       VARCHAR             -- nullable; Phase 1 vocabulary: 'bq_lib_missing', 'remote_scan_too_large', 'bq_path_not_registered', 'auth_denied', 'tool_timeout'. 'wrong_tool' is Phase 2 (heuristic TBD).
+  bytes_scanned     BIGINT              -- nullable; query events. Source of truth: BqAccess (server-side), NOT JSONL — see "Data flow" below.
+  rows_returned     BIGINT              -- nullable
+  privacy_mode      BOOLEAN             -- TRUE when this event came from a metadata-only session
+  payload           JSON                -- nullable; NULL when privacy_mode=TRUE (extraction-time contract)
+```
+
+Daily rollups (parquet, `query_mode='local'` → distributed via `agnes pull`):
+- `activity_daily_user(user_id, day, prompts, tool_calls, queries, bq_bytes, failures)`
+- `activity_daily_plugin(plugin_name, day, distinct_users, invocations, failures)`
+- `activity_daily_department(group_id, day, prompts, tool_calls, queries, bq_bytes, failures)`
+
+Aggregate kept past retention (no payload):
+- `plugin_adoption(user_id, plugin_name, first_seen_at, last_seen_at)` — upserted by the daily extractor; survives the 90-day rolling delete so the granted-vs-adopted ratio remains computable for grants older than the retention window.
+
+Extractor checkpoint state (avoids collision with `services/session_collector`'s `session_extraction_state`):
+- `activity_extraction_state(jsonl_path VARCHAR, jsonl_hash VARCHAR, processed_at TIMESTAMP, PRIMARY KEY (jsonl_path, jsonl_hash))`
+
+### Data flow & invariants
+
+These are ship-blocking invariants the implementation must hold, not nice-to-haves:
+
+1. **bytes_scanned authority.** BigQuery scan bytes are computed server-side in `app/api/query.py` / `app/api/v2_scan.py`; they are NOT in Claude Code session JSONLs. Reviewer-flagged collision: writing synchronously to `activity_events` in `extract.duckdb` from the BQ query path conflicts with the orchestrator's exclusive-write lock during `rebuild()`. Resolution: the BQ scan path writes to `audit_log` (in `system.duckdb`, where the app already writes) with `action='bq_scan', params={bytes_scanned, rows_returned, target_table, query_id}`. The nightly extractor projects matching `audit_log` rows into `activity_events` with the session_id/user_id join from the JSONL. Until that join completes, the BQ-cost data is visible only via `audit_log` queries, not the activity dashboards — acceptable for daily-refresh cadence. This avoids the cross-DB write race entirely.
+2. **JSONL is source of truth for prompts/tool params.** The server stores the JSONL as `agnes push` sent it. The activity-center extractor reads it and applies the privacy filter at extract time. There is no second client-side strip happening before upload — a private session's `agnes push` sends a *manifest* (counts + tool names + targets) instead of the JSONL, never a partially-stripped JSONL. This makes reprocessing well-defined and right-to-forget straightforward.
+3. **Right-to-forget cascades.** Deleting a user's events requires recomputing affected rollup rows. Scope of the cascade (reviewer-flagged: previously incomplete):
+   - `activity_events`: delete rows where `user_id = <id>`.
+   - `activity_daily_user`, `activity_daily_department`: delete rows where `user_id = <id>`.
+   - `activity_daily_plugin`: recompute affected `(plugin_name, day)` rows from remaining users — the deleted user's contribution to plugin-level aggregates must be removed too.
+   - `plugin_scores`: recompute affected `(plugin_name, day)` rows — `adoption_breadth`, `adoption_intensity`, `retention` all derive from per-user behavior; the deleted user's contribution removes cleanly only via recompute.
+   - `session_scores`, `user_scores`: delete rows where `user_id = <id>`.
+   - `plugin_adoption`: delete rows where `user_id = <id>`.
+   The right-to-forget tool is **a transaction within `extract.duckdb`** (the activity store); the user row in `system.duckdb` is unaffected unless the operator separately deletes the account. If the recompute step fails after the delete, the next nightly extractor pass restores the rollup to a consistent state and the right-to-forget tool exits non-zero — the operator re-runs. Atomicity is single-DB, not cross-DB; the design cannot promise more than DuckDB delivers.
+4. **Reprocessing.** When extraction logic changes, `DELETE FROM activity_events` + replay JSONLs in the retention window. Private-session JSONLs are not present on the server (manifest-only), so reprocessing is well-defined: those sessions stay metadata-only across schema versions. New columns added in a schema bump are NULL for replayed rows — explicitly accepted. Reviewer-flagged constraint: a future schema bump that derives *new content* from manifest fields (e.g. structured tool-target parsing) does not violate the disclosure-at-acceptance contract because the manifest fields themselves are the same data the user accepted at first run; the derived structure is interpretation, not new collection.
+
+5. **Schema migration plan (reviewer-flagged).** v25 (next available; current `SCHEMA_VERSION = 24` per `src/db.py`) bundles the activity-center additions:
+   - **New tables in `system.duckdb`**: `activity_disclosure_state` (or extend `users` with `activity_disclosure_accepted_at TIMESTAMP NULLABLE` + `activity_disclosure_version INTEGER NULLABLE`), `users.activity_disclosure_*` columns, no FKs. Setup-wizard acknowledgement table `activity_center_operator_ack(operator_id, ack_works_council BOOL, ack_dpia BOOL, ack_disclosure BOOL, acked_at TIMESTAMP)`.
+   - **New column on `user_groups`**: `is_department BOOLEAN DEFAULT FALSE`. Does not collide with existing `is_system` row contract.
+   - **New tables in `extract.duckdb` (the new activity_center extract)**: `activity_events`, `activity_daily_user`, `activity_daily_plugin`, `activity_daily_department`, `plugin_adoption`, `activity_extraction_state`, `session_scores`, `plugin_scores`, `user_scores`. No FKs to `system.duckdb` because cross-DB FKs are not supported by DuckDB; integrity maintained by extractor logic. `activity_events.user_id` is intentionally not a FK to `users.id` because right-to-forget may delete events without deleting the user (or vice versa).
+   - **Reserved column slot**: `activity_events.payload_key_id VARCHAR NULLABLE` for future column-level encryption. Documented as forward-compat slot, NULL on initial release, populated only when iteration-backlog encryption ships.
+   - **Migration ordering**: setup wizard table → `users` columns → `is_department` column → activity tables. Each step idempotent; rollback drops in reverse.
+   - **Backfill**: none required for new tables. `users.activity_disclosure_accepted_at` defaults NULL, meaning every user must accept on next session start — explicit by design.
+
+## Implementation approach (proposed, for `/ce:plan`)
+
+Three approaches considered. Recommendation: **A→B progression based on observed corpus size.**
+
+**A — Lazy/CTAS DuckDB over JSONLs.**
+Zero new service. Scheduler runs a nightly CTAS that materializes `activity_events`, the three daily rollups, `plugin_adoption`, and the score tables directly from `read_json_auto('${DATA_DIR}/user_sessions/**/*.jsonl')` joined with the manifest sidecars. Scoring runs as additional CTAS layers on top. Privacy filter applied during the CTAS as SQL predicates. Pros: ships in days; no new service; no extractor checkpoint state; reprocessing = rerun the scheduler job; minimal new surface; scoring engine = SQL, easy to inspect and tune. Cons: full corpus rescan each night becomes painful past ~5–10M JSONL events; no incremental processing.
+
+**B — Materialized rollups + dedicated extractor.**
+Shared JSONL walker with `services/session_collector` (one walker, two extractors as plug-ins) checkpoints in `activity_extraction_state`, writes incrementally to `activity_events` + rollups + `plugin_adoption` + score tables. Pros: incremental; scales past A's painful zone; the synchronous BQ-cost-event path joins seamlessly. Cons: extractor service to maintain; LLM-as-judge sampling has to be plumbed through the extractor process.
+
+**C — Inline extraction in upload endpoint** (rejected).
+`/api/upload/sessions` extracts at receive time. Rejected for upload-latency, reprocessing fragility, uptime coupling. The narrow synchronous-write path for BQ scan-bytes (server-side, not in JSONL) survives because that data does not flow through the JSONL.
+
+**Recommendation.** Implement A. Plan-phase 1-day spike validates corpus-size assumption against the largest expected operator deployment (back-of-envelope: 50 analysts × ~100 tool calls/day × 90 days ≈ 450K rows — trivial; 500 analysts × chatty workflow ≈ 50M rows — borderline). If A's nightly CTAS fits inside the maintenance window, ship A and add B as iteration-backlog work. If not, ship B from day one. The user-visible surface (schema, dashboards, RBAC, exports, scoring) is identical across A and B — only the extractor implementation differs. Track C hardening sits on top of either.
+
+## Open questions for `/ce:plan`
+
+1. **Encryption at rest — filesystem-only by default (decision recorded).** The `payload` JSON column is stored unencrypted at the DuckDB layer; operators are responsible for volume-level encryption (LUKS, GCP CMEK, equivalent). The runbook calls this out explicitly. Column-level encryption is in the iteration backlog if an instance handles regulated data or the operator's risk model demands it; the schema is forward-compatible (key-id column slot reserved in the v25 migration so a later toggle is non-breaking).
+2. Where does the privacy-mode toggle UI live in the analyst workflow? CLI-only is enough for Phase 1; a status-bar widget might come later.
+3. **Per-prompt redaction is a decision, not a deferred question.** Reviewer feedback (security-lens, adversarial) classifies "ship without redaction; revisit on incident" as the wrong default for an irreversible exposure class. Phase 1 ships with regex-based stripping at extract time for known-shape secrets:
+
+   **Generic patterns:**
+   - AWS-style access keys (`AKIA[0-9A-Z]{16}`) and secret keys (`(?i)aws[_-]?secret[_-]?access[_-]?key`)
+   - GitHub tokens (`gh[pousr]_[A-Za-z0-9]{36,}`, `github_pat_[A-Za-z0-9_]{82}`)
+   - OpenAI / Anthropic keys (`sk-[A-Za-z0-9-_]{32,}`, `sk-ant-[A-Za-z0-9-_]{32,}`)
+   - JWTs (`ey[A-Za-z0-9_-]+\.ey[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+`)
+   - Basic-auth URLs (`https?://[^/\s:]+:[^@/\s]+@`)
+   - `<email>:<password>` pairs (`[^\s@]+@[^\s@]+:\S+`)
+   - High-entropy strings ≥32 chars, mixed alphanumeric, no dictionary-word substring (catches secrets the curated patterns miss; accepts higher false-positive rate against UUIDs and hashes)
+
+   **Platform-specific patterns:**
+   - Keboola Storage tokens (`[a-z0-9]+-[0-9]+-[A-Za-z0-9]{40}` — tenant-stack-secret triple)
+   - Atlassian PATs (`ATATT[A-Za-z0-9_-]{180,}`) and Atlassian session cookies (`cloud\.session\.token=[^;\s]+`)
+   - BigQuery service-account JSON blobs: any JSON object containing a `"private_key"` field with a `-----BEGIN PRIVATE KEY-----` body — the whole object is replaced with `"<redacted:gcp-sa-json>"`
+
+   Detection is best-effort, not exhaustive — privacy mode remains the only complete-redaction layer. The redaction module is versioned in `instance.yaml` (`activity_center.redaction.patterns`, `activity_center.redaction.high_entropy_min_length`) so operators can extend the pattern set without a code release. Each redaction action emits a counter to the existing platform metrics so unusually high redaction rates surface as anomalies.
+4. **`department` = a `user_group` marked `is_department=TRUE`.** Decision recorded explicitly: a "department" is exactly a `user_group` with `is_department=TRUE`. Only `is_department` groups appear in `activity_daily_department` rollups and the "BQ bytes by department" tile. Users can belong to multiple departments; rollups are computed at `(user_id, group_id, day)` grain so a user in two departments contributes to both — totals are additive, not partitioned. The CEO sees potentially-overlapping totals (a user counted twice if they're in two departments) — this is correct for matrix organizations and documented on the tile. If a single canonical department per user is ever required, sync from a Google Workspace `department` directory attribute into a separate column on `users` rather than overloading `user_groups` further.
+5. **Failure taxonomy (Track B).** Initial list: `bq_path_not_registered`, `remote_scan_too_large`, `wrong_tool` (heuristic), `tool_timeout`, `auth_denied`. The `wrong_tool` heuristic is the underspecified one — plan-phase task in Track B is to define it concretely (candidate: tool calls that returned the documented "use X instead" error from Agnes server, or tool calls followed within N seconds by a different tool against the same target).
+6. **Existing `/activity-center` route.** `app/web/router.py` already has a stub `GET /activity-center` returning `activity_center.html`. Initial release reuses this route and extends it with `/users`, `/users/<user_id>`, `/plugins`, `/plugins/<plugin>` sub-routes (plan-phase task: replace stub context with live tile data; do not introduce `/admin/activity` as a parallel path).
+
+7. **LLM-as-judge — deferred to iteration backlog.** Pass 2 review surfaced three load-bearing problems: judgeability (Claude scoring its own output biases toward verbose work), Art. 28 third-party processor surface (Anthropic must be named in disclosure + DPA executed), and cost-metering path (existing `connectors/llm/anthropic_provider.py:extract_json` doesn't surface usage data, so per-instance budget caps require an extractor protocol extension). Together these exceed the value of a 1-line model-written summary at 5% sampling. Track A ships deterministic-only scoring. Iteration backlog: revisit when (a) operator-side evidence shows the qualitative gap matters, (b) the cost-metering path is built, (c) disclosure language is updated to name Anthropic as a sub-processor, and (d) the rubric is versioned and visible to the analyst with a re-judgment-request mechanism.
+
+8. **Track A vs Track B/C sequencing — honest commitment.** Track A (data + scoring + dashboards + privacy + baseline RBAC) ships in the initial release. Track B (failure intelligence) and Track C (advanced hardening — dual-approver, mutual-visibility digest, bulk-query rejection, setup wizard) ship as iteration 1, within weeks of Track A. The user-facing brief describes the whole product; the implementation commitment is honest about ordering.
+
+## Success criteria
+
+The single Activity Center release ships when all of the following are true. Tracks A/B/C are parallel work streams; A is critical path, B and C ride alongside.
+
+### Track A — Data, scoring, dashboards (critical path)
+
+**Data & pipeline:**
+- `activity_events` populated daily from session JSONLs and manifest sidecars (extract.duckdb pattern); privacy-mode events sourced from `*.manifest.json` and metadata-only.
+- Daily rollups: `activity_daily_user`, `activity_daily_plugin`, `activity_daily_department` refreshed nightly.
+- `plugin_adoption` aggregate upserted nightly and survives the 90d rolling delete.
+- 90d retention purge runs daily, idempotent, emits a verification row to `audit_log`; missed runs >48h surface in `app/api/health.py`.
+- `activity_extraction_state` dedup table prevents collision with `services/session_collector`.
+- Two upload routes ship: existing `/api/upload/sessions` (PAT-authed, 50 MB streaming JSONL); new `/api/upload/sessions/manifest` (PAT-authed, pydantic-validated JSON for privacy-mode sessions). Mixed payloads are structurally impossible.
+- BQ scan-byte rows written synchronously by `BqAccess` at scan time; nightly extractor enriches with session_id/user_id when the JSONL lands.
+
+**Scoring engine:**
+- `session_scores`, `plugin_scores`, `user_scores` populated nightly. Composite + sub-scores per definitions in §7. LLM-as-judge deferred to iteration backlog (no `llm_judge_*` columns in initial release).
+- Composite weights are configurable in `instance.yaml` (`activity_center.scoring.session.*`, `.plugin.*`, `.user.*`); default weights documented in the operator runbook.
+- Score tables retain up to `aggregate_retention_days` (default 365), then hard-deleted by the same purge job that handles raw events. User-keyed score data is personal data under GDPR Art. 4 — the bound is non-negotiable, not "aggregate-only no retention."
+- Right-to-forget cascades fully (see Data flow §3): activity_events delete + plugin_scores recompute + plugin_adoption delete + score-table user-row delete + rollup recompute, all in a single `extract.duckdb` transaction.
+- **Composite per-user score is hidden from the leadership tile by default** (`scoring.show_user_composite_to_admin: false`). Sub-scores and trends remain visible on per-user drill-down (when `per_user_audit_enabled: true`); the analyst sees their own composite always on `/me/activity`.
+
+**Admin surfaces:**
+- `/activity-center` overview tiles render: active users 7d/30d, top plugins by composite score, BQ bytes by department, failure-rate trend, redaction-counter anomaly tile, **the weekly leadership digest tile** (templated narrative; richer when LLM-judge ships).
+- `/activity-center/weekly` leadership digest page — paragraph-shaped synthesis of the week from rollups (Sunday-generated, Monday-morning ready).
+- `/activity-center/users` and `/activity-center/users/<user_id>` per-user dashboard — *gated behind* `per_user_audit_enabled: true` (post-setup-wizard); sub-score trends, click-through to session detail with RBAC + rate-limit + dual-approver gates for `payload` access.
+- `/activity-center/plugins` and `/activity-center/plugins/<plugin>` per-plugin dashboard with adoption + retention trends.
+- All tiles and tables have CSV + Parquet export buttons. Export scopes per Decision 6.
+- NL prompting works against `analytics.duckdb` rollup views; per-user `payload` access is `query_mode='remote'` so admin queries land server-side and trigger audit-log writes at the API boundary.
+
+**Analyst-facing:**
+- `agnes private on|off|status` toggles privacy mode; per-session mechanism (or workspace-wide fallback) verified during plan-phase 1-day spike, not assumed.
+- First-run disclosure in `agnes init` describes collection, retention, scoring, and the operator's per-user-audit posture for this instance. Acceptance recorded with timestamp + version (`users.activity_disclosure_accepted_at`, `users.activity_disclosure_version`); uploads from unaccepted or stale-version users are rejected with `403 disclosure_required`.
+- `/me/activity` self-view renders the analyst's own dashboard plus the recourse mechanisms: weight transparency, score-dispute action per session, "who looked at me" list (last 30d), disclosure history. Symmetric *data* + symmetric *recourse* — the rhetoric of "symmetry as trust contract" earned, not asserted.
+- `agnes admin activity forget --user <id>` deletes / recomputes per the cascade in Data flow §3.
+
+### Track B — Failure intelligence
+
+- Failure events classified into the taxonomy: `bq_path_not_registered`, `remote_scan_too_large`, `auth_denied`, `tool_timeout`, `bq_lib_missing`, `wrong_tool` (heuristic).
+- `wrong_tool` heuristic defined concretely (candidate: tool calls returning Agnes' "use X instead" guidance, or tool calls followed within N seconds by a different tool against the same target). Validated against ≥10 sample sessions before the metric is published.
+- Failure-rate trend tile + a CLI report (`agnes admin activity failures --since 7d`).
+- Plugin churn (granted-vs-adopted ratio): zombie plugins (granted, never adopted by anyone in the granted group), abandoned plugins (last-seen > N days). Surfaced on the `/activity-center/plugins` page.
+
+### Track C — Hardening (paranoid defaults, configurable)
+
+Reviewer pass 2 surfaced that earlier defaults shipped a configuration menu rather than defenses. Pass 2 flips the defaults to enforce informed consent on first deploy; operators relax for convenience after explicit acknowledgement, not before.
+
+- **Admin role + `resource_grants(resource_type='per_user_audit', resource_id=<target_user_id>)`** — both required for any read of `activity_events.payload`. Two-of-two technical gate.
+- **`activity_center.per_user_audit_enabled: true|false`** master switch in `instance.yaml`. **Defaults to `false`.** First-boot operator wizard at `/admin/activity-center/setup` requires the operator to acknowledge three checkboxes ("works-council consulted or not applicable", "DPIA completed or not applicable under Art. 35", "users disclosed and accepted") before the wizard flips this flag. Acknowledgement is recorded in `audit_log` (`action='activity_center_enabled', user_id=<operator>, params={ack_works_council, ack_dpia, ack_disclosure}`). Refusing the wizard ships degraded mode: overview tiles + aggregates work; per-user-detail returns 403 with the runbook link. This converts "operator's responsibility" from rhetoric into structure.
+- **Per-user-detail read rate-limit** — `activity_center.per_user_audit.rate_limit_per_hour: 5` (default 5 user-detail queries per hour per admin). Reviewer flagged the prior 1/min default as permitting full corpus traversal in 2 hours — 5/hour caps it at hundreds of users per workday, sufficient for legitimate investigation, structurally insufficient for systematic monitoring. Breach triggers a warning row in `audit_log` and a notification to the configured alerts channel.
+- **`activity_center.per_user_audit_dual_approver: true|false`** — **defaults to `true`**. Reviewer flagged the most-important intra-admin abuse control was previously default-off. When the instance has fewer admins than the dual-approver minimum (default 2), dual-approver auto-disables with an audit-log warning ("dual-approver self-disabled: only N admins on instance") so single-admin small-instance deployments aren't bricked. The disabling is logged, visible to the analyst on their detail page, and the operator can flip the dual_approver_min_admins to 1 if they explicitly want to.
+- **Bulk-query detection** — `activity_center.per_user_audit.bulk_query_max_distinct_users: 1` (default 1). Any SQL statement scanning >1 distinct user_id is rejected with `403 bulk_query_rejected` and a typed error message directing the admin to rollup views. Legitimate cross-user aggregation goes through the rollup tables (which are the right shape anyway). Operators can raise the threshold; raising it requires re-acknowledging the setup wizard (sticky-default protection).
+- **Mutual-visibility digest** — weekly report listing per-user-detail reads from the prior week (requester / target / timestamp). Delivered via the existing **Telegram bot infrastructure** (`services/telegram_bot`) — not email, since the OSS has no SMTP/SES dependency and adding one for this single use case is unjustified. Operators who need email can route Telegram → email at the Telegram side. **Symmetric delivery: each analyst whose record was queried also receives a Telegram notification** ("user X looked at your activity record on date Y") if they have linked their Telegram account; if not, the same information appears on `/me/activity` for self-discovery. The previous design sent the digest only to admins, which made it a one-way mirror; symmetric notification closes the loop.
+- **Operator runbook** (`docs/operator/activity-center.md`) ships with the release, documenting: per-user telemetry triggers Czech Labour Code §316 / GDPR Art. 88 obligations; the setup wizard is the operator's compliance forcing function; default scoring weights and how to tune them; rate-limit and dual-approver knobs and when to flip them; *minimum-collection profile* `instance.yaml` snippet that operators can adopt as a one-line override (`activity_center.minimum_collection: true` sets retention to 30d, disables payload storage entirely, disables scoring, leaves only failure-class counts and per-department aggregates — for operators who want the failure-classification value without the surveillance surface).
+
+### Iteration backlog (not initial release, not blocking)
+
+- **LLM-as-judge** (deferred per §7) — qualitative tile + sampled summaries, gated behind cost-metering protocol extension, Art. 28 disclosure update, judgeability-mitigation (rubric versioning + analyst dispute mechanism + leadership-invisibility-by-default).
+- **Shared JSONL walker abstraction** — refactor `corporate_memory` + `verification_detector` + `activity_center` to plug into one walker rather than triple-scanning `/data/user_sessions/`.
+- **Survey-based ROI complement** — quarterly self-reported value, orthogonal to telemetry, useful triangulation.
+- **Per-user persistent privacy default** — currently per-session only.
+- **Column-level encryption for `payload`** — slot reserved in v25 schema (`payload_key_id`).
+- **Tiered retention** — longer aggregate retention than raw, beyond the current 90/365 split.
+- **Per-grant `expires_at`** on `activity_export` grants.
+- **Email delivery infrastructure** — if operators consistently report Telegram-only digest is insufficient.

--- a/docs/plans/2026-05-05-001-feat-activity-center-plan.md
+++ b/docs/plans/2026-05-05-001-feat-activity-center-plan.md
@@ -1,0 +1,1059 @@
+---
+title: Activity Center — comprehensive per-user telemetry with scoring
+type: feat
+status: active
+date: 2026-05-05
+origin: docs/brainstorms/activity-center-requirements.md
+---
+
+# Activity Center — comprehensive per-user telemetry with scoring
+
+## Overview
+
+Build the Activity Center: a comprehensive per-user telemetry surface for Agnes. Sessions (Claude Code JSONLs), tool calls, plugin invocations, BigQuery scans, and failures are extracted nightly into a queryable store; sessions / plugins / users get composite + sub-scores; leadership browses dashboards and prompts Claude Code naturally for the long tail; analysts have a symmetric self-view with recourse mechanisms (dispute, weight transparency, who-looked-at-me); per-user prompt-level access is gated behind a setup wizard, dual-approver, and rate-limit. Privacy mode is a per-session opt-out that ships a metadata manifest instead of the JSONL.
+
+The plan delivers in two waves: **Track A (initial release)** is the data + scoring + dashboards + privacy + baseline RBAC + disclosure flow + right-to-forget; **Track B + Track C (iteration 1)** add failure intelligence, plugin churn, the operator setup wizard, dual-approver, and the mutual-visibility digest.
+
+## Problem Frame
+
+Agnes already collects rich behavioral data (Claude Code session JSONLs uploaded via `agnes push`, admin actions in `audit_log`, BigQuery scans via `BqAccess`), but none of it is exposed in a form leadership can interrogate. The CEO has asked for comprehensive per-user activity visibility — what each analyst prompts, which tools and plugins they invoke, which queries succeed or fail, and how good each session is (scored). Aggregates alone don't satisfy the ask; CEO wants drill-down per user with quantitative scoring of sessions and plugins, and a way to export the full picture. (See origin: `docs/brainstorms/activity-center-requirements.md`.)
+
+## Requirements Trace
+
+- **R1.** Per-user dashboards with drill-down: all-users → individual user → session timeline → individual session detail → individual prompt/tool call.
+- **R1b.** Chronological session replay: single-session step-by-step view (prompt → tool calls → tool results → next prompt), cross-session chronology timeline, jump-to-failure / jump-to-prompt affordances, deep-linkable event anchors. For private sessions: manifest-only view with "content not collected" placeholders. Same RBAC + audit-log gates as per-user-detail. Available on admin dashboards (gated) and on `/me/activity` for self-debugging without admin involvement. CLI mirror via `agnes admin activity replay` and `agnes activity replay --self`.
+- **R2.** Scored sessions: composite (0–100) + sub-scores (productivity, success-rate, error-density, output-density, prompt-iteration). Deterministic SQL only at initial release (LLM-as-judge deferred).
+- **R3.** Scored plugins: composite + sub-scores (adoption-breadth, adoption-intensity, success-rate, retention).
+- **R4.** Scored users: composite + sub-scores (productivity-trend, plugin-mastery, query-cost-efficiency).
+- **R5.** Privacy mode: per-session opt-out via `agnes private on|off|status`, ships metadata manifest instead of JSONL.
+- **R6.** Disclosure: first-run notice in `agnes init`, server-side acceptance recording, upload rejection for unaccepted users.
+- **R7.** Self-view symmetry + recourse: `/me/activity` shows the analyst the same data leadership sees (gated by RBAC) plus weight transparency, score dispute, "who looked at me", disclosure history.
+- **R8.** RBAC gates for per-user content: admin role + per-user `resource_grants(resource_type='per_user_audit')` + rate-limit + audit-log writes.
+- **R9.** Right-to-forget: `agnes admin activity forget --user <id>` with full cascade (events + rollups + plugin_scores recompute + plugin_adoption + score tables).
+- **R10.** Export: CSV + Parquet for "all" / "per department" / "myself" / "per user — other (admin)" with scope-dependent column inclusion.
+- **R11.** Failure classification: typed `error_class` taxonomy + `wrong_tool` heuristic, failure-rate tile + CLI report.
+- **R12.** Plugin churn: granted-vs-adopted ratio, zombie / abandonment dashboard.
+- **R13.** Compliance setup wizard: forces operator acknowledgement of §316 / Art. 88 / Art. 35 obligations before per-user audit unlocks.
+- **R14.** Dual-approver (configurable, default ON for ≥2-admin instances) + bulk-query rejection (default N=1) + mutual-visibility digest (Telegram, symmetric to analyst).
+- **R15.** Retention: raw events 90d, score tables 365d, configurable down per `instance.yaml`. Operator `minimum_collection: true` profile available.
+
+## Scope Boundaries
+
+- **Real-time monitoring or alerting** for the dashboard. Daily refresh; worst-case t+24h tail.
+- **Forking the JSONL walker.** Activity-center extractor is a third *content* consumer of `/data/user_sessions/*.jsonl` alongside `services/corporate_memory` and `services/verification_detector`; runs an independent third scan with its own `activity_extraction_state` dedup table at initial release. Walker abstraction is iteration backlog.
+- **Tracking activity outside Agnes-managed sessions.** If a user runs Claude Code without `agnes init` hooks, nothing is captured.
+- **Surveillance of private sessions.** Privacy mode is a per-session opt-out; admins still see metadata + counts but never the content of private sessions.
+- **Cross-tenant analytics.** Each instance is self-contained.
+
+### Deferred to Separate Tasks
+
+- **LLM-as-judge sampling**: deferred to iteration backlog. Three load-bearing problems unresolved (judgeability, Art. 28 third-party processor surface, cost-metering protocol extension). Track A scoring is deterministic-only.
+- **Survey-based ROI complement**: orthogonal triangulation, iteration backlog.
+- **Per-user persistent privacy default**: currently per-session only.
+- **Column-level encryption for `payload`**: schema slot reserved (`payload_key_id`); enable when an instance handles regulated data.
+- **Tiered retention** beyond the 90/365 split.
+- **Per-grant `expires_at`** on `activity_export` grants.
+- **Email delivery infrastructure**: digest uses existing Telegram bot; email is iteration backlog if operators report Telegram-only is insufficient.
+- **Shared JSONL walker abstraction** across `corporate_memory` + `verification_detector` + `activity_center`: refactor task in iteration backlog.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **`src/db.py`** — `SCHEMA_VERSION = 24`. v25 is the next available migration. Pattern: each migration is one focused change with idempotent re-run + rollback in reverse. v14 split orphan cleanup from FK addition (DuckDB FK enforcement blocks parent DELETE while children exist).
+- **`src/orchestrator.py`** — `SyncOrchestrator.rebuild()` scans `/data/extracts/*/extract.duckdb`, ATTACHes each into `analytics.duckdb`, creates master views, updates `sync_state`. Activity-center produces `/data/extracts/activity_center/extract.duckdb` matching this pattern.
+- **`connectors/keboola/extractor.py`** + **`connectors/bigquery/extractor.py`** — extract.duckdb contract template (`_meta` table + views + optional `data/` for parquet rollups).
+- **`app/api/upload.py`** — existing `/api/upload/sessions` streaming endpoint with 50 MB cap; uses `get_current_user` for auth (PAT auth for `agnes push` flows through this dependency). Pattern to mirror for `/api/upload/sessions/manifest`.
+- **`app/api/access.py`** — `resource_grants` RBAC layer, `require_resource_access(ResourceType.X, "{path}")` dependency. Pattern for new `per_user_audit` and `activity_export` resource types.
+- **`app/resource_types.py`** — `ResourceType` `StrEnum` + `ResourceTypeSpec` registration with `list_blocks` delegate. Adding a resource type is one enum member + one spec entry, no DB migration.
+- **`services/corporate_memory`** + **`services/verification_detector`** — existing JSONL content extractors using `session_extraction_state` dedup. Activity-center adds a third extractor with its own `activity_extraction_state` table.
+- **`services/scheduler/__main__.py`** — DuckDB single-writer constraint enforced; app is sole writer to `system.duckdb`. BQ-cost path writes to `audit_log` (not `activity_events` directly) to avoid cross-DB write race during orchestrator rebuild.
+- **`connectors/bigquery/access.py`** — `BqAccess` already throws typed errors (`BqAccessError`) used as the basis of the `error_class` taxonomy.
+- **`app/web/router.py`** line 706 — existing `GET /activity-center` stub returning `activity_center.html`. Phase 1 implementation extends this route + template.
+- **`services/telegram_bot/`** — existing notification infrastructure for the mutual-visibility digest (no SMTP/SES dependency added).
+- **`cli/lib/hooks.py`** — `agnes init` writes SessionStart → `agnes pull` and SessionEnd → `agnes push` into `<workspace>/.claude/settings.json`. Pattern for privacy-mode toggle integration.
+- **`cli/commands/push.py`** — `agnes push` upload path; branches between `/api/upload/sessions` (full JSONL) vs `/api/upload/sessions/manifest` based on per-session privacy state.
+- **`audit_log`** schema in `src/db.py` — `(id, timestamp, user_id, action, resource, params JSON, result, duration_ms)`. New `action` values: `activity_purge`, `activity_center_enabled`, `score_disputed`, `bq_scan`, `per_user_audit_read`, `per_user_audit_request`, `per_user_audit_approved`.
+
+### Institutional Learnings
+
+- DuckDB cross-DB ACID does not exist via ATTACH; right-to-forget atomicity is single-DB-scoped (within `extract.duckdb`).
+- DuckDB single-writer-per-file: synchronous writes from the BQ query path into `extract.duckdb` would race the orchestrator's exclusive lock during `rebuild()`. The codebase pattern (per `services/scheduler/__main__.py`) is "app is sole writer to `system.duckdb`" — projecting `audit_log` rows into the activity store nightly avoids the race.
+- Same-named plugins from different marketplaces collide in the catalog by design (per CLAUDE.md). Plugin-name attribution from JSONL tool prefixes therefore needs a registered-plugin disambiguation rule.
+
+### External References
+
+- GDPR Art. 4 (personal data), Art. 5(1)(e) (storage limitation), Art. 13/14 (disclosure at collection), Art. 17 (right to erasure), Art. 28 (data processor obligations — relevant when LLM-judge eventually ships), Art. 32 (encryption), Art. 35 (DPIA).
+- Czech Labour Code §316 (employee monitoring) — invoked in operator runbook.
+
+## Key Technical Decisions
+
+- **Single-release Track A; iteration-1 Track B+C.** Don't pretend B+C ship simultaneously when in practice they land within weeks of A. (See origin: §Goals — Sequencing.)
+- **Storage topology = extract.duckdb.** Activity Center is a new connector-shaped extract under `/data/extracts/activity_center/extract.duckdb`. Avoids inventing a cross-DB ATTACH; orchestrator already knows how to surface it.
+- **Approach A (CTAS over JSONLs) for initial implementation.** Plan-phase 1-day spike validates corpus-size assumption; promote to Approach B (incremental extractor service) if the nightly CTAS exceeds the operator's maintenance window. Same schema, same RBAC, same exports — only the extractor implementation differs.
+- **Privacy mode = manifest XOR JSONL upload routes.** Two routes (`/api/upload/sessions` JSONL, `/api/upload/sessions/manifest` JSON), structurally separated. Threat model is accidental disclosure, not hostile clients.
+- **BQ-cost write path = `audit_log` first, projected nightly.** Avoids cross-DB write race during orchestrator rebuild.
+- **Composite per-user score is hidden from leadership tile by default** (`scoring.show_user_composite_to_admin: false`). Composite stays on analyst self-view; leadership sees aggregates and per-plugin scores. Operators flip the flag explicitly in the setup wizard.
+- **Per-user audit defaults FALSE.** Setup wizard is the structural forcing function; "operator's responsibility" is enforced by gated routes, not just runbook prose.
+- **Dual-approver defaults TRUE** for ≥2-admin instances, auto-disables for single-admin instances with logged warning.
+- **Rate-limit = 5 user-detail queries / hour / admin** (not 1/min — that permitted full corpus traversal in 2h).
+- **Bulk-query N = 1.** Cross-user aggregation goes through rollups.
+- **Score table retention = 365d.** User-keyed score data is personal under Art. 4 even without payload; aggregate-only framing does not override Art. 5(1)(e).
+- **`department` = `user_group` with `is_department=TRUE`.** Multi-membership additive at `(user_id, group_id, day)` grain.
+- **Mutual-visibility digest via Telegram (existing infra), symmetric to analyst.** No SMTP dependency added.
+- **LLM-as-judge deferred to iteration backlog.** Judgeability + Art. 28 + cost-metering all unsolved; deterministic-only scoring is the initial release.
+- **Sub-score gaming defenses baked in:** capped productivity (95th-percentile shell-loop kill), dropped tool-efficiency (rewarded wrong behavior), output cross-validation against subsequent prompt usage, bell-curve prompt-iteration weighting.
+- **Existing `/activity-center` route is reused, not duplicated.** Stub at `app/web/router.py:706` extended in Unit 8.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Schema version**: v25 (current `SCHEMA_VERSION = 24`).
+- **Walker abstraction now or later**: Later. Activity-center runs an independent third scan with its own dedup table at initial release; refactor is iteration-backlog.
+- **BQ-cost write path**: `audit_log` first, then nightly projection (avoids cross-DB write race).
+- **Approach A vs B for extractor**: A first, validated by 1-day corpus-size spike at the start of implementation; promote to B only if A exceeds the maintenance window.
+- **Department disambiguation**: `is_department=TRUE` flag on `user_groups`, multi-membership additive.
+- **Email vs Telegram for digest**: Telegram (existing infrastructure).
+- **Composite score visibility default**: Hidden from leadership tile; visible on analyst self-view always.
+- **Per-user audit default**: FALSE; gated by setup wizard.
+- **Dual-approver default**: TRUE for ≥2-admin; auto-disables for single-admin with logged warning.
+- **Rate-limit value**: 5/hour/admin.
+- **Bulk-query threshold**: N=1.
+
+### Deferred to Implementation
+
+- **`$CLAUDE_SESSION_ID` exposure to hooks**: 1-day spike at the start of Unit 6 verifies whether Claude Code exposes session-id to SessionStart/SessionEnd hooks. If yes, per-session privacy toggle. If no, workspace-wide fallback with explicit "stays on until `agnes private off`" semantics — documented as the actual behavior, not approximated.
+- **Approach A corpus-size validation**: 1-day spike at the start of Unit 3 measures nightly CTAS against synthetic 50M-row corpus. If the CTAS fits the maintenance window, A ships; otherwise pivot to B before Unit 3 implementation.
+- **Composite weight defaults**: Sensible-default weights tuned during Unit 5 implementation against ≥3 sample sessions, then documented in the runbook. Operators tune from there.
+- **`wrong_tool` heuristic concrete definition**: Validated against ≥10 sample sessions in Unit 13.
+- **Plugin attribution coverage threshold validation**: Unit 3 validates against ≥3 known plugins (heavy / zombie / ambiguous) — if <70% coverage, dashboard reports "unobservable" rather than zero.
+- **Setup wizard UX shape**: Unit 15 — exact form fields, copy, and acceptance flow are implementation detail. The contract (3 checkboxes, audit-log row on completion, degraded mode without acknowledgement) is fixed.
+
+## Output Structure
+
+```
+src/
+├── activity_center/                          # NEW
+│   ├── __init__.py
+│   ├── extractor.py                          # CTAS-based extractor (Unit 3)
+│   ├── scoring.py                            # Deterministic SQL composite + sub-scores (Unit 5)
+│   ├── redaction.py                          # Regex pattern set + UUID exclusion (Unit 3)
+│   ├── manifest.py                           # Pydantic manifest schema (Unit 2)
+│   ├── retention.py                          # Daily purge job (Unit 1, scheduled)
+│   └── right_to_forget.py                    # Cascade implementation (Unit 10)
+├── db.py                                     # MODIFY: v25 migration (Unit 1)
+├── repositories/
+│   └── activity_center.py                    # NEW: read paths for dashboard/export queries (Unit 8, 11)
+└── resource_types.py                         # MODIFY: per_user_audit + activity_export enum members (Units 11, 15)
+
+app/
+├── api/
+│   ├── upload.py                             # MODIFY: disclosure check + manifest endpoint (Units 2, 7)
+│   ├── activity.py                           # NEW: per-user-detail read API w/ rate-limit + dual-approver (Units 8, 15, 16)
+│   └── activity_export.py                    # NEW: CSV/Parquet export endpoints (Unit 11)
+└── web/
+    ├── router.py                             # MODIFY: extend /activity-center sub-routes (Unit 8)
+    └── templates/
+        ├── activity_center.html              # MODIFY: live tile data (Unit 8)
+        ├── activity_center/
+        │   ├── users.html                    # NEW
+        │   ├── user_detail.html              # NEW
+        │   ├── session_replay.html           # NEW (Unit 8 — shared with self-view)
+        │   ├── plugins.html                  # NEW
+        │   ├── plugin_detail.html            # NEW
+        │   ├── weekly.html                   # NEW
+        │   ├── setup_wizard.html             # NEW (Unit 15)
+        │   └── me.html                       # NEW (Unit 9)
+
+cli/
+├── commands/
+│   ├── private.py                            # NEW: agnes private on|off|status (Unit 6)
+│   ├── activity.py                           # NEW: agnes activity self (Unit 9)
+│   ├── push.py                               # MODIFY: branch between JSONL vs manifest (Unit 6)
+│   └── admin.py                              # MODIFY: agnes admin activity forget|failures (Units 10, 13)
+└── lib/
+    └── privacy_state.py                      # NEW: session-id-keyed or workspace-keyed flag store (Unit 6)
+
+services/
+├── activity_center_extractor/                # NEW (only if Approach B is chosen post-spike)
+│   ├── __main__.py
+│   └── walker.py
+└── scheduler/
+    └── __main__.py                           # MODIFY: register nightly activity_center jobs
+
+config/
+└── instance.yaml.example                     # MODIFY: activity_center.* knobs documented (Unit 12)
+
+docs/
+└── operator/
+    └── activity-center.md                    # NEW: runbook (Unit 12)
+
+tests/
+├── activity_center/
+│   ├── test_extractor.py                     # Unit 3
+│   ├── test_scoring.py                       # Unit 5
+│   ├── test_redaction.py                     # Unit 3
+│   ├── test_manifest.py                      # Unit 2
+│   ├── test_retention.py                     # Unit 1
+│   ├── test_right_to_forget.py               # Unit 10
+│   ├── test_dashboards.py                    # Unit 8
+│   └── test_session_replay.py                # Unit 8
+├── api/
+│   ├── test_upload_manifest.py               # Unit 2
+│   ├── test_activity.py                      # Units 8, 15, 16
+│   └── test_activity_export.py               # Unit 11
+├── cli/
+│   ├── test_private.py                       # Unit 6
+│   ├── test_activity_self.py                 # Unit 9
+│   └── test_activity_replay.py               # Unit 10
+├── repositories/
+│   └── test_activity_repository.py           # Units 8, 11
+└── db/
+    └── test_v25_migration.py                 # Unit 1
+```
+
+> *This tree shows the expected output shape. Per-unit `**Files:**` sections remain authoritative; the implementer may adjust if a better layout emerges.*
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification.*
+
+### Data flow
+
+```mermaid
+graph LR
+  A[Analyst's Claude Code session] -->|SessionEnd hook| B[agnes push]
+  B -->|privacy off| C1[POST /api/upload/sessions<br/>full JSONL]
+  B -->|privacy on| C2[POST /api/upload/sessions/manifest<br/>structured JSON]
+  C1 --> D[/data/user_sessions/&lt;uid&gt;/*.jsonl]
+  C2 --> D2[/data/user_sessions/&lt;uid&gt;/*.manifest.json]
+  E[BqAccess scan] --> F[audit_log<br/>action=bq_scan]
+
+  D --> G[Nightly extractor]
+  D2 --> G
+  F --> G
+
+  G -->|CTAS over JSONL+manifest+audit_log| H[/data/extracts/activity_center/<br/>extract.duckdb]
+  H -->|orchestrator rebuild| I[analytics.duckdb<br/>master views]
+
+  I --> J1[/activity-center dashboards]
+  I --> J2[NL prompting via Claude Code]
+  I --> J3[CSV/Parquet exports]
+  H --> K[Daily purge: 90d raw / 365d aggregates]
+```
+
+### Privacy-mode upload separation
+
+```mermaid
+sequenceDiagram
+  participant U as Analyst
+  participant CLI as agnes CLI
+  participant State as privacy_state
+  participant Server as FastAPI
+  participant Store as user_sessions/
+
+  U->>CLI: agnes private on
+  CLI->>State: write privacy=on (session-id or workspace)
+  Note over U,Server: ... session work ...
+  U->>CLI: SessionEnd → agnes push
+  CLI->>State: read privacy state for this session
+  alt privacy=off
+    CLI->>Server: POST /api/upload/sessions (JSONL stream)
+    Server->>Store: save *.jsonl
+  else privacy=on
+    CLI->>CLI: synthesize manifest from JSONL (counts only)
+    CLI->>Server: POST /api/upload/sessions/manifest (JSON)
+    Server->>Store: save *.manifest.json
+  end
+  Note over Server: server cannot accept both for same session_id
+```
+
+### RBAC + dual-approver gate
+
+```mermaid
+graph TD
+  A[Admin clicks /activity-center/users/X] --> B{per_user_audit_enabled?}
+  B -->|false| Z1[403 setup-wizard-required]
+  B -->|true| C{has resource_grant<br/>'per_user_audit', user_id=X?}
+  C -->|no| Z2[403 not-granted]
+  C -->|yes| D{rate-limit OK?<br/>≤5/hour}
+  D -->|no| Z3[429 rate-limited<br/>+ audit_log warning]
+  D -->|yes| E{bulk-query?<br/>scans >1 user_id}
+  E -->|yes| Z4[403 bulk-query-rejected]
+  E -->|no| F{dual_approver<br/>required?}
+  F -->|no| H[Read payload<br/>+ audit_log row]
+  F -->|yes| G{review request<br/>approved by<br/>second admin?}
+  G -->|no| Z5[409 awaiting-approval]
+  G -->|yes| H
+  H --> I[Notify target analyst<br/>via Telegram + /me/activity]
+```
+
+## Implementation Units
+
+### Track A — Initial release (critical path)
+
+- [ ] **Unit 1: Schema migration v25**
+
+**Goal:** Bundle all activity-center schema additions in one auto-migration step, preserving the codebase's "one focused change per migration" pattern.
+
+**Requirements:** R6, R8, R9, R13, R15.
+
+**Dependencies:** None — foundational.
+
+**Files:**
+- Modify: `src/db.py` (add `_migrate_to_v25` function, bump `SCHEMA_VERSION = 25`).
+- Create: `tests/db/test_v25_migration.py`.
+
+**Approach:**
+- New columns on `system.duckdb.users`: `activity_disclosure_accepted_at TIMESTAMP NULLABLE`, `activity_disclosure_version INTEGER NULLABLE`.
+- New column on `system.duckdb.user_groups`: `is_department BOOLEAN DEFAULT FALSE`.
+- New table on `system.duckdb`: `activity_center_operator_ack(operator_id, ack_works_council, ack_dpia, ack_disclosure, acked_at, instance_yaml_snapshot)`.
+- Reserved column slot `activity_events.payload_key_id VARCHAR NULLABLE` (for future encryption — NULL on initial release).
+- New tables on `extract.duckdb` (created on first orchestrator rebuild via the extractor's `_meta` setup, not in v25 itself): `activity_events`, `activity_daily_user`, `activity_daily_plugin`, `activity_daily_department`, `plugin_adoption`, `activity_extraction_state`, `session_scores`, `plugin_scores`, `user_scores`. (Cross-DB FKs are intentionally not used; integrity maintained by extractor logic.)
+- Migration ordering inside v25: users columns → is_department column → operator_ack table. Each step idempotent; rollback drops in reverse.
+- Backfill: none. `users.activity_disclosure_accepted_at` defaults NULL — every user must accept on next session start by design.
+
+**Patterns to follow:**
+- `src/db.py:_migrate_to_v14` — orphan cleanup before FK addition pattern.
+- `src/db.py:_migrate_to_v23` — singleton-table addition pattern (`claude_md_template`).
+
+**Test scenarios:**
+- *Happy path:* Fresh DB at v24, `bootstrap()` runs `_migrate_to_v25`, post-migration `SCHEMA_VERSION` reads 25.
+- *Happy path:* All v25 columns exist with correct types and defaults.
+- *Edge case:* Re-running the migration on an already-v25 DB is a no-op (idempotent).
+- *Edge case:* `users.activity_disclosure_accepted_at` defaults to NULL for every existing user.
+- *Edge case:* `user_groups.is_department` defaults FALSE for every existing group, including `is_system=TRUE` Admin and Everyone.
+- *Error path:* If the migration fails partway through (simulate via interrupting after the first column add), running the migration again completes cleanly.
+
+**Verification:**
+- `pytest tests/db/test_v25_migration.py -q` passes.
+- Manual: existing dev instance migrates from v24 to v25 without errors; existing data preserved.
+
+- [ ] **Unit 2: Upload endpoints — disclosure gate + manifest route**
+
+**Goal:** Extend `/api/upload/sessions` with disclosure-acceptance check; add `/api/upload/sessions/manifest` for privacy-mode uploads.
+
+**Requirements:** R5, R6.
+
+**Dependencies:** Unit 1.
+
+**Files:**
+- Modify: `app/api/upload.py` (add disclosure check; add manifest endpoint).
+- Create: `src/activity_center/manifest.py` (pydantic model).
+- Create: `tests/api/test_upload_manifest.py`.
+
+**Approach:**
+- New pydantic model `SessionManifest`: `session_id: str`, `started_at: datetime`, `ended_at: datetime`, `tool_calls: list[ToolCallSummary]` (each: `name: str`, `target: str | None`, `duration_ms: int`, `outcome: Literal['ok','error','rejected']`), `query_count: int`, `bq_bytes_scanned: int`, `exit_status: str`. No prompt content, no tool params, no SQL.
+- `POST /api/upload/sessions/manifest` writes `${DATA_DIR}/user_sessions/<user_id>/<session_id>.manifest.json`. Idempotent on `(user_id, session_id)`: re-uploading the same session_id replaces the manifest.
+- Both endpoints check `users.activity_disclosure_accepted_at IS NOT NULL` and `users.activity_disclosure_version >= current_version`; reject with `403 disclosure_required` (typed JSON error including `current_version` and the disclosure URL) if stale.
+- "Manifest XOR JSONL" enforcement: when a `*.manifest.json` exists for a `(user_id, session_id)`, an incoming JSONL upload for the same session_id is rejected with `409 manifest_already_exists`. The reverse (manifest after JSONL) is also rejected. Same-session_id implies the same session is being uploaded twice.
+- Auth: same `Depends(get_current_user)` used by existing `/api/upload/sessions` (PAT auth flows through this).
+
+**Patterns to follow:**
+- `app/api/upload.py:upload_session` — streaming size cap and tempfile cleanup.
+- `app/api/tokens.py` — pydantic request body pattern.
+
+**Test scenarios:**
+- *Happy path:* Authenticated user with accepted disclosure POSTs valid manifest → 200, manifest file appears at expected path.
+- *Happy path:* Authenticated user POSTs full JSONL → 200, JSONL file appears.
+- *Error path:* User without `activity_disclosure_accepted_at` → 403 `disclosure_required` for both endpoints.
+- *Error path:* User with stale `activity_disclosure_version` → 403 `disclosure_required` with `current_version` in body.
+- *Error path:* Manifest with missing required fields → 422 with pydantic-validation details.
+- *Error path:* JSONL > 50 MB → 413 (existing behavior preserved).
+- *Edge case:* Manifest XOR violation — manifest exists, JSONL upload for same session_id → 409 `manifest_already_exists`.
+- *Edge case:* Re-uploading same manifest replaces existing file (idempotent).
+- *Integration:* Disclosure rejection sets the `WWW-Authenticate`-style hint header pointing at `/me/activity/disclosure`.
+
+**Verification:**
+- `pytest tests/api/test_upload_manifest.py -q` passes.
+- Manual: `curl` reproduces the rejection flow when disclosure is missing.
+
+- [ ] **Unit 3: Activity-center extractor (Approach A — CTAS over JSONLs + manifests)**
+
+**Goal:** Nightly extractor that materializes `activity_events`, daily rollups, `plugin_adoption` from `${DATA_DIR}/user_sessions/**/*.jsonl` + `*.manifest.json` + `audit_log` (BQ-scan rows). Privacy filter and redaction applied at extract time.
+
+**Requirements:** R5, R6, R11 (data shape), R15.
+
+**Dependencies:** Unit 1 (extract.duckdb tables created here on first run); Unit 2 (manifest format).
+
+**Execution note:** Begin with a 1-day corpus-size spike — generate a synthetic 50M-row JSONL corpus and time the nightly CTAS in DuckDB. If it fits the operator's maintenance window (target: <30 minutes for 50M rows), continue Approach A. If not, pivot to Approach B (incremental extractor service) before further Unit 3 work.
+
+**Files:**
+- Create: `src/activity_center/extractor.py`.
+- Create: `src/activity_center/redaction.py`.
+- Create: `tests/activity_center/test_extractor.py`.
+- Create: `tests/activity_center/test_redaction.py`.
+- Modify: `services/scheduler/__main__.py` (register nightly activity_center extractor job).
+
+**Approach:**
+- **Pipeline shape:** `read_json_auto` over JSONLs + `read_json_auto` over manifest sidecars + `audit_log WHERE action='bq_scan'`, joined and projected into `activity_events`. Privacy filter is a SQL predicate at projection time (private-session rows have `privacy_mode=TRUE` and `payload=NULL`).
+- **Plugin attribution:** Tool name prefix-match against `marketplace_plugins`; built-ins (Read/Edit/Bash/Grep/Glob/Task) → `plugin_name=NULL`. Coverage validation against ≥3 known plugins (heavy / zombie / ambiguous) before dashboard publishes the metric.
+- **Redaction at extract time** before insertion into `activity_events.payload`:
+  - Generic patterns: AWS keys, GitHub tokens, OpenAI/Anthropic keys, JWTs, basic-auth URLs, `<email>:<password>`.
+  - High-entropy strings ≥32 chars, mixed alphanumeric, **with UUID exclusion (8-4-4-4-12 hex format) to avoid false positives**.
+  - Platform-specific: Keboola Storage tokens, Atlassian PATs + cookies, BQ service-account JSON blobs.
+  - Operator can extend via `instance.yaml: activity_center.redaction.patterns` without a code release.
+  - Each redaction emits a counter to existing platform metrics (anomaly tile fed from this).
+- **Rollup tables** computed in the same nightly run:
+  - `activity_daily_user(user_id, day, prompts, tool_calls, queries, bq_bytes, failures)`.
+  - `activity_daily_plugin(plugin_name, day, distinct_users, invocations, failures)`.
+  - `activity_daily_department(group_id, day, prompts, tool_calls, queries, bq_bytes, failures)` — only for `user_groups WHERE is_department=TRUE`; multi-membership additive.
+- **`plugin_adoption(user_id, plugin_name, first_seen_at, last_seen_at)`** upserted (survives 90d raw-event purge).
+- **`activity_extraction_state(jsonl_path, jsonl_hash, processed_at, PRIMARY KEY (jsonl_path, jsonl_hash))`** dedup; activity-center never touches `session_extraction_state` (owned by `corporate_memory` + `verification_detector`).
+- **`_meta` table** in `extract.duckdb` per the connector contract: table_name, description, rows, size_bytes, extracted_at, query_mode (`local` for rollups, `remote` is N/A here). No `_remote_attach` because the activity store isn't a remote source.
+
+**Patterns to follow:**
+- `connectors/keboola/extractor.py` — extract.duckdb contract template.
+- `connectors/bigquery/extractor.py` — extract.duckdb pattern with `_meta` setup.
+- `services/corporate_memory/extractor.py` — JSONL walker pattern (referenced for shape; activity-center maintains its own walker per non-goal).
+
+**Test scenarios:**
+- *Happy path:* Synthetic JSONL corpus (10 sessions, 3 users, 2 plugins) → `activity_events` populated correctly; rollups match hand-computed expected values.
+- *Happy path:* Manifest sidecar produces metadata-only row with `payload=NULL` and `privacy_mode=TRUE`.
+- *Happy path:* `audit_log` row with `action='bq_scan'` projects into a `query` event row with `bytes_scanned` populated.
+- *Edge case:* Empty corpus produces empty rollups, no crash.
+- *Edge case:* Built-in tool calls (`Read`, `Bash`) produce `plugin_name=NULL`.
+- *Edge case:* MCP-prefixed tool calls produce correct plugin_name.
+- *Edge case:* Same JSONL re-processed via `activity_extraction_state` is a no-op.
+- *Error path:* Malformed JSONL line is skipped with a warning; the rest of the file processes.
+- *Error path:* Extractor crash partway through is recoverable on next run (state is persisted only on commit).
+- *Integration:* After extractor + orchestrator rebuild, `analytics.duckdb` master views resolve `activity_events` and the rollup tables.
+
+**Test scenarios for redaction:**
+- *Happy path:* AWS key in tool params → redacted; rest of payload preserved.
+- *Happy path:* Keboola Storage token in prompt → redacted.
+- *Happy path:* GitHub PAT in URL → redacted.
+- *Edge case:* UUID (`123e4567-e89b-12d3-a456-426614174000`) in payload → NOT redacted (UUID exclusion).
+- *Edge case:* High-entropy string ≥32 chars (random alphanumeric) → redacted.
+- *Edge case:* Operator adds custom pattern via `instance.yaml` → redaction respects it.
+- *Edge case:* Each redaction increments the metrics counter.
+
+**Verification:**
+- `pytest tests/activity_center/test_extractor.py tests/activity_center/test_redaction.py -q` passes.
+- Manual: nightly job runs against a dev corpus; `agnes query` against rollups returns plausible numbers.
+
+- [ ] **Unit 4: BQ-cost write path**
+
+**Goal:** Server-side BQ scans write `audit_log` rows; nightly extractor (Unit 3) projects them into `activity_events`.
+
+**Requirements:** R3, R4, R10 (department BQ-bytes tile).
+
+**Dependencies:** Unit 1.
+
+**Files:**
+- Modify: `connectors/bigquery/access.py` (`BqAccess` writes `audit_log` row on each scan).
+- Modify: `app/api/v2_scan.py` (or wherever the BQ query path lives) — call into the new audit hook.
+- Create: `tests/connectors/test_bq_audit.py`.
+
+**Approach:**
+- After a BQ scan completes, `BqAccess` writes one row to `audit_log`: `action='bq_scan'`, `user_id=<scan-issuer>`, `params={"bytes_scanned": N, "rows_returned": M, "target_table": "...", "query_id": "...", "session_id": "..."}` (session_id from the request context if available; NULL otherwise — extractor enriches via JSONL match).
+- This avoids the cross-DB write race entirely: `audit_log` is in `system.duckdb` (the app is the sole writer); the extractor is read-only on `audit_log` and writer-only on `extract.duckdb`.
+
+**Patterns to follow:**
+- `app/api/admin.py` — `audit_log` write pattern (already used for grant/revoke events).
+
+**Test scenarios:**
+- *Happy path:* Successful BQ scan via `BqAccess.query` → one `audit_log` row with `action='bq_scan'` and correct `bytes_scanned`.
+- *Happy path:* Failed BQ scan still writes an `audit_log` row with `result='failed'` and `error_class` populated.
+- *Edge case:* Scan with no `session_id` available → `audit_log.params.session_id` is NULL.
+- *Integration:* After extractor runs (Unit 3), the `audit_log` row is projected into `activity_events` with `event_type='query'` and the matching session_id resolved (if a JSONL with matching window exists).
+
+**Verification:**
+- `pytest tests/connectors/test_bq_audit.py -q` passes.
+- Manual: trigger a `agnes query --remote` and confirm an `audit_log` row appears.
+
+- [ ] **Unit 5: Scoring engine (deterministic SQL)**
+
+**Goal:** Nightly CTAS that computes `session_scores`, `plugin_scores`, `user_scores` per the formulas in §7 of the requirements, with sub-score gaming defenses.
+
+**Requirements:** R2, R3, R4.
+
+**Dependencies:** Unit 3 (data shape).
+
+**Files:**
+- Create: `src/activity_center/scoring.py`.
+- Create: `tests/activity_center/test_scoring.py`.
+- Modify: `config/instance.yaml.example` (document `activity_center.scoring.*` weight knobs).
+
+**Approach:**
+- All scoring is deterministic SQL (LLM-as-judge deferred to backlog). Pure CTAS over `activity_events` + rollups; no LLM API calls in initial release.
+- **Session sub-scores:**
+  - `productivity = LEAST(tool_calls_per_min × success_rate, p95_tool_call_rate)` — capped at 95th-percentile of operator's historical tool-call rate (recomputed weekly from previous 30d).
+  - `success_rate = ok_outcomes / total_tool_calls`.
+  - `error_density = 1 - (error_events / total_events)`.
+  - `output_density` — sum of (artifacts uploaded) + (queries whose returned rows are referenced in a subsequent prompt within the same session, 5-min window heuristic) / session minutes.
+  - `prompt_iteration` — bell-curve weighted: ideal range 2–5 prompts per accomplished tool sequence; penalize both <2 and >5.
+  - **`tool_efficiency` is dropped** (penalized correct repetitive-tool workflows).
+  - `composite = weighted_geomean(sub_scores) × 100`.
+- **Plugin sub-scores:** `adoption_breadth`, `adoption_intensity`, `success_rate`, `retention` per definitions.
+- **User sub-scores:** `productivity_trend` (slope of session-score median over 30d), `plugin_mastery` (distinct plugins with success-rate > `activity_center.scoring.user.plugin_mastery_success_threshold` (default 0.75) over 30d), `query_cost_efficiency` (useful-bytes / total-bytes via 5-min subsequent-prompt heuristic).
+- **`disputed_session_count` and `disputed_summary_count`** in `user_scores` are populated from `audit_log WHERE action='score_disputed'` (Unit 9 wires the writes).
+- **Composite weights** read from `instance.yaml`. Default weights ship in the runbook (Unit 12).
+- **Composite is hidden from the leadership tile by default**: `activity_center.scoring.show_user_composite_to_admin: false`. Sub-scores still computed; visibility decision is in the dashboard layer (Unit 8), not the scoring layer.
+
+**Patterns to follow:**
+- DuckDB CTAS over rollups, no Python data processing — keep the pipeline SQL-shaped for inspectability.
+
+**Test scenarios:**
+- *Happy path:* A session with 10 tool calls / 1 minute / 9 ok / 1 error / 2 artifacts uploaded → expected sub-score values match hand-computed.
+- *Happy path:* Plugin with 5 distinct users, 80% success rate, 14d retention → expected plugin score matches.
+- *Edge case:* Session with 1000 tool calls in 30 seconds → productivity sub-score capped at p95 (gaming defense fires).
+- *Edge case:* Session with 1 prompt and 50 tool calls → prompt_iteration low (bell-curve penalizes).
+- *Edge case:* Session with 20 prompts and 2 tool calls → prompt_iteration low (bell-curve penalizes both extremes).
+- *Edge case:* User with 0 sessions in window → all sub-scores NULL, composite NULL, no division-by-zero crash.
+- *Edge case:* Plugin granted to 100 users, used by 0 → adoption_breadth=0, composite=0.
+- *Integration:* After Unit 9 ships, `disputed_session_count > 0` for a user shows up correctly in `user_scores`.
+- *Integration:* Operator-tuned weights produce different composite for the same input data.
+
+**Verification:**
+- `pytest tests/activity_center/test_scoring.py -q` passes.
+- Manual: run scoring against a dev corpus; sample composites are 0–100, sub-scores are 0–1.
+
+- [ ] **Unit 6: Privacy mode CLI + hooks integration**
+
+**Goal:** `agnes private on|off|status` toggles per-session privacy state; `agnes push` branches between `/api/upload/sessions` and `/api/upload/sessions/manifest` based on the state.
+
+**Requirements:** R5.
+
+**Dependencies:** Unit 2.
+
+**Execution note:** Begin with a 1-day spike — verify whether Claude Code exposes `$CLAUDE_SESSION_ID` (or equivalent) to SessionStart/SessionEnd hooks. Document the answer in this unit's PR description. If exposed → per-session toggle stored at `.claude/agnes-private-<session_id>.json`. If not → workspace-level toggle at `.claude/agnes-private.json` with explicit "stays on until `agnes private off`" semantics in CLI output and docs.
+
+**Files:**
+- Create: `cli/commands/private.py`.
+- Create: `cli/lib/privacy_state.py`.
+- Modify: `cli/commands/push.py` (read privacy state, branch upload route, synthesize manifest from JSONL when privacy is on).
+- Modify: `cli/lib/hooks.py` (SessionStart hook clears stale workspace-level state if session-id-keyed mode is unavailable; SessionEnd hook deletes per-session state file).
+- Create: `tests/cli/test_private.py`.
+
+**Approach:**
+- Privacy state location depends on spike outcome (per execution note).
+- `agnes private on` → write `{"privacy": true, "set_at": "<iso>"}`. `off` → delete file (or write `{"privacy": false}`).
+- `agnes private status` → print current state + mechanism (per-session vs workspace) + when it was set.
+- `agnes push`:
+  - Discover Claude Code's just-ended session JSONL via `cli/lib/claude_sessions.py`.
+  - Read privacy state.
+  - If off → POST JSONL to `/api/upload/sessions` (existing behavior).
+  - If on → synthesize manifest from JSONL (counts + tool names + targets + outcomes; never prompt content) and POST to `/api/upload/sessions/manifest`. Discard the JSONL (don't upload).
+- All uploads append `|| true` per the existing `agnes init` hook pattern (server outage doesn't block session).
+
+**Patterns to follow:**
+- `cli/commands/push.py` — existing upload pattern, including `--quiet` flag handling for hook contexts.
+- `cli/commands/admin.py` — subcommand registration.
+
+**Test scenarios:**
+- *Happy path:* `agnes private on` → state written; `agnes private status` → reports on.
+- *Happy path:* `agnes push` with privacy off → JSONL POSTed to `/api/upload/sessions`.
+- *Happy path:* `agnes push` with privacy on → manifest POSTed to `/api/upload/sessions/manifest`; JSONL is NOT uploaded.
+- *Happy path:* Manifest contains tool counts, durations, outcomes; contains no prompt text or tool params.
+- *Edge case:* `agnes push` with no JSONL found is a graceful no-op.
+- *Edge case:* SessionStart hook clears stale workspace-level state (when in workspace-level mode).
+- *Edge case:* Server unreachable → push exits with `|| true` semantics; no error surfaces in Claude Code.
+- *Error path:* Server returns 403 `disclosure_required` → CLI surfaces clear message ("Run `agnes activity disclose` to accept the disclosure").
+- *Integration:* Round-trip: `agnes private on` → session work → SessionEnd hook → `agnes push` → server has manifest, no JSONL for that session.
+
+**Verification:**
+- `pytest tests/cli/test_private.py -q` passes.
+- Manual: end-to-end via dev instance — toggle on, run a Claude Code session, verify only the manifest landed.
+
+- [ ] **Unit 7: Disclosure flow**
+
+**Goal:** First-run disclosure in `agnes init`, server-side acceptance recording, upload rejection for unaccepted users.
+
+**Requirements:** R6.
+
+**Dependencies:** Unit 1, Unit 2.
+
+**Files:**
+- Modify: `cli/commands/init.py` (print disclosure, prompt acceptance, POST acceptance to server).
+- Create: `app/api/me.py` (or extend existing) — `POST /api/me/disclosure/accept` endpoint, `GET /api/me/disclosure` to read current state.
+- Create: `tests/cli/test_init_disclosure.py`.
+- Create: `tests/api/test_disclosure.py`.
+
+**Approach:**
+- Disclosure text (versioned in code; bump triggers re-acceptance):
+  > "Activity Center collects per-session telemetry: tool calls, queries, durations, outcomes. Prompts and tool parameters are also collected unless you turn private mode on for that session (`agnes private on`). Data is retained 90 days; aggregate scores 365 days. Your activity is scored — see `agnes activity self`. Operators may have enabled per-user prompt-level inspection on this instance; that flag is visible at `/me/activity`."
+- `agnes init` prints the disclosure, prompts `[y/N]`, and on `y` POSTs to `/api/me/disclosure/accept` with `version=N`. On `N` (or missing acceptance), `agnes push` will fail with a clear message until the user accepts.
+- `users.activity_disclosure_accepted_at` + `users.activity_disclosure_version` updated on accept.
+- When operator updates the disclosure (changes the version constant), `users.activity_disclosure_version < current_version` triggers re-acceptance on next `agnes init` or next session start.
+- Both upload endpoints (Unit 2) check this; the rejection includes the disclosure URL/text in the error body so CLI can re-prompt.
+
+**Patterns to follow:**
+- `cli/commands/init.py` — interactive prompt pattern.
+- `app/api/tokens.py` — `/api/me/*` self-scoped endpoint pattern.
+
+**Test scenarios:**
+- *Happy path:* Fresh `agnes init` prompts disclosure; user accepts; `users.activity_disclosure_accepted_at` populated.
+- *Happy path:* User declines; subsequent `agnes push` returns 403 with the disclosure-required message.
+- *Happy path:* User re-runs `agnes init` after declining; disclosure re-prompts.
+- *Edge case:* Disclosure version bump → existing accepted users marked stale; next session start re-prompts.
+- *Edge case:* `agnes init --quiet` (hook context) does NOT prompt interactively; instead, prints a one-line "disclosure pending — run `agnes init`" and exits 0 so the hook doesn't break.
+- *Integration:* Disclosure acceptance is logged to `audit_log` (`action='disclosure_accepted'`).
+
+**Verification:**
+- `pytest tests/cli/test_init_disclosure.py tests/api/test_disclosure.py -q` passes.
+- Manual: fresh dev instance → `agnes init` flow works end-to-end.
+
+- [ ] **Unit 8: Web dashboards + session-replay surface**
+
+**Goal:** Extend `/activity-center` route + template; add `/users[/<id>]`, `/users/<id>/sessions/<sid>` (session-replay), `/plugins[/<plugin>]`, `/weekly` sub-routes plus a cross-session chronology view.
+
+**Requirements:** R1, R1b (chronology + replay), R7, R10 (dashboard exports), R12 (plugin churn surface).
+
+**Dependencies:** Unit 3, Unit 5.
+
+**Files:**
+- Modify: `app/web/router.py` (extend existing `/activity-center` route + add sub-routes including session-replay).
+- Create: `app/api/activity.py` (per-user-detail read API w/ RBAC + rate-limit hooks for Unit 15+16; tile-data endpoints; session-replay event-stream endpoint).
+- Create: `src/repositories/activity_center.py` (read paths for dashboard queries + chronological event reads).
+- Modify: `app/web/templates/activity_center.html` (live tile data).
+- Create: `app/web/templates/activity_center/{users,user_detail,session_replay,plugins,plugin_detail,weekly,me}.html`.
+- Create: `tests/activity_center/test_dashboards.py`.
+- Create: `tests/activity_center/test_session_replay.py`.
+- Create: `tests/repositories/test_activity_repository.py`.
+- Create: `tests/api/test_activity.py`.
+
+**Approach:**
+- **`/activity-center` (overview)** tiles: active users 7d/30d, top plugins by composite, BQ bytes by department, failure-rate trend, redaction-counter anomaly, **weekly leadership digest tile** (link into `/activity-center/weekly`). The "top users by composite" tile is gated behind `activity_center.scoring.show_user_composite_to_admin: true`.
+- **`/activity-center/weekly`** — templated narrative synthesizing the prior week from rollups: top accomplishments by department, top friction points (failure-class trends), plugin highlights, recommended actions tied to named decisions in the requirements §7. Generated nightly Sunday from deterministic data — no LLM call. Templated string-build, not a model.
+- **`/activity-center/users` + `/users/<user_id>`** — gated behind `per_user_audit_enabled: true` (returns 403 with setup-wizard link if not). All-users table with sub-scores; per-user detail = session timeline + plugin histogram + BQ cost trend + error-class breakdown + sub-score trends + disputed-count flag tile + **cross-session chronology view** (single timeline of all events across the user's sessions, filterable by date range / error_class / plugin_name) + click-through to session-replay. Session-replay surface (next bullet) requires the full Track C gate stack from Unit 15 (RBAC + rate-limit + dual-approver) for `payload` access.
+- **`/activity-center/users/<user_id>/sessions/<session_id>` (session-replay surface)** — step-by-step chronological reconstruction of one session: events ordered by `event_ts ASC`, rendered as a vertical timeline. Each event card shows `event_type` + `tool_name` + `duration_ms` + `outcome` + `error_class` + collapsed `payload` (expand on click). Affordances:
+  - **Jump-to-next-failure** button skips to the next event with `outcome='error'`.
+  - **Jump-to-prompt-N** sidebar lists prompts in order, click-jumps.
+  - **Collapse-successful-tool-calls** toggle reduces noise.
+  - Each event has a deep-link anchor (`#event-<event_id>`) for shareable URLs to specific failure points.
+  - For private sessions (`privacy_mode=TRUE`): render the manifest only (tool names, durations, outcomes); content fields show `<private session — content not collected>` placeholders. Page header notes "This was a private session" prominently.
+  - One audit_log row written per render of a non-private session (regardless of how many events the admin scrolled through — page-load is the audit unit, not per-event).
+- **`/activity-center/plugins` + `/plugins/<plugin>`** — ranked table; per-plugin detail with adoption + retention trends, top users by intensity (only when composite-visibility flag is on), abandonment list.
+- **`/me/activity`** — per Unit 9 (includes self-replay for own sessions).
+- All tile/table queries hit `analytics.duckdb` master views (rollups are `query_mode='local'` parquet); per-user `payload` access (including session-replay event-stream) goes through `query_mode='remote'` so server-side audit fires.
+- Each tile has CSV/Parquet export buttons (Unit 11).
+- Render with the existing Jinja + htmx pattern (consistent with `/activity-center` stub already in `app/web/router.py`). Session-replay timeline uses htmx for lazy-loading event chunks (sessions can have hundreds of events; don't render them all at once).
+
+**Patterns to follow:**
+- Existing dashboard tiles in `app/web/templates/dashboard.html`.
+- `app/api/access.py` — RBAC `Depends` pattern.
+
+**Test scenarios:**
+- *Happy path:* GET `/activity-center` (admin authed, accepted disclosure) → 200, tiles render with rollup data.
+- *Happy path:* GET `/activity-center/weekly` → templated narrative reads coherently against fixture data.
+- *Happy path:* GET `/activity-center/plugins` → plugins ranked by composite.
+- *Happy path:* GET `/activity-center/users/<user_id>` → cross-session chronology view renders all events across all sessions for the user, ordered by `event_ts`.
+- *Happy path:* GET `/activity-center/users/<user_id>/sessions/<session_id>` → session-replay timeline renders events in `event_ts ASC` order with prompt → tool_call → tool_result interleaving correct.
+- *Happy path:* Session-replay "jump-to-next-failure" anchors to the first event with `outcome='error'`.
+- *Edge case:* `per_user_audit_enabled=false` + GET `/activity-center/users` → 403 with link to setup wizard.
+- *Edge case:* `show_user_composite_to_admin=false` + GET `/activity-center` → "top users by composite" tile is absent; rest of the page renders.
+- *Edge case:* Session-replay for a private session (`privacy_mode=TRUE`) → renders manifest only; payload fields show "private session — content not collected" placeholder; no `payload` data in the HTTP response body.
+- *Edge case:* Session with 500+ events → htmx lazy-loads in chunks; initial response is fast.
+- *Edge case:* Cross-session chronology with date-range filter → only events in range returned.
+- *Error path:* User without admin role + GET `/activity-center/users/<other>` → 403 not_granted.
+- *Error path:* Admin without `resource_grants(per_user_audit, target=X)` + GET session-replay for X → 403.
+- *Integration:* Per-user payload access (including session-replay page render) → exactly one `audit_log` row appears per page-load (not per event).
+- *Integration:* Session-replay deep-link `#event-<id>` round-trips: open shared URL → page scrolls to the anchored event.
+- *Integration:* CSV export on a tile produces a file with the expected schema.
+
+**Verification:**
+- `pytest tests/activity_center/test_dashboards.py tests/api/test_activity.py tests/repositories/test_activity_repository.py -q` passes.
+- Manual: dev instance renders all five named surfaces.
+
+- [ ] **Unit 9: Self-view recourse mechanisms + self-replay**
+
+**Goal:** `/me/activity` is symmetric in data (analyst sees what admins see of them) plus active recourse: weight transparency, score dispute, "who looked at me", disclosure history, **plus self-replay surface so analysts can review their own sessions for self-debugging without admin involvement**.
+
+**Requirements:** R1b (self-replay), R7.
+
+**Dependencies:** Unit 5, Unit 8.
+
+**Files:**
+- Modify: `app/web/router.py` (add `/me/activity` route + `/me/activity/sessions/<sid>` self-replay).
+- Create: `app/web/templates/activity_center/me.html`.
+- Modify: `app/web/templates/activity_center/session_replay.html` (shared between admin and self-view; same template, different RBAC entry points).
+- Modify: `app/api/activity.py` (add self-scoped endpoints: `GET /api/me/activity`, `POST /api/me/activity/dispute`, `GET /api/me/activity/who-looked-at-me`, `GET /api/me/activity/disclosure-history`, `GET /api/me/activity/sessions/<sid>` for self-replay event stream).
+- Create: `cli/commands/activity.py` (`agnes activity self`, `agnes activity replay --self [--session <sid>] [--since 7d]`).
+- Create: `tests/cli/test_activity_self.py`.
+
+**Approach:**
+- **Weight transparency**: page displays the active composite weights for sessions / plugins / users and the weight-version + last-changed-by-operator timestamp. Direct read from `instance.yaml`.
+- **Score dispute**: per-session "Dispute" button posts `{session_id, sub_score_disputed, reason}` → `audit_log(action='score_disputed', user_id=<self>, params={...})` → bumps `user_scores.disputed_session_count` for that user (Unit 5 reads this on next nightly run). The leadership view of the user shows the disputed-count as a flag tile.
+- **"Who looked at me"**: query `audit_log WHERE action='per_user_audit_read' AND params->>'target_user_id' = <self> AND timestamp > now() - interval '30 days'`. Display: who, when. Symmetric to the admin mutual-visibility digest.
+- **Disclosure history**: query the audit-log entries for `action='disclosure_accepted'` for self → versions accepted, when.
+- **Self-replay**: `/me/activity/sessions/<sid>` reuses the session-replay template from Unit 8 but scoped to `user_id = <self>`. No `per_user_audit` RBAC needed (you can always read your own data). No audit-log row written (reading your own data is not a per-user-audit event). The CLI mirror `agnes activity replay --self --session <sid>` walks events in the terminal with `--filter errors` / `--filter prompts` flags and color-coding by outcome.
+- `agnes activity self` CLI mirrors `/me/activity` content (scores, weights, who-looked-at-me) for terminal use; `agnes activity replay --self` is the replay-specific command.
+
+**Patterns to follow:**
+- `app/api/tokens.py` — self-scoped `/api/me/*` endpoint pattern.
+- `app/web/router.py` — Jinja + htmx page pattern.
+
+**Test scenarios:**
+- *Happy path:* GET `/me/activity` (any authed user) → 200 with self's data; no need for `per_user_audit_enabled`.
+- *Happy path:* POST `/api/me/activity/dispute` with valid session_id → 200, audit_log row appears.
+- *Happy path:* GET `/api/me/activity/who-looked-at-me` returns admin lookups in the prior 30d.
+- *Happy path:* GET `/me/activity/sessions/<sid>` (self-replay) → 200 with full event timeline, no audit_log row written.
+- *Happy path:* `agnes activity self` prints the analyst's dashboard data.
+- *Happy path:* `agnes activity replay --self --session <sid>` walks events in chronological order in the terminal.
+- *Happy path:* `agnes activity replay --self --session <sid> --filter errors` shows only events with `outcome='error'`.
+- *Error path:* GET `/me/activity/sessions/<sid>` where `<sid>` belongs to another user → 403.
+- *Error path:* POST dispute with session_id belonging to another user → 403 (you can only dispute your own sessions).
+- *Edge case:* No prior admin lookups → "who-looked-at-me" returns empty list.
+- *Edge case:* Self-replay for own private session → renders manifest only, content placeholder.
+- *Integration:* Disputed-count appears on the leadership view of the user (Unit 8).
+- *Integration:* Self-replay reads same events the admin would see — symmetry verified by comparing fixtures.
+
+**Verification:**
+- `pytest tests/cli/test_activity_self.py -q` passes; relevant `tests/api/test_activity.py` cases pass.
+- Manual: end-to-end via dev — analyst can dispute, admin sees the flag.
+
+- [ ] **Unit 10: Right-to-forget tool + admin replay CLI**
+
+**Goal:** `agnes admin activity forget --user <id>` cascades through all activity tables transactionally within `extract.duckdb`. Plus `agnes admin activity replay --user <id> --session <sid>` for terminal-based session replay (mirrors the web surface; same RBAC + audit-log gates apply).
+
+**Requirements:** R1b (admin replay CLI), R9.
+
+**Dependencies:** Unit 1, Unit 3, Unit 5, Unit 8 (replay endpoint).
+
+**Files:**
+- Create: `src/activity_center/right_to_forget.py`.
+- Modify: `cli/commands/admin.py` (add `agnes admin activity forget` + `agnes admin activity replay` subcommands).
+- Create: `tests/activity_center/test_right_to_forget.py`.
+- Create: `tests/cli/test_activity_replay.py`.
+
+**Approach (admin replay CLI):**
+- `agnes admin activity replay --user <id> --session <sid>` calls the same `/api/activity/users/<id>/sessions/<sid>` endpoint Unit 8 exposes; rate-limit + dual-approver + audit-log all fire at the API boundary (terminal access is not a back-door).
+- Flags: `--filter errors|prompts|all` (default `all`), `--since <duration>` to scope cross-session timeline, `--format text|json` (default `text` with color-coded outcomes).
+- When the API returns 409 awaiting-approval (dual-approver case), the CLI surfaces a clear message ("Approval needed; have admin Y run `agnes admin activity approve <request_id>`").
+- Pure terminal-renderable output — no curses/tui, just colored stdout for grep-ability and SSH ergonomics.
+
+**Approach:**
+- Single transaction inside `/data/extracts/activity_center/extract.duckdb`:
+  1. `DELETE FROM activity_events WHERE user_id = <id>`.
+  2. `DELETE FROM activity_daily_user WHERE user_id = <id>`.
+  3. `DELETE FROM activity_daily_department WHERE user_id = <id>`.
+  4. **Recompute** `activity_daily_plugin` rows for `(plugin_name, day)` pairs the deleted user contributed to (delete + reinsert from remaining sources).
+  5. **Recompute** `plugin_scores` rows for `(plugin_name, day)` pairs affected (`adoption_breadth`, `adoption_intensity`, `retention` all derive from per-user behavior).
+  6. `DELETE FROM session_scores WHERE user_id = <id>`.
+  7. `DELETE FROM user_scores WHERE user_id = <id>`.
+  8. `DELETE FROM plugin_adoption WHERE user_id = <id>`.
+- The user row in `system.duckdb.users` is **unaffected** (account remains; right-to-forget is for activity data, not account deletion).
+- If the recompute step fails after the delete, the next nightly extractor pass restores the rollup to a consistent state and the right-to-forget tool exits non-zero — the operator re-runs.
+- Writes an `audit_log` row: `action='activity_forget', user_id=<operator>, params={target_user_id, deleted_event_count, deleted_session_count}`.
+- Also deletes the user's session-JSONLs and manifest sidecars from `${DATA_DIR}/user_sessions/<user_id>/` (raw source data), otherwise reprocessing would resurrect the activity events.
+
+**Patterns to follow:**
+- `cli/commands/admin.py` — admin subcommand registration.
+- DuckDB transaction pattern (`BEGIN; ... COMMIT;`) in `src/repositories/`.
+
+**Test scenarios (right-to-forget):**
+- *Happy path:* User with 50 events / 5 sessions / 3 plugins is forgotten → all event rows deleted, plugin rollups recomputed, plugin_scores recomputed, score tables deleted, JSONLs deleted from disk.
+- *Happy path:* `audit_log` row written with operator + target + counts.
+- *Edge case:* User with no activity → tool exits 0 with "no rows to delete" message.
+- *Error path:* Recompute step interrupted (simulate by killing mid-transaction) → next extractor pass restores consistency; tool exits non-zero on this run.
+- *Integration:* Plugin rollups for plugins the deleted user used reflect remaining-user data correctly post-forget.
+- *Integration:* Re-running `agnes admin activity forget --user <same_id>` is a no-op.
+
+**Test scenarios (admin replay CLI):**
+- *Happy path:* `agnes admin activity replay --user X --session sid` (admin with grants) → events stream to stdout in chronological order with color-coded outcomes; one audit_log row written.
+- *Happy path:* `--filter errors` shows only `outcome='error'` events.
+- *Happy path:* `--format json` produces machine-readable line-delimited JSON for grep/jq pipelines.
+- *Error path:* Admin without `resource_grants(per_user_audit, X)` → CLI exits non-zero with "403 not_granted" message; no audit_log row.
+- *Error path:* Rate-limit hit → CLI exits non-zero with retry-after hint; warning row in audit_log.
+- *Error path:* Dual-approver mode + no approved request → CLI exits with "approval needed; ask admin Y to run `agnes admin activity approve <request_id>`".
+- *Edge case:* Replaying a private session → CLI shows manifest events only, content fields show `<private session — content not collected>` placeholder.
+
+**Verification:**
+- `pytest tests/activity_center/test_right_to_forget.py -q` passes.
+- Manual: dev instance with seeded data → forget → verify cascade.
+
+- [ ] **Unit 11: Export endpoints**
+
+**Goal:** CSV + Parquet export for "all" / "per department" / "myself" / "per user — other (admin)" with scope-dependent column inclusion.
+
+**Requirements:** R10.
+
+**Dependencies:** Unit 3, Unit 5, Unit 8.
+
+**Files:**
+- Create: `app/api/activity_export.py`.
+- Modify: `src/resource_types.py` (add `ResourceType.ACTIVITY_EXPORT` enum member + spec).
+- Create: `tests/api/test_activity_export.py`.
+
+**Approach:**
+- Endpoints:
+  - `GET /api/activity/export?scope=all&format={csv,parquet}` — admin only.
+  - `GET /api/activity/export?scope=department&group_id=X&format=...` — gated by `resource_grants(resource_type='activity_export', resource_id=group_id)`.
+  - `GET /api/activity/export?scope=myself&format=...` — any authed user against own user_id.
+  - `GET /api/activity/export?scope=user&user_id=X&format=...` — admin only + `per_user_audit_enabled=true` + RBAC + audit-log write.
+- Column inclusion:
+  - `payload` included only for "all" admin export and "myself".
+  - "per department" exports strip `payload`; counts/metadata/scores only.
+  - Private-session rows (`privacy_mode=TRUE`) never include `payload` regardless of scope (NULL by extraction-time contract).
+- Every export action writes one `audit_log` row with `action='activity_export', params={scope, row_count, target_user_id_or_group_id, format}`.
+- Streaming CSV/Parquet response (DuckDB `COPY ... TO 'stream.csv|parquet' (FORMAT ...)`); no full-buffer in memory.
+
+**Patterns to follow:**
+- `src/resource_types.py` existing pattern (one enum member + one `ResourceTypeSpec` with `list_blocks` delegate, no DB migration).
+- `app/api/admin.py` — audit-log-on-action pattern.
+
+**Test scenarios:**
+- *Happy path:* Admin GET `?scope=all&format=csv` → CSV stream with all rows; audit_log row written.
+- *Happy path:* Group-lead GET `?scope=department&group_id=<their_group>` → CSV stream with rollup-shaped rows (no payload).
+- *Happy path:* Authed user GET `?scope=myself` → CSV with own rows including payload.
+- *Error path:* Group-lead GET `?scope=department&group_id=<other_group>` → 403.
+- *Error path:* Non-admin GET `?scope=all` → 403.
+- *Error path:* Admin GET `?scope=user&user_id=X` with `per_user_audit_enabled=false` → 403.
+- *Edge case:* Empty result → CSV with header row only, 200 (not 204).
+- *Edge case:* Private-session rows in "all" export → present with `payload=NULL`.
+- *Integration:* Audit-log row contains correct row_count.
+
+**Verification:**
+- `pytest tests/api/test_activity_export.py -q` passes.
+- Manual: download via curl, inspect Parquet via DuckDB.
+
+- [ ] **Unit 12: Operator runbook + minimum_collection profile**
+
+**Goal:** `docs/operator/activity-center.md` ships with the release, documenting compliance posture, default knobs, and the `minimum_collection: true` one-line override.
+
+**Requirements:** R13, R15.
+
+**Dependencies:** Units 1, 5, 11, 15 (the runbook documents what these ship).
+
+**Files:**
+- Create: `docs/operator/activity-center.md`.
+- Modify: `config/instance.yaml.example` (full `activity_center.*` section with comments).
+- Modify: `CHANGELOG.md` (per `CLAUDE.md` discipline rules — `### Added` entry for Activity Center initial release).
+- Modify: `README.md` (one-paragraph mention with link to runbook).
+
+**Approach:**
+- Runbook structure:
+  - **What Activity Center collects**, retention, scoring overview.
+  - **Czech Labour Code §316 / GDPR Art. 88** monitoring trigger explanation.
+  - **DPIA (Art. 35)** trigger and template-link (operator's responsibility; OSS does not provide legal templates).
+  - **Default knobs table** (per `Privacy & legal posture > Defaults are product opinions` in the requirements doc).
+  - **Setup wizard checklist** — what each acknowledgement means and what proof the operator should keep.
+  - **`minimum_collection: true` profile** — one-line `instance.yaml` override:
+    ```yaml
+    activity_center:
+      minimum_collection: true  # 30d retention, no payload storage, scoring disabled, only failure-class counts + per-department aggregates
+    ```
+  - **Tuning scoring weights** — defaults explained, when to change.
+  - **Right-to-forget runbook** — when to invoke, what to verify after.
+  - **Disclosure refresh** — when to bump the version, how to communicate to users.
+- `config/instance.yaml.example` shows every `activity_center.*` knob with inline comments and the default value.
+
+**Patterns to follow:**
+- Existing `docs/DEPLOYMENT.md` structure for operator-facing prose.
+- `docs/RBAC.md` pattern for RBAC-shaped runbooks.
+
+**Test scenarios:** *Test expectation: none — documentation only. Verification is editorial review + operator dry-run.*
+
+**Verification:**
+- A teammate unfamiliar with the project can deploy a dev instance and complete the setup wizard using only the runbook.
+- `instance.yaml.example` has every knob documented; no orphaned references in code without docs.
+
+### Track B — Iteration 1
+
+- [ ] **Unit 13: Failure classification + heuristic**
+
+**Goal:** `wrong_tool` heuristic concretely defined and validated; failure-rate trend tile + CLI report.
+
+**Requirements:** R11.
+
+**Dependencies:** Unit 3, Unit 8.
+
+**Files:**
+- Modify: `src/activity_center/extractor.py` (add `wrong_tool` classification rule).
+- Modify: `cli/commands/admin.py` (`agnes admin activity failures --since 7d`).
+- Modify: `app/web/templates/activity_center.html` (failure-rate tile).
+- Create: `tests/activity_center/test_failure_classification.py`.
+
+**Approach:**
+- **`wrong_tool` heuristic** (validated against ≥10 sample sessions before publication):
+  - Tool calls that returned Agnes's documented "use X instead" guidance → mark `error_class='wrong_tool'`.
+  - Tool calls followed within 5 minutes by a different tool against the same target with `outcome='ok'` → mark the first as `error_class='wrong_tool'` (the user pivoted to the right tool).
+- **Failure-rate trend tile** on `/activity-center` overview: stacked area chart by `error_class` over the last 30 days.
+- **CLI**: `agnes admin activity failures --since 7d` prints a table grouped by `error_class` with counts + top affected users.
+
+**Patterns to follow:**
+- `connectors/bigquery/access.py` `BqAccessError` taxonomy — basis for failure classes.
+
+**Test scenarios:**
+- *Happy path:* Tool call with "use X instead" error → classified as `wrong_tool`.
+- *Happy path:* Tool A fails → tool B succeeds against same target within 5min → A classified as `wrong_tool`.
+- *Edge case:* Tool A fails → 10 minutes later tool B succeeds → A NOT classified as wrong_tool (heuristic window).
+- *Edge case:* Failure with no recognizable error_class → `error_class=NULL`, counted in error_density but not in failure-rate tile.
+- *Integration:* CLI report numbers match dashboard tile numbers.
+
+**Verification:**
+- `pytest tests/activity_center/test_failure_classification.py -q` passes.
+- Validation: heuristic applied to ≥10 real-world sample sessions; precision ≥80%.
+
+- [ ] **Unit 14: Plugin churn dashboard**
+
+**Goal:** `/activity-center/plugins/<plugin>` shows zombies, abandonment list, granted-vs-adopted ratio.
+
+**Requirements:** R12.
+
+**Dependencies:** Unit 8, Unit 13.
+
+**Files:**
+- Modify: `app/web/templates/activity_center/plugin_detail.html`.
+- Modify: `src/repositories/activity_center.py` (add churn-query methods).
+- Create: `tests/activity_center/test_plugin_churn.py`.
+
+**Approach:**
+- **Zombie plugins**: granted to ≥1 group but `plugin_adoption.last_seen_at IS NULL` for all granted users.
+- **Abandoned plugins**: `last_seen_at < now() - interval '<N> days'` (default `N=30`, configurable as `activity_center.plugin_abandonment_threshold_days`).
+- **Granted-vs-adopted ratio**: count of granted users / count of users in `plugin_adoption` for that plugin.
+- All three rendered as tiles on the per-plugin detail page.
+
+**Test scenarios:**
+- *Happy path:* Plugin granted to 50 users, used by 10 → ratio 20% rendered correctly.
+- *Happy path:* Plugin granted but no `plugin_adoption` rows → marked zombie.
+- *Edge case:* Plugin granted 10 days ago and used 5 days ago → not abandoned (within threshold).
+- *Integration:* `plugin_adoption` survives 90d retention purge → ratio computable for plugins granted >90d ago.
+
+**Verification:**
+- `pytest tests/activity_center/test_plugin_churn.py -q` passes.
+
+### Track C — Iteration 1
+
+- [ ] **Unit 15: Setup wizard + per-user-audit gates**
+
+**Goal:** Operator setup wizard at `/admin/activity-center/setup` is the structural forcing function for compliance acknowledgement; per-user-audit RBAC + rate-limit + bulk-query rejection wired through.
+
+**Requirements:** R8, R13, R14.
+
+**Dependencies:** Unit 1 (operator_ack table), Unit 8 (route exists).
+
+**Files:**
+- Modify: `app/web/router.py` (add `/admin/activity-center/setup` GET + POST).
+- Create: `app/web/templates/activity_center/setup_wizard.html`.
+- Modify: `src/resource_types.py` (`ResourceType.PER_USER_AUDIT` member + spec).
+- Modify: `app/api/activity.py` (rate-limit middleware + bulk-query detection on per-user-detail reads).
+- Create: `tests/activity_center/test_setup_wizard.py`.
+- Modify: `tests/api/test_activity.py` (RBAC, rate-limit, bulk-query cases).
+
+**Approach:**
+- **Setup wizard**: single-page form with 3 checkboxes ("works-council consulted or N/A", "DPIA completed or N/A", "users disclosed and accepted") + an "Enable per-user audit" submit. POST writes `activity_center_operator_ack` row + flips `activity_center.per_user_audit_enabled` to `true` (the wizard is the only path that flips it from false → true; manual `instance.yaml` edits are read but logged with a warning).
+- **`/activity-center/users[/<id>]` 403** with link to setup wizard when `per_user_audit_enabled=false`.
+- **RBAC two-of-two gate**: `Depends(require_admin)` + `Depends(require_resource_access(ResourceType.PER_USER_AUDIT, "{user_id}"))` on per-user-detail read endpoints.
+- **Rate-limit** (default 5 user-detail reads / hour / admin): tracked via `audit_log` count over rolling 1h window; breach returns 429 + writes warning row + fires Telegram alert if configured.
+- **Bulk-query rejection** (default N=1): SQL parser checks the admin-supplied query for distinct `user_id` predicates; if >1, reject with 403 `bulk_query_rejected` directing to rollup views. Operators raising N must re-run setup wizard.
+
+**Patterns to follow:**
+- `app/api/access.py` — RBAC `Depends` chain.
+- `services/scheduler/__main__.py` — admin-token auth pattern (the wizard endpoint requires admin role).
+
+**Test scenarios:**
+- *Happy path:* Admin GETs setup wizard → 200, form renders. POST with all three boxes checked → 200, ack written, flag flipped, audit_log row written.
+- *Happy path:* Admin reads `/activity-center/users/X` after wizard → 200 (gates pass).
+- *Error path:* POST with missing checkboxes → 400, no ack written, flag stays false.
+- *Error path:* Non-admin attempts wizard → 403.
+- *Error path:* Admin without `per_user_audit` grant for user X → 403 not_granted.
+- *Error path:* Admin reads 6 user-detail pages in an hour → 6th returns 429 with rate-limit details.
+- *Error path:* Admin SQL with `WHERE user_id IN ('a','b','c')` → 403 `bulk_query_rejected`.
+- *Edge case:* `per_user_audit_enabled=true` set manually in `instance.yaml` (without wizard) → loaded but logged with warning row.
+- *Integration:* Setup-wizard `audit_log` row visible in `/admin/audit-log`.
+
+**Verification:**
+- `pytest tests/activity_center/test_setup_wizard.py -q` passes.
+- Relevant `tests/api/test_activity.py` cases pass.
+
+- [ ] **Unit 16: Dual-approver + mutual-visibility digest**
+
+**Goal:** Per-user-detail reads support optional dual-approver flow; weekly mutual-visibility digest delivered via Telegram, symmetric to analyst.
+
+**Requirements:** R14.
+
+**Dependencies:** Unit 15.
+
+**Files:**
+- Modify: `src/db.py` (add `per_user_audit_requests` table — small migration v25 follow-up if needed; alternatively store state in `audit_log.params` per the keep-audit-rich pattern. Implementation note: prefer dedicated table for clarity).
+- Modify: `app/api/activity.py` (request creation, approval endpoint, gate the read on approval state).
+- Create: `services/telegram_bot/digest.py` (or extend existing) — weekly digest Telegram delivery + per-event analyst notification.
+- Modify: `services/scheduler/__main__.py` (register weekly digest cron).
+- Create: `tests/activity_center/test_dual_approver.py`.
+- Create: `tests/services/test_digest.py`.
+
+**Approach:**
+- **Dual-approver flow** (when `per_user_audit_dual_approver=true` and `>=dual_approver_min_admins` admins exist):
+  - Admin clicks "Read X's payload" → POST `/api/activity/per-user-audit-request` with `target_user_id` + `reason`.
+  - Server creates row in `per_user_audit_requests(id, requester_id, target_user_id, reason, created_at, status='pending', expires_at=created_at+24h)`.
+  - Other admins see pending requests on `/admin/activity-center/approvals`.
+  - Second admin approves → status flips to `approved`, `approved_by` populated; requester can now read for the next 1 hour.
+  - Expired requests auto-cancel.
+  - Requester reading their own approved request → standard rate-limit + audit-log apply.
+- **Auto-disable** when `count(active_admins) < dual_approver_min_admins` (default 2): logged warning ("dual-approver self-disabled: only N admins on instance"), shown on `/me/activity` and admin overview.
+- **Per-event analyst notification**: every `per_user_audit_read` writes a row + sends Telegram notification to the target analyst ("user X looked at your activity record on date Y") if linked, otherwise visible on `/me/activity > who-looked-at-me`.
+- **Weekly digest** (Sundays via scheduler): aggregates `per_user_audit_read` rows from the prior week, sends Telegram message to each admin with the full table (requester / target / timestamp / count). Also sent to each target analyst summarizing reads against them.
+
+**Patterns to follow:**
+- `services/telegram_bot/` existing notification flow.
+- `audit_log` write-on-action pattern.
+
+**Test scenarios:**
+- *Happy path:* Admin creates request; second admin approves; first admin can read for 1h.
+- *Happy path:* Approved request expires after 1h; subsequent read attempts → 409 expired.
+- *Happy path:* Weekly digest Sunday 23:00 UTC → Telegram messages sent to all admins with last week's reads.
+- *Happy path:* Analyst with linked Telegram receives "user X looked at you" notification on read.
+- *Edge case:* Single-admin instance + `dual_approver=true` → auto-disables with warning; admin can read directly (with rate-limit + audit-log).
+- *Edge case:* Request without approval after 24h → status=expired, audit_log row written, requester notified.
+- *Error path:* Admin tries to approve their own request → 403 (must be a distinct admin).
+- *Error path:* Telegram delivery failure → audit_log captures the failure; weekly digest does not crash (best-effort delivery).
+- *Integration:* Mutual-visibility digest delivered before Monday-morning leadership session.
+
+**Verification:**
+- `pytest tests/activity_center/test_dual_approver.py tests/services/test_digest.py -q` passes.
+- Manual: end-to-end via dev instance + Telegram bot.
+
+## System-Wide Impact
+
+- **Interaction graph:** New extractor reads `${DATA_DIR}/user_sessions/*.jsonl` (shared with `corporate_memory` + `verification_detector` — no shared walker yet, all three scan independently). New extractor writes `extract.duckdb` (orchestrator picks up). Privacy-mode CLI integrates with `agnes init` SessionStart/SessionEnd hooks. `BqAccess` writes `audit_log` rows on every scan (new dependency for the existing query path). Setup wizard mediates per-user audit flag — no other writer to that flag in ordinary operation.
+- **Error propagation:** Extractor failures degrade dashboard freshness (t+24h becomes t+48h); existing `app/api/health.py` catches the lag. Upload-endpoint disclosure rejection bubbles to `agnes push` with a clear message; `|| true` semantics mean Claude Code sessions never block on the rejection. Telegram delivery failures are best-effort + logged. DuckDB transaction failures during right-to-forget recompute → tool exits non-zero, next nightly run restores consistency.
+- **State lifecycle risks:** Manifest XOR JSONL — server enforces by route separation; same-session_id duplicate uploads are 409. Cross-DB atomicity (right-to-forget): not provided by DuckDB; extractor's nightly pass is the consistency restorer. Setup-wizard ack row is irrevocable (operator can't un-ack); if compliance posture changes, operator updates the disclosure version (which forces user re-acceptance) and runs a new wizard cycle.
+- **API surface parity:** Two new upload routes; six new web routes (`/activity-center` already exists; `/users[/<id>]`, `/plugins[/<plugin>]`, `/weekly`, `/me/activity`, `/admin/activity-center/setup`, `/admin/activity-center/approvals`). New API endpoints under `/api/activity/*`, `/api/me/activity/*`, `/api/activity/export`. CLI subcommands: `agnes private`, `agnes activity self`, `agnes admin activity {forget,failures}`. New `instance.yaml` section: `activity_center.*`.
+- **Integration coverage:** End-to-end test in Track A scope: `agnes init` → disclosure accept → session work → `agnes private on` → SessionEnd → `agnes push` → manifest lands → next-day extractor → admin opens dashboard → composite hidden → admin opens self-view → sees own composite. End-to-end Track B+C: setup wizard → dual-approver request → second admin approves → admin reads payload → analyst notified via Telegram → analyst disputes a session → flag tile appears on leadership view.
+- **Unchanged invariants:** `audit_log` schema unchanged (only new `action` values added). `users` gets two new columns; `user_groups` gets one. `resource_grants` schema unchanged. The `extract.duckdb` connector contract is unchanged — Activity Center is just another extract. `agnes push --quiet` and `|| true` semantics in hooks are preserved. The existing `/activity-center` stub route is extended, not replaced.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Approach A nightly CTAS exceeds maintenance window at scale | 1-day spike at start of Unit 3; pivot to Approach B before further work if it doesn't fit. Same schema either way; user-visible surface identical. |
+| `$CLAUDE_SESSION_ID` not exposed to hooks → privacy mode degrades to workspace-wide | 1-day spike at start of Unit 6 verifies; either way is documented honestly. The contract is clear regardless. |
+| Sub-score formulas calibrate poorly against real analyst workflows | Sub-score gaming defenses (caps, cross-validation, bell-curve weighting) baked in; default weights tuned during Unit 5 against ≥3 sample sessions; weights configurable per `instance.yaml` so operators can adjust. |
+| Plugin-name attribution coverage <70% → adoption metric unreliable | Unit 3 validates against ≥3 known plugins; below threshold the dashboard reports "unobservable", not zero. Disclosure caveat in operator runbook. |
+| Setup wizard skipped via manual `instance.yaml` edit | Unit 15 logs a warning when `per_user_audit_enabled=true` is read without a corresponding `activity_center_operator_ack` row; surfaces on `/admin/activity-center` overview as compliance-flag tile. |
+| Right-to-forget recompute fails partway → stale rollups | Next-night extractor restores consistency; tool exits non-zero so operator re-runs. Documented in runbook. |
+| Telegram delivery flakiness for digest | Best-effort delivery + audit-log capture of failures + `/me/activity > who-looked-at-me` view always available as fallback. Email infrastructure deferred to backlog if Telegram proves insufficient. |
+| Operator deploys without reading runbook → defaults catch them off guard | Defaults are paranoid (per-user audit OFF, dual-approver ON, rate-limit 5/h, bulk-query N=1, retention 90d). Reading the runbook *raises* permissiveness; the OSS doesn't ship a one-click surveillance lever. |
+| Analyst routes around `agnes init` to avoid telemetry | Acknowledged in non-goals + chilling-effect risk section. Symmetric self-view + recourse mechanisms are the trust contract that should reduce this; not all analysts will be persuaded. |
+| Schema migration v25 fails on a customer instance with corrupted prior state | Migration is idempotent + reversible; failure mode: customer support + manual repair. Per the v14 precedent (orphan cleanup). |
+
+## Documentation / Operational Notes
+
+- **Runbook ships in Track A** (Unit 12). Operator readiness is a Track A criterion, not a follow-up.
+- **CHANGELOG** entry under `### Added` at release time (per `CLAUDE.md` discipline).
+- **Disclosure version** lives in code; bumping triggers user re-acceptance — operators update via PR, not a config knob.
+- **Monitoring**: existing `app/api/health.py` extended to catch extractor lag (t+48h triggers warning); redaction-rate anomaly tile on `/activity-center` for unusual spikes.
+- **Rollout**: behind `activity_center.enabled: true` master flag in `instance.yaml` (defaulting to `false` until the operator opts in via setup wizard) so customers can deploy the release without auto-enabling Activity Center.
+- **Backwards compatibility**: existing `/api/upload/sessions` endpoint behavior preserved; new disclosure-rejection is gated by Activity Center being enabled (so existing deployments with Activity Center off continue working unchanged).
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/activity-center-requirements.md`
+- Related code:
+  - `src/db.py` (schema migrations)
+  - `src/orchestrator.py` (extract.duckdb pattern)
+  - `app/api/upload.py` (upload endpoint pattern)
+  - `app/api/access.py` (RBAC dependency pattern)
+  - `app/resource_types.py` (ResourceType enum pattern)
+  - `app/web/router.py:706` (existing `/activity-center` stub)
+  - `services/corporate_memory`, `services/verification_detector` (JSONL extractor patterns)
+  - `services/telegram_bot/` (digest delivery infrastructure)
+  - `connectors/keboola/extractor.py`, `connectors/bigquery/extractor.py` (extract.duckdb contract)
+  - `cli/lib/hooks.py`, `cli/commands/push.py` (CLI hook + push patterns)
+- External docs:
+  - GDPR Art. 4, 5(1)(e), 13, 14, 17, 28, 32, 35.
+  - Czech Labour Code §316.
+- Related: this plan supersedes any earlier Activity Center scoping. No prior plan exists.


### PR DESCRIPTION
## Summary

Planning artifacts for the Activity Center feature (per-user telemetry + scoring + dashboards + privacy mode + RBAC hardening + chronological session-replay). No code yet — this PR adds two markdown documents only.

Produced via `/ce-brainstorm` + `/ce-plan` with two rounds of six-persona document review (coherence, feasibility, product-lens, security-lens, scope-guardian, adversarial).

## Documents

- **`docs/brainstorms/activity-center-requirements.md`** — requirements, decisions, scope boundaries, data flow invariants, schema migration plan, defaults posture, alternatives considered, chilling-effect risk, recourse mechanisms.
- **`docs/plans/2026-05-05-001-feat-activity-center-plan.md`** — 16 implementation units across Track A (initial release), Track B (failure intelligence), Track C (hardening config). Spike tasks, test scenarios per unit, system-wide impact, risks.

## Key design decisions to validate

- **Paranoid defaults**: `per_user_audit_enabled` OFF; `dual_approver` ON for ≥2-admin instances; rate-limit 5 user-detail reads/hour/admin; bulk-query N=1; `show_user_composite_to_admin` OFF (analyst sees own composite, leadership sees aggregates by default).
- **Privacy mode = manifest XOR JSONL upload routes** (`/api/upload/sessions` vs new `/api/upload/sessions/manifest`). Threat model = accidental disclosure, not hostile clients.
- **LLM-as-judge deferred to iteration backlog** — judgeability + GDPR Art. 28 third-party processor surface + cost-metering protocol extension all unsolved. Track A scoring is deterministic SQL only.
- **Composite per-user score is hidden from leadership tile by default** to avoid the OSS shipping a one-click performance-management proxy. Operator flips the flag in setup wizard with explicit acknowledgement.
- **Setup wizard** at `/admin/activity-center/setup` is the structural compliance forcing function (3 acknowledgement checkboxes for §316 / Art. 88 / Art. 35 obligations); refusing yields degraded mode (overview + aggregates only).
- **BQ-cost write topology**: `BqAccess` writes `audit_log` rows on scan; nightly extractor projects them into `activity_events`. Avoids cross-DB write race against orchestrator rebuild.
- **Session-replay surface**: chronological step-by-step view at `/activity-center/users/<id>/sessions/<sid>` (admin) and `/me/activity/sessions/<sid>` (self) with jump-to-failure / jump-to-prompt / collapse-successful affordances + deep-link anchors. Same RBAC stack on admin side; no audit-log row on self-reads. CLI mirror via `agnes admin activity replay` + `agnes activity replay --self`.
- **Self-view symmetry + recourse**: `/me/activity` shows weight transparency, score-dispute action, who-looked-at-me list (last 30d), disclosure history, self-replay. Symmetric data + symmetric recourse — not just a one-way mirror.
- **Schema migration v25**: bundles 9 new tables + 2 columns + reserved encryption slot. No cross-DB FKs (DuckDB doesn't support them); integrity via extractor logic.
- **Storage**: activity-center is a new `extract.duckdb` connector-shaped extract under `/data/extracts/activity_center/`; orchestrator picks it up and surfaces views through `analytics.duckdb` master views.

## Open questions for review

- Sub-score formulas + composite weight defaults — calibration TBD during Unit 5 against real sample sessions.
- `\$CLAUDE_SESSION_ID` exposure to hooks — 1-day spike at start of Unit 6 to verify; either way (per-session or workspace-wide privacy state) is documented honestly.
- Approach A (CTAS-over-JSONLs) vs Approach B (incremental extractor) — 1-day spike at start of Unit 3 validates corpus-size assumption against synthetic 50M-row corpus.

## Track plan

- **Track A** (initial release, critical path): Units 1–12 — schema, upload routes, extractor, scoring, dashboards, replay surface, privacy CLI, disclosure flow, self-view recourse, right-to-forget, exports, runbook.
- **Track B** (iteration 1): Units 13–14 — failure classification + plugin churn dashboard.
- **Track C** (iteration 1): Units 15–16 — setup wizard + RBAC gates + dual-approver + mutual-visibility digest (Telegram).

## Reviewer ask

@minasarustamyan — would value your review on: (a) the privacy/legal posture for the EU/CZ context (defaults, setup wizard, runbook scope), (b) the scoring engine shape (sub-score gaming defenses, composite-visibility default, deterministic-vs-LLM-judge tradeoff), and (c) the schema-migration plan for v25 (9 tables + 2 columns bundled — is the ordering right, are the FK trade-offs acceptable). Anything else that catches your eye is welcome.

PR is draft — no implementation yet, this is the planning artifact pair for review before code starts.