### PR TITLE
docs(marketplace): document two-step fallback for marketplace registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.38.1] — 2026-05-06
+
+### Internal
+- `CLAUDE.md` — `Claude Code marketplace endpoint` section now documents the
+  two-step fallback (system `git clone` + local `claude plugin marketplace
+  add`) for users registering manually against a private-CA Agnes instance.
+  Bun-compiled `claude` ignores the OS trust store and CA env vars on the
+  marketplace HTTPS path, so direct `/plugin marketplace add` over HTTPS can
+  fail with TLS errors on macOS / Windows even when system tools work fine.
+  The dashboard-served setup payload (`app/web/setup_instructions.py`)
+  already branches between the two automatically based on platform; the
+  doc snippet now matches that behavior for manual flows.
+
 ## [0.38.0] — 2026-05-06
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -363,9 +363,31 @@ User registration inside Claude Code:
 # ZIP channel (typically via a SessionStart hook that unpacks into ./marketplace/)
 curl -H "Authorization: Bearer $AGNES_PAT" https://agnes.example.com/marketplace.zip
 
-# Git channel — one-time registration
+# Git channel — one-time registration. Two paths; pick the first that works.
+
+# (a) Direct registration — preferred when it works.
 /plugin marketplace add https://x:$AGNES_PAT@agnes.example.com/marketplace.git/
+
+# (b) Two-step fallback — required when (a) fails. Bun-compiled `claude` on
+#     macOS / Windows ignores the OS trust store and CA env vars on the
+#     marketplace HTTPS path, so direct add can fail with TLS errors against
+#     a private-CA Agnes instance even when system tools work fine. System
+#     `git` honors GIT_SSL_CAINFO + the OS trust store, so cloning manually
+#     and pointing Claude Code at the local clone sidesteps the Bun TLS path
+#     entirely.
+git clone https://x:$AGNES_PAT@agnes.example.com/marketplace.git/ ~/agnes-marketplace
+claude plugin marketplace add ~/agnes-marketplace
+# Optional hardening: strip the PAT from the cloned repo's origin so it
+# doesn't sit in plaintext at ~/agnes-marketplace/.git/config — re-clone via
+# the dashboard's setup flow when the PAT rotates.
+git -C ~/agnes-marketplace remote set-url origin https://agnes.example.com/marketplace.git/
 ```
+
+The dashboard-served setup payload (see `app/web/setup_instructions.py`) already
+branches between (a) and (b) automatically based on platform when a private CA
+is in play. The block above is the manual equivalent for users registering
+outside that flow (e.g. operators bringing up a new instance, or
+analysts whose first attempt failed and need to retry by hand).
 
 ## Hybrid Queries (BigQuery + Local)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.38.0"
+version = "0.38.1"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"


### PR DESCRIPTION
## Why

The \`Claude Code marketplace endpoint\` section in \`CLAUDE.md\` previously showed only the direct registration path:

\`\`\`
/plugin marketplace add https://x:\$AGNES_PAT@agnes.example.com/marketplace.git/
\`\`\`

That path fails on macOS / Windows against an Agnes instance with a private CA — Bun-compiled \`claude\` ignores the OS trust store and CA env vars (\`NODE_EXTRA_CA_CERTS\`, \`SSL_CERT_FILE\`, \`REQUESTS_CA_BUNDLE\`, \`CURL_CA_BUNDLE\`) on the marketplace HTTPS path. The full rationale is already documented in \`app/web/setup_instructions.py\` (Cross-platform trust strategy, point #3) and the dashboard-served setup payload already branches between direct registration and a system-\`git\`-clone fallback automatically based on platform. The user-facing doc snippet did not match that behavior — anyone reading \`CLAUDE.md\` and following the example verbatim hit the failure with no in-doc guidance for the workaround.

This PR makes the two-step fallback explicit in the docs so users registering manually (operators bringing up a new instance, analysts whose first attempt failed, anyone outside the dashboard flow) can resolve it without having to read the Python source.

## What changes

\`CLAUDE.md\` \`Claude Code marketplace endpoint\` block now shows two paths labelled (a) and (b), with a short explanation of when (b) is needed:

\`\`\`
# (a) Direct registration — preferred when it works.
/plugin marketplace add https://x:\$AGNES_PAT@agnes.example.com/marketplace.git/

# (b) Two-step fallback — required when (a) fails.
git clone https://x:\$AGNES_PAT@agnes.example.com/marketplace.git/ ~/agnes-marketplace
claude plugin marketplace add ~/agnes-marketplace
git -C ~/agnes-marketplace remote set-url origin https://agnes.example.com/marketplace.git/
\`\`\`

The closing prose points the reader at \`app/web/setup_instructions.py\` for the automated equivalent.

## What does **not** change

- \`app/web/setup_instructions.py\` is not touched. Its \`has_ca\` path already implements the same two-step fallback automatically (Linux: try direct, fall back to clone; macOS/Windows: clone directly). The legacy path (no \`ca_pem\` on disk) still ships only the direct add — that's a separate question worth its own PR if/when an instance with no \`ca_pem\` hits this on macOS / Windows. Flagging here so a reviewer can decide.
- No code changes; pure documentation update. No CHANGELOG entry needed (no user-visible behavior change beyond the doc itself).

## Test plan

- Read the updated section in \`CLAUDE.md\`. Confirm the two-step fallback is reproducible by hand against an Agnes instance where direct \`/plugin marketplace add\` over HTTPS fails.
- No automated tests touch this section.