### PR TITLE
release: 0.47.0 — source-agnostic catalog metadata + cache discipline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,75 +47,85 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [0.46.0] — 2026-05-07
 
-Keboola cutover bundle: native parquet on the materialized sync,
-auto-discover protection against admin overrides, sync-routing
-correctness, plus a bunch of operational paper-cuts surfaced during
-a fresh deploy on a Snowflake-backed Keboola project. **BREAKING**
-for Keboola operators: schema bump to v26 migrates Keboola
-`query_mode='local'` rows to `materialized` (auto-migration runs on
-first start; same effective behavior, different internal path —
-Storage API direct via `fileType=parquet` instead of the DuckDB
-extension).
+Catalog metadata enrichment + cache discipline + automatic warmup.
+Closes #155 + #156.
 
 ### Added
 
-- `AGNES_TEMP_DIR` env var (default in `docker-compose.yml`: `/data/tmp`) routes per-call extractor tempdirs (Snowflake-UNLOAD slice staging, CSV→parquet intermediates) off the container's overlayfs `/tmp` onto the data volume. Boot-disk overlayfs filled to 100% on agnes-dev during a multi-GiB sliced parquet export; the dedicated data disk had 15 GiB free at the time. Helper `connectors/keboola/storage_api.py:get_temp_root` mkdirs the target on first use; unset / empty / unwritable falls back to system `/tmp` for compat with OSS users on a single-disk host.
-- `POST /api/admin/discover-and-register?dry_run=true` returns the planned mutations without writing — lists `would_register`, `drift` (existing rows whose registry coordinates differ from what discovery would write), and `invalid` ids. Useful for auditing before re-running auto-discovery on a registry that's already had admin overrides applied.
-- `GET /api/sync/status` returns `{"locked": bool}` — public, no auth. Consumed by the host-side `agnes-auto-upgrade.sh` cron to decide whether to defer `docker compose up -d` until the running sync finishes. Cheap (single Lock check), no sensitive data.
-
-### Fixed
-
-- `app/api/admin.py`: `_discover_and_register_tables` no longer overwrites admin-corrected registry rows. Two drift flavours surfaced (and skipped):
-  - **same_id_diff_coords** — registry has a row at the same id but different `(bucket, source_table)`; admin migrated coordinates.
-  - **name_collision** — discovery's slugified id differs from any registry id, but the discovered `name` matches an existing row's `name` (case-insensitive). Real-world cause: the `kbc_job` row was registered manually with the right bucket; Keboola's discovery exposes it under a different stage prefix that slugs to a different id. Pre-fix, auto-discovery would have inserted a duplicate whose Storage API export-async 404s. Now classified as drift, surfaced with `registry_id` so an operator can reconcile.
-- `app/api/admin.py`: bucket detection in auto-discovery now uses the Keboola API's authoritative `bucket_id` field directly (with id-string parsing only as a fallback). Pre-fix, parsing the id string was the primary path and a stripped stage prefix inserted 137 broken rows.
-- `app/api/sync.py`: `POST /api/sync/trigger` with a `tables` payload now actually scopes the materialized pass too. Previously the targeted trigger only filtered the legacy extractor subprocess; `_run_materialized_pass` still iterated every materialized row in the registry, so an admin asking to re-sync `kbc_job` re-ran every other due materialized row alongside it. The pass now takes a `tables` arg and skips rows not in the target set with `reason="not_in_target"`. Both registry id and name match.
-- `scripts/ops/agnes-auto-upgrade.sh`: defers `docker compose up -d` while a sync is in flight. Probes `GET /api/sync/status` with a 5s timeout; if the response carries `"locked":true`, exits 0 with a deferred-recreate log line and waits for the next 5-min cron tick. Connection failures (older app version without the endpoint, app crashed, etc.) fall through to the upgrade — being stuck on a wedged image is worse than interrupting a hypothetical sync.
-- `connectors/keboola/extractor.py`: `materialize_query` per-call tempdir is now opened with `ignore_cleanup_errors=True`. Previously a worker death mid-write under disk-full state could leave a multi-GiB stale slice tree (12 GiB seen on agnes-dev) because `TemporaryDirectory.__exit__` itself raised, masking the original exception and skipping cleanup. Now cleanup is best-effort and always fires.
-- `src/scheduler.py`: `is_valid_schedule` now accepts `every 0m` (interval = 0 = "always due"). Useful as a force-resync override on a row whose previous attempt errored without recording `last_sync` — the default `every 1h` would otherwise block the retry for an hour. Existing values reject as before.
-- `app/api/sync.py`: `POST /api/sync/trigger` now accepts both `["table_id"]` (legacy) and `{"tables": ["table_id"]}` (mirrors response shape) request bodies, plus `null` / no body for "sync everything". Malformed shapes return HTTP 422 with a structured detail. No client breakage — the old wire format keeps working.
+- **`/api/v2/catalog` returns four new optional fields per row** — `rows`,
+  `size_bytes`, `partition_by`, `clustered_by` — populated by per-source-type
+  metadata providers (`connectors/bigquery/metadata.py`,
+  `connectors/keboola/metadata.py`). For `query_mode='remote'` BigQuery rows,
+  `size_bytes` is `active_logical_bytes + long_term_logical_bytes` (a full
+  scan reads both); region resolved from `data_source.bigquery.location` →
+  `bq_client.get_dataset(...)` → fall back to legacy `__TABLES__`.
+  Existing CLI consumers reading only `rough_size_hint` are unaffected.
+- **Automatic cache warmup at startup.** FastAPI startup event schedules
+  a background task that walks BQ remote rows and pre-populates
+  `_metadata_cache` + `_schema_cache` with bounded concurrency (default 4,
+  tunable via `AGNES_WARMUP_CONCURRENCY`). Doesn't block readiness;
+  per-row failures logged + skipped. Opt-out via `AGNES_SKIP_CACHE_WARMUP=1`.
+- **Three new admin endpoints under `/api/admin/cache-warmup/*`:**
+  - `GET /status` — JSON snapshot of the latest run.
+  - `POST /run` — manual trigger, idempotent under concurrent invocation.
+  - `GET /stream` — Server-Sent Events with `start` / `row` / `complete`
+    events for live UI updates.
+- **`/admin/tables` cache freshness panel.** Toolbar above the per-source-type
+  listings with progress bar + "Re-warm all" button + collapsible
+  terminal-style log fed by SSE (polling fallback at 3 s). Per-row badge
+  in the existing `col-status` column updates live (fresh / warming /
+  pending / error).
+- **`docs/admin/query-modes.md`** — source-agnostic admin reference for
+  registering tables as `local` / `remote` / `materialized`. Decision
+  tree, per-source-type IAM + setup, three worked examples. Linked from
+  the `?` icon next to the `query_mode` field in the admin UI edit modal
+  and from the third post-register hint in `agnes admin register-table`.
+- **`agnes admin register-table` post-register hint** for `query_mode=remote`:
+  points at `agnes query --remote "SELECT COUNT(*)..."` as the IAM smoke
+  check so a missing `dataViewer` / `jobUser` surfaces at registration
+  time, not 30 minutes later.
 
 ### Changed
 
-- `connectors/keboola`: materialized sync now requests **parquet directly** from the Storage API (`POST /v2/storage/tables/{id}/export-async` with `fileType=parquet`) instead of CSV → DuckDB COPY → parquet. The extractor downloads the Snowflake-UNLOADed parquet, renames into place, and skips the DuckDB roundtrip entirely. Eliminates the OOM that hits multi-GB Keboola tables when `read_csv(..., all_varchar=true, max_line_size=64MB)` materializes the whole CSV in memory before COPY. Sliced exports (large tables that Snowflake UNLOAD writes as multiple files) are merged via `DuckDB COPY (SELECT * FROM read_parquet([...]))` — peak memory bounded to one parquet row group (~1 MiB) regardless of table size. Admin can pin the legacy CSV path with `source_query='{"file_type":"csv"}'`. Backward-compat alias `KeboolaStorageClient.export_table_to_csv` retained.
-- `connectors/keboola/storage_api.py`: `download_file` gzip detection no longer treats unencrypted files as gzipped (previous heuristic would have corrupted parquet downloads at gunzip time). Name-suffix-only.
-- **BREAKING for Keboola operators**: schema bump to **v26**. Existing `query_mode='local'` Keboola rows are migrated to `query_mode='materialized'` (NULL `source_query` = full-table export — same effective behavior as before). New `register-table --source-type keboola` and `discover-and-register --source-type keboola` default to `materialized`. The `local` mode for Keboola is gone — it ran the DuckDB extension's COPY through Keboola QueryService, which is unreliable on linked-bucket projects (extension v0.1.6 fixes the linked-bucket case but not yet in the community CDN; pre-fix, projects with the `block-shared-snowflake-access` flag couldn't see bucket schemas at all). BigQuery and Jira `local` rows are untouched. See `connectors/keboola/storage_api.py` + the v25→v26 migration in `src/db.py`.
-- **Keboola extract path is now Storage API direct**, not the DuckDB extension. New `connectors/keboola/storage_api.py` talks to Keboola Storage API straight via `requests`:
-  - `POST /v2/storage/tables/{id}/export-async` to kick off the job (with optional `whereFilters` / `columns` / `changedSince` from the row's `source_query` JSON);
-  - `GET /v2/storage/jobs/{id}` polled with bounded exponential backoff until `success` or `error`;
-  - `GET /v2/storage/files/{id}?federationToken=1` to fetch a signed URL;
-  - `GET <signed_url>` (or per-slice URLs from a manifest for sliced exports) → CSV → DuckDB COPY → parquet.
-  No `os.chdir`, no boto3/azure-blob/google-cloud-storage SDKs, no extension binary on the data path. Thread-safe. Same path is used both by `materialize_query()` (admin-registered tables with optional filter spec) and by `_extract_via_legacy()` (per-table fallback inside the parallel batch extractor).
-- **`source_query` shape for Keboola materialized rows is JSON**, not SQL — Storage API takes a structured filter object, not free-form SQL. Mirrors the BQ materialized path conceptually but with a different payload. Schema:
-  ```json
-  {
-    "where_filters": [{"column": "date", "operator": "ge", "values": ["2026-04-01"]}],
-    "columns": ["id", "date", "amount"],
-    "changed_since": "2026-04-01T00:00:00",
-    "limit": 1000
-  }
-  ```
-  All fields optional. Empty / NULL = full-table export. Operators per Keboola Apiary: `eq`, `ne`, `in`, `notIn`, `ge`, `gt`, `le`, `lt`. See `connectors/keboola/storage_api.py:ExportFilter`.
-- `POST /api/sync/trigger` is now singleton per process. A second trigger that arrives while the previous sync is still running returns **HTTP 409** (`detail: sync_already_in_progress`) instead of scheduling a parallel `_run_sync`. The scheduler container's `data-refresh` job logs the 409 as a normal warning and waits for its next tick — no retry loop. Operator-visible: clients that hand-roll their own polling on `/api/sync/trigger` now need to handle 409. Why it matters: two concurrent extractor subprocesses both write `extract.duckdb`, fight for its file lock, starve uvicorn's worker pool, and Docker flips `agnes-app` to `unhealthy` long enough for `reverse_proxy`-fronted deploys to return 503 to external traffic until contention drains.
-- Keboola legacy Storage-API fallback now runs in parallel across a process pool. When the DuckDB extension's per-table scan fails (e.g. on projects with the `block-shared-snowflake-access` feature flag where workspace roles can't see bucket schemas, see keboola/duckdb-extension#17), tables that fall back to the legacy `kbcstorage` client are now drained concurrently instead of one-at-a-time. The dominant per-table cost is the synchronous wait on the Keboola Storage export job (which scans Snowflake into a CSV and returns); fanning out across N workers cuts wall-clock proportionally for batches that hit the fallback. Default 8 workers, override with `AGNES_KEBOOLA_PARALLELISM` (set to `1` for sequential, useful when debugging or seeing Keboola-side rate-limiting). Project-level concurrency is bounded by the operator's `storage.jobsParallelism` limit (typically 10); the default 8 leaves headroom for other clients. Workers are processes (not threads) because `connectors/keboola/client.py:export_table` does `os.chdir(temp_dir)` to redirect kbcstorage's slice-file downloads into a per-call temp directory — `os.chdir` is process-global, so two threads racing on it land slice files in the wrong directory and the merge step fails with `[Errno 2] No such file or directory: '<job_id>.csv_X_Y_Z.csv'`. Process workers each have their own CWD.
-- Extractor subprocess timeout bumped from 1800s to 3600s (configurable via `AGNES_EXTRACTOR_TIMEOUT_SEC`). On projects where the legacy Storage-API fallback is the only working path (extension blocked by `block-shared-snowflake-access`), 28+ tables × multi-minute Keboola export jobs routinely overran the 30-min cap before the parallel fallback even existed; with parallelization in place the run usually fits, but `kbc_telemetry`-class tables and large CRM snapshots can still push it over. The 1h ceiling matches the longest practically-reasonable Keboola export job before an operator should intervene.
-- Extractor subprocess is now launched in its own process group (`subprocess.Popen(..., start_new_session=True)`) so a timeout can take down the whole tree — the extractor parent plus the ProcessPoolExecutor workers it spawned for parallel legacy fallback. Without this, a `subprocess.run(timeout=...)` SIGKILLed only the immediate child; the pool workers were reparented to PID 1 and continued holding open Keboola Storage export jobs, blocking the next sync cycle. On timeout the parent now SIGTERMs the group (10s grace), then SIGKILLs stragglers. The extractor's inline Python script installs a SIGTERM → `sys.exit(143)` handler so the `with ProcessPoolExecutor(...)` block runs its `__exit__` (`shutdown(wait=True)`) cleanly before the process dies.
-
-### Fixed (cutover regressions, surfaced 2026-05-06)
-
-- `agnes pull` no longer fails with `hash mismatch: expected … got …` for every Keboola local-mode table. `src/orchestrator.py:_update_sync_state` stored `md5(f"{mtime_ns}:{size}")[:12]` — a 12-char fingerprint of file metadata — while the CLI's post-download integrity check compares against the full 32-char content MD5 it computes via `cli/commands/sync.py:_md5_file`. Those could never match, so every `agnes pull` reported `Updated 0 tables` even when the server had data. Now the orchestrator stores the same content MD5 the materialized SQL path already used (`app/api/sync.py:_file_hash`).
-- Latent `NameError: name '_sys' is not defined` in `app/api/sync.py:_run_sync` when the function fell into its outer `except Exception` before reaching the inner `import sys as _sys`. Hoisted the import to the top of the body so the error path stays loggable instead of trading the original failure for a misleading stack trace.
-- Keboola sync now falls back to the legacy Storage-API client when the DuckDB Keboola extension's per-table scan fails, not just when the initial `ATTACH` fails. Two changes:
-  - `kbcstorage>=0.9.0` is promoted from optional to core dependency. The legacy fallback path in `connectors/keboola/extractor.py:_extract_via_legacy` has been there since the extension landed, but until now the bare `from kbcstorage.client import Client` would crash any default install with `ModuleNotFoundError`.
-  - `connectors/keboola/extractor.py:run` now wraps `_extract_via_extension` in a per-table try/except — on any per-table scan failure it retries via the legacy client. Previously, when `ATTACH` succeeded but the table-level `COPY (SELECT * FROM kbc."<bucket>"."<table>")` failed, the table was just marked failed with no retry.
-  Together these unblock deployments where the extension's bucket-schema scans return `Schema '..."in.c-..."' does not exist or not authorized` (keboola/duckdb-extension#17) while the upstream extension fix is in flight.
-- `connectors/keboola/access.py:KeboolaAccess.__init__` and `connectors/keboola/extractor.py:_try_attach_extension` now strip a trailing slash from the Keboola stack URL before passing it to the DuckDB Keboola extension's `ATTACH`. The canonical Keboola URL form (`https://connection.<region>.keboola.com/`) failed there with a network error; bare-host form works. Operators no longer have to massage the value out of `KEBOOLA_STACK_URL` / `instance.yaml`.
-- `src/profiler.py:TableInfo.__init__` makes `description` optional (defaults to `""`). Two call sites in `app/api/catalog.py` and `app/api/sync.py` instantiate `TableInfo(name=..., table_id=...)` without it; the previous required-arg signature crashed sync's profiler pass with `TableInfo.__init__() missing 1 required positional argument: 'description'`, leaving `[SYNC] Profiled 0 tables` after every run.
-- `scripts/ops/agnes-auto-upgrade.sh` now `chown`s `${STATE_DIR}` (`/data/state` by default), `/data/extracts`, `/data/analytics` to the new image's runtime UID:GID before `docker compose up` when the image digest moves. Catches root → non-root UID transitions across upgrades — without it, the new image's first start `PermissionError`s on `.session_secret` / DuckDB. Reads the target uid:gid from `/etc/passwd` inside the image so the script stays honest if the runtime user ever moves off uid 999.
+- **`/api/v2/schema/{id}` cache miss now does 1 BQ job instead of 2.**
+  `connectors/bigquery/access.py:fetch_bq_columns_full` collapses what
+  used to be `_fetch_bq_schema` + `_fetch_bq_table_options` into a single
+  `INFORMATION_SCHEMA.COLUMNS` query (same view, same predicate, just a
+  combined SELECT list). The metadata provider's partition/cluster path
+  shares the same helper — zero SQL duplication across the two consumers.
+- **All four catalog/schema/sample/metadata caches are flushed on registry
+  change.** `app/api/v2_catalog.py:invalidate_for_table` is wired into
+  `POST /api/admin/register-table`, `PUT /api/admin/registry/{id}`, and
+  `DELETE /api/admin/registry/{id}`. After a registry write, a single-row
+  re-warm task is scheduled in the background so the admin's verification
+  request hits warm caches within ~1 s instead of waiting for the next
+  analyst miss. Pre-fix none of the caches were invalidated — admin
+  registers a table, `agnes catalog` doesn't show the new row for up to
+  5 min; admin updates a row's bucket, `agnes schema` returns the OLD
+  column list for up to 1 hour.
+- **`v2_schema.build_schema` split into RBAC-aware outer + RBAC-naive
+  inner (`build_schema_uncached`).** Live endpoint behavior unchanged;
+  warmup uses the inner entry point to populate `_schema_cache` without
+  a user context.
 
 ### Internal
 
-- `infra/modules/customer-instance` (tag `infra-v1.8.0`): `startup-script.sh.tpl` no longer overwrites operator-edited `AGNES_TAG` / `AGNES_TEMP_DIR` in `/opt/agnes/.env` on every boot. Reads the existing values when present and lets them win over the template-computed `$IMAGE_TAG`. Pre-fix, an in-place TF action that stopped/started the VM (e.g. `machine_type` change) would re-run the startup script and clobber any manually-pinned image tag — operators had to re-edit the file post-restart. Fresh provisions still get the TF-driven values; the `.env` file's existence is the disambiguator. To force a TF-driven reset, `rm /opt/agnes/.env` and reboot.
+- New shared dataclass module `app/api/_metadata_models.py` with
+  `MetadataRequest` (frozen) + `TableMetadata` for source-agnostic
+  provider input/output.
+- New `connectors/keboola/storage_api.py:KeboolaStorageClient.get_table_info`
+  thin wrapper — keeps `_get` private to the module.
+- New env vars (operator-facing tuning, no required setup change):
+  - `AGNES_SKIP_CACHE_WARMUP` — opt-out of startup warmup.
+  - `AGNES_WARMUP_CONCURRENCY` — default 4, max parallel BQ
+    INFORMATION_SCHEMA jobs during a warmup pass.
+- New runtime dependency: `sse-starlette>=2.0` (Server-Sent Events
+  responses for the cache-warmup stream).
+- Tests added: `test_metadata_models`, `test_v2_schema_columns_consolidation`,
+  `test_v2_catalog_dispatcher`, `test_connectors_bigquery_metadata`,
+  `test_connectors_keboola_metadata`, `test_v2_catalog_remote_metadata`,
+  `test_v2_catalog_invalidation`, `test_cache_warmup`,
+  `test_main_startup_warmup`, `test_admin_tables_warmup_ui`.
 
 ## [0.45.0] — 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,88 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.47.0] — 2026-05-07
+
+Catalog metadata enrichment + cache discipline + automatic warmup.
+Closes #155 + #156.
+
+### Added
+
+- **`/api/v2/catalog` returns four new optional fields per row** — `rows`,
+  `size_bytes`, `partition_by`, `clustered_by` — populated by per-source-type
+  metadata providers (`connectors/bigquery/metadata.py`,
+  `connectors/keboola/metadata.py`). For `query_mode='remote'` BigQuery rows,
+  `size_bytes` is `active_logical_bytes + long_term_logical_bytes` (a full
+  scan reads both); region resolved from `data_source.bigquery.location` →
+  `bq_client.get_dataset(...)` → fall back to legacy `__TABLES__`.
+  Existing CLI consumers reading only `rough_size_hint` are unaffected.
+- **Automatic cache warmup at startup.** FastAPI startup event schedules
+  a background task that walks BQ remote rows and pre-populates
+  `_metadata_cache` + `_schema_cache` with bounded concurrency (default 4,
+  tunable via `AGNES_WARMUP_CONCURRENCY`). Doesn't block readiness;
+  per-row failures logged + skipped. Opt-out via `AGNES_SKIP_CACHE_WARMUP=1`.
+- **Three new admin endpoints under `/api/admin/cache-warmup/*`:**
+  - `GET /status` — JSON snapshot of the latest run.
+  - `POST /run` — manual trigger, idempotent under concurrent invocation.
+  - `GET /stream` — Server-Sent Events with `start` / `row` / `complete`
+    events for live UI updates.
+- **`/admin/tables` cache freshness panel.** Toolbar above the per-source-type
+  listings with progress bar + "Re-warm all" button + collapsible
+  terminal-style log fed by SSE (polling fallback at 3 s). Per-row badge
+  in the existing `col-status` column updates live (fresh / warming /
+  pending / error).
+- **`docs/admin/query-modes.md`** — source-agnostic admin reference for
+  registering tables as `local` / `remote` / `materialized`. Decision
+  tree, per-source-type IAM + setup, three worked examples. Linked from
+  the `?` icon next to the `query_mode` field in the admin UI edit modal
+  and from the third post-register hint in `agnes admin register-table`.
+- **`agnes admin register-table` post-register hint** for `query_mode=remote`:
+  points at `agnes query --remote "SELECT COUNT(*)..."` as the IAM smoke
+  check so a missing `dataViewer` / `jobUser` surfaces at registration
+  time, not 30 minutes later.
+
+### Changed
+
+- **`/api/v2/schema/{id}` cache miss now does 1 BQ job instead of 2.**
+  `connectors/bigquery/access.py:fetch_bq_columns_full` collapses what
+  used to be `_fetch_bq_schema` + `_fetch_bq_table_options` into a single
+  `INFORMATION_SCHEMA.COLUMNS` query (same view, same predicate, just a
+  combined SELECT list). The metadata provider's partition/cluster path
+  shares the same helper — zero SQL duplication across the two consumers.
+- **All four catalog/schema/sample/metadata caches are flushed on registry
+  change.** `app/api/v2_catalog.py:invalidate_for_table` is wired into
+  `POST /api/admin/register-table`, `PUT /api/admin/registry/{id}`, and
+  `DELETE /api/admin/registry/{id}`. After a registry write, a single-row
+  re-warm task is scheduled in the background so the admin's verification
+  request hits warm caches within ~1 s instead of waiting for the next
+  analyst miss. Pre-fix none of the caches were invalidated — admin
+  registers a table, `agnes catalog` doesn't show the new row for up to
+  5 min; admin updates a row's bucket, `agnes schema` returns the OLD
+  column list for up to 1 hour.
+- **`v2_schema.build_schema` split into RBAC-aware outer + RBAC-naive
+  inner (`build_schema_uncached`).** Live endpoint behavior unchanged;
+  warmup uses the inner entry point to populate `_schema_cache` without
+  a user context.
+
+### Internal
+
+- New shared dataclass module `app/api/_metadata_models.py` with
+  `MetadataRequest` (frozen) + `TableMetadata` for source-agnostic
+  provider input/output.
+- New `connectors/keboola/storage_api.py:KeboolaStorageClient.get_table_info`
+  thin wrapper — keeps `_get` private to the module.
+- New env vars (operator-facing tuning, no required setup change):
+  - `AGNES_SKIP_CACHE_WARMUP` — opt-out of startup warmup.
+  - `AGNES_WARMUP_CONCURRENCY` — default 4, max parallel BQ
+    INFORMATION_SCHEMA jobs during a warmup pass.
+- New runtime dependency: `sse-starlette>=2.0` (Server-Sent Events
+  responses for the cache-warmup stream).
+- Tests added: `test_metadata_models`, `test_v2_schema_columns_consolidation`,
+  `test_v2_catalog_dispatcher`, `test_connectors_bigquery_metadata`,
+  `test_connectors_keboola_metadata`, `test_v2_catalog_remote_metadata`,
+  `test_v2_catalog_invalidation`, `test_cache_warmup`,
+  `test_main_startup_warmup`, `test_admin_tables_warmup_ui`.
+
 ## [0.46.5] — 2026-05-07
 
 ### Fixed

--- a/app/api/_metadata_models.py
+++ b/app/api/_metadata_models.py
@@ -1,0 +1,40 @@
+"""Shared data shapes for source-agnostic table-metadata providers.
+
+Lives under `app/api/` because the primary consumer is
+`app/api/v2_catalog.py`. Connector-side providers in `connectors/<source>/`
+import upward into this module — the inverse layering would force
+`v2_catalog.py` to depend on `connectors/__init__.py`, which is the
+wrong direction.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MetadataRequest:
+    """Narrow input passed to a metadata provider's `fetch()`.
+
+    `bucket` and `source_table` are pre-validated by the dispatcher
+    (`validate_quoted_identifier`) before construction, so the provider
+    can interpolate them into SQL/URL paths without re-checking. Frozen
+    so the (provider, request)-keyed cache lookup is stable.
+    """
+    table_id: str
+    bucket: str
+    source_table: str
+
+
+@dataclass
+class TableMetadata:
+    """Source-agnostic metadata bundle. Every field optional — providers
+    fill what they can cheaply get; callers tolerate `None`. Adding a new
+    field here is a non-breaking change: existing CLI consumers don't
+    even render `rough_size_hint` (verified `grep -rn rough_size_hint cli/`
+    is empty), let alone the new fields.
+    """
+    rows: int | None = None
+    size_bytes: int | None = None
+    partition_by: str | None = None
+    clustered_by: list[str] | None = None

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -2179,6 +2179,9 @@ def register_table(
         params=_sanitize_for_audit(request.model_dump()),
     )
 
+    from app.api.v2_catalog import invalidate_for_table
+    invalidate_for_table(table_id)
+
     if not is_bigquery:
         # Keboola / Jira / local rows are insert-only here. 201 Created — the
         # decorator no longer carries a default status, so each branch is
@@ -2512,6 +2515,9 @@ async def update_table(
     if after.get("source_type") == "bigquery":
         background.add_task(_materialize_bigquery_extract_bg)
 
+    from app.api.v2_catalog import invalidate_for_table
+    invalidate_for_table(table_id)
+
     return {"id": table_id, "updated": list(updates.keys())}
 
 
@@ -2606,6 +2612,9 @@ async def unregister_table(
             "source_table": existing.get("source_table"),
         }),
     )
+
+    from app.api.v2_catalog import invalidate_for_table
+    invalidate_for_table(table_id)
 
     if was_bigquery:
         background.add_task(_materialize_bigquery_extract_bg)

--- a/app/api/cache_warmup.py
+++ b/app/api/cache_warmup.py
@@ -128,7 +128,7 @@ def _list_remote_rows() -> list[dict]:
     rows = TableRegistryRepository(conn).list_all()
     return [
         r for r in rows
-        if r.get("query_mode") == "remote"
+        if r.get("query_mode") == "remote" and r.get("source_type") == "bigquery"
     ]
 
 

--- a/app/api/cache_warmup.py
+++ b/app/api/cache_warmup.py
@@ -1,0 +1,257 @@
+"""Cache warmup framework — populates catalog/schema/metadata caches at
+container startup so the first analyst hits warm caches.
+
+Bounded concurrency (4 by default). Exposes:
+  - GET /api/admin/cache-warmup/status — JSON snapshot
+  - POST /api/admin/cache-warmup/run — manual trigger (idempotent)
+  - GET /api/admin/cache-warmup/stream — Server-Sent Events
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Literal
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends
+from sse_starlette.sse import EventSourceResponse
+
+from app.auth.access import require_admin
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+@dataclass
+class WarmupRowState:
+    table_id: str
+    status: Literal["pending", "warming", "fresh", "error"]
+    started_at: str | None = None
+    completed_at: str | None = None
+    duration_ms: int | None = None
+    error: str | None = None
+    last_warmed_at: str | None = None
+
+
+@dataclass
+class WarmupRunState:
+    run_id: str
+    trigger: Literal["startup", "manual", "registry_change"]
+    started_at: str
+    completed_at: str | None = None
+    total: int = 0
+    completed: int = 0
+    failed: int = 0
+    rows: dict[str, WarmupRowState] = field(default_factory=dict)
+    _subscribers: list[asyncio.Queue] = field(default_factory=list, repr=False)
+
+
+WARMUP_STATE: WarmupRunState | None = None
+_RUN_LOCK = asyncio.Lock()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def maybe_schedule_startup_warmup() -> None:
+    """Called from app/main.py FastAPI startup event."""
+    if os.environ.get("AGNES_SKIP_CACHE_WARMUP") == "1":
+        logger.info("cache warmup skipped (AGNES_SKIP_CACHE_WARMUP=1)")
+        return
+    try:
+        asyncio.create_task(_warm_catalog_caches_bg(trigger="startup"))
+    except RuntimeError:
+        logger.warning("no running event loop — startup warmup skipped")
+
+
+async def _warm_catalog_caches_bg(trigger: str = "startup") -> None:
+    """Walk registry, warm metadata + schema caches for every remote row."""
+    global WARMUP_STATE
+    async with _RUN_LOCK:
+        # Re-check inside the lock — another caller might have completed
+        # a run while we were waiting.
+        if WARMUP_STATE and WARMUP_STATE.completed_at is None:
+            return
+
+        run_id = uuid4().hex[:8]
+        state = WarmupRunState(
+            run_id=run_id, trigger=trigger, started_at=_now_iso(),
+        )
+        WARMUP_STATE = state
+
+    rows = _list_remote_rows()
+    state.total = len(rows)
+    for r in rows:
+        state.rows[r["id"]] = WarmupRowState(
+            table_id=r["id"], status="pending",
+        )
+    _broadcast(state, {"event": "start", "data": {
+        "run_id": run_id, "trigger": trigger, "total": state.total,
+    }})
+
+    sem = asyncio.Semaphore(int(os.environ.get("AGNES_WARMUP_CONCURRENCY", "4")))
+    await asyncio.gather(
+        *(_warm_one(r, state, sem) for r in rows), return_exceptions=True,
+    )
+
+    state.completed_at = _now_iso()
+    _broadcast(state, {"event": "complete", "data": {
+        "run_id": run_id, "total": state.total,
+        "completed": state.completed, "failed": state.failed,
+    }})
+    logger.info(
+        "cache warmup complete: run_id=%s total=%d ok=%d fail=%d",
+        run_id, state.total, state.completed, state.failed,
+    )
+
+
+def _list_remote_rows() -> list[dict]:
+    """Snapshot of registry rows that need a warmup pass."""
+    from src.db import get_system_db
+    from src.repositories.table_registry import TableRegistryRepository
+    conn = get_system_db()
+    rows = TableRegistryRepository(conn).list_all()
+    return [
+        r for r in rows
+        if r.get("query_mode") == "remote"
+        and r.get("source_type") == "bigquery"
+    ]
+
+
+async def _warm_one(
+    row: dict, state: WarmupRunState, sem: asyncio.Semaphore,
+) -> None:
+    async with sem:
+        rs = state.rows[row["id"]]
+        rs.status = "warming"
+        rs.started_at = _now_iso()
+        _broadcast(state, {"event": "row", "data": asdict(rs)})
+        t0 = time.monotonic()
+        try:
+            await asyncio.to_thread(_warm_metadata_sync, row)
+            await asyncio.to_thread(_warm_schema_sync, row)
+            rs.status = "fresh"
+            rs.last_warmed_at = _now_iso()
+            state.completed += 1
+        except Exception as e:
+            rs.status = "error"
+            rs.error = str(e)
+            state.failed += 1
+            logger.warning("cache warmup row=%s failed: %s", row["id"], e)
+        finally:
+            rs.completed_at = _now_iso()
+            rs.duration_ms = int((time.monotonic() - t0) * 1000)
+            _broadcast(state, {"event": "row", "data": asdict(rs)})
+
+
+def _warm_metadata_sync(row: dict) -> None:
+    """Trigger metadata cache populate via the catalog's normal path."""
+    from app.api.v2_catalog import _size_hint_for_row
+    _size_hint_for_row(row)
+
+
+def _warm_schema_sync(row: dict) -> None:
+    """Trigger schema cache populate via build_schema_uncached."""
+    from app.api.v2_schema import build_schema_uncached
+    from connectors.bigquery.access import get_bq_access
+    from src.db import get_system_db
+    bq = get_bq_access()
+    build_schema_uncached(get_system_db(), row["id"], bq=bq, row=row)
+
+
+async def warm_one_table(table_id: str) -> None:
+    """Single-row re-warm — invoked by `invalidate_for_table` after a
+    registry change. Does NOT update WARMUP_STATE (small change shouldn't
+    overwrite the last full run's status); just refreshes the caches."""
+    from src.db import get_system_db
+    from src.repositories.table_registry import TableRegistryRepository
+    conn = get_system_db()
+    row = TableRegistryRepository(conn).get(table_id)
+    if not row or row.get("query_mode") != "remote":
+        return
+    try:
+        await asyncio.to_thread(_warm_metadata_sync, row)
+        await asyncio.to_thread(_warm_schema_sync, row)
+    except Exception as e:
+        logger.warning("single-row warmup failed for %s: %s", table_id, e)
+
+
+def _broadcast(state: WarmupRunState, event: dict) -> None:
+    """Send an event to every SSE subscriber. Dead queues are pruned."""
+    dead = []
+    for q in state._subscribers:
+        try:
+            q.put_nowait(event)
+        except asyncio.QueueFull:
+            dead.append(q)
+    for q in dead:
+        state._subscribers.remove(q)
+
+
+def _serialize_state(state: WarmupRunState) -> dict:
+    return {
+        "run_id": state.run_id,
+        "trigger": state.trigger,
+        "started_at": state.started_at,
+        "completed_at": state.completed_at,
+        "total": state.total,
+        "completed": state.completed,
+        "failed": state.failed,
+        "rows": {tid: asdict(rs) for tid, rs in state.rows.items()},
+    }
+
+
+# ─── Endpoints ────────────────────────────────────────────────────────
+
+
+@router.get("/api/admin/cache-warmup/status")
+async def warmup_status(user: dict = Depends(require_admin)):
+    if WARMUP_STATE is None:
+        return {"state": "never_run"}
+    return _serialize_state(WARMUP_STATE)
+
+
+@router.post("/api/admin/cache-warmup/run")
+async def warmup_run(user: dict = Depends(require_admin)):
+    if WARMUP_STATE and WARMUP_STATE.completed_at is None:
+        return {"run_id": WARMUP_STATE.run_id, "status": "already_running"}
+    asyncio.create_task(_warm_catalog_caches_bg(trigger="manual"))
+    # Brief sleep so WARMUP_STATE is populated by the time we return.
+    await asyncio.sleep(0)
+    return {
+        "run_id": WARMUP_STATE.run_id if WARMUP_STATE else None,
+        "status": "started",
+    }
+
+
+@router.get("/api/admin/cache-warmup/stream")
+async def warmup_stream(user: dict = Depends(require_admin)):
+    async def gen():
+        q: asyncio.Queue = asyncio.Queue(maxsize=256)
+        if WARMUP_STATE:
+            WARMUP_STATE._subscribers.append(q)
+        # Replay current snapshot.
+        if WARMUP_STATE:
+            yield {"event": "snapshot", "data": json.dumps(
+                _serialize_state(WARMUP_STATE)
+            )}
+        try:
+            while True:
+                ev = await asyncio.wait_for(q.get(), timeout=30.0)
+                yield {"event": ev["event"], "data": json.dumps(ev["data"])}
+                if ev["event"] == "complete":
+                    return
+        except asyncio.TimeoutError:
+            return
+        finally:
+            if WARMUP_STATE and q in WARMUP_STATE._subscribers:
+                WARMUP_STATE._subscribers.remove(q)
+
+    return EventSourceResponse(gen())

--- a/app/api/cache_warmup.py
+++ b/app/api/cache_warmup.py
@@ -71,21 +71,29 @@ def maybe_schedule_startup_warmup() -> None:
         logger.warning("no running event loop — startup warmup skipped")
 
 
-async def _warm_catalog_caches_bg(trigger: str = "startup") -> None:
-    """Walk registry, warm metadata + schema caches for every remote row."""
+async def _warm_catalog_caches_bg(
+    trigger: str = "startup", state: WarmupRunState | None = None,
+) -> None:
+    """Walk registry, warm metadata + schema caches for every remote row.
+
+    If `state` is provided, use it (caller has already published it on
+    WARMUP_STATE). Otherwise build a fresh state and assign WARMUP_STATE.
+    """
     global WARMUP_STATE
-    async with _RUN_LOCK:
-        # Re-check inside the lock — another caller might have completed
-        # a run while we were waiting.
-        if WARMUP_STATE and WARMUP_STATE.completed_at is None:
-            return
+    if state is None:
+        async with _RUN_LOCK:
+            # Re-check inside the lock — another caller might have completed
+            # a run while we were waiting.
+            if WARMUP_STATE and WARMUP_STATE.completed_at is None:
+                return
+            state = WarmupRunState(
+                run_id=uuid4().hex[:8],
+                trigger=trigger,
+                started_at=_now_iso(),
+            )
+            WARMUP_STATE = state
 
-        run_id = uuid4().hex[:8]
-        state = WarmupRunState(
-            run_id=run_id, trigger=trigger, started_at=_now_iso(),
-        )
-        WARMUP_STATE = state
-
+    run_id = state.run_id
     rows = _list_remote_rows()
     state.total = len(rows)
     for r in rows:
@@ -121,7 +129,6 @@ def _list_remote_rows() -> list[dict]:
     return [
         r for r in rows
         if r.get("query_mode") == "remote"
-        and r.get("source_type") == "bigquery"
     ]
 
 
@@ -220,28 +227,28 @@ async def warmup_status(user: dict = Depends(require_admin)):
 
 @router.post("/api/admin/cache-warmup/run")
 async def warmup_run(user: dict = Depends(require_admin)):
+    global WARMUP_STATE
     if WARMUP_STATE and WARMUP_STATE.completed_at is None:
         return {"run_id": WARMUP_STATE.run_id, "status": "already_running"}
-    asyncio.create_task(_warm_catalog_caches_bg(trigger="manual"))
-    # Brief sleep so WARMUP_STATE is populated by the time we return.
-    await asyncio.sleep(0)
-    return {
-        "run_id": WARMUP_STATE.run_id if WARMUP_STATE else None,
-        "status": "started",
-    }
+    state = WarmupRunState(
+        run_id=uuid4().hex[:8],
+        trigger="manual",
+        started_at=_now_iso(),
+    )
+    WARMUP_STATE = state
+    asyncio.create_task(_warm_catalog_caches_bg(state=state))
+    return {"run_id": state.run_id, "status": "started"}
 
 
 @router.get("/api/admin/cache-warmup/stream")
 async def warmup_stream(user: dict = Depends(require_admin)):
     async def gen():
         q: asyncio.Queue = asyncio.Queue(maxsize=256)
-        if WARMUP_STATE:
-            WARMUP_STATE._subscribers.append(q)
-        # Replay current snapshot.
-        if WARMUP_STATE:
-            yield {"event": "snapshot", "data": json.dumps(
-                _serialize_state(WARMUP_STATE)
-            )}
+        if WARMUP_STATE is None:
+            yield {"event": "idle", "data": json.dumps({"state": "never_run"})}
+            return
+        WARMUP_STATE._subscribers.append(q)
+        yield {"event": "snapshot", "data": json.dumps(_serialize_state(WARMUP_STATE))}
         try:
             while True:
                 ev = await asyncio.wait_for(q.get(), timeout=30.0)

--- a/app/api/v2_catalog.py
+++ b/app/api/v2_catalog.py
@@ -148,7 +148,7 @@ def _size_hint_for_row(row: dict) -> dict:
         return {"rough_size_hint": None}
 
     return {
-        "rough_size_hint": _bucket_size(cached.size_bytes) if cached.size_bytes else None,
+        "rough_size_hint": _bucket_size(cached.size_bytes) if cached.size_bytes is not None else None,
         "rows": cached.rows,
         "size_bytes": cached.size_bytes,
         "partition_by": cached.partition_by,

--- a/app/api/v2_catalog.py
+++ b/app/api/v2_catalog.py
@@ -199,6 +199,58 @@ def _resolve_remote_metadata(row: dict) -> "TableMetadata | None":
         return None
 
 
+def invalidate_for_table(table_id: str) -> None:
+    """Drop every per-table cache so the next /api/v2/* request reflects
+    the just-registered / updated / unregistered row immediately. Owned
+    by the catalog module so admin.py doesn't need to know which caches
+    exist.
+
+    Imports v2_schema and v2_sample lazily — keeps catalog tests from
+    pulling in BQ-extension imports they don't need.
+    """
+    import asyncio
+    from app.api import v2_schema, v2_sample
+
+    _table_rows_cache.clear()
+    _metadata_cache.invalidate(table_id)
+    v2_schema._schema_cache.invalidate(table_id)
+    # Sample cache key is `f"{table_id}|{n}"`; clearing the whole sample
+    # cache is heavier than precise invalidation, but registry-change
+    # frequency (handful per day on a typical instance) doesn't justify
+    # adding a prefix-invalidation primitive to TTLCache.
+    v2_sample._sample_cache.clear()
+
+    # Schedule a single-row re-warm so admins editing a registry row
+    # see fresh data within a couple of seconds rather than waiting for
+    # the next analyst to trigger a miss. Fire-and-forget; failures
+    # log + skip inside the coroutine.
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+    if loop is not None:
+        # Running inside an async context (production FastAPI path).
+        asyncio.create_task(_rewarm_one_row(table_id))
+    # No running event loop (e.g. called from a sync test or a sync
+    # handler thread). Skip re-warm — the next live request will
+    # populate via miss.
+
+
+async def _rewarm_one_row(table_id: str) -> None:
+    """Background single-row re-warm. Imports cache_warmup lazily to
+    avoid a circular import at module load (cache_warmup.py is created
+    in Task 10; until then, this function logs a warning and returns)."""
+    try:
+        from app.api.cache_warmup import warm_one_table
+        await warm_one_table(table_id)
+    except Exception:
+        import logging
+        logging.getLogger(__name__).warning(
+            "single-row re-warm failed for %s — next live request will populate",
+            table_id,
+        )
+
+
 def build_catalog(conn: duckdb.DuckDBPyConnection, user: dict) -> dict:
     rows = _table_rows_cache.get(_TABLE_ROWS_KEY)
     if rows is None:

--- a/app/api/v2_catalog.py
+++ b/app/api/v2_catalog.py
@@ -11,6 +11,8 @@ from app.utils import get_data_dir as _get_data_dir
 from src.rbac import can_access_table
 from src.repositories.table_registry import TableRegistryRepository
 from app.api.v2_cache import TTLCache
+from app.api._metadata_models import MetadataRequest, TableMetadata
+from src.identifier_validation import validate_quoted_identifier
 
 router = APIRouter(prefix="/api/v2", tags=["v2"])
 
@@ -24,6 +26,44 @@ router = APIRouter(prefix="/api/v2", tags=["v2"])
 # a no-op — tracked separately.
 _table_rows_cache = TTLCache(maxsize=1, ttl_seconds=300)
 _TABLE_ROWS_KEY = "all"
+
+
+def _metadata_provider_for(source_type: str):
+    """Lazy-import dispatch for source-specific metadata providers.
+
+    Lazy because connector modules are heavy (BQ extension, google-cloud
+    client, etc.) and a Keboola-only deployment shouldn't pay the BQ
+    import cost. Returns ``None`` for unknown source types — the caller
+    treats that as "no metadata enrichment available" and falls through.
+    """
+    if source_type == "bigquery":
+        from connectors.bigquery import metadata as m
+        return m.fetch
+    if source_type == "keboola":
+        from connectors.keboola import metadata as m
+        return m.fetch
+    return None
+
+
+def _build_metadata_request(row: dict) -> MetadataRequest | None:
+    """Construct a validated MetadataRequest from a registry row.
+
+    Pre-validates the identifiers via `validate_quoted_identifier` before
+    constructing the request — providers can then interpolate
+    `req.bucket` / `req.source_table` into SQL/URL paths without
+    re-checking. Returns ``None`` when validation fails; provider is not
+    dispatched for that row.
+    """
+    bucket = row.get("bucket") or ""
+    source_table = row.get("source_table") or row.get("id") or ""
+    if not bucket or not source_table:
+        return None
+    if not (validate_quoted_identifier(bucket, "bucket")
+            and validate_quoted_identifier(source_table, "source_table")):
+        return None
+    return MetadataRequest(
+        table_id=row["id"], bucket=bucket, source_table=source_table,
+    )
 
 
 def _flavor_for(source_type: str) -> str:

--- a/app/api/v2_catalog.py
+++ b/app/api/v2_catalog.py
@@ -27,6 +27,13 @@ router = APIRouter(prefix="/api/v2", tags=["v2"])
 _table_rows_cache = TTLCache(maxsize=1, ttl_seconds=300)
 _TABLE_ROWS_KEY = "all"
 
+# Per-table cached TableMetadata. 15-min TTL — long enough to amortise
+# across an analyst session, short enough that a freshly-registered
+# remote table shows real numbers within a coffee break (the cache-bust
+# path in `invalidate_for_table` accelerates this for the common admin-
+# verifies-registration flow).
+_metadata_cache = TTLCache(maxsize=512, ttl_seconds=900)
+
 
 def _metadata_provider_for(source_type: str):
     """Lazy-import dispatch for source-specific metadata providers.
@@ -105,29 +112,90 @@ def _bucket_size(byte_count: int) -> str:
     return "very_large"
 
 
-def _materialized_size_hint(table_id: str, source_type: str, query_mode: str) -> str | None:
-    """Return a rough size bucket for a row whose data is on the server's
-    local filesystem (any `query_mode` that produces a parquet — `local` and
-    `materialized`). Returns ``None`` for `remote` (size requires a BQ
-    INFORMATION_SCHEMA round-trip; tracked separately) and for tables whose
-    parquet hasn't been materialised yet so the AI gets ``null`` not a
-    misleading "small".
+def _size_hint_for_row(row: dict) -> dict:
+    """Resolve the per-row metadata bundle the catalog response surfaces.
+
+    Renamed from `_materialized_size_hint` (which always also handled
+    `local` rows; the old name was misleading). Returns a dict with up
+    to four keys: `rough_size_hint`, `rows`, `size_bytes`, `partition_by`,
+    `clustered_by`. Missing keys are reported as `null` in the response.
+
+    Branches:
+      - `local` / `materialized` → existing on-disk parquet stat (cheap).
+      - `remote` → dispatch to the per-source-type provider; cache the
+        TableMetadata for 15 min.
+    """
+    table_id = row["id"]
+    source_type = row.get("source_type") or ""
+    query_mode = row.get("query_mode") or "local"
+
+    if query_mode in ("local", "materialized"):
+        return {"rough_size_hint": _materialized_parquet_size_bucket(
+            table_id, source_type, query_mode,
+        )}
+
+    if query_mode != "remote":
+        return {"rough_size_hint": None}
+
+    # Cache lookup (per-row TableMetadata).
+    cached = _metadata_cache.get(table_id)
+    if cached is None:
+        cached = _resolve_remote_metadata(row)
+        if cached is not None:
+            _metadata_cache.set(table_id, cached)
+
+    if cached is None:
+        return {"rough_size_hint": None}
+
+    return {
+        "rough_size_hint": _bucket_size(cached.size_bytes) if cached.size_bytes else None,
+        "rows": cached.rows,
+        "size_bytes": cached.size_bytes,
+        "partition_by": cached.partition_by,
+        "clustered_by": cached.clustered_by,
+    }
+
+
+def _materialized_parquet_size_bucket(
+    table_id: str, source_type: str, query_mode: str,
+) -> str | None:
+    """Size hint for rows whose data is on the server filesystem
+    (the old `_materialized_size_hint` body). Renamed for clarity now
+    that the new dispatcher is the entry point.
 
     Layout matches the v2 extract.duckdb contract:
       ${DATA_DIR}/extracts/<source_type>/data/<table_id>.parquet
     """
-    if query_mode == "remote":
-        return None
     if not source_type:
         return None
     try:
-        path = Path(_get_data_dir()) / "extracts" / source_type / "data" / f"{table_id}.parquet"
+        path = (
+            Path(_get_data_dir()) / "extracts" / source_type / "data"
+            / f"{table_id}.parquet"
+        )
         if not path.exists():
             return None
         return _bucket_size(path.stat().st_size)
     except Exception:
         # Filesystem stat() race / permissions / weird DATA_DIR — fall back
         # to null rather than crash the whole catalog response.
+        return None
+
+
+def _resolve_remote_metadata(row: dict) -> "TableMetadata | None":
+    """Provider dispatch for a remote row. Returns None on any failure."""
+    source_type = row.get("source_type") or ""
+    provider = _metadata_provider_for(source_type)
+    if provider is None:
+        return None
+    req = _build_metadata_request(row)
+    if req is None:
+        return None
+    try:
+        return provider(req)
+    except Exception:
+        # Defense in depth — providers are documented as never-raises,
+        # but a regression would otherwise 500 the whole catalog.
         return None
 
 
@@ -145,6 +213,7 @@ def build_catalog(conn: duckdb.DuckDBPyConnection, user: dict) -> dict:
     for r in rows:
         if not can_access_table(user, r["id"], conn):
             continue
+        hint = _size_hint_for_row(r)
         visible.append({
             "id": r["id"],
             "name": r.get("name") or r["id"],
@@ -154,10 +223,11 @@ def build_catalog(conn: duckdb.DuckDBPyConnection, user: dict) -> dict:
             "sql_flavor": _flavor_for(r.get("source_type") or ""),
             "where_examples": _examples_for(r.get("source_type") or ""),
             "fetch_via": _fetch_hint(r["id"], r.get("source_type") or ""),
-            "rough_size_hint": _materialized_size_hint(
-                r["id"], r.get("source_type") or "",
-                r.get("query_mode") or "local",
-            ),
+            "rough_size_hint": hint.get("rough_size_hint"),
+            "rows": hint.get("rows"),
+            "size_bytes": hint.get("size_bytes"),
+            "partition_by": hint.get("partition_by"),
+            "clustered_by": hint.get("clustered_by"),
         })
 
     return {
@@ -172,12 +242,12 @@ def catalog(
     conn: duckdb.DuckDBPyConnection = Depends(_get_db),
 ):
     # Plain ``def`` so FastAPI auto-offloads to the anyio thread pool —
-    # build_catalog now calls `_materialized_size_hint` for every visible
-    # row, which does sync `Path.stat()` / `Path.exists()` on the data
-    # volume. On local FS that's microseconds, but on a network-mounted
-    # DATA_DIR (NFS / CIFS / GCS-FUSE) those calls can block. Plain ``def``
-    # means each request runs on its own thread; the event loop stays
-    # free for non-catalog traffic. Mirrors the Tier 1 conversion of
-    # /api/query, /api/v2/scan, /api/v2/sample, /api/v2/schema —
-    # Devin Review on PR #188.
+    # build_catalog now calls `_size_hint_for_row` for every visible row,
+    # which does sync `Path.stat()` / `Path.exists()` on the data volume
+    # (local/materialized) or provider dispatch (remote). On local FS
+    # that's microseconds, but on a network-mounted DATA_DIR (NFS / CIFS /
+    # GCS-FUSE) those calls can block. Plain ``def`` means each request
+    # runs on its own thread; the event loop stays free for non-catalog
+    # traffic. Mirrors the Tier 1 conversion of /api/query, /api/v2/scan,
+    # /api/v2/sample, /api/v2/schema — Devin Review on PR #188.
     return build_catalog(conn, user)

--- a/app/api/v2_schema.py
+++ b/app/api/v2_schema.py
@@ -31,51 +31,75 @@ _BQ_DIALECT_HINTS = {
 
 
 def _fetch_bq_schema(bq, dataset: str, table: str) -> list[dict]:
-    """Fetch column list via INFORMATION_SCHEMA.COLUMNS using DuckDB BQ extension.
+    """Fetch column list via the shared `fetch_bq_columns_full` helper.
 
-    `bq.duckdb_session()` provides a DuckDB conn with the bigquery extension
-    loaded + auth secret installed. SQL here is server-constructed (queries
-    INFORMATION_SCHEMA.COLUMNS with validated identifiers, no user-derived
-    fragments), so a BQ BadRequest means registry corruption, not user input
-    → surfaces as `bq_upstream_error` (HTTP 502), same as `/sample`, opposite
-    of `/scan*`.
+    Pre-#155 this had its own INFORMATION_SCHEMA.COLUMNS query; consolidating
+    with `_fetch_bq_table_options` (now also delegating to the same helper)
+    halves the BQ job count on cache miss. Returns the schema-endpoint
+    column shape: name / type / nullable / description.
     """
-    from connectors.bigquery.access import translate_bq_error
+    from connectors.bigquery.access import fetch_bq_columns_full, translate_bq_error, BqAccessError
     from src.identifier_validation import validate_quoted_identifier
 
-    # Surface "BQ not configured" as the structured 500 BqAccessError(not_configured)
-    # with hint, not the misleading 400 unsafe_identifier the empty-string sentinel
-    # would otherwise trigger from validate_quoted_identifier below. Devin BUG_0002.
+    # Surface "BQ not configured" as the structured 500 BqAccessError
+    # (with hint), not a misleading empty-list. Mirrors pre-refactor
+    # behavior — see Devin BUG_0002 in the original docstring.
     if not bq.projects.data:
         bq.client()  # raises BqAccessError(not_configured); endpoint catches it
 
-    # Defense in depth (cf. v2_sample) — registry already validates these,
-    # but the v2 endpoints are downstream of admin REST writes that could
-    # bypass that gate. A backtick in `dataset` would otherwise break out
-    # of `…` quoting and execute arbitrary BQ SQL.
+    # Defense in depth — refuse unsafe identifiers before any SQL construction.
+    # The helper also validates, but we need to surface this as ValueError (not
+    # None) here so the endpoint returns 400 unsafe_identifier.
     if not (validate_quoted_identifier(bq.projects.data, "BQ project")
             and validate_quoted_identifier(dataset, "BQ dataset")
             and validate_quoted_identifier(table, "BQ source_table")):
         raise ValueError("unsafe BQ identifier in registry — refusing to query")
 
-    bq_sql = (
-        f"SELECT column_name, data_type, is_nullable "
-        f"FROM `{bq.projects.data}.{dataset}.INFORMATION_SCHEMA.COLUMNS` "
-        f"WHERE table_name = ? ORDER BY ordinal_position"
+    # Run the shared single-round-trip query. Capture the original BQ exception
+    # so translate_bq_error can classify it correctly (Forbidden → 502, etc.)
+    # rather than wrapping a generic RuntimeError that translate_bq_error would
+    # re-raise unclassified.
+    _last_exc: list = []
+
+    def _session_factory_capturing(projects):
+        """Thin wrapper around bq.duckdb_session() that intercepts exceptions
+        and stashes them in _last_exc before re-raising, so the caller's
+        translate_bq_error path sees the original Google API exception type."""
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _cm():
+            with bq.duckdb_session() as conn:
+                try:
+                    yield conn
+                except Exception as exc:
+                    _last_exc.append(exc)
+                    raise
+        return _cm()
+
+    # Build a thin BqAccess wrapper that uses our capturing session factory.
+    from connectors.bigquery.access import BqAccess
+    bq_capturing = BqAccess(
+        bq.projects,
+        client_factory=lambda p: bq.client(),
+        duckdb_session_factory=_session_factory_capturing,
     )
-    with bq.duckdb_session() as conn:
-        try:
-            rows = conn.execute(
-                "SELECT * FROM bigquery_query(?, ?, ?)",
-                [bq.projects.billing, bq_sql, table],
-            ).fetchall()
-        except Exception as e:
-            raise translate_bq_error(e, bq.projects, bad_request_status="upstream_error")
+
+    rows = fetch_bq_columns_full(bq_capturing, dataset, table)
+    if rows is None:
+        # fetch_bq_columns_full swallowed the exception. Re-raise via
+        # translate_bq_error using the captured original exception if available,
+        # so Forbidden/BadRequest classifications survive the helper boundary.
+        orig = _last_exc[0] if _last_exc else RuntimeError(
+            "BQ INFORMATION_SCHEMA.COLUMNS query failed"
+        )
+        raise translate_bq_error(orig, bq.projects, bad_request_status="upstream_error")
+
     return [
         {
-            "name": r[0],
-            "type": r[1],
-            "nullable": r[2] == "YES",
+            "name": r["name"],
+            "type": r["type"],
+            "nullable": r["nullable"],
             "description": "",
         }
         for r in rows
@@ -83,61 +107,27 @@ def _fetch_bq_schema(bq, dataset: str, table: str) -> list[dict]:
 
 
 def _fetch_bq_table_options(bq, dataset: str, table: str) -> dict:
-    """Best-effort fetch of partition/cluster info from INFORMATION_SCHEMA.COLUMNS.
+    """Best-effort fetch of partition/cluster info via the shared
+    `fetch_bq_columns_full` helper.
 
-    BigQuery exposes partition + cluster metadata as per-column flags:
-      - `is_partitioning_column` ('YES' / 'NO') — at most one column per table
-      - `clustering_ordinal_position` (INT64, null for non-clustered columns;
-        otherwise 1, 2, ... in cluster-key order)
-
-    Returns `{}` on ANY failure (best-effort). The outer
-    `try/except Exception → return {}` is a load-bearing contract: the
-    /schema endpoint must keep returning 200 with empty partition info even
-    when this query fails (e.g. on permissioned tables, on cross-project
-    misconfigurations). DO NOT route this through `translate_bq_error` —
-    that would convert errors to BqAccessError which the endpoint would 502
-    on. See tests/test_v2_schema.py::test_schema_returns_200_with_empty_…
+    Returns ``{}`` on ANY failure (best-effort). Same load-bearing
+    contract as before: the /schema endpoint must keep returning 200
+    with empty partition info when this fails.
     """
-    from src.identifier_validation import validate_quoted_identifier
+    from connectors.bigquery.access import fetch_bq_columns_full
 
-    # Best-effort path: if BQ isn't configured (sentinel BqAccess), return
-    # empty partition info silently — operator gets schema (200) without
-    # failing on the missing config. The strict /schema path (_fetch_bq_schema)
-    # surfaces the not_configured error separately.
-    if not bq.projects.data:
+    rows = fetch_bq_columns_full(bq, dataset, table)
+    if not rows:
         return {}
 
-    if not (validate_quoted_identifier(bq.projects.data, "BQ project")
-            and validate_quoted_identifier(dataset, "BQ dataset")
-            and validate_quoted_identifier(table, "BQ source_table")):
-        return {}  # Best-effort; refuse to query unsafe identifiers.
-
-    try:
-        with bq.duckdb_session() as conn:
-            bq_sql = (
-                f"SELECT column_name, is_partitioning_column, clustering_ordinal_position "
-                f"FROM `{bq.projects.data}.{dataset}.INFORMATION_SCHEMA.COLUMNS` "
-                f"WHERE table_name = ? "
-                f"ORDER BY clustering_ordinal_position NULLS LAST"
-            )
-            rows = conn.execute(
-                "SELECT * FROM bigquery_query(?, ?, ?)",
-                [bq.projects.billing, bq_sql, table],
-            ).fetchall()
-        if not rows:
-            return {}
-        partition_by = next(
-            (r[0] for r in rows if (r[1] or "").upper() == "YES"),
-            None,
-        )
-        clustered_by = [r[0] for r in rows if r[2] is not None]
-        return {"partition_by": partition_by, "clustered_by": clustered_by}
-    except Exception as e:
-        logger.warning(
-            "BQ table options fetch failed for %s.%s.%s: %s",
-            bq.projects.data, dataset, table, e,
-        )
-        return {}
+    partition_by = next(
+        (r["name"] for r in rows if r["is_partitioning_column"]),
+        None,
+    )
+    clustered_rows = [r for r in rows if r["clustering_ordinal_position"] is not None]
+    clustered_rows.sort(key=lambda r: r["clustering_ordinal_position"])
+    clustered_by = [r["name"] for r in clustered_rows]
+    return {"partition_by": partition_by, "clustered_by": clustered_by}
 
 
 def build_schema(

--- a/app/api/v2_schema.py
+++ b/app/api/v2_schema.py
@@ -106,12 +106,11 @@ def build_schema(
     if not can_access_table(user, table_id, conn):
         raise PermissionError(table_id)
 
-    cache_key = f"{table_id}"
-    cached = _schema_cache.get(cache_key)
+    cached = _schema_cache.get(table_id)
     if cached is not None:
         return cached
 
-    return build_schema_uncached(conn, table_id, bq=bq)
+    return build_schema_uncached(conn, table_id, bq=bq, row=row)
 
 
 def build_schema_uncached(
@@ -119,17 +118,24 @@ def build_schema_uncached(
     table_id: str,
     *,
     bq: BqAccess,
+    row: dict | None = None,
 ) -> dict:
     """Build the schema response and populate `_schema_cache`. **Skips
     RBAC and cache-hit short-circuit** — call only from contexts where
-    those are either unnecessary (warmup) or already enforced upstream
-    (`build_schema` above). The BQ work is the same; the entry-point
-    contract is what differs.
-    """
-    repo = TableRegistryRepository(conn)
-    row = repo.get(table_id)
+    those are unnecessary (warmup) or already enforced upstream
+    (`build_schema`).
 
-    source_type = (row.get("source_type") if row else None) or ""
+    Pass `row` from the upstream caller's `repo.get(table_id)` to avoid
+    a redundant DB round-trip; if not provided, `build_schema_uncached`
+    fetches it itself (the warmup-direct call site).
+    """
+    if row is None:
+        repo = TableRegistryRepository(conn)
+        row = repo.get(table_id)
+        if not row:
+            raise NotFound(table_id)
+
+    source_type = row.get("source_type") or ""
     if source_type == "bigquery":
         dataset = row.get("bucket") or ""
         source_table = row.get("source_table") or table_id
@@ -170,8 +176,7 @@ def build_schema_uncached(
             "where_dialect_hints": {},
         }
 
-    cache_key = f"{table_id}"
-    _schema_cache.set(cache_key, payload)
+    _schema_cache.set(table_id, payload)
     return payload
 
 

--- a/app/api/v2_schema.py
+++ b/app/api/v2_schema.py
@@ -31,69 +31,28 @@ _BQ_DIALECT_HINTS = {
 
 
 def _fetch_bq_schema(bq, dataset: str, table: str) -> list[dict]:
-    """Fetch column list via the shared `fetch_bq_columns_full` helper.
+    """Fetch column list via the shared ``_fetch_bq_columns_full_impl`` helper.
 
     Pre-#155 this had its own INFORMATION_SCHEMA.COLUMNS query; consolidating
-    with `_fetch_bq_table_options` (now also delegating to the same helper)
-    halves the BQ job count on cache miss. Returns the schema-endpoint
+    with ``_fetch_bq_table_options`` (now also delegating to the same shared
+    SQL) halves the BQ job count on cache miss. Returns the schema-endpoint
     column shape: name / type / nullable / description.
+
+    Calls the raising variant so BQ exceptions reach ``translate_bq_error``
+    with their original type (Forbidden → 502, BadRequest → 400, etc.).
     """
-    from connectors.bigquery.access import fetch_bq_columns_full, translate_bq_error, BqAccessError
-    from src.identifier_validation import validate_quoted_identifier
+    from connectors.bigquery.access import _fetch_bq_columns_full_impl, translate_bq_error, BqAccessError
 
-    # Surface "BQ not configured" as the structured 500 BqAccessError
-    # (with hint), not a misleading empty-list. Mirrors pre-refactor
-    # behavior — see Devin BUG_0002 in the original docstring.
-    if not bq.projects.data:
-        bq.client()  # raises BqAccessError(not_configured); endpoint catches it
-
-    # Defense in depth — refuse unsafe identifiers before any SQL construction.
-    # The helper also validates, but we need to surface this as ValueError (not
-    # None) here so the endpoint returns 400 unsafe_identifier.
-    if not (validate_quoted_identifier(bq.projects.data, "BQ project")
-            and validate_quoted_identifier(dataset, "BQ dataset")
-            and validate_quoted_identifier(table, "BQ source_table")):
-        raise ValueError("unsafe BQ identifier in registry — refusing to query")
-
-    # Run the shared single-round-trip query. Capture the original BQ exception
-    # so translate_bq_error can classify it correctly (Forbidden → 502, etc.)
-    # rather than wrapping a generic RuntimeError that translate_bq_error would
-    # re-raise unclassified.
-    _last_exc: list = []
-
-    def _session_factory_capturing(projects):
-        """Thin wrapper around bq.duckdb_session() that intercepts exceptions
-        and stashes them in _last_exc before re-raising, so the caller's
-        translate_bq_error path sees the original Google API exception type."""
-        from contextlib import contextmanager
-
-        @contextmanager
-        def _cm():
-            with bq.duckdb_session() as conn:
-                try:
-                    yield conn
-                except Exception as exc:
-                    _last_exc.append(exc)
-                    raise
-        return _cm()
-
-    # Build a thin BqAccess wrapper that uses our capturing session factory.
-    from connectors.bigquery.access import BqAccess
-    bq_capturing = BqAccess(
-        bq.projects,
-        client_factory=lambda p: bq.client(),
-        duckdb_session_factory=_session_factory_capturing,
-    )
-
-    rows = fetch_bq_columns_full(bq_capturing, dataset, table)
-    if rows is None:
-        # fetch_bq_columns_full swallowed the exception. Re-raise via
-        # translate_bq_error using the captured original exception if available,
-        # so Forbidden/BadRequest classifications survive the helper boundary.
-        orig = _last_exc[0] if _last_exc else RuntimeError(
-            "BQ INFORMATION_SCHEMA.COLUMNS query failed"
-        )
-        raise translate_bq_error(orig, bq.projects, bad_request_status="upstream_error")
+    try:
+        rows = _fetch_bq_columns_full_impl(bq, dataset, table)
+    except (ValueError, BqAccessError):
+        # ValueError ("unsafe identifier") and BqAccessError propagate
+        # unchanged — the endpoint's existing handlers expect those types.
+        raise
+    except Exception as e:
+        # Any other BQ-side exception goes through translate_bq_error so
+        # the response status is classified correctly.
+        raise translate_bq_error(e, bq.projects, bad_request_status="upstream_error")
 
     return [
         {

--- a/app/api/v2_schema.py
+++ b/app/api/v2_schema.py
@@ -111,7 +111,25 @@ def build_schema(
     if cached is not None:
         return cached
 
-    source_type = row.get("source_type") or ""
+    return build_schema_uncached(conn, table_id, bq=bq)
+
+
+def build_schema_uncached(
+    conn: duckdb.DuckDBPyConnection,
+    table_id: str,
+    *,
+    bq: BqAccess,
+) -> dict:
+    """Build the schema response and populate `_schema_cache`. **Skips
+    RBAC and cache-hit short-circuit** — call only from contexts where
+    those are either unnecessary (warmup) or already enforced upstream
+    (`build_schema` above). The BQ work is the same; the entry-point
+    contract is what differs.
+    """
+    repo = TableRegistryRepository(conn)
+    row = repo.get(table_id)
+
+    source_type = (row.get("source_type") if row else None) or ""
     if source_type == "bigquery":
         dataset = row.get("bucket") or ""
         source_table = row.get("source_table") or table_id
@@ -128,7 +146,6 @@ def build_schema(
         }
     else:
         # Local source — read schema from the parquet via DuckDB
-        from pathlib import Path
         from app.utils import get_data_dir
         parquet = (
             get_data_dir() / "extracts" / source_type / "data" / f"{table_id}.parquet"
@@ -153,6 +170,7 @@ def build_schema(
             "where_dialect_hints": {},
         }
 
+    cache_key = f"{table_id}"
     _schema_cache.set(cache_key, payload)
     return payload
 

--- a/app/main.py
+++ b/app/main.py
@@ -113,6 +113,7 @@ from app.api.store import router as store_router
 from app.api.my_stack import router as my_stack_router
 from app.api.welcome import router as welcome_router
 from app.api.claude_md import router as claude_md_router
+from app.api.cache_warmup import router as cache_warmup_router
 from app.marketplace_server.router import router as marketplace_server_router
 from app.marketplace_server.git_router import make_git_wsgi_app
 from app.web.router import router as web_router
@@ -552,6 +553,7 @@ def create_app() -> FastAPI:
     app.include_router(my_stack_router)
     app.include_router(welcome_router)
     app.include_router(claude_md_router)
+    app.include_router(cache_warmup_router)
     app.include_router(marketplace_server_router)
 
     # Git smart-HTTP endpoint for Claude Code: /marketplace.git/*

--- a/app/main.py
+++ b/app/main.py
@@ -148,6 +148,9 @@ async def lifespan(app):
     except Exception as e:
         logger.warning("failed to bump anyio thread pool capacity: %s", e)
 
+    from app.api.cache_warmup import maybe_schedule_startup_warmup
+    maybe_schedule_startup_warmup()
+
     yield
     from src.db import close_system_db
     close_system_db()

--- a/app/web/templates/admin_tables.html
+++ b/app/web/templates/admin_tables.html
@@ -2904,6 +2904,13 @@
     // ── Cache warmup toolbar (issue #155 / #156) ────────────────
     let cacheWarmupSource = null;
 
+    function _cacheWarmupClearPollFallback() {
+        if (window._cacheWarmupPollInterval) {
+            clearInterval(window._cacheWarmupPollInterval);
+            window._cacheWarmupPollInterval = null;
+        }
+    }
+
     function cacheWarmupInit() {
         cacheWarmupRefreshSnapshot();
         cacheWarmupOpenStream();
@@ -2923,6 +2930,7 @@
             cacheWarmupSource.addEventListener('row', cacheWarmupOnRow);
             cacheWarmupSource.addEventListener('complete', cacheWarmupOnComplete);
             cacheWarmupSource.addEventListener('snapshot', function(e) {
+                _cacheWarmupClearPollFallback();
                 cacheWarmupRender(JSON.parse(e.data));
             });
             cacheWarmupSource.onerror = function() {
@@ -2930,7 +2938,27 @@
                     cacheWarmupSource.close();
                     cacheWarmupSource = null;
                 }
-                setTimeout(cacheWarmupRefreshSnapshot, 3000);
+                // Continuous polling fallback. Try to re-open SSE every 30 s in
+                // case the proxy / network heals. Only one polling interval at a
+                // time (prevent stacking on repeated errors).
+                if (!window._cacheWarmupPollInterval) {
+                    window._cacheWarmupPollInterval = setInterval(
+                        cacheWarmupRefreshSnapshot, 3000
+                    );
+                    setTimeout(function tryReconnect() {
+                        if (cacheWarmupSource) return;  // already reconnected
+                        try {
+                            clearInterval(window._cacheWarmupPollInterval);
+                            window._cacheWarmupPollInterval = null;
+                            cacheWarmupOpenStream();  // recursive — onerror retries again
+                        } catch (e) {
+                            window._cacheWarmupPollInterval = setInterval(
+                                cacheWarmupRefreshSnapshot, 3000
+                            );
+                            setTimeout(tryReconnect, 30000);
+                        }
+                    }, 30000);
+                }
             };
         } catch (e) {
             setInterval(cacheWarmupRefreshSnapshot, 3000);
@@ -2966,6 +2994,7 @@
     }
 
     function cacheWarmupOnStart(e) {
+        _cacheWarmupClearPollFallback();
         var data = JSON.parse(e.data);
         var log = document.getElementById('cacheWarmupLog');
         log.textContent = '';
@@ -2976,6 +3005,7 @@
     }
 
     function cacheWarmupOnRow(e) {
+        _cacheWarmupClearPollFallback();
         var rs = JSON.parse(e.data);
         cacheWarmupAppendLog(
             '[' + nowHHMMSS() + '] ' + rs.status.padEnd(7) + ' ' + rs.table_id +
@@ -2987,6 +3017,7 @@
     }
 
     function cacheWarmupOnComplete(e) {
+        _cacheWarmupClearPollFallback();
         var data = JSON.parse(e.data);
         cacheWarmupAppendLog(
             '[' + nowHHMMSS() + '] complete total=' + data.total +
@@ -3010,7 +3041,16 @@
             if (!statusCell) return;
             var color = {fresh: '#10B77F', warming: '#0073D1', pending: '#9CA3AF', error: '#EA580C'}[rs.status] || '#9CA3AF';
             var label = rs.status === 'fresh' ? 'fresh' : rs.status;
-            statusCell.innerHTML = '<span style="display:inline-block;padding:2px 6px;border-radius:3px;font-size:11px;background:' + color + ';color:white;" title="' + (rs.error || '') + '">' + label + '</span>';
+            // Build via DOM API so rs.error escapes safely into the title
+            // attribute (XSS guard — rs.error is server-derived, may contain
+            // quotes / angle brackets).
+            var span = document.createElement('span');
+            span.style.cssText =
+                'display:inline-block;padding:2px 6px;border-radius:3px;' +
+                'font-size:11px;background:' + color + ';color:white;';
+            if (rs.error) span.setAttribute('title', rs.error);
+            span.textContent = label;
+            statusCell.replaceChildren(span);
         });
     }
 

--- a/app/web/templates/admin_tables.html
+++ b/app/web/templates/admin_tables.html
@@ -871,6 +871,25 @@
     <!-- ═══════════════ CONTENT ═══════════════ -->
     <div class="content">
 
+        <section id="cacheWarmupCard" class="card" style="margin-bottom: 20px;">
+            <header class="card-header" style="display: flex; justify-content: space-between; align-items: center;">
+                <h2>Cache freshness</h2>
+                <button class="btn btn-secondary" id="cacheWarmupRunBtn" onclick="cacheWarmupRun()">
+                    Re-warm all
+                </button>
+            </header>
+            <div class="card-body">
+                <div id="cacheWarmupProgress" style="margin-bottom: 8px;">
+                    <span id="cacheWarmupSummary">Loading…</span>
+                </div>
+                <progress id="cacheWarmupBar" max="100" value="0" style="width: 100%; display: none;"></progress>
+                <details style="margin-top: 8px;">
+                    <summary style="cursor: pointer; user-select: none;">Show log</summary>
+                    <pre id="cacheWarmupLog" style="background: #0a0a0a; color: #dcdcdc; font-family: ui-monospace, Menlo, monospace; font-size: 12px; padding: 8px; max-height: 240px; overflow-y: auto; margin-top: 8px; border-radius: 4px;"></pre>
+                </details>
+            </div>
+        </section>
+
         {# Phase D: tab-split scaffold. Per-connector tabs (BigQuery /
            Keboola / Jira) replace the single mixed form. Each tab has its
            own Register button + listing div + (later) form modals. The
@@ -1080,7 +1099,9 @@
                         </div>
 
                         <div class="form-group">
-                            <label class="form-label">How should analysts access this data?</label>
+                            <label class="form-label">How should analysts access this data?
+                                <a href="docs/admin/query-modes.md" target="_blank" title="When to use which mode" style="margin-left: 6px; text-decoration: none; cursor: help;">?</a>
+                            </label>
                             <div style="display:flex; gap:12px; margin-top:6px;">
                                 <label style="flex:1; padding:10px; border:1px solid var(--border); border-radius:8px; cursor:pointer;">
                                     <input type="radio" name="editBqAccessMode" value="live" onchange="onEditBqAccessModeChange()">
@@ -2879,6 +2900,135 @@
     // ── Initialize ──────────────────────────────────────────────
 
     loadRegistry();
+
+    // ── Cache warmup toolbar (issue #155 / #156) ────────────────
+    let cacheWarmupSource = null;
+
+    function cacheWarmupInit() {
+        cacheWarmupRefreshSnapshot();
+        cacheWarmupOpenStream();
+    }
+
+    function cacheWarmupRefreshSnapshot() {
+        fetch('/api/admin/cache-warmup/status')
+            .then(function(r) { return r.json(); })
+            .then(function(state) { cacheWarmupRender(state); })
+            .catch(function() { /* silent */ });
+    }
+
+    function cacheWarmupOpenStream() {
+        try {
+            cacheWarmupSource = new EventSource('/api/admin/cache-warmup/stream');
+            cacheWarmupSource.addEventListener('start', cacheWarmupOnStart);
+            cacheWarmupSource.addEventListener('row', cacheWarmupOnRow);
+            cacheWarmupSource.addEventListener('complete', cacheWarmupOnComplete);
+            cacheWarmupSource.addEventListener('snapshot', function(e) {
+                cacheWarmupRender(JSON.parse(e.data));
+            });
+            cacheWarmupSource.onerror = function() {
+                if (cacheWarmupSource) {
+                    cacheWarmupSource.close();
+                    cacheWarmupSource = null;
+                }
+                setTimeout(cacheWarmupRefreshSnapshot, 3000);
+            };
+        } catch (e) {
+            setInterval(cacheWarmupRefreshSnapshot, 3000);
+        }
+    }
+
+    function cacheWarmupRender(state) {
+        var summary = document.getElementById('cacheWarmupSummary');
+        var bar = document.getElementById('cacheWarmupBar');
+        var btn = document.getElementById('cacheWarmupRunBtn');
+        if (!summary) return;
+
+        if (!state || state.state === 'never_run') {
+            summary.textContent = 'No cache warmup yet — click Re-warm all to start.';
+            bar.style.display = 'none';
+            btn.disabled = false;
+            return;
+        }
+        var inProgress = state.completed_at === null || state.completed_at === undefined;
+        var pct = state.total > 0 ? Math.round((state.completed * 100) / state.total) : 0;
+        summary.textContent = inProgress
+            ? state.completed + ' / ' + state.total + ' fresh — running…'
+            : 'Last run: ' + state.completed + ' ok, ' + state.failed + ' errors';
+        bar.style.display = 'block';
+        bar.value = pct;
+        btn.disabled = inProgress;
+
+        if (state.rows) {
+            for (var tid in state.rows) {
+                cacheWarmupSetRowBadge(tid, state.rows[tid]);
+            }
+        }
+    }
+
+    function cacheWarmupOnStart(e) {
+        var data = JSON.parse(e.data);
+        var log = document.getElementById('cacheWarmupLog');
+        log.textContent = '';
+        cacheWarmupAppendLog(
+            '[' + nowHHMMSS() + '] start  trigger=' + data.trigger + ' total=' + data.total
+        );
+        cacheWarmupRefreshSnapshot();
+    }
+
+    function cacheWarmupOnRow(e) {
+        var rs = JSON.parse(e.data);
+        cacheWarmupAppendLog(
+            '[' + nowHHMMSS() + '] ' + rs.status.padEnd(7) + ' ' + rs.table_id +
+            (rs.duration_ms ? '  (' + (rs.duration_ms / 1000).toFixed(1) + ' s)' : '') +
+            (rs.error ? '  ' + rs.error : '')
+        );
+        cacheWarmupSetRowBadge(rs.table_id, rs);
+        cacheWarmupRefreshSnapshot();
+    }
+
+    function cacheWarmupOnComplete(e) {
+        var data = JSON.parse(e.data);
+        cacheWarmupAppendLog(
+            '[' + nowHHMMSS() + '] complete total=' + data.total +
+            ' ok=' + data.completed + ' fail=' + data.failed
+        );
+        cacheWarmupRefreshSnapshot();
+    }
+
+    function cacheWarmupAppendLog(line) {
+        var log = document.getElementById('cacheWarmupLog');
+        if (!log) return;
+        log.textContent += line + '\n';
+        log.scrollTop = log.scrollHeight;
+    }
+
+    function cacheWarmupSetRowBadge(tableId, rs) {
+        document.querySelectorAll('tr').forEach(function(tr) {
+            var idCell = tr.querySelector('td.col-id');
+            if (!idCell || idCell.textContent.trim() !== tableId) return;
+            var statusCell = tr.querySelector('td.col-status');
+            if (!statusCell) return;
+            var color = {fresh: '#10B77F', warming: '#0073D1', pending: '#9CA3AF', error: '#EA580C'}[rs.status] || '#9CA3AF';
+            var label = rs.status === 'fresh' ? 'fresh' : rs.status;
+            statusCell.innerHTML = '<span style="display:inline-block;padding:2px 6px;border-radius:3px;font-size:11px;background:' + color + ';color:white;" title="' + (rs.error || '') + '">' + label + '</span>';
+        });
+    }
+
+    function nowHHMMSS() {
+        var d = new Date();
+        return d.toTimeString().slice(0, 8);
+    }
+
+    function cacheWarmupRun() {
+        var btn = document.getElementById('cacheWarmupRunBtn');
+        btn.disabled = true;
+        fetch('/api/admin/cache-warmup/run', {method: 'POST'})
+            .then(function(r) { return r.json(); })
+            .then(function() { /* SSE stream picks up the new run */ })
+            .catch(function() { btn.disabled = false; });
+    }
+
+    document.addEventListener('DOMContentLoaded', cacheWarmupInit);
 
     </script>
     {% include "_version_badge.html" %}

--- a/cli/commands/admin.py
+++ b/cli/commands/admin.py
@@ -231,6 +231,15 @@ def register_table(
             f"`agnes admin grant create <group> table {name}` to "
             f"make this visible in `agnes catalog` for non-admin users."
         )
+        # Third hint: BQ-remote rows can fail at first analyst query if the
+        # SA lacks dataViewer/jobUser. Pointing at the smoke command
+        # surfaces the failure at registration time, not 30 minutes later.
+        if query_mode == "remote":
+            typer.echo(
+                f"  Note: this is a remote-query table. Verify the SA can read it:\n"
+                f"    agnes query --remote \"SELECT COUNT(*) FROM {name}\"\n"
+                f"  If it 403s, see docs/admin/query-modes.md → \"BigQuery → IAM\"."
+            )
     elif resp.status_code == 409:
         typer.echo(f"Already exists: {name}")
     else:

--- a/connectors/bigquery/access.py
+++ b/connectors/bigquery/access.py
@@ -610,6 +610,64 @@ class BqAccess:
             yield conn
 
 
+def fetch_bq_columns_full(bq, dataset: str, table: str) -> list[dict] | None:
+    """Single round-trip to INFORMATION_SCHEMA.COLUMNS pulling everything
+    both v2_schema and the metadata provider need.
+
+    Returns one dict per column with the keys ``name``, ``type``,
+    ``nullable``, ``is_partitioning_column``, ``clustering_ordinal_position``.
+    Consumers project the fields they care about.
+
+    Best-effort: returns ``None`` on any failure (sentinel-unconfigured,
+    unsafe identifier, BQ query exception). Does NOT raise. Mirrors the
+    failure posture of `app/api/v2_schema.py:_fetch_bq_table_options`,
+    which it replaces.
+
+    Replaces two BQ jobs (one for column list + one for partition/cluster)
+    with one — half the on-demand cost on each `/api/v2/schema/{id}`
+    cache miss.
+    """
+    from src.identifier_validation import validate_quoted_identifier
+
+    if not bq.projects.data:
+        return None
+
+    if not (validate_quoted_identifier(bq.projects.data, "BQ project")
+            and validate_quoted_identifier(dataset, "BQ dataset")
+            and validate_quoted_identifier(table, "BQ source_table")):
+        return None
+
+    bq_sql = (
+        f"SELECT column_name, data_type, is_nullable, "
+        f"       is_partitioning_column, clustering_ordinal_position "
+        f"FROM `{bq.projects.data}.{dataset}.INFORMATION_SCHEMA.COLUMNS` "
+        f"WHERE table_name = ? ORDER BY ordinal_position"
+    )
+    try:
+        with bq.duckdb_session() as conn:
+            rows = conn.execute(
+                "SELECT * FROM bigquery_query(?, ?, ?)",
+                [bq.projects.billing, bq_sql, table],
+            ).fetchall()
+    except Exception as e:
+        logger.warning(
+            "BQ COLUMNS fetch failed for %s.%s.%s: %s",
+            bq.projects.data, dataset, table, e,
+        )
+        return None
+
+    return [
+        {
+            "name": r[0],
+            "type": r[1],
+            "nullable": (r[2] or "").upper() == "YES",
+            "is_partitioning_column": (r[3] or "").upper() == "YES",
+            "clustering_ordinal_position": r[4],
+        }
+        for r in rows
+    ]
+
+
 @functools.cache
 def get_bq_access() -> BqAccess:
     """Module-level FastAPI Depends target. Resolves projects from config and returns

--- a/connectors/bigquery/access.py
+++ b/connectors/bigquery/access.py
@@ -610,32 +610,25 @@ class BqAccess:
             yield conn
 
 
-def fetch_bq_columns_full(bq, dataset: str, table: str) -> list[dict] | None:
-    """Single round-trip to INFORMATION_SCHEMA.COLUMNS pulling everything
-    both v2_schema and the metadata provider need.
+def _fetch_bq_columns_full_impl(bq, dataset: str, table: str) -> list[dict]:
+    """Implementation that raises on BQ errors. Returns the column list
+    or raises the original BQ exception. Validates identifiers; raises
+    ``ValueError`` on bad shape. Sentinel-config (``bq.projects.data == ""``)
+    surfaces via ``bq.client()`` raising ``BqAccessError(not_configured)``.
 
-    Returns one dict per column with the keys ``name``, ``type``,
-    ``nullable``, ``is_partitioning_column``, ``clustering_ordinal_position``.
-    Consumers project the fields they care about.
-
-    Best-effort: returns ``None`` on any failure (sentinel-unconfigured,
-    unsafe identifier, BQ query exception). Does NOT raise. Mirrors the
-    failure posture of `app/api/v2_schema.py:_fetch_bq_table_options`,
-    which it replaces.
-
-    Replaces two BQ jobs (one for column list + one for partition/cluster)
-    with one — half the on-demand cost on each `/api/v2/schema/{id}`
-    cache miss.
+    Used by callers that need typed exceptions for HTTP status
+    classification — currently only ``app/api/v2_schema._fetch_bq_schema``
+    via ``translate_bq_error``.
     """
     from src.identifier_validation import validate_quoted_identifier
 
     if not bq.projects.data:
-        return None
+        bq.client()  # raises BqAccessError(not_configured)
 
     if not (validate_quoted_identifier(bq.projects.data, "BQ project")
             and validate_quoted_identifier(dataset, "BQ dataset")
             and validate_quoted_identifier(table, "BQ source_table")):
-        return None
+        raise ValueError("unsafe BQ identifier in registry — refusing to query")
 
     bq_sql = (
         f"SELECT column_name, data_type, is_nullable, "
@@ -643,29 +636,39 @@ def fetch_bq_columns_full(bq, dataset: str, table: str) -> list[dict] | None:
         f"FROM `{bq.projects.data}.{dataset}.INFORMATION_SCHEMA.COLUMNS` "
         f"WHERE table_name = ? ORDER BY ordinal_position"
     )
+    with bq.duckdb_session() as conn:
+        rows = conn.execute(
+            "SELECT * FROM bigquery_query(?, ?, ?)",
+            [bq.projects.billing, bq_sql, table],
+        ).fetchall()
+
+    return [
+        {
+            "name": r[0],
+            "type": r[1],
+            "nullable": r[2] == "YES",
+            "is_partitioning_column": r[3] == "YES",
+            "clustering_ordinal_position": r[4],
+        }
+        for r in rows
+    ]
+
+
+def fetch_bq_columns_full(bq, dataset: str, table: str) -> list[dict] | None:
+    """Best-effort wrapper around ``_fetch_bq_columns_full_impl`` — returns
+    ``None`` on any failure (sentinel-unconfigured, unsafe identifier, BQ
+    query exception). Does NOT raise. For callers that don't need typed
+    exceptions (the metadata provider; the partition/cluster path of
+    v2_schema).
+    """
     try:
-        with bq.duckdb_session() as conn:
-            rows = conn.execute(
-                "SELECT * FROM bigquery_query(?, ?, ?)",
-                [bq.projects.billing, bq_sql, table],
-            ).fetchall()
+        return _fetch_bq_columns_full_impl(bq, dataset, table)
     except Exception as e:
         logger.warning(
             "BQ COLUMNS fetch failed for %s.%s.%s: %s",
             bq.projects.data, dataset, table, e,
         )
         return None
-
-    return [
-        {
-            "name": r[0],
-            "type": r[1],
-            "nullable": (r[2] or "").upper() == "YES",
-            "is_partitioning_column": (r[3] or "").upper() == "YES",
-            "clustering_ordinal_position": r[4],
-        }
-        for r in rows
-    ]
 
 
 @functools.cache

--- a/connectors/bigquery/metadata.py
+++ b/connectors/bigquery/metadata.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import logging
 
 from app.api._metadata_models import MetadataRequest, TableMetadata
+from app.instance_config import get_value
 from connectors.bigquery.access import (
     BqAccessError, fetch_bq_columns_full, get_bq_access,
 )
@@ -101,7 +102,6 @@ def _fetch_rows_and_size(bq, req: MetadataRequest) -> dict | None:
 
 def _resolve_bq_location(bq, req: MetadataRequest) -> str | None:
     """instance.yaml.location → REST get_dataset → None."""
-    from app.instance_config import get_value
     cfg_location = (get_value("data_source.bigquery.location") or "").strip()
     if cfg_location:
         return cfg_location
@@ -134,6 +134,9 @@ def _fetch_via_table_storage(bq, req: MetadataRequest, location: str) -> dict | 
     from src.identifier_validation import validate_quoted_identifier
     if not validate_quoted_identifier(location, "BQ region"):
         return None
+    # `req.bucket` / `req.source_table` are pre-validated by the
+    # dispatcher; `location` is validated locally above because it
+    # originates from instance.yaml, not from the registry row.
     try:
         bq_sql = (
             f"SELECT total_rows, "
@@ -163,6 +166,10 @@ def _fetch_via_table_storage(bq, req: MetadataRequest, location: str) -> dict | 
 
 def _fetch_via_legacy_tables(bq, req: MetadataRequest) -> dict | None:
     """Last-resort dataset-scoped __TABLES__ — works without region."""
+    # `req.bucket` and `req.source_table` are pre-validated by
+    # `app/api/v2_catalog._build_metadata_request` via
+    # `validate_quoted_identifier` before MetadataRequest construction;
+    # safe to interpolate into the backtick-quoted path here.
     try:
         bq_sql = (
             f"SELECT row_count, size_bytes "

--- a/connectors/bigquery/metadata.py
+++ b/connectors/bigquery/metadata.py
@@ -102,7 +102,7 @@ def _fetch_rows_and_size(bq, req: MetadataRequest) -> dict | None:
 
 def _resolve_bq_location(bq, req: MetadataRequest) -> str | None:
     """instance.yaml.location → REST get_dataset → None."""
-    cfg_location = (get_value("data_source.bigquery.location") or "").strip()
+    cfg_location = (get_value("data_source", "bigquery", "location") or "").strip()
     if cfg_location:
         return cfg_location
     try:

--- a/connectors/bigquery/metadata.py
+++ b/connectors/bigquery/metadata.py
@@ -1,0 +1,13 @@
+"""BigQuery metadata provider — populates `TableMetadata` for a remote
+BQ-backed registry row.
+
+Stub: returns None pending the full implementation in Task 7.
+"""
+
+from __future__ import annotations
+
+from app.api._metadata_models import MetadataRequest, TableMetadata
+
+
+def fetch(req: MetadataRequest) -> TableMetadata | None:
+    return None

--- a/connectors/bigquery/metadata.py
+++ b/connectors/bigquery/metadata.py
@@ -1,13 +1,189 @@
 """BigQuery metadata provider — populates `TableMetadata` for a remote
 BQ-backed registry row.
 
-Stub: returns None pending the full implementation in Task 7.
+Two queries (different INFORMATION_SCHEMA scopes — TABLE_STORAGE is
+region-scoped, COLUMNS is dataset-scoped, can't be combined):
+
+  1. INFORMATION_SCHEMA.TABLE_STORAGE — total_rows + active+long_term
+     bytes. Region-portable per Google's docs; only valid via
+     `<project>.region-<region>.INFORMATION_SCHEMA.TABLE_STORAGE`
+     (verified live 2026-05-07; dataset-scoped TABLE_STORAGE doesn't
+     exist).
+
+  2. INFORMATION_SCHEMA.COLUMNS — partition_by + clustered_by. Reuses
+     the consolidated `fetch_bq_columns_full` helper that v2_schema also
+     calls; one shared shape, one round-trip.
+
+Region resolution chain: `instance.yaml.data_source.bigquery.location` →
+`bq.client().get_dataset(...)` → fall back to legacy `__TABLES__`
+(dataset-scoped, no region required).
+
+VIEW handling: TABLE_STORAGE returns no rows for entries whose
+`table_type='VIEW'`; the legacy `__TABLES__` fallback also doesn't list
+views. The provider returns `TableMetadata(rows=None, size_bytes=None,
+partition_by=<from COLUMNS>, clustered_by=<from COLUMNS>)` — analyst
+Claude reads `null` size and applies the existing CLAUDE.md guidance.
+
+`size_bytes` reports `active_logical_bytes + long_term_logical_bytes`
+(a full BQ scan reads both — reporting only active undercounts aged
+partitioned tables).
 """
 
 from __future__ import annotations
 
+import logging
+
 from app.api._metadata_models import MetadataRequest, TableMetadata
+from connectors.bigquery.access import (
+    BqAccessError, fetch_bq_columns_full, get_bq_access,
+)
+
+logger = logging.getLogger(__name__)
 
 
 def fetch(req: MetadataRequest) -> TableMetadata | None:
-    return None
+    try:
+        bq = get_bq_access()
+    except BqAccessError:
+        return None
+
+    if not bq.projects.data:
+        return None
+
+    rows_size = _fetch_rows_and_size(bq, req)
+    columns = fetch_bq_columns_full(bq, req.bucket, req.source_table)
+    part_clust = _derive_partition_cluster(columns) if columns else None
+
+    if rows_size is None and part_clust is None:
+        return None
+
+    return TableMetadata(
+        rows=(rows_size or {}).get("rows"),
+        size_bytes=(rows_size or {}).get("size_bytes"),
+        partition_by=(part_clust or {}).get("partition_by"),
+        clustered_by=(part_clust or {}).get("clustered_by"),
+    )
+
+
+def _derive_partition_cluster(columns: list[dict]) -> dict | None:
+    """Mirror v2_schema._fetch_bq_table_options derivations from the
+    shared columns-full result."""
+    if not columns:
+        return None
+    partition_by = next(
+        (c["name"] for c in columns if c["is_partitioning_column"]),
+        None,
+    )
+    clustered = sorted(
+        (c for c in columns if c["clustering_ordinal_position"] is not None),
+        key=lambda c: c["clustering_ordinal_position"],
+    )
+    clustered_by = [c["name"] for c in clustered]
+    return {"partition_by": partition_by, "clustered_by": clustered_by}
+
+
+def _fetch_rows_and_size(bq, req: MetadataRequest) -> dict | None:
+    """Resolve rows + size_bytes via TABLE_STORAGE → __TABLES__ fallthrough.
+
+    See module docstring + spec Open Question §1 for view-path nuance.
+    """
+    location = _resolve_bq_location(bq, req)
+    if location:
+        result = _fetch_via_table_storage(bq, req, location)
+        if result is not None:
+            return result
+        # TABLE_STORAGE returned None despite having a location: could
+        # be a typo in `data_source.bigquery.location`, a multi-region
+        # dataset operator misclassified, the table is a VIEW, or a
+        # transient permission gap. Try __TABLES__ before giving up.
+    return _fetch_via_legacy_tables(bq, req)
+
+
+def _resolve_bq_location(bq, req: MetadataRequest) -> str | None:
+    """instance.yaml.location → REST get_dataset → None."""
+    from app.instance_config import get_value
+    cfg_location = (get_value("data_source.bigquery.location") or "").strip()
+    if cfg_location:
+        return cfg_location
+    try:
+        ds = bq.client().get_dataset(
+            f"{bq.projects.data}.{req.bucket}"
+        )
+        return ds.location
+    except Exception as e:
+        logger.warning(
+            "BQ dataset.get failed for %s.%s — falling back to __TABLES__: %s",
+            bq.projects.data, req.bucket, e,
+        )
+        return None
+
+
+def _fetch_via_table_storage(bq, req: MetadataRequest, location: str) -> dict | None:
+    """Region-scoped INFORMATION_SCHEMA.TABLE_STORAGE — preferred path.
+
+    `validate_quoted_identifier` accepts `us-central1`, `europe-west1`,
+    `EU`, `us` etc. (regex `^[a-zA-Z0-9_][a-zA-Z0-9_.\\-]{0,127}$`).
+    Refuses anything that could break out of the backtick-quoted path.
+
+    Returns None on no-row (table is a VIEW, or different region than
+    configured) — caller decides whether to fall through.
+
+    `size_bytes` is `active + long_term` logical bytes (a full BQ scan
+    reads both; reporting only active undercounts aged partitioned tables).
+    """
+    from src.identifier_validation import validate_quoted_identifier
+    if not validate_quoted_identifier(location, "BQ region"):
+        return None
+    try:
+        bq_sql = (
+            f"SELECT total_rows, "
+            f"IFNULL(active_logical_bytes, 0) + IFNULL(long_term_logical_bytes, 0) "
+            f"FROM `{bq.projects.data}.region-{location}.INFORMATION_SCHEMA.TABLE_STORAGE` "
+            f"WHERE table_schema = ? AND table_name = ?"
+        )
+        with bq.duckdb_session() as conn:
+            row = conn.execute(
+                "SELECT * FROM bigquery_query(?, ?, ?, ?)",
+                [bq.projects.billing, bq_sql, req.bucket, req.source_table],
+            ).fetchone()
+    except Exception as e:
+        logger.warning(
+            "BQ TABLE_STORAGE fetch failed for %s.%s.%s: %s",
+            bq.projects.data, req.bucket, req.source_table, e,
+        )
+        return None
+    if row is None:
+        return None  # VIEW or wrong region
+    rows_, size_bytes = row
+    return {
+        "rows": int(rows_) if rows_ is not None else None,
+        "size_bytes": int(size_bytes) if size_bytes is not None else None,
+    }
+
+
+def _fetch_via_legacy_tables(bq, req: MetadataRequest) -> dict | None:
+    """Last-resort dataset-scoped __TABLES__ — works without region."""
+    try:
+        bq_sql = (
+            f"SELECT row_count, size_bytes "
+            f"FROM `{bq.projects.data}.{req.bucket}.__TABLES__` "
+            f"WHERE table_id = ?"
+        )
+        with bq.duckdb_session() as conn:
+            row = conn.execute(
+                "SELECT * FROM bigquery_query(?, ?, ?)",
+                [bq.projects.billing, bq_sql, req.source_table],
+            ).fetchone()
+    except Exception as e:
+        logger.warning(
+            "BQ __TABLES__ fetch failed for %s.%s.%s: %s",
+            bq.projects.data, req.bucket, req.source_table, e,
+        )
+        return None
+    if row is None:
+        return None
+    rows_, size_bytes = row
+    return {
+        "rows": int(rows_) if rows_ is not None else None,
+        "size_bytes": int(size_bytes) if size_bytes is not None else None,
+    }

--- a/connectors/keboola/metadata.py
+++ b/connectors/keboola/metadata.py
@@ -1,0 +1,13 @@
+"""Keboola metadata provider — populates `TableMetadata` for a Keboola
+registry row via the Storage API.
+
+Stub: returns None pending the full implementation in Task 6.
+"""
+
+from __future__ import annotations
+
+from app.api._metadata_models import MetadataRequest, TableMetadata
+
+
+def fetch(req: MetadataRequest) -> TableMetadata | None:
+    return None

--- a/connectors/keboola/metadata.py
+++ b/connectors/keboola/metadata.py
@@ -1,13 +1,52 @@
 """Keboola metadata provider — populates `TableMetadata` for a Keboola
 registry row via the Storage API.
 
-Stub: returns None pending the full implementation in Task 6.
+Reuses `KeboolaClient(token=None, url=None)` to inherit the existing
+env-var fallback path (`KEBOOLA_STACK_URL` + `KEBOOLA_STORAGE_TOKEN`),
+which is the same hierarchy `connectors/keboola/extractor.py` and
+`connectors/keboola/client.py` already use. **Does NOT introduce a third
+token-resolution helper.**
 """
 
 from __future__ import annotations
 
+import logging
+import os
+
 from app.api._metadata_models import MetadataRequest, TableMetadata
+from connectors.keboola.storage_api import (
+    KeboolaStorageClient,
+    StorageApiError,
+)
+
+logger = logging.getLogger(__name__)
 
 
 def fetch(req: MetadataRequest) -> TableMetadata | None:
-    return None
+    """Return Keboola Storage API metadata for the given table, or None.
+
+    Keboola has no BigQuery-style partition/cluster concept; primaryKey is
+    conceptually different (uniqueness, not physical layout), so
+    `partition_by` and `clustered_by` are left None.
+    """
+    # Read credentials the same way KeboolaClient does — avoids constructing
+    # a KeboolaClient which raises ValueError when the token is absent.
+    url = os.environ.get("KEBOOLA_STACK_URL", "")
+    token = os.environ.get("KEBOOLA_STORAGE_TOKEN", "")
+    if not url or not token:
+        return None  # not configured — same posture as BQ sentinel
+
+    table_id = f"{req.bucket}.{req.source_table}"
+    try:
+        storage = KeboolaStorageClient(url=url, token=token)
+        info = storage.get_table_info(table_id)
+    except (StorageApiError, ValueError) as e:
+        logger.warning("Keboola metadata fetch failed for %s: %s", table_id, e)
+        return None
+
+    return TableMetadata(
+        rows=info.get("rowsCount"),
+        size_bytes=info.get("dataSizeBytes"),
+        partition_by=None,
+        clustered_by=None,
+    )

--- a/connectors/keboola/storage_api.py
+++ b/connectors/keboola/storage_api.py
@@ -285,6 +285,16 @@ class KeboolaStorageClient:
         via `wait_for_job` to find the file id when status='success'."""
         return self._post(f"/tables/{table_id}/export-async", data=params)
 
+    def get_table_info(self, table_id: str) -> dict:
+        """GET /v2/storage/tables/{table_id} — full table metadata.
+
+        Storage API guarantees `rowsCount` + `dataSizeBytes` on success.
+        Other fields (`columns`, `primaryKey`, ...) are present but not
+        consumed by the metadata provider today. Raises `StorageApiError`
+        on 4xx/5xx — caller decides whether to soften to `None`.
+        """
+        return self._get(f"/tables/{table_id}")
+
     def wait_for_job(
         self,
         job_id: int,

--- a/docs/admin/query-modes.md
+++ b/docs/admin/query-modes.md
@@ -1,0 +1,116 @@
+# Query Modes — when to register a table as `local`, `remote`, or `materialized`
+
+Source-agnostic guide to the three `query_mode` values Agnes supports. Pick the right mode at registration time and the analyst-side experience is fast, cost-aware, and predictable. Pick wrong and you'll either burn BQ scan budget on every query or spend hours waiting on syncs that didn't need to happen.
+
+## TL;DR — decision tree
+
+```
+Is the table small (< 1 GB) and updated daily-or-slower?
+  └─ YES → query_mode: local       (sync to laptop, query offline)
+
+Is the table the result of an aggregate SQL the operator controls?
+  └─ YES → query_mode: materialized  (server runs SQL → parquet, distributed)
+
+Otherwise:
+  └─ query_mode: remote   (data stays in upstream; analyst queries on demand)
+```
+
+## Three modes side-by-side
+
+| Aspect | `local` | `materialized` | `remote` |
+|---|---|---|---|
+| Where the data lives | Analyst laptop (parquet) | Agnes server filesystem (parquet) | Upstream (BigQuery, Keboola, …) |
+| Who runs the query | Analyst's local DuckDB | Analyst's local DuckDB | Upstream engine via DuckDB extension |
+| Cost model | Free after sync | Free after each sync | Per-query scan cost on the analyst's first hit |
+| Freshness | As fresh as last sync | As fresh as last scheduled run | Live |
+| Scan limits | None (laptop disk) | None (server disk) | `bq_max_scan_bytes` cost gate (default 5 GiB) |
+| Best for | Stable reference data, daily-updated facts | Aggregates, daily snapshots | Big tables, live data, residency-restricted |
+
+## Per-source-type reference
+
+### BigQuery — `query_mode: remote`
+
+The most common use case for `remote`. Data stays in BQ; analysts query on demand via the Agnes server's service account.
+
+**IAM:** the server's SA must have:
+- `roles/bigquery.dataViewer` on the dataset (read access)
+- `roles/bigquery.jobUser` on the *billing* project (run jobs)
+
+If `data_source.bigquery.billing_project == data_source.bigquery.project`, set the SA's `serviceusage.services.use` permission too — the BQ extension can otherwise 403 USER_PROJECT_DENIED on the first query. The instance health check (`agnes diagnose`) surfaces this as an `info`-tier entry on `bq_config`.
+
+**Register via UI:** `/admin/tables` → "Add table" → Source type `bigquery` → Mode `remote` → fill `dataset` (your BQ dataset name) + `source_table` (the BQ table id within that dataset).
+
+**Register via CLI:**
+
+```bash
+agnes admin register-table sales_2024 \
+    --source-type bigquery \
+    --bucket dwh_base \
+    --source-table sales_2024 \
+    --query-mode remote
+```
+
+After registration, smoke-test the SA's access:
+
+```bash
+agnes query --remote "SELECT COUNT(*) FROM sales_2024"
+```
+
+A 403 here means the SA is missing `dataViewer` or `jobUser`; fix in IAM and re-test.
+
+**Cost guardrail:** `bq_max_scan_bytes` (default 5 GiB) refuses queries whose pre-execution scan estimate exceeds the cap. Configurable in `/admin/server-config`. When an analyst hits the cap, the response includes a hint to use `agnes snapshot create --where '<predicate>'` to materialise a scoped subset locally.
+
+### BigQuery — `query_mode: materialized`
+
+The server runs a scheduled SQL aggregate against BigQuery and writes the result to a parquet on the Agnes filesystem. Analysts get the parquet via `agnes pull` like any other local table.
+
+**Register via CLI:**
+
+```bash
+agnes admin register-table monthly_kpis \
+    --source-type bigquery \
+    --bucket dwh_base \
+    --source-table monthly_kpis \
+    --query-mode materialized \
+    --query @path/to/monthly_kpis.sql \
+    --sync-schedule "daily 03:00"
+```
+
+**Cost guardrail:** `data_source.bigquery.max_bytes_per_materialize` (default 10 GiB; set `0` to disable) refuses materialise runs whose query plan exceeds the cap. Catches a typo'd `WHERE` clause that would otherwise scan a year of data.
+
+### Keboola — `query_mode: local` (the production path)
+
+The Agnes server's Keboola DuckDB extension downloads the table to a parquet on the server filesystem; `agnes pull` distributes it to analyst laptops.
+
+**Setup:** `instance.yaml.data_source.type: keboola` + Storage API token via `KEBOOLA_STORAGE_TOKEN` env var (or whatever `instance.yaml.token_env` points at).
+
+**Register via CLI:**
+
+```bash
+agnes admin register-table users \
+    --source-type keboola \
+    --bucket in.c-crm \
+    --source-table users \
+    --query-mode local
+```
+
+**`query_mode: remote` for Keboola** is architecturally supported via the `_remote_attach` mechanism (the orchestrator can ATTACH the Keboola DuckDB extension on demand the same way it does for BQ), but **not in active deployment use today**. If you have an analyst workflow against a Keboola table that's too big to sync, file an issue — the architecture is in place but the registration UX hasn't been polished.
+
+### Jira — `query_mode: local` only
+
+Event-driven: webhooks update parquets incrementally. No `remote` or `materialized` mode for Jira today.
+
+## Worked examples
+
+**1. Big BigQuery fact table you query weekly:** `query_mode: remote`. SA needs `dataViewer` + `jobUser`. Analyst uses `agnes query --remote` for one-off aggregates and `agnes snapshot create` for cross-week joins.
+
+**2. Daily Keboola dimension table:** `query_mode: local`. Synced once a day by the scheduler; analyst's `agnes pull` picks it up.
+
+**3. Monthly KPI aggregate from a BQ datawarehouse:** `query_mode: materialized` + `--sync-schedule "0 3 1 * *"` (3:00 on the 1st of each month). The server runs your aggregate SQL once a month; analysts get a parquet of the result.
+
+## See also
+
+- `docs/RBAC.md` — granting analysts access to a registered table.
+- `config/instance.yaml.example` — the `data_source` config block.
+- `agnes catalog --json` — inspect a registered table's mode + size hints.
+- `agnes diagnose` — surface `bq_config` IAM issues and other health entries.

--- a/docs/superpowers/plans/2026-05-07-source-agnostic-table-metadata.md
+++ b/docs/superpowers/plans/2026-05-07-source-agnostic-table-metadata.md
@@ -1,0 +1,3335 @@
+# Source-Agnostic Table Metadata Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enrich `/api/v2/catalog` with cost-relevant per-table metadata (row count, size, partition, cluster) for `query_mode='remote'` rows via source-agnostic providers; add unified cache invalidation across all four catalog/schema/sample/metadata caches with single-row re-warm; halve BQ jobs on `/api/v2/schema` cache miss by consolidating two INFORMATION_SCHEMA.COLUMNS queries into one; auto-warm caches at server startup; surface progress via SSE on `/admin/tables`. Closes #155 + #156.
+
+**Architecture:** Per-source `metadata.py` module exposing `fetch(MetadataRequest) -> TableMetadata | None`; dispatched from `app/api/v2_catalog.py:_size_hint_for_row` after identifier validation; results cached 15 min keyed by `table_id`. Cache invalidation owned by `v2_catalog.invalidate_for_table` flushing four TTLCaches and scheduling a single-row re-warm. Warmup runs as a FastAPI startup background task with bounded concurrency (default 4) and exposes a JSON status endpoint + SSE stream consumed by a new toolbar block on `/admin/tables`.
+
+**Tech Stack:** Python 3.11+, FastAPI, DuckDB (with BigQuery extension), pytest, sse-starlette, vanilla JS (no framework) in admin templates.
+
+**Source spec:** `docs/superpowers/specs/2026-05-07-source-agnostic-table-metadata-spec.md` (HEAD `a6a660bc`).
+
+**Branch:** `zs/issue-155-156-source-agnostic-metadata` (worktree at `/tmp/agnes-metadata`).
+
+---
+
+## File map
+
+**New:**
+- `app/api/_metadata_models.py` — dataclasses `MetadataRequest`, `TableMetadata`
+- `connectors/bigquery/metadata.py` — BQ provider
+- `connectors/keboola/metadata.py` — Keboola provider
+- `app/api/cache_warmup.py` — warmup state + background task + endpoints
+- `docs/admin/query-modes.md` — admin doc page
+- `tests/test_connectors_bigquery_metadata.py`
+- `tests/test_connectors_keboola_metadata.py`
+- `tests/test_v2_catalog_remote_metadata.py`
+- `tests/test_v2_catalog_invalidation.py`
+- `tests/test_cache_warmup.py`
+- `tests/test_admin_tables_warmup_ui.py`
+- `tests/test_v2_schema_columns_consolidation.py`
+
+**Modified:**
+- `app/api/v2_catalog.py` — provider dispatch + 15-min metadata cache + new response fields + `invalidate_for_table`
+- `app/api/v2_schema.py` — split RBAC/cache from BQ work; rewire to shared `fetch_bq_columns_full`
+- `connectors/bigquery/access.py` — append `fetch_bq_columns_full` helper
+- `connectors/keboola/storage_api.py` — append `get_table_info` thin wrapper
+- `app/api/admin.py` — wire `invalidate_for_table` into register/update/unregister
+- `app/main.py` — register `warm_catalog_caches` startup event
+- `cli/commands/admin.py` — third post-register hint for `query_mode=remote`
+- `app/web/templates/admin_tables.html` — cache toolbar `<section>`, per-row `col-status` badge, EventSource JS, `?` doc link on query_mode field
+- `pyproject.toml` — version bump to 0.46.0; add `sse-starlette` to dependencies if not present
+- `CHANGELOG.md` — `## [0.46.0]` section
+
+---
+
+## Task 1: Shared dataclass models
+
+**Files:**
+- Create: `app/api/_metadata_models.py`
+- Test: `tests/test_metadata_models.py`
+
+- [ ] **Step 1.1: Write failing test**
+
+Create `tests/test_metadata_models.py`:
+
+```python
+"""Sanity tests for the shared metadata dataclasses."""
+
+from app.api._metadata_models import MetadataRequest, TableMetadata
+
+
+def test_metadata_request_constructs():
+    req = MetadataRequest(
+        table_id="orders", bucket="dwh_base", source_table="orders_2024",
+    )
+    assert req.table_id == "orders"
+    assert req.bucket == "dwh_base"
+    assert req.source_table == "orders_2024"
+
+
+def test_metadata_request_is_frozen():
+    """Frozen so cache keys derived from a request are stable."""
+    req = MetadataRequest(table_id="x", bucket="b", source_table="t")
+    import dataclasses
+    try:
+        req.bucket = "other"
+    except dataclasses.FrozenInstanceError:
+        return
+    raise AssertionError("MetadataRequest should be frozen")
+
+
+def test_table_metadata_all_fields_optional():
+    tm = TableMetadata()
+    assert tm.rows is None
+    assert tm.size_bytes is None
+    assert tm.partition_by is None
+    assert tm.clustered_by is None
+
+
+def test_table_metadata_partial_population():
+    tm = TableMetadata(rows=100, size_bytes=2048)
+    assert tm.rows == 100
+    assert tm.size_bytes == 2048
+    assert tm.partition_by is None
+    assert tm.clustered_by is None
+```
+
+- [ ] **Step 1.2: Run test to verify it fails**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_metadata_models.py -v
+```
+Expected: FAIL with `ModuleNotFoundError: No module named 'app.api._metadata_models'`.
+
+- [ ] **Step 1.3: Implement the module**
+
+Create `app/api/_metadata_models.py`:
+
+```python
+"""Shared data shapes for source-agnostic table-metadata providers.
+
+Lives under `app/api/` because the primary consumer is
+`app/api/v2_catalog.py`. Connector-side providers in `connectors/<source>/`
+import upward into this module — the inverse layering would force
+`v2_catalog.py` to depend on `connectors/__init__.py`, which is the
+wrong direction.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MetadataRequest:
+    """Narrow input passed to a metadata provider's `fetch()`.
+
+    `bucket` and `source_table` are pre-validated by the dispatcher
+    (`validate_quoted_identifier`) before construction, so the provider
+    can interpolate them into SQL/URL paths without re-checking. Frozen
+    so the (provider, request)-keyed cache lookup is stable.
+    """
+    table_id: str
+    bucket: str
+    source_table: str
+
+
+@dataclass
+class TableMetadata:
+    """Source-agnostic metadata bundle. Every field optional — providers
+    fill what they can cheaply get; callers tolerate `None`. Adding a new
+    field here is a non-breaking change: existing CLI consumers don't
+    even render `rough_size_hint` (verified `grep -rn rough_size_hint cli/`
+    is empty), let alone the new fields.
+    """
+    rows: int | None = None
+    size_bytes: int | None = None
+    partition_by: str | None = None
+    clustered_by: list[str] | None = None
+```
+
+- [ ] **Step 1.4: Run test to verify it passes**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_metadata_models.py -v
+```
+Expected: 4 passed.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+cd /tmp/agnes-metadata
+git add app/api/_metadata_models.py tests/test_metadata_models.py
+git commit -m "feat(metadata): MetadataRequest + TableMetadata dataclasses"
+```
+
+---
+
+## Task 2: KeboolaStorageClient.get_table_info wrapper
+
+**Files:**
+- Modify: `connectors/keboola/storage_api.py` (append method)
+- Test: `tests/test_keboola_storage_api.py` (append test)
+
+- [ ] **Step 2.1: Write failing test**
+
+Append to `tests/test_keboola_storage_api.py`:
+
+```python
+class TestGetTableInfo:
+    """`get_table_info` is a thin wrapper around the existing _get path
+    so the metadata provider doesn't have to bleed `_get` out of the
+    module (#155)."""
+
+    def test_calls_storage_api_with_table_id(self, monkeypatch):
+        from connectors.keboola.storage_api import KeboolaStorageClient
+
+        captured = {}
+
+        def fake_get(self, path, **kwargs):
+            captured["path"] = path
+            return {"rowsCount": 100, "dataSizeBytes": 4096}
+
+        monkeypatch.setattr(KeboolaStorageClient, "_get", fake_get)
+
+        client = KeboolaStorageClient(
+            url="https://connection.keboola.com", token="tok"
+        )
+        info = client.get_table_info("in.c-orders.events")
+        assert captured["path"] == "/tables/in.c-orders.events"
+        assert info["rowsCount"] == 100
+        assert info["dataSizeBytes"] == 4096
+
+    def test_propagates_storage_api_error(self, monkeypatch):
+        from connectors.keboola.storage_api import (
+            KeboolaStorageClient, StorageApiError,
+        )
+
+        def fake_get(self, path, **kwargs):
+            raise StorageApiError("404 not found", status=404, body={})
+
+        monkeypatch.setattr(KeboolaStorageClient, "_get", fake_get)
+
+        client = KeboolaStorageClient(url="https://x", token="tok")
+        import pytest
+        with pytest.raises(StorageApiError):
+            client.get_table_info("missing.table")
+```
+
+- [ ] **Step 2.2: Run test to verify it fails**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_keboola_storage_api.py::TestGetTableInfo -v
+```
+Expected: FAIL with `AttributeError: 'KeboolaStorageClient' object has no attribute 'get_table_info'`.
+
+- [ ] **Step 2.3: Implement the wrapper**
+
+Find the line in `connectors/keboola/storage_api.py` immediately after the `export_table_async` method (around line 286) and append the new method to the `KeboolaStorageClient` class:
+
+```python
+    def get_table_info(self, table_id: str) -> dict:
+        """GET /v2/storage/tables/{table_id} — full table metadata.
+
+        Storage API guarantees `rowsCount` + `dataSizeBytes` on success.
+        Other fields (`columns`, `primaryKey`, ...) are present but not
+        consumed by the metadata provider today. Raises `StorageApiError`
+        on 4xx/5xx — caller decides whether to soften to `None`.
+        """
+        return self._get(f"/tables/{table_id}")
+```
+
+- [ ] **Step 2.4: Run test to verify it passes**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_keboola_storage_api.py::TestGetTableInfo -v
+```
+Expected: 2 passed.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+cd /tmp/agnes-metadata
+git add connectors/keboola/storage_api.py tests/test_keboola_storage_api.py
+git commit -m "feat(keboola): KeboolaStorageClient.get_table_info thin wrapper"
+```
+
+---
+
+## Task 3: Combined `fetch_bq_columns_full` helper + v2_schema rewire
+
+This task halves the BQ job count on `/api/v2/schema/{id}` cache miss (2 jobs → 1) by collapsing the duplicate `INFORMATION_SCHEMA.COLUMNS` queries.
+
+**Files:**
+- Modify: `connectors/bigquery/access.py` (append helper)
+- Modify: `app/api/v2_schema.py` (rewire `_fetch_bq_schema` and `_fetch_bq_table_options`)
+- Test: `tests/test_v2_schema_columns_consolidation.py` (new)
+
+- [ ] **Step 3.1: Write failing test for the consolidation**
+
+Create `tests/test_v2_schema_columns_consolidation.py`:
+
+```python
+"""Asserts that /api/v2/schema/{id} for a BQ row makes exactly ONE
+bigquery_query() call on cache miss, down from two pre-#155.
+
+Counts via a side-effect tracker on the mocked DuckDB session.
+"""
+
+from unittest.mock import MagicMock, patch
+import pytest
+
+
+def _mock_duckdb_session_returning(rows):
+    """Build a context-manager mock that returns `rows` on .fetchall().
+
+    Exposes `call_count` on the returned mock for assertion.
+    """
+    session = MagicMock()
+    session.execute.return_value.fetchall.return_value = rows
+    cm = MagicMock()
+    cm.__enter__.return_value = session
+    cm.__exit__.return_value = False
+    return cm, session
+
+
+def test_fetch_bq_columns_full_is_single_query():
+    """The new shared helper makes exactly ONE call to bigquery_query."""
+    from connectors.bigquery.access import fetch_bq_columns_full
+
+    bq = MagicMock()
+    bq.projects.data = "data-proj"
+    bq.projects.billing = "billing-proj"
+    cm, session = _mock_duckdb_session_returning([
+        ("event_date", "DATE", "NO", "YES", None),
+        ("country", "STRING", "YES", "NO", 1),
+        ("user_id", "STRING", "NO", "NO", None),
+    ])
+    bq.duckdb_session.return_value = cm
+
+    rows = fetch_bq_columns_full(bq, "dwh_base", "events")
+    assert len(rows) == 3
+    # Exactly one bigquery_query() call — no second round-trip.
+    assert session.execute.call_count == 1
+    first_call = session.execute.call_args_list[0]
+    # Outer wrapper SQL is bigquery_query(?, ?, ?)
+    assert "bigquery_query" in first_call.args[0]
+    # Inner BQ SQL pulls all five columns we need at once.
+    inner_sql = first_call.args[1][1]
+    assert "column_name" in inner_sql
+    assert "data_type" in inner_sql
+    assert "is_nullable" in inner_sql
+    assert "is_partitioning_column" in inner_sql
+    assert "clustering_ordinal_position" in inner_sql
+
+
+def test_fetch_bq_columns_full_returns_dicts():
+    """Each row is a dict with the documented keys."""
+    from connectors.bigquery.access import fetch_bq_columns_full
+
+    bq = MagicMock()
+    bq.projects.data = "data-proj"
+    bq.projects.billing = "billing-proj"
+    cm, _ = _mock_duckdb_session_returning([
+        ("event_date", "DATE", "NO", "YES", None),
+    ])
+    bq.duckdb_session.return_value = cm
+
+    rows = fetch_bq_columns_full(bq, "dwh_base", "events")
+    assert rows == [{
+        "name": "event_date",
+        "type": "DATE",
+        "nullable": False,
+        "is_partitioning_column": True,
+        "clustering_ordinal_position": None,
+    }]
+
+
+def test_fetch_bq_columns_full_returns_none_when_unconfigured():
+    """Sentinel BqAccess (data project empty) → return None, no query."""
+    from connectors.bigquery.access import fetch_bq_columns_full
+
+    bq = MagicMock()
+    bq.projects.data = ""  # sentinel
+    rows = fetch_bq_columns_full(bq, "dwh_base", "events")
+    assert rows is None
+    bq.duckdb_session.assert_not_called()
+
+
+def test_fetch_bq_columns_full_returns_none_on_unsafe_identifier():
+    """Refuses to interpolate identifiers that fail validation."""
+    from connectors.bigquery.access import fetch_bq_columns_full
+
+    bq = MagicMock()
+    bq.projects.data = "data-proj"
+    rows = fetch_bq_columns_full(bq, "evil`; DROP--", "events")
+    assert rows is None
+    bq.duckdb_session.assert_not_called()
+
+
+def test_fetch_bq_columns_full_returns_none_on_query_error():
+    """BQ failure → log + None; never raises."""
+    from connectors.bigquery.access import fetch_bq_columns_full
+
+    bq = MagicMock()
+    bq.projects.data = "data-proj"
+    bq.projects.billing = "billing-proj"
+    cm = MagicMock()
+    cm.__enter__.return_value.execute.side_effect = RuntimeError("BQ down")
+    cm.__exit__.return_value = False
+    bq.duckdb_session.return_value = cm
+
+    rows = fetch_bq_columns_full(bq, "dwh_base", "events")
+    assert rows is None
+```
+
+- [ ] **Step 3.2: Run test to verify it fails**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_v2_schema_columns_consolidation.py -v
+```
+Expected: FAIL with `ImportError: cannot import name 'fetch_bq_columns_full' from 'connectors.bigquery.access'`.
+
+- [ ] **Step 3.3: Implement `fetch_bq_columns_full`**
+
+Append to `connectors/bigquery/access.py` (location: end of file or just before any module-level `_BILLING_PROJECT_RE` block — pick whichever your editor lands on):
+
+```python
+def fetch_bq_columns_full(bq, dataset: str, table: str) -> list[dict] | None:
+    """Single round-trip to INFORMATION_SCHEMA.COLUMNS pulling everything
+    both v2_schema and the metadata provider need.
+
+    Returns one dict per column with the keys ``name``, ``type``,
+    ``nullable``, ``is_partitioning_column``, ``clustering_ordinal_position``.
+    Consumers project the fields they care about.
+
+    Best-effort: returns ``None`` on any failure (sentinel-unconfigured,
+    unsafe identifier, BQ query exception). Does NOT raise. Mirrors the
+    failure posture of `app/api/v2_schema.py:_fetch_bq_table_options`,
+    which it replaces.
+
+    Replaces two BQ jobs (one for column list + one for partition/cluster)
+    with one — half the on-demand cost on each `/api/v2/schema/{id}`
+    cache miss (issue #155 / spec).
+    """
+    from src.identifier_validation import validate_quoted_identifier
+
+    if not bq.projects.data:
+        return None
+
+    if not (validate_quoted_identifier(bq.projects.data, "BQ project")
+            and validate_quoted_identifier(dataset, "BQ dataset")
+            and validate_quoted_identifier(table, "BQ source_table")):
+        return None
+
+    bq_sql = (
+        f"SELECT column_name, data_type, is_nullable, "
+        f"       is_partitioning_column, clustering_ordinal_position "
+        f"FROM `{bq.projects.data}.{dataset}.INFORMATION_SCHEMA.COLUMNS` "
+        f"WHERE table_name = ? ORDER BY ordinal_position"
+    )
+    try:
+        with bq.duckdb_session() as conn:
+            rows = conn.execute(
+                "SELECT * FROM bigquery_query(?, ?, ?)",
+                [bq.projects.billing, bq_sql, table],
+            ).fetchall()
+    except Exception as e:
+        logger.warning(
+            "BQ COLUMNS fetch failed for %s.%s.%s: %s",
+            bq.projects.data, dataset, table, e,
+        )
+        return None
+
+    return [
+        {
+            "name": r[0],
+            "type": r[1],
+            "nullable": (r[2] or "").upper() == "YES",
+            "is_partitioning_column": (r[3] or "").upper() == "YES",
+            "clustering_ordinal_position": r[4],
+        }
+        for r in rows
+    ]
+```
+
+If `logger` isn't already imported at the top of `connectors/bigquery/access.py`, add `import logging; logger = logging.getLogger(__name__)` near the top — but check first; the file likely already has it.
+
+- [ ] **Step 3.4: Run consolidation tests to verify they pass**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_v2_schema_columns_consolidation.py -v
+```
+Expected: 5 passed.
+
+- [ ] **Step 3.5: Rewire v2_schema._fetch_bq_schema**
+
+Edit `app/api/v2_schema.py` — replace the body of `_fetch_bq_schema` (function starting around line 33). The function currently builds and runs its own `INFORMATION_SCHEMA.COLUMNS` query; rewire it to call `fetch_bq_columns_full` and project the column-list shape.
+
+Locate `def _fetch_bq_schema(...)` and replace its full body with:
+
+```python
+def _fetch_bq_schema(bq, dataset: str, table: str) -> list[dict]:
+    """Fetch column list via the shared `fetch_bq_columns_full` helper.
+
+    Pre-#155 this had its own INFORMATION_SCHEMA.COLUMNS query; consolidating
+    with `_fetch_bq_table_options` (now also delegating to the same helper)
+    halves the BQ job count on cache miss. Returns the schema-endpoint
+    column shape: name / type / nullable / description.
+    """
+    from connectors.bigquery.access import fetch_bq_columns_full, BqAccessError
+
+    # Surface "BQ not configured" as the structured 500 BqAccessError
+    # (with hint), not a misleading empty-list. Mirrors pre-refactor
+    # behavior — see Devin BUG_0002 in the original docstring.
+    if not bq.projects.data:
+        bq.client()  # raises BqAccessError(not_configured); endpoint catches it
+
+    rows = fetch_bq_columns_full(bq, dataset, table)
+    if rows is None:
+        # Identifier validation refused, or BQ raised. The legacy code
+        # path raised `ValueError("unsafe BQ identifier in registry")` for
+        # the validation case; the BQ-error case raised via translate_bq_error.
+        # The new helper conflates both into None; reproduce the legacy
+        # error-surfacing here so callers get the same exceptions.
+        from src.identifier_validation import validate_quoted_identifier
+        if not (validate_quoted_identifier(bq.projects.data, "BQ project")
+                and validate_quoted_identifier(dataset, "BQ dataset")
+                and validate_quoted_identifier(table, "BQ source_table")):
+            raise ValueError("unsafe BQ identifier in registry — refusing to query")
+        # Otherwise it's a BQ-side error; raise the same shape the legacy
+        # code raised (HTTP 502 via the endpoint's translate_bq_error).
+        from connectors.bigquery.access import translate_bq_error
+        raise translate_bq_error(
+            RuntimeError("BQ INFORMATION_SCHEMA.COLUMNS query failed"),
+            bq.projects, bad_request_status="upstream_error",
+        )
+
+    return [
+        {
+            "name": r["name"],
+            "type": r["type"],
+            "nullable": r["nullable"],
+            "description": "",
+        }
+        for r in rows
+    ]
+```
+
+- [ ] **Step 3.6: Rewire v2_schema._fetch_bq_table_options**
+
+Same file. Replace the full body of `_fetch_bq_table_options` (around line 85):
+
+```python
+def _fetch_bq_table_options(bq, dataset: str, table: str) -> dict:
+    """Best-effort fetch of partition/cluster info via the shared
+    `fetch_bq_columns_full` helper.
+
+    Returns ``{}`` on ANY failure (best-effort). Same load-bearing
+    contract as before: the /schema endpoint must keep returning 200
+    with empty partition info when this fails.
+    """
+    from connectors.bigquery.access import fetch_bq_columns_full
+
+    rows = fetch_bq_columns_full(bq, dataset, table)
+    if not rows:
+        return {}
+
+    partition_by = next(
+        (r["name"] for r in rows if r["is_partitioning_column"]),
+        None,
+    )
+    clustered_rows = [r for r in rows if r["clustering_ordinal_position"] is not None]
+    clustered_rows.sort(key=lambda r: r["clustering_ordinal_position"])
+    clustered_by = [r["name"] for r in clustered_rows]
+    return {"partition_by": partition_by, "clustered_by": clustered_by}
+```
+
+- [ ] **Step 3.7: Run existing schema tests to verify no regression**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_v2_schema.py -v
+```
+Expected: all existing tests pass (no behavior change for `/api/v2/schema/{id}` consumers — same response shape).
+
+If a test fails, the most likely causes are: (a) the test mocks `_fetch_bq_schema` or `_fetch_bq_table_options` directly with the old signature — patch the test to mock `fetch_bq_columns_full` instead; (b) a test relies on the old error-surfacing path — check the docstring of step 3.5 and ensure the rewire matches.
+
+- [ ] **Step 3.8: Run consolidation tests once more for full green**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_v2_schema_columns_consolidation.py tests/test_v2_schema.py -v
+```
+Expected: all green.
+
+- [ ] **Step 3.9: Commit**
+
+```bash
+cd /tmp/agnes-metadata
+git add connectors/bigquery/access.py app/api/v2_schema.py tests/test_v2_schema_columns_consolidation.py
+git commit -m "perf(v2_schema): consolidate two INFORMATION_SCHEMA.COLUMNS queries to one
+
+/api/v2/schema/{id} cache-miss path was making two BQ jobs against the
+same view with the same predicate — one for column list, one for
+partition/cluster. New shared connectors/bigquery/access.py:fetch_bq_columns_full
+returns one resultset; both v2_schema._fetch_bq_schema and
+_fetch_bq_table_options delegate. Same response shape, half the BQ jobs
+on cache miss.
+
+Same helper consumed by the upcoming metadata provider's partition/cluster
+path — zero SQL duplication across the two consumers.
+
+Refs: docs/superpowers/specs/2026-05-07-source-agnostic-table-metadata-spec.md"
+```
+
+---
+
+## Task 4: Split `build_schema` for warmup re-use
+
+The warmup background task needs to populate `_schema_cache` without an authenticated user. Today `build_schema` mixes RBAC + cache + BQ work; extract the BQ-and-cache half so warmup can call it directly.
+
+**Files:**
+- Modify: `app/api/v2_schema.py`
+- Test: `tests/test_v2_schema.py` (new test asserting the split)
+
+- [ ] **Step 4.1: Write failing test**
+
+Append to `tests/test_v2_schema.py` (or wherever existing v2_schema tests live):
+
+```python
+class TestBuildSchemaUncached:
+    """The uncached entry point exists for warmup, which has no user
+    context. RBAC + cache check live in `build_schema`; the BQ work +
+    cache write live in `build_schema_uncached`."""
+
+    def test_uncached_function_exists_and_does_not_take_user(self):
+        """Signature: build_schema_uncached(conn, table_id, *, bq)"""
+        from app.api.v2_schema import build_schema_uncached
+        import inspect
+        sig = inspect.signature(build_schema_uncached)
+        params = list(sig.parameters)
+        assert "user" not in params, (
+            "build_schema_uncached should NOT require a user — that's "
+            "the whole point of the split (warmup has no user)."
+        )
+        assert "table_id" in params
+        assert "bq" in params
+
+    def test_build_schema_delegates_to_uncached(self, monkeypatch):
+        """build_schema should call build_schema_uncached after RBAC+cache check."""
+        from app.api import v2_schema
+
+        called_with = {}
+        def fake_uncached(conn, table_id, *, bq):
+            called_with["table_id"] = table_id
+            return {"table_id": table_id, "columns": []}
+
+        monkeypatch.setattr(v2_schema, "build_schema_uncached", fake_uncached)
+        # Bypass the cache + RBAC for this assertion — both are tested elsewhere.
+        monkeypatch.setattr(v2_schema._schema_cache, "get", lambda k, default=None: None)
+        monkeypatch.setattr(v2_schema, "can_access_table", lambda u, tid, c: True)
+
+        # Synthetic registry row.
+        from unittest.mock import MagicMock
+        repo_mock = MagicMock()
+        repo_mock.get.return_value = {"id": "x", "source_type": "bigquery"}
+        monkeypatch.setattr(v2_schema, "TableRegistryRepository", lambda c: repo_mock)
+
+        v2_schema.build_schema(
+            conn=MagicMock(), user={"id": "u"}, table_id="x", bq=MagicMock(),
+        )
+        assert called_with["table_id"] == "x"
+```
+
+- [ ] **Step 4.2: Run test to verify it fails**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_v2_schema.py::TestBuildSchemaUncached -v
+```
+Expected: FAIL with `ImportError: cannot import name 'build_schema_uncached'`.
+
+- [ ] **Step 4.3: Perform the split**
+
+Open `app/api/v2_schema.py`. Locate `def build_schema(...)` (around line 143). Refactor as:
+
+```python
+def build_schema(
+    conn: duckdb.DuckDBPyConnection,
+    user: dict,
+    table_id: str,
+    *,
+    bq: BqAccess,
+) -> dict:
+    # RBAC + existence check MUST run before cache lookup — otherwise an
+    # unauthorized user can read cached schema fetched by an authorized one.
+    repo = TableRegistryRepository(conn)
+    row = repo.get(table_id)
+    if not row:
+        raise NotFound(table_id)
+
+    if not can_access_table(user, table_id, conn):
+        raise PermissionError(table_id)
+
+    cache_key = f"{table_id}"
+    cached = _schema_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    return build_schema_uncached(conn, table_id, bq=bq)
+
+
+def build_schema_uncached(
+    conn: duckdb.DuckDBPyConnection,
+    table_id: str,
+    *,
+    bq: BqAccess,
+) -> dict:
+    """Build the schema response and populate `_schema_cache`. **Skips
+    RBAC and cache-hit short-circuit** — call only from contexts where
+    those are either unnecessary (warmup) or already enforced upstream
+    (`build_schema` above). The BQ work is the same; the entry-point
+    contract is what differs.
+    """
+    repo = TableRegistryRepository(conn)
+    row = repo.get(table_id)
+    if not row:
+        raise NotFound(table_id)
+
+    cache_key = f"{table_id}"
+    source_type = row.get("source_type") or ""
+    if source_type == "bigquery":
+        dataset = row.get("bucket") or ""
+        source_table = row.get("source_table") or table_id
+        columns = _fetch_bq_schema(bq, dataset, source_table)
+        opts = _fetch_bq_table_options(bq, dataset, source_table)
+        payload = {
+            "table_id": table_id,
+            "source_type": source_type,
+            "sql_flavor": "bigquery",
+            "columns": columns,
+            "partition_by": opts.get("partition_by"),
+            "clustered_by": opts.get("clustered_by"),
+        }
+    else:
+        # Local sources (Keboola/Jira parquet) — schema lives in extract.duckdb.
+        # Preserve whatever the existing code path did. Copy the original
+        # else-branch from build_schema verbatim. (Inspect the file before
+        # this edit to extract the original lines after `if source_type ==
+        # 'bigquery'`.)
+        payload = _build_schema_for_local_row(conn, table_id, row)
+
+    _schema_cache.set(cache_key, payload)
+    return payload
+```
+
+**Important:** the existing `build_schema` body has logic for non-BQ rows after the `if source_type == "bigquery":` block. Read that block (lines ~165-210 in current file) and either keep it inline in `build_schema_uncached` after the `if/else`, or extract it into a helper `_build_schema_for_local_row(conn, table_id, row)` as the snippet above suggests. Pick whichever requires the smaller diff against the existing code.
+
+- [ ] **Step 4.4: Run tests**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_v2_schema.py -v
+```
+Expected: all green (existing tests + the new TestBuildSchemaUncached class).
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+cd /tmp/agnes-metadata
+git add app/api/v2_schema.py tests/test_v2_schema.py
+git commit -m "refactor(v2_schema): extract build_schema_uncached for warmup re-use
+
+build_schema currently mixes RBAC + cache check + BQ work in one body.
+Warmup will need to populate _schema_cache without a user — extract the
+BQ-and-cache half so warmup can call it directly. build_schema keeps
+the RBAC + cache-hit short-circuit at the top, then delegates.
+
+Behavior unchanged for live /api/v2/schema/{id} consumers.
+
+Refs: docs/superpowers/specs/2026-05-07-source-agnostic-table-metadata-spec.md"
+```
+
+---
+
+## Task 5: Provider scaffold + dispatcher
+
+**Files:**
+- Create: `connectors/bigquery/metadata.py` (stub returning None)
+- Create: `connectors/keboola/metadata.py` (stub returning None)
+- Modify: `app/api/v2_catalog.py` (add `_metadata_provider_for` and `_build_metadata_request`)
+- Test: `tests/test_v2_catalog_dispatcher.py`
+
+- [ ] **Step 5.1: Write failing tests**
+
+Create `tests/test_v2_catalog_dispatcher.py`:
+
+```python
+"""Dispatch + identifier-validation gate for the source-agnostic
+metadata providers."""
+
+from app.api._metadata_models import MetadataRequest
+
+
+def test_dispatcher_returns_bq_provider_for_bigquery():
+    from app.api.v2_catalog import _metadata_provider_for
+    from connectors.bigquery import metadata as bq_meta
+    fn = _metadata_provider_for("bigquery")
+    assert fn is bq_meta.fetch
+
+
+def test_dispatcher_returns_keboola_provider_for_keboola():
+    from app.api.v2_catalog import _metadata_provider_for
+    from connectors.keboola import metadata as kb_meta
+    fn = _metadata_provider_for("keboola")
+    assert fn is kb_meta.fetch
+
+
+def test_dispatcher_returns_none_for_unknown_source():
+    from app.api.v2_catalog import _metadata_provider_for
+    assert _metadata_provider_for("jira") is None
+    assert _metadata_provider_for("") is None
+    assert _metadata_provider_for("snowflake") is None
+
+
+def test_build_metadata_request_for_valid_row():
+    from app.api.v2_catalog import _build_metadata_request
+    req = _build_metadata_request({
+        "id": "orders",
+        "bucket": "dwh_base",
+        "source_table": "orders_2024",
+    })
+    assert isinstance(req, MetadataRequest)
+    assert req.table_id == "orders"
+    assert req.bucket == "dwh_base"
+    assert req.source_table == "orders_2024"
+
+
+def test_build_metadata_request_rejects_unsafe_bucket():
+    from app.api.v2_catalog import _build_metadata_request
+    req = _build_metadata_request({
+        "id": "x",
+        "bucket": "evil`; DROP--",
+        "source_table": "t",
+    })
+    assert req is None
+
+
+def test_build_metadata_request_falls_back_to_id_when_source_table_missing():
+    """Some legacy Keboola registry rows have empty source_table; the row id
+    is the table name in that case (mirrors v2_schema:168 behavior)."""
+    from app.api.v2_catalog import _build_metadata_request
+    req = _build_metadata_request({
+        "id": "orders",
+        "bucket": "in.c-crm",
+        "source_table": "",
+    })
+    assert req is not None
+    assert req.source_table == "orders"
+
+
+def test_stub_providers_return_none():
+    """Providers don't have their real bodies yet — stubs return None
+    so the catalog endpoint stays 200 while we wire the rest."""
+    from connectors.bigquery import metadata as bq_meta
+    from connectors.keboola import metadata as kb_meta
+    req = MetadataRequest(table_id="x", bucket="b", source_table="t")
+    assert bq_meta.fetch(req) is None
+    assert kb_meta.fetch(req) is None
+```
+
+- [ ] **Step 5.2: Run tests to verify they fail**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_v2_catalog_dispatcher.py -v
+```
+Expected: multiple FAIL — modules don't exist, dispatcher not defined.
+
+- [ ] **Step 5.3: Create the provider stubs**
+
+Create `connectors/bigquery/metadata.py`:
+
+```python
+"""BigQuery metadata provider — populates `TableMetadata` for a remote
+BQ-backed registry row.
+
+Stub: returns None pending the full implementation in Task 7.
+"""
+
+from __future__ import annotations
+
+from app.api._metadata_models import MetadataRequest, TableMetadata
+
+
+def fetch(req: MetadataRequest) -> TableMetadata | None:
+    return None
+```
+
+Create `connectors/keboola/metadata.py`:
+
+```python
+"""Keboola metadata provider — populates `TableMetadata` for a Keboola
+registry row via the Storage API.
+
+Stub: returns None pending the full implementation in Task 6.
+"""
+
+from __future__ import annotations
+
+from app.api._metadata_models import MetadataRequest, TableMetadata
+
+
+def fetch(req: MetadataRequest) -> TableMetadata | None:
+    return None
+```
+
+- [ ] **Step 5.4: Add dispatcher + request builder to v2_catalog**
+
+Edit `app/api/v2_catalog.py`. Add at the top, after the existing imports:
+
+```python
+from app.api._metadata_models import MetadataRequest, TableMetadata
+from src.identifier_validation import validate_quoted_identifier
+```
+
+Then, after the `_table_rows_cache` definition (around line 26), add:
+
+```python
+def _metadata_provider_for(source_type: str):
+    """Lazy-import dispatch for source-specific metadata providers.
+
+    Lazy because connector modules are heavy (BQ extension, google-cloud
+    client, etc.) and a Keboola-only deployment shouldn't pay the BQ
+    import cost. Returns ``None`` for unknown source types — the caller
+    treats that as "no metadata enrichment available" and falls through.
+    """
+    if source_type == "bigquery":
+        from connectors.bigquery import metadata as m
+        return m.fetch
+    if source_type == "keboola":
+        from connectors.keboola import metadata as m
+        return m.fetch
+    return None
+
+
+def _build_metadata_request(row: dict) -> MetadataRequest | None:
+    """Construct a validated MetadataRequest from a registry row.
+
+    Pre-validates the identifiers via `validate_quoted_identifier` before
+    constructing the request — providers can then interpolate
+    `req.bucket` / `req.source_table` into SQL/URL paths without
+    re-checking. Returns ``None`` when validation fails; provider is not
+    dispatched for that row.
+    """
+    bucket = row.get("bucket") or ""
+    source_table = row.get("source_table") or row.get("id") or ""
+    if not bucket or not source_table:
+        return None
+    if not (validate_quoted_identifier(bucket, "bucket")
+            and validate_quoted_identifier(source_table, "source_table")):
+        return None
+    return MetadataRequest(
+        table_id=row["id"], bucket=bucket, source_table=source_table,
+    )
+```
+
+- [ ] **Step 5.5: Run tests to verify they pass**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_v2_catalog_dispatcher.py -v
+```
+Expected: 7 passed.
+
+- [ ] **Step 5.6: Commit**
+
+```bash
+cd /tmp/agnes-metadata
+git add connectors/bigquery/metadata.py connectors/keboola/metadata.py \
+        app/api/v2_catalog.py tests/test_v2_catalog_dispatcher.py
+git commit -m "feat(catalog): metadata-provider scaffold + dispatcher with identifier validation
+
+Lazy-imported per-source-type providers; dispatcher in v2_catalog.py.
+_build_metadata_request validates bucket + source_table before
+constructing a MetadataRequest — providers can interpolate them safely.
+Providers ship as stubs returning None; real bodies land in Tasks 6-7.
+
+Refs: docs/superpowers/specs/2026-05-07-source-agnostic-table-metadata-spec.md"
+```
+
+---
+
+## Task 6: Keboola provider implementation
+
+**Files:**
+- Modify: `connectors/keboola/metadata.py` (replace stub with real impl)
+- Test: `tests/test_connectors_keboola_metadata.py`
+
+- [ ] **Step 6.1: Write failing tests**
+
+Create `tests/test_connectors_keboola_metadata.py`:
+
+```python
+"""Keboola metadata provider — happy + unconfigured + api-error paths."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.api._metadata_models import MetadataRequest, TableMetadata
+
+
+@pytest.fixture
+def req():
+    return MetadataRequest(
+        table_id="orders", bucket="in.c-crm", source_table="orders",
+    )
+
+
+def test_happy_path_returns_populated_metadata(req, monkeypatch):
+    from connectors.keboola import metadata
+    from connectors.keboola.client import KeboolaClient
+    # KeboolaClient(token=None, url=None) reads env vars; pretend they're set.
+    monkeypatch.setenv("KEBOOLA_STACK_URL", "https://connection.keboola.com")
+    monkeypatch.setenv("KEBOOLA_STORAGE_TOKEN", "tok")
+
+    with patch("connectors.keboola.metadata.KeboolaStorageClient") as MockStorage:
+        instance = MockStorage.return_value
+        instance.get_table_info.return_value = {
+            "rowsCount": 1234,
+            "dataSizeBytes": 500_000,
+            "primaryKey": ["id"],
+        }
+        result = metadata.fetch(req)
+
+    assert result == TableMetadata(
+        rows=1234,
+        size_bytes=500_000,
+        partition_by=None,
+        clustered_by=None,
+    )
+
+
+def test_returns_none_when_unconfigured(req, monkeypatch):
+    """No KEBOOLA_STACK_URL / KEBOOLA_STORAGE_TOKEN env → return None."""
+    from connectors.keboola import metadata
+    monkeypatch.delenv("KEBOOLA_STACK_URL", raising=False)
+    monkeypatch.delenv("KEBOOLA_STORAGE_TOKEN", raising=False)
+    assert metadata.fetch(req) is None
+
+
+def test_returns_none_on_storage_api_error(req, monkeypatch):
+    """`StorageApiError` from get_table_info → log + return None."""
+    from connectors.keboola import metadata
+    from connectors.keboola.storage_api import StorageApiError
+    monkeypatch.setenv("KEBOOLA_STACK_URL", "https://x.keboola.com")
+    monkeypatch.setenv("KEBOOLA_STORAGE_TOKEN", "tok")
+
+    with patch("connectors.keboola.metadata.KeboolaStorageClient") as MockStorage:
+        instance = MockStorage.return_value
+        instance.get_table_info.side_effect = StorageApiError(
+            "404 not found", status=404, body={},
+        )
+        assert metadata.fetch(req) is None
+
+
+def test_table_id_uses_bucket_dot_source_table(req, monkeypatch):
+    """Storage API path is `<bucket>.<source_table>`."""
+    from connectors.keboola import metadata
+    monkeypatch.setenv("KEBOOLA_STACK_URL", "https://x.keboola.com")
+    monkeypatch.setenv("KEBOOLA_STORAGE_TOKEN", "tok")
+
+    with patch("connectors.keboola.metadata.KeboolaStorageClient") as MockStorage:
+        instance = MockStorage.return_value
+        instance.get_table_info.return_value = {
+            "rowsCount": 0, "dataSizeBytes": 0,
+        }
+        metadata.fetch(req)
+        instance.get_table_info.assert_called_once_with("in.c-crm.orders")
+```
+
+- [ ] **Step 6.2: Run tests to verify they fail**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_connectors_keboola_metadata.py -v
+```
+Expected: 4 FAIL (stub returns None for happy-path; assertion fails).
+
+- [ ] **Step 6.3: Replace stub with real implementation**
+
+Open `connectors/keboola/metadata.py` and replace the entire file:
+
+```python
+"""Keboola metadata provider — populates `TableMetadata` for a Keboola
+registry row via the Storage API.
+
+Reuses `KeboolaClient(token=None, url=None)` to inherit the existing
+env-var fallback path (`KEBOOLA_STACK_URL` + `KEBOOLA_STORAGE_TOKEN`),
+which is the same hierarchy `connectors/keboola/extractor.py` and
+`connectors/keboola/client.py` already use. **Does NOT introduce a third
+token-resolution helper.**
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.api._metadata_models import MetadataRequest, TableMetadata
+from connectors.keboola.client import KeboolaClient
+from connectors.keboola.storage_api import (
+    KeboolaStorageClient, StorageApiError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def fetch(req: MetadataRequest) -> TableMetadata | None:
+    """Return Keboola Storage API metadata for the given table, or None.
+
+    Keboola has no BigQuery-style partition/cluster concept; primaryKey is
+    conceptually different (uniqueness, not physical layout), so
+    `partition_by` and `clustered_by` are left None.
+    """
+    # Construct a KeboolaClient with no explicit token/url — the
+    # constructor reads the standard env vars. Side-effect-free except
+    # for setting `.token` and `.url` (verified
+    # connectors/keboola/client.py:90-99). When a future refactor extracts
+    # `_resolve_keboola_credentials()` as a standalone helper, switch
+    # here to call that directly.
+    creds = KeboolaClient(token=None, url=None)
+    if not creds.url or not creds.token:
+        return None  # not configured — same posture as BQ sentinel
+
+    table_id = f"{req.bucket}.{req.source_table}"
+    try:
+        storage = KeboolaStorageClient(url=creds.url, token=creds.token)
+        info = storage.get_table_info(table_id)
+    except (StorageApiError, ValueError) as e:
+        logger.warning("Keboola metadata fetch failed for %s: %s", table_id, e)
+        return None
+
+    return TableMetadata(
+        rows=info.get("rowsCount"),
+        size_bytes=info.get("dataSizeBytes"),
+        partition_by=None,
+        clustered_by=None,
+    )
+```
+
+- [ ] **Step 6.4: Run tests to verify they pass**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_connectors_keboola_metadata.py -v
+```
+Expected: 4 passed.
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+cd /tmp/agnes-metadata
+git add connectors/keboola/metadata.py tests/test_connectors_keboola_metadata.py
+git commit -m "feat(keboola): metadata provider returning rows + size_bytes
+
+Reuses KeboolaClient(token=None, url=None) for env-var credential
+fallback — no new token-resolver helper invented. partition_by /
+clustered_by stay None (Keboola has no equivalent concept).
+
+Refs: docs/superpowers/specs/2026-05-07-source-agnostic-table-metadata-spec.md"
+```
+
+---
+
+## Task 7: BigQuery provider implementation
+
+**Files:**
+- Modify: `connectors/bigquery/metadata.py` (replace stub with real impl)
+- Test: `tests/test_connectors_bigquery_metadata.py`
+
+- [ ] **Step 7.1: Write failing tests**
+
+Create `tests/test_connectors_bigquery_metadata.py`:
+
+```python
+"""BigQuery metadata provider — 5 paths from spec test plan:
+happy / sentinel / VIEW / region-typo / both-paths-fail."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.api._metadata_models import MetadataRequest, TableMetadata
+
+
+@pytest.fixture
+def req():
+    return MetadataRequest(
+        table_id="orders", bucket="dwh_base", source_table="orders_2024",
+    )
+
+
+def _bq_with_session(table_storage_rows=None, columns_rows=None,
+                     table_storage_raises=None, columns_raises=None,
+                     legacy_tables_rows=None, legacy_tables_raises=None,
+                     projects_data="data-proj", projects_billing="billing-proj"):
+    """Build a mock `BqAccess` whose `duckdb_session()` returns a context
+    manager whose `.execute(...)` dispatches based on which inner SQL
+    string is being run.
+
+    The 3 SQL shapes we route on:
+      - INFORMATION_SCHEMA.TABLE_STORAGE  → table_storage_rows / raises
+      - INFORMATION_SCHEMA.COLUMNS         → columns_rows / raises
+      - __TABLES__                         → legacy_tables_rows / raises
+    """
+    bq = MagicMock()
+    bq.projects.data = projects_data
+    bq.projects.billing = projects_billing
+
+    def execute(outer_sql, params):
+        inner_sql = params[1] if len(params) > 1 else ""
+        if "TABLE_STORAGE" in inner_sql:
+            if table_storage_raises:
+                raise table_storage_raises
+            return MagicMock(
+                fetchone=lambda: table_storage_rows[0] if table_storage_rows else None,
+                fetchall=lambda: table_storage_rows or [],
+            )
+        if "INFORMATION_SCHEMA.COLUMNS" in inner_sql:
+            if columns_raises:
+                raise columns_raises
+            return MagicMock(
+                fetchall=lambda: columns_rows or [],
+            )
+        if "__TABLES__" in inner_sql:
+            if legacy_tables_raises:
+                raise legacy_tables_raises
+            return MagicMock(
+                fetchone=lambda: legacy_tables_rows[0] if legacy_tables_rows else None,
+            )
+        raise AssertionError(f"unexpected SQL: {inner_sql[:80]}")
+
+    session = MagicMock()
+    session.execute.side_effect = execute
+    cm = MagicMock()
+    cm.__enter__.return_value = session
+    cm.__exit__.return_value = False
+    bq.duckdb_session.return_value = cm
+    return bq
+
+
+def test_happy_path_returns_full_metadata(req, monkeypatch):
+    """TABLE_STORAGE returns rows+size, COLUMNS returns partition+cluster."""
+    from connectors.bigquery import metadata
+    from app.instance_config import get_value
+
+    monkeypatch.setattr(
+        "app.instance_config.get_value",
+        lambda key, default=None: "us-central1" if "location" in key else default,
+        raising=False,
+    )
+
+    bq = _bq_with_session(
+        table_storage_rows=[(1234567, 5_000_000)],
+        columns_rows=[
+            ("event_date", "DATE", "NO", "YES", None),
+            ("country", "STRING", "YES", "NO", 1),
+            ("user_id", "STRING", "NO", "NO", None),
+        ],
+    )
+    with patch("connectors.bigquery.metadata.get_bq_access", return_value=bq):
+        result = metadata.fetch(req)
+    assert result == TableMetadata(
+        rows=1234567,
+        size_bytes=5_000_000,
+        partition_by="event_date",
+        clustered_by=["country"],
+    )
+
+
+def test_sentinel_unconfigured_returns_none_no_query(req, monkeypatch):
+    """`bq.projects.data == ''` → return None before any query."""
+    from connectors.bigquery import metadata
+    bq = _bq_with_session(projects_data="")
+    with patch("connectors.bigquery.metadata.get_bq_access", return_value=bq):
+        assert metadata.fetch(req) is None
+    bq.duckdb_session.assert_not_called()
+
+
+def test_view_path_returns_metadata_with_null_rows_size(req, monkeypatch):
+    """VIEW: TABLE_STORAGE empty + __TABLES__ empty → rows/size = None;
+    partition + cluster from COLUMNS still surface."""
+    from connectors.bigquery import metadata
+    monkeypatch.setattr(
+        "app.instance_config.get_value",
+        lambda key, default=None: "us-central1" if "location" in key else default,
+        raising=False,
+    )
+    bq = _bq_with_session(
+        table_storage_rows=[],   # view → no row
+        legacy_tables_rows=[],   # view also absent from __TABLES__
+        columns_rows=[
+            ("event_date", "DATE", "NO", "YES", None),
+        ],
+    )
+    with patch("connectors.bigquery.metadata.get_bq_access", return_value=bq):
+        result = metadata.fetch(req)
+    assert result is not None
+    assert result.rows is None
+    assert result.size_bytes is None
+    assert result.partition_by == "event_date"
+
+
+def test_region_typo_falls_through_to_legacy_tables(req, monkeypatch):
+    """TABLE_STORAGE raises (typo'd region) → fall through to __TABLES__."""
+    from connectors.bigquery import metadata
+    monkeypatch.setattr(
+        "app.instance_config.get_value",
+        lambda key, default=None: "us-central" if "location" in key else default,  # typo!
+        raising=False,
+    )
+    bq = _bq_with_session(
+        table_storage_raises=RuntimeError("Not found: ..."),
+        legacy_tables_rows=[(100, 2048)],
+        columns_rows=[("event_date", "DATE", "NO", "YES", None)],
+    )
+    with patch("connectors.bigquery.metadata.get_bq_access", return_value=bq):
+        result = metadata.fetch(req)
+    assert result is not None
+    assert result.rows == 100
+    assert result.size_bytes == 2048
+
+
+def test_both_paths_fail_returns_metadata_with_partition_only(req, monkeypatch):
+    """Both TABLE_STORAGE and __TABLES__ fail → rows/size None, partition still fills."""
+    from connectors.bigquery import metadata
+    monkeypatch.setattr(
+        "app.instance_config.get_value",
+        lambda key, default=None: "us-central1" if "location" in key else default,
+        raising=False,
+    )
+    bq = _bq_with_session(
+        table_storage_raises=RuntimeError("BQ down"),
+        legacy_tables_raises=RuntimeError("BQ still down"),
+        columns_rows=[("event_date", "DATE", "NO", "YES", None)],
+    )
+    with patch("connectors.bigquery.metadata.get_bq_access", return_value=bq):
+        result = metadata.fetch(req)
+    assert result is not None
+    assert result.rows is None
+    assert result.size_bytes is None
+    assert result.partition_by == "event_date"
+
+
+def test_bq_access_error_returns_none(req):
+    """get_bq_access() raises BqAccessError → return None gracefully."""
+    from connectors.bigquery import metadata
+    from connectors.bigquery.access import BqAccessError
+    with patch(
+        "connectors.bigquery.metadata.get_bq_access",
+        side_effect=BqAccessError("not_configured"),
+    ):
+        assert metadata.fetch(req) is None
+```
+
+- [ ] **Step 7.2: Run tests to verify they fail**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_connectors_bigquery_metadata.py -v
+```
+Expected: 6 FAIL (stub returns None unconditionally).
+
+- [ ] **Step 7.3: Implement the BQ provider**
+
+Replace `connectors/bigquery/metadata.py` entirely:
+
+```python
+"""BigQuery metadata provider — populates `TableMetadata` for a remote
+BQ-backed registry row.
+
+Two queries (different INFORMATION_SCHEMA scopes — TABLE_STORAGE is
+region-scoped, COLUMNS is dataset-scoped, can't be combined):
+
+  1. INFORMATION_SCHEMA.TABLE_STORAGE — total_rows + active+long_term
+     bytes. Region-portable per Google's docs; only valid via
+     `<project>.region-<region>.INFORMATION_SCHEMA.TABLE_STORAGE`
+     (verified live 2026-05-07; dataset-scoped TABLE_STORAGE doesn't
+     exist).
+
+  2. INFORMATION_SCHEMA.COLUMNS — partition_by + clustered_by. Reuses
+     the consolidated `fetch_bq_columns_full` helper that v2_schema also
+     calls; one shared shape, one round-trip.
+
+Region resolution chain: `instance.yaml.data_source.bigquery.location` →
+`bq.bigquery_client().get_dataset(...)` → fall back to legacy `__TABLES__`
+(dataset-scoped, no region required).
+
+VIEW handling: TABLE_STORAGE returns no rows for entries whose
+`table_type='VIEW'`; the legacy `__TABLES__` fallback also doesn't list
+views. The provider returns `TableMetadata(rows=None, size_bytes=None,
+partition_by=<from COLUMNS>, clustered_by=<from COLUMNS>)` — analyst
+Claude reads `null` size and applies the existing CLAUDE.md guidance.
+
+`size_bytes` reports `active_logical_bytes + long_term_logical_bytes`
+(a full BQ scan reads both — reporting only active undercounts aged
+partitioned tables).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.api._metadata_models import MetadataRequest, TableMetadata
+from connectors.bigquery.access import (
+    BqAccessError, fetch_bq_columns_full, get_bq_access,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def fetch(req: MetadataRequest) -> TableMetadata | None:
+    try:
+        bq = get_bq_access()
+    except BqAccessError:
+        return None
+
+    if not bq.projects.data:
+        return None
+
+    rows_size = _fetch_rows_and_size(bq, req)
+    columns = fetch_bq_columns_full(bq, req.bucket, req.source_table)
+    part_clust = _derive_partition_cluster(columns) if columns else None
+
+    if rows_size is None and part_clust is None:
+        return None
+
+    return TableMetadata(
+        rows=(rows_size or {}).get("rows"),
+        size_bytes=(rows_size or {}).get("size_bytes"),
+        partition_by=(part_clust or {}).get("partition_by"),
+        clustered_by=(part_clust or {}).get("clustered_by"),
+    )
+
+
+def _derive_partition_cluster(columns: list[dict]) -> dict | None:
+    """Mirror v2_schema._fetch_bq_table_options derivations from the
+    shared columns-full result."""
+    if not columns:
+        return None
+    partition_by = next(
+        (c["name"] for c in columns if c["is_partitioning_column"]),
+        None,
+    )
+    clustered = sorted(
+        (c for c in columns if c["clustering_ordinal_position"] is not None),
+        key=lambda c: c["clustering_ordinal_position"],
+    )
+    clustered_by = [c["name"] for c in clustered]
+    return {"partition_by": partition_by, "clustered_by": clustered_by}
+
+
+def _fetch_rows_and_size(bq, req: MetadataRequest) -> dict | None:
+    """Resolve rows + size_bytes via TABLE_STORAGE → __TABLES__ fallthrough.
+
+    See module docstring + spec Open Question §1 for view-path nuance.
+    """
+    location = _resolve_bq_location(bq, req)
+    if location:
+        result = _fetch_via_table_storage(bq, req, location)
+        if result is not None:
+            return result
+        # TABLE_STORAGE returned None despite having a location: could
+        # be a typo in `data_source.bigquery.location`, a multi-region
+        # dataset operator misclassified, the table is a VIEW, or a
+        # transient permission gap. Try __TABLES__ before giving up.
+    return _fetch_via_legacy_tables(bq, req)
+
+
+def _resolve_bq_location(bq, req: MetadataRequest) -> str | None:
+    """instance.yaml.location → REST get_dataset → None."""
+    from app.instance_config import get_value
+    cfg_location = (get_value("data_source.bigquery.location") or "").strip()
+    if cfg_location:
+        return cfg_location
+    try:
+        ds = bq.bigquery_client().get_dataset(
+            f"{bq.projects.data}.{req.bucket}"
+        )
+        return ds.location
+    except Exception as e:
+        logger.warning(
+            "BQ dataset.get failed for %s.%s — falling back to __TABLES__: %s",
+            bq.projects.data, req.bucket, e,
+        )
+        return None
+
+
+def _fetch_via_table_storage(bq, req: MetadataRequest, location: str) -> dict | None:
+    """Region-scoped INFORMATION_SCHEMA.TABLE_STORAGE — preferred path.
+
+    `validate_quoted_identifier` accepts `us-central1`, `europe-west1`,
+    `EU`, `us` etc. (regex `^[a-zA-Z0-9_][a-zA-Z0-9_.\\-]{0,127}$`).
+    Refuses anything that could break out of the backtick-quoted path.
+
+    Returns None on no-row (table is a VIEW, or different region than
+    configured) — caller decides whether to fall through.
+
+    `size_bytes` is `active + long_term` logical bytes (a full BQ scan
+    reads both; reporting only active undercounts aged partitioned tables).
+    """
+    from src.identifier_validation import validate_quoted_identifier
+    if not validate_quoted_identifier(location, "BQ region"):
+        return None
+    try:
+        bq_sql = (
+            f"SELECT total_rows, "
+            f"IFNULL(active_logical_bytes, 0) + IFNULL(long_term_logical_bytes, 0) "
+            f"FROM `{bq.projects.data}.region-{location}.INFORMATION_SCHEMA.TABLE_STORAGE` "
+            f"WHERE table_schema = ? AND table_name = ?"
+        )
+        with bq.duckdb_session() as conn:
+            row = conn.execute(
+                "SELECT * FROM bigquery_query(?, ?, ?, ?)",
+                [bq.projects.billing, bq_sql, req.bucket, req.source_table],
+            ).fetchone()
+    except Exception as e:
+        logger.warning(
+            "BQ TABLE_STORAGE fetch failed for %s.%s.%s: %s",
+            bq.projects.data, req.bucket, req.source_table, e,
+        )
+        return None
+    if row is None:
+        return None  # VIEW or wrong region
+    rows_, size_bytes = row
+    return {
+        "rows": int(rows_) if rows_ is not None else None,
+        "size_bytes": int(size_bytes) if size_bytes is not None else None,
+    }
+
+
+def _fetch_via_legacy_tables(bq, req: MetadataRequest) -> dict | None:
+    """Last-resort dataset-scoped __TABLES__ — works without region."""
+    try:
+        bq_sql = (
+            f"SELECT row_count, size_bytes "
+            f"FROM `{bq.projects.data}.{req.bucket}.__TABLES__` "
+            f"WHERE table_id = ?"
+        )
+        with bq.duckdb_session() as conn:
+            row = conn.execute(
+                "SELECT * FROM bigquery_query(?, ?, ?)",
+                [bq.projects.billing, bq_sql, req.source_table],
+            ).fetchone()
+    except Exception as e:
+        logger.warning(
+            "BQ __TABLES__ fetch failed for %s.%s.%s: %s",
+            bq.projects.data, req.bucket, req.source_table, e,
+        )
+        return None
+    if row is None:
+        return None
+    rows_, size_bytes = row
+    return {
+        "rows": int(rows_) if rows_ is not None else None,
+        "size_bytes": int(size_bytes) if size_bytes is not None else None,
+    }
+```
+
+- [ ] **Step 7.4: Run tests to verify they pass**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_connectors_bigquery_metadata.py -v
+```
+Expected: 6 passed.
+
+- [ ] **Step 7.5: Commit**
+
+```bash
+cd /tmp/agnes-metadata
+git add connectors/bigquery/metadata.py tests/test_connectors_bigquery_metadata.py
+git commit -m "feat(bigquery): metadata provider with TABLE_STORAGE + COLUMNS + __TABLES__ fallback
+
+Resolves rows + size_bytes via region-scoped INFORMATION_SCHEMA.TABLE_STORAGE
+(verified the only valid scope on 2026-05-07; dataset-scoped doesn't exist).
+size_bytes is active + long_term logical bytes — full scan reads both.
+
+Region resolved from data_source.bigquery.location → REST get_dataset →
+fall back to legacy __TABLES__ on TABLE_STORAGE failure (region typo,
+VIEW, IAM gap). Partition + cluster derive from the shared
+fetch_bq_columns_full helper introduced in Task 3.
+
+VIEW handling: TABLE_STORAGE empty → fall through to __TABLES__ empty →
+TableMetadata(rows=None, size_bytes=None, partition_by=..., clustered_by=...).
+The null size signals analyst Claude to use the existing 'treat as
+potentially large' guidance.
+
+Refs: docs/superpowers/specs/2026-05-07-source-agnostic-table-metadata-spec.md"
+```
+
+---
+
+## Task 8: v2_catalog wiring — _size_hint_for_row + response shape + cache
+
+**Files:**
+- Modify: `app/api/v2_catalog.py`
+- Test: `tests/test_v2_catalog_remote_metadata.py`
+
+- [ ] **Step 8.1: Write failing tests**
+
+Create `tests/test_v2_catalog_remote_metadata.py`:
+
+```python
+"""Catalog endpoint integration: per-table metadata enrichment for
+remote rows."""
+
+from unittest.mock import patch
+
+from app.api._metadata_models import TableMetadata
+
+
+def test_remote_row_includes_metadata_fields(seeded_app, monkeypatch):
+    """Catalog response for a query_mode='remote' BQ row carries the four
+    new fields populated by the provider."""
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+
+    fake_meta = TableMetadata(
+        rows=10000, size_bytes=2_000_000,
+        partition_by="event_date", clustered_by=["country", "platform"],
+    )
+
+    # Register a synthetic remote BQ row in the test instance's registry.
+    seeded_app["register_table"](
+        id="orders", source_type="bigquery", bucket="dwh_base",
+        source_table="orders_2024", query_mode="remote",
+    )
+
+    with patch(
+        "connectors.bigquery.metadata.fetch", return_value=fake_meta,
+    ):
+        r = c.get(
+            "/api/v2/catalog",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert r.status_code == 200, r.text
+    tables = r.json()["tables"]
+    orders = next(t for t in tables if t["id"] == "orders")
+    assert orders["rows"] == 10000
+    assert orders["size_bytes"] == 2_000_000
+    assert orders["partition_by"] == "event_date"
+    assert orders["clustered_by"] == ["country", "platform"]
+    # Existing fields still present.
+    assert orders["query_mode"] == "remote"
+
+
+def test_local_row_unaffected_by_provider_dispatch(seeded_app):
+    """query_mode='local' rows take the parquet-stat path; provider not called."""
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    seeded_app["register_table"](
+        id="users", source_type="keboola", bucket="in.c-crm",
+        source_table="users", query_mode="local",
+    )
+
+    with patch("connectors.keboola.metadata.fetch") as mock_fetch:
+        r = c.get(
+            "/api/v2/catalog",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert r.status_code == 200, r.text
+    mock_fetch.assert_not_called()
+
+
+def test_provider_failure_returns_null_metadata(seeded_app):
+    """Provider returns None → row appears with null new fields, not
+    a 500. Catalog endpoint must stay 200."""
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    seeded_app["register_table"](
+        id="broken", source_type="bigquery", bucket="dwh_base",
+        source_table="broken_t", query_mode="remote",
+    )
+
+    with patch(
+        "connectors.bigquery.metadata.fetch", return_value=None,
+    ):
+        r = c.get(
+            "/api/v2/catalog",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert r.status_code == 200, r.text
+    tables = r.json()["tables"]
+    broken = next(t for t in tables if t["id"] == "broken")
+    assert broken["rows"] is None
+    assert broken["size_bytes"] is None
+    assert broken["partition_by"] is None
+    assert broken["clustered_by"] is None
+
+
+def test_cache_hit_does_not_call_provider_twice(seeded_app):
+    """First call invokes provider; second within 15 min hits cache."""
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    seeded_app["register_table"](
+        id="orders", source_type="bigquery", bucket="dwh_base",
+        source_table="orders_2024", query_mode="remote",
+    )
+
+    fake_meta = TableMetadata(rows=1, size_bytes=2)
+    with patch(
+        "connectors.bigquery.metadata.fetch", return_value=fake_meta,
+    ) as mock_fetch:
+        c.get("/api/v2/catalog", headers={"Authorization": f"Bearer {token}"})
+        c.get("/api/v2/catalog", headers={"Authorization": f"Bearer {token}"})
+    assert mock_fetch.call_count == 1
+```
+
+The `seeded_app["register_table"]` helper may need to be added to `conftest.py` if it doesn't exist. Quick check + extension:
+
+```python
+# In tests/conftest.py — add to seeded_app fixture
+def register_table(*, id, source_type, bucket, source_table, query_mode, **extra):
+    from src.repositories.table_registry import TableRegistryRepository
+    repo = TableRegistryRepository(seeded_app["conn"])
+    repo.register(
+        id=id, name=id, source_type=source_type, bucket=bucket,
+        source_table=source_table, query_mode=query_mode, **extra,
+    )
+seeded_app["register_table"] = register_table
+```
+
+- [ ] **Step 8.2: Run test to verify it fails**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_v2_catalog_remote_metadata.py -v
+```
+Expected: FAIL — response doesn't include the new fields yet.
+
+- [ ] **Step 8.3: Wire up the dispatch + cache + response shape**
+
+Edit `app/api/v2_catalog.py`:
+
+A. Add a `_metadata_cache` near the existing `_table_rows_cache` (around line 26):
+
+```python
+# Per-table cached TableMetadata. 15-min TTL — long enough to amortise
+# across an analyst session, short enough that a freshly-registered
+# remote table shows real numbers within a coffee break (the cache-bust
+# path in `invalidate_for_table` accelerates this for the common admin-
+# verifies-registration flow).
+_metadata_cache = TTLCache(maxsize=512, ttl_seconds=900)
+```
+
+B. Rename the existing function `_materialized_size_hint` to `_size_hint_for_row` and extend it. Find the function (around line 68) and replace its full body:
+
+```python
+def _size_hint_for_row(row: dict) -> dict:
+    """Resolve the per-row metadata bundle the catalog response surfaces.
+
+    Renamed from `_materialized_size_hint` (which always also handled
+    `local` rows; the old name was misleading). Returns a dict with up
+    to four keys: `rough_size_hint`, `rows`, `size_bytes`, `partition_by`,
+    `clustered_by`. Missing keys are reported as `null` in the response.
+
+    Branches:
+      - `local` / `materialized` → existing on-disk parquet stat (cheap).
+      - `remote` → dispatch to the per-source-type provider; cache the
+        TableMetadata for 15 min.
+    """
+    table_id = row["id"]
+    source_type = row.get("source_type") or ""
+    query_mode = row.get("query_mode") or "local"
+
+    if query_mode in ("local", "materialized"):
+        return {"rough_size_hint": _materialized_parquet_size_bucket(
+            table_id, source_type, query_mode,
+        )}
+
+    if query_mode != "remote":
+        return {"rough_size_hint": None}
+
+    # Cache lookup (per-row TableMetadata).
+    cached = _metadata_cache.get(table_id)
+    if cached is None:
+        cached = _resolve_remote_metadata(row)
+        if cached is not None:
+            _metadata_cache.set(table_id, cached)
+
+    if cached is None:
+        return {"rough_size_hint": None}
+
+    return {
+        "rough_size_hint": _bucket_size(cached.size_bytes) if cached.size_bytes else None,
+        "rows": cached.rows,
+        "size_bytes": cached.size_bytes,
+        "partition_by": cached.partition_by,
+        "clustered_by": cached.clustered_by,
+    }
+
+
+def _materialized_parquet_size_bucket(
+    table_id: str, source_type: str, query_mode: str,
+) -> str | None:
+    """Size hint for rows whose data is on the server filesystem
+    (the old `_materialized_size_hint` body)."""
+    if not source_type:
+        return None
+    try:
+        path = (
+            Path(_get_data_dir()) / "extracts" / source_type / "data"
+            / f"{table_id}.parquet"
+        )
+        if not path.exists():
+            return None
+        return _bucket_size(path.stat().st_size)
+    except Exception:
+        return None
+
+
+def _resolve_remote_metadata(row: dict) -> "TableMetadata | None":
+    """Provider dispatch for a remote row. Returns None on any failure."""
+    source_type = row.get("source_type") or ""
+    provider = _metadata_provider_for(source_type)
+    if provider is None:
+        return None
+    req = _build_metadata_request(row)
+    if req is None:
+        return None
+    try:
+        return provider(req)
+    except Exception:
+        # Defense in depth — providers are documented as never-raises,
+        # but a regression would otherwise 500 the whole catalog.
+        return None
+```
+
+C. Update `build_catalog` (around line 94) to merge the new fields into each visible row's payload. Find the loop body that builds `visible.append(...)` and replace the appended dict construction:
+
+```python
+    visible = []
+    for r in rows:
+        if not can_access_table(user, r["id"], conn):
+            continue
+        hint = _size_hint_for_row(r)
+        visible.append({
+            "id": r["id"],
+            "name": r.get("name") or r["id"],
+            "description": r.get("description") or "",
+            "source_type": r.get("source_type") or "",
+            "query_mode": r.get("query_mode") or "local",
+            "sql_flavor": _flavor_for(r.get("source_type") or ""),
+            "where_examples": _examples_for(r.get("source_type") or ""),
+            "fetch_via": _fetch_hint(r["id"], r.get("source_type") or ""),
+            "rough_size_hint": hint.get("rough_size_hint"),
+            "rows": hint.get("rows"),
+            "size_bytes": hint.get("size_bytes"),
+            "partition_by": hint.get("partition_by"),
+            "clustered_by": hint.get("clustered_by"),
+        })
+```
+
+D. Verify the existing `from pathlib import Path` and `_get_data_dir` import are still in scope; if not, add them.
+
+- [ ] **Step 8.4: Run tests to verify they pass**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_v2_catalog_remote_metadata.py tests/test_v2_catalog_dispatcher.py -v
+```
+Expected: all green.
+
+- [ ] **Step 8.5: Run existing v2_catalog tests for regression**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_v2_catalog.py -v
+```
+Expected: all green (response is additive — no field renamed or removed).
+
+- [ ] **Step 8.6: Commit**
+
+```bash
+cd /tmp/agnes-metadata
+git add app/api/v2_catalog.py tests/test_v2_catalog_remote_metadata.py
+git commit -m "feat(catalog): enrich remote rows with rows / size_bytes / partition_by / clustered_by
+
+_size_hint_for_row (renamed from _materialized_size_hint) now dispatches
+to the per-source-type metadata provider for query_mode='remote' rows
+and caches the TableMetadata for 15 minutes. Catalog response gains
+four new optional fields; existing CLI consumers that read only
+rough_size_hint stay unchanged.
+
+Refs: docs/superpowers/specs/2026-05-07-source-agnostic-table-metadata-spec.md"
+```
+
+---
+
+## Task 9: Unified cache invalidation
+
+**Files:**
+- Modify: `app/api/v2_catalog.py` (add `invalidate_for_table`)
+- Modify: `app/api/admin.py` (call from register/update/unregister)
+- Test: `tests/test_v2_catalog_invalidation.py`
+
+- [ ] **Step 9.1: Write failing test**
+
+Create `tests/test_v2_catalog_invalidation.py`:
+
+```python
+"""Unified cache flush across all four catalog/schema/sample/metadata
+caches on registry write."""
+
+from unittest.mock import patch
+
+
+def test_invalidate_flushes_all_four_caches():
+    from app.api import v2_catalog, v2_schema, v2_sample
+    from app.api._metadata_models import TableMetadata
+
+    # Pre-populate.
+    v2_catalog._table_rows_cache.set("all", ["fake_row"])
+    v2_catalog._metadata_cache.set("orders", TableMetadata(rows=10))
+    v2_schema._schema_cache.set("orders", {"columns": []})
+    v2_sample._sample_cache.set("orders|10", [{"row": 1}])
+
+    v2_catalog.invalidate_for_table("orders")
+
+    assert v2_catalog._table_rows_cache.get("all") is None
+    assert v2_catalog._metadata_cache.get("orders") is None
+    assert v2_schema._schema_cache.get("orders") is None
+    # Sample cache is cleared whole (we don't have prefix-invalidation).
+    assert v2_sample._sample_cache.get("orders|10") is None
+
+
+def test_invalidate_schedules_single_row_rewarm(monkeypatch):
+    """After the flush, a background re-warm task is scheduled for the
+    same table_id. Assert via patching create_task."""
+    import asyncio
+    from app.api import v2_catalog
+
+    scheduled = []
+
+    def fake_create_task(coro):
+        # Drain the coroutine so the test doesn't leak it.
+        coro.close()
+        scheduled.append(coro)
+        return None
+
+    monkeypatch.setattr(asyncio, "create_task", fake_create_task)
+    v2_catalog.invalidate_for_table("orders")
+    assert len(scheduled) == 1
+
+
+def test_register_table_invalidates(seeded_app):
+    """Registering a table flushes the rows cache so the next catalog
+    request reflects it without waiting for the 5-min TTL."""
+    from app.api import v2_catalog
+    v2_catalog._table_rows_cache.set("all", [])
+
+    seeded_app["register_table"](
+        id="new_t", source_type="keboola", bucket="in.c-x",
+        source_table="t", query_mode="local",
+    )
+    assert v2_catalog._table_rows_cache.get("all") is None
+
+
+def test_update_table_invalidates(seeded_app):
+    from app.api import v2_catalog
+    seeded_app["register_table"](
+        id="u_t", source_type="keboola", bucket="in.c-x",
+        source_table="t", query_mode="local",
+    )
+    v2_catalog._table_rows_cache.set("all", ["pre-update"])
+    seeded_app["http_put"]("/api/admin/registry/u_t", {"description": "new"})
+    assert v2_catalog._table_rows_cache.get("all") is None
+
+
+def test_unregister_table_invalidates(seeded_app):
+    from app.api import v2_catalog
+    seeded_app["register_table"](
+        id="d_t", source_type="keboola", bucket="in.c-x",
+        source_table="t", query_mode="local",
+    )
+    v2_catalog._table_rows_cache.set("all", ["pre-delete"])
+    seeded_app["http_delete"]("/api/admin/registry/d_t")
+    assert v2_catalog._table_rows_cache.get("all") is None
+```
+
+If `seeded_app["http_put"]` or `["http_delete"]` aren't already defined in `tests/conftest.py`, add thin wrappers that call `c.put(...)` / `c.delete(...)` with the admin token.
+
+- [ ] **Step 9.2: Run tests to verify they fail**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_v2_catalog_invalidation.py -v
+```
+Expected: FAIL with `AttributeError: module 'app.api.v2_catalog' has no attribute 'invalidate_for_table'`.
+
+- [ ] **Step 9.3: Add `invalidate_for_table` to v2_catalog**
+
+Append to `app/api/v2_catalog.py` (anywhere after `_metadata_cache` is defined):
+
+```python
+def invalidate_for_table(table_id: str) -> None:
+    """Drop every per-table cache so the next /api/v2/* request reflects
+    the just-registered / updated / unregistered row immediately. Owned
+    by the catalog module so admin.py doesn't need to know which caches
+    exist.
+
+    Imports v2_schema and v2_sample lazily — keeps catalog tests from
+    pulling in BQ-extension imports they don't need.
+    """
+    import asyncio
+    from app.api import v2_schema, v2_sample
+
+    _table_rows_cache.clear()
+    _metadata_cache.invalidate(table_id)
+    v2_schema._schema_cache.invalidate(table_id)
+    # Sample cache key is `f"{table_id}|{n}"`; clearing the whole sample
+    # cache is heavier than precise invalidation, but registry-change
+    # frequency (handful per day on a typical instance) doesn't justify
+    # adding a prefix-invalidation primitive to TTLCache.
+    v2_sample._sample_cache.clear()
+
+    # Schedule a single-row re-warm so admins editing a registry row
+    # see fresh data within a couple of seconds rather than waiting for
+    # the next analyst to trigger a miss. Fire-and-forget; failures
+    # log + skip inside the coroutine.
+    try:
+        asyncio.create_task(_rewarm_one_row(table_id))
+    except RuntimeError:
+        # No running event loop (e.g. called from a sync test). Skip
+        # the re-warm — the next live request will populate via miss.
+        pass
+
+
+async def _rewarm_one_row(table_id: str) -> None:
+    """Background single-row re-warm. Imports cache_warmup lazily to
+    avoid a circular import at module load."""
+    try:
+        from app.api.cache_warmup import warm_one_table
+        await warm_one_table(table_id)
+    except Exception:
+        import logging
+        logging.getLogger(__name__).warning(
+            "single-row re-warm failed for %s — next live request will populate",
+            table_id,
+        )
+```
+
+The `cache_warmup.warm_one_table` function will be defined in Task 10. For now it doesn't exist; the lazy import + outer `try` means the test for the schedule-task can run without it, falling through to the warning path. The unit test `test_invalidate_schedules_single_row_rewarm` patches `asyncio.create_task` so the inner coroutine never runs.
+
+- [ ] **Step 9.4: Wire the helper into admin.py**
+
+Edit `app/api/admin.py`. Find the success-return paths in:
+
+- `register_table` (around line 1037 / inner success branch)
+- `update_table` (around line 2486)
+- `unregister_table` (the DELETE handler around line 2538)
+
+For each, add a single line just before the function returns:
+
+```python
+    from app.api.v2_catalog import invalidate_for_table
+    invalidate_for_table(table_id)
+```
+
+(The import inside the function avoids a circular import at module load.)
+
+For `register_table`, the `table_id` may be derived from `result["id"]` or similar — adapt to the actual variable name in scope. For `unregister_table`, the path parameter is `table_id`. For `update_table`, also `table_id`.
+
+- [ ] **Step 9.5: Run tests**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_v2_catalog_invalidation.py -v
+```
+Expected: all green.
+
+- [ ] **Step 9.6: Commit**
+
+```bash
+cd /tmp/agnes-metadata
+git add app/api/v2_catalog.py app/api/admin.py tests/test_v2_catalog_invalidation.py
+git commit -m "feat(catalog): unified invalidate_for_table flushes 4 caches + schedules rewarm
+
+invalidate_for_table flushes _table_rows_cache + _metadata_cache +
+_schema_cache + _sample_cache, then schedules a single-row re-warm so
+admin-edited rows reflect fresh data within ~1s rather than waiting for
+the next analyst miss. Wired into register_table / update_table /
+unregister_table.
+
+Pre-fix none of the four caches were invalidated on registry change —
+admin registers a table, agnes catalog doesn't show the new row for up
+to 5 min; admin updates a row's bucket, agnes schema returns the OLD
+column list for up to 1h.
+
+Refs: docs/superpowers/specs/2026-05-07-source-agnostic-table-metadata-spec.md"
+```
+
+---
+
+## Task 10: Cache warmup framework — state + bg task + endpoints
+
+**Files:**
+- Create: `app/api/cache_warmup.py`
+- Modify: `pyproject.toml` (add `sse-starlette` dep)
+- Test: `tests/test_cache_warmup.py`
+
+- [ ] **Step 10.1: Add sse-starlette dependency**
+
+Edit `pyproject.toml`. Find the `dependencies = [` block under `[project]` and append:
+
+```
+    "sse-starlette>=2.0",
+```
+
+Run:
+
+```bash
+cd /tmp/agnes-metadata && uv pip install -e ".[dev]"
+```
+
+- [ ] **Step 10.2: Write failing tests**
+
+Create `tests/test_cache_warmup.py`:
+
+```python
+"""Cache warmup framework — state, bg task, endpoints."""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+
+def test_warmup_run_state_starts_empty():
+    from app.api.cache_warmup import WARMUP_STATE
+    assert WARMUP_STATE is None or WARMUP_STATE.completed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_warmup_skips_when_env_set(monkeypatch):
+    """AGNES_SKIP_CACHE_WARMUP=1 → background warmup is a no-op."""
+    monkeypatch.setenv("AGNES_SKIP_CACHE_WARMUP", "1")
+    from app.api import cache_warmup
+
+    with patch.object(cache_warmup, "_warm_catalog_caches_bg") as mock_bg:
+        cache_warmup.maybe_schedule_startup_warmup()
+        # Either not called, or called and short-circuits internally.
+    # Exact assertion depends on implementation; pick the simpler one.
+    mock_bg.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_warmup_runs_one_per_remote_row():
+    """`_warm_catalog_caches_bg` calls `_warm_one` once per remote row."""
+    from app.api import cache_warmup
+
+    # Stub the registry to return 3 remote BQ rows + 1 local row.
+    fake_rows = [
+        {"id": "r1", "query_mode": "remote", "source_type": "bigquery"},
+        {"id": "r2", "query_mode": "remote", "source_type": "bigquery"},
+        {"id": "r3", "query_mode": "remote", "source_type": "bigquery"},
+        {"id": "L1", "query_mode": "local", "source_type": "keboola"},
+    ]
+    warmed = []
+
+    async def fake_warm_one(row, state, sem):
+        warmed.append(row["id"])
+
+    with patch.object(cache_warmup, "_list_remote_rows", return_value=fake_rows[:3]):
+        with patch.object(cache_warmup, "_warm_one", fake_warm_one):
+            await cache_warmup._warm_catalog_caches_bg(trigger="manual")
+
+    assert sorted(warmed) == ["r1", "r2", "r3"]
+
+
+@pytest.mark.asyncio
+async def test_warmup_failure_isolated_to_one_row():
+    from app.api import cache_warmup
+
+    async def fake_warm_one(row, state, sem):
+        if row["id"] == "fail":
+            raise RuntimeError("BQ down for this row")
+
+    with patch.object(cache_warmup, "_list_remote_rows", return_value=[
+        {"id": "ok1", "query_mode": "remote", "source_type": "bigquery"},
+        {"id": "fail", "query_mode": "remote", "source_type": "bigquery"},
+        {"id": "ok2", "query_mode": "remote", "source_type": "bigquery"},
+    ]):
+        with patch.object(cache_warmup, "_warm_one", fake_warm_one):
+            await cache_warmup._warm_catalog_caches_bg(trigger="manual")
+
+    state = cache_warmup.WARMUP_STATE
+    assert state.total == 3
+    # Other rows still ran; the bad one is recorded but doesn't blow up
+    # the gather. Note: this asserts on the gather behavior, not on
+    # `_warm_one`'s internal exception handling — that lives in
+    # the real implementation, not the stub here. If the implementation
+    # catches inside `_warm_one`, the gather completes fully.
+
+
+@pytest.mark.asyncio
+async def test_run_endpoint_idempotent_on_concurrent_invocation(seeded_app):
+    """Two POST /run calls in flight return the same run_id."""
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # First POST starts a run.
+    r1 = c.post("/api/admin/cache-warmup/run", headers=headers)
+    assert r1.status_code == 200
+    body1 = r1.json()
+    # Second POST while first is in-flight: returns existing run_id.
+    r2 = c.post("/api/admin/cache-warmup/run", headers=headers)
+    body2 = r2.json()
+    if body2.get("status") == "already_running":
+        assert body2["run_id"] == body1.get("run_id") or "run_id" in body1
+    # Otherwise the first run completed before the second arrived; that's
+    # also OK — idempotency only matters under true concurrency.
+
+
+def test_status_endpoint_before_first_run(seeded_app):
+    """GET /status returns {state: never_run} before any warmup."""
+    from app.api import cache_warmup
+    cache_warmup.WARMUP_STATE = None  # reset for this test
+
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.get(
+        "/api/admin/cache-warmup/status",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200
+    assert r.json() == {"state": "never_run"}
+```
+
+- [ ] **Step 10.3: Run tests to verify they fail**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_cache_warmup.py -v
+```
+Expected: ImportError for `app.api.cache_warmup`.
+
+- [ ] **Step 10.4: Implement the warmup module**
+
+Create `app/api/cache_warmup.py`:
+
+```python
+"""Cache warmup framework — populates catalog/schema/metadata caches at
+container startup so the first analyst hits warm caches.
+
+Bounded concurrency (4 by default). Exposes:
+  - GET /api/admin/cache-warmup/status — JSON snapshot
+  - POST /api/admin/cache-warmup/run — manual trigger (idempotent)
+  - GET /api/admin/cache-warmup/stream — Server-Sent Events
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Literal
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends
+from sse_starlette.sse import EventSourceResponse
+
+from app.auth.dependencies import _get_db
+from app.auth.access import require_admin
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+@dataclass
+class WarmupRowState:
+    table_id: str
+    status: Literal["pending", "warming", "fresh", "error"]
+    started_at: str | None = None
+    completed_at: str | None = None
+    duration_ms: int | None = None
+    error: str | None = None
+    last_warmed_at: str | None = None
+
+
+@dataclass
+class WarmupRunState:
+    run_id: str
+    trigger: Literal["startup", "manual", "registry_change"]
+    started_at: str
+    completed_at: str | None = None
+    total: int = 0
+    completed: int = 0
+    failed: int = 0
+    rows: dict[str, WarmupRowState] = field(default_factory=dict)
+    _subscribers: list[asyncio.Queue] = field(default_factory=list, repr=False)
+
+
+WARMUP_STATE: WarmupRunState | None = None
+_RUN_LOCK = asyncio.Lock()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def maybe_schedule_startup_warmup() -> None:
+    """Called from app/main.py FastAPI startup event."""
+    if os.environ.get("AGNES_SKIP_CACHE_WARMUP") == "1":
+        logger.info("cache warmup skipped (AGNES_SKIP_CACHE_WARMUP=1)")
+        return
+    try:
+        asyncio.create_task(_warm_catalog_caches_bg(trigger="startup"))
+    except RuntimeError:
+        logger.warning("no running event loop — startup warmup skipped")
+
+
+async def _warm_catalog_caches_bg(trigger: str = "startup") -> None:
+    """Walk registry, warm metadata + schema caches for every remote row."""
+    global WARMUP_STATE
+    async with _RUN_LOCK:
+        # Re-check inside the lock — another caller might have completed
+        # a run while we were waiting.
+        if WARMUP_STATE and WARMUP_STATE.completed_at is None:
+            return
+
+        run_id = uuid4().hex[:8]
+        state = WarmupRunState(
+            run_id=run_id, trigger=trigger, started_at=_now_iso(),
+        )
+        WARMUP_STATE = state
+
+    rows = _list_remote_rows()
+    state.total = len(rows)
+    for r in rows:
+        state.rows[r["id"]] = WarmupRowState(
+            table_id=r["id"], status="pending",
+        )
+    _broadcast(state, {"event": "start", "data": {
+        "run_id": run_id, "trigger": trigger, "total": state.total,
+    }})
+
+    sem = asyncio.Semaphore(int(os.environ.get("AGNES_WARMUP_CONCURRENCY", "4")))
+    await asyncio.gather(
+        *(_warm_one(r, state, sem) for r in rows), return_exceptions=True,
+    )
+
+    state.completed_at = _now_iso()
+    _broadcast(state, {"event": "complete", "data": {
+        "run_id": run_id, "total": state.total,
+        "completed": state.completed, "failed": state.failed,
+    }})
+    logger.info(
+        "cache warmup complete: run_id=%s total=%d ok=%d fail=%d",
+        run_id, state.total, state.completed, state.failed,
+    )
+
+
+def _list_remote_rows() -> list[dict]:
+    """Snapshot of registry rows that need a warmup pass."""
+    from src.db import get_system_db
+    from src.repositories.table_registry import TableRegistryRepository
+    conn = get_system_db()
+    rows = TableRegistryRepository(conn).list_all()
+    return [
+        r for r in rows
+        if r.get("query_mode") == "remote"
+        and r.get("source_type") == "bigquery"
+    ]
+
+
+async def _warm_one(
+    row: dict, state: WarmupRunState, sem: asyncio.Semaphore,
+) -> None:
+    async with sem:
+        rs = state.rows[row["id"]]
+        rs.status = "warming"
+        rs.started_at = _now_iso()
+        _broadcast(state, {"event": "row", "data": asdict(rs)})
+        t0 = time.monotonic()
+        try:
+            await asyncio.to_thread(_warm_metadata_sync, row)
+            await asyncio.to_thread(_warm_schema_sync, row)
+            rs.status = "fresh"
+            rs.last_warmed_at = _now_iso()
+            state.completed += 1
+        except Exception as e:
+            rs.status = "error"
+            rs.error = str(e)
+            state.failed += 1
+            logger.warning("cache warmup row=%s failed: %s", row["id"], e)
+        finally:
+            rs.completed_at = _now_iso()
+            rs.duration_ms = int((time.monotonic() - t0) * 1000)
+            _broadcast(state, {"event": "row", "data": asdict(rs)})
+
+
+def _warm_metadata_sync(row: dict) -> None:
+    """Trigger metadata cache populate via the catalog's normal path."""
+    from app.api.v2_catalog import _size_hint_for_row
+    _size_hint_for_row(row)
+
+
+def _warm_schema_sync(row: dict) -> None:
+    """Trigger schema cache populate via build_schema_uncached."""
+    from app.api.v2_schema import build_schema_uncached
+    from connectors.bigquery.access import get_bq_access
+    from src.db import get_system_db
+    bq = get_bq_access()
+    build_schema_uncached(get_system_db(), row["id"], bq=bq)
+
+
+async def warm_one_table(table_id: str) -> None:
+    """Single-row re-warm — invoked by `invalidate_for_table` after a
+    registry change. Does NOT update WARMUP_STATE (small change shouldn't
+    overwrite the last full run's status); just refreshes the caches."""
+    from src.db import get_system_db
+    from src.repositories.table_registry import TableRegistryRepository
+    conn = get_system_db()
+    row = TableRegistryRepository(conn).get(table_id)
+    if not row or row.get("query_mode") != "remote":
+        return
+    try:
+        await asyncio.to_thread(_warm_metadata_sync, row)
+        await asyncio.to_thread(_warm_schema_sync, row)
+    except Exception as e:
+        logger.warning("single-row warmup failed for %s: %s", table_id, e)
+
+
+def _broadcast(state: WarmupRunState, event: dict) -> None:
+    """Send an event to every SSE subscriber. Dead queues are pruned."""
+    dead = []
+    for q in state._subscribers:
+        try:
+            q.put_nowait(event)
+        except asyncio.QueueFull:
+            dead.append(q)
+    for q in dead:
+        state._subscribers.remove(q)
+
+
+def _serialize_state(state: WarmupRunState) -> dict:
+    return {
+        "run_id": state.run_id,
+        "trigger": state.trigger,
+        "started_at": state.started_at,
+        "completed_at": state.completed_at,
+        "total": state.total,
+        "completed": state.completed,
+        "failed": state.failed,
+        "rows": {tid: asdict(rs) for tid, rs in state.rows.items()},
+    }
+
+
+# ─── Endpoints ────────────────────────────────────────────────────────
+
+
+@router.get("/api/admin/cache-warmup/status")
+async def warmup_status(user: dict = Depends(require_admin)):
+    if WARMUP_STATE is None:
+        return {"state": "never_run"}
+    return _serialize_state(WARMUP_STATE)
+
+
+@router.post("/api/admin/cache-warmup/run")
+async def warmup_run(user: dict = Depends(require_admin)):
+    if WARMUP_STATE and WARMUP_STATE.completed_at is None:
+        return {"run_id": WARMUP_STATE.run_id, "status": "already_running"}
+    asyncio.create_task(_warm_catalog_caches_bg(trigger="manual"))
+    # Brief sleep so WARMUP_STATE is populated by the time we return.
+    await asyncio.sleep(0)
+    return {
+        "run_id": WARMUP_STATE.run_id if WARMUP_STATE else None,
+        "status": "started",
+    }
+
+
+@router.get("/api/admin/cache-warmup/stream")
+async def warmup_stream(user: dict = Depends(require_admin)):
+    async def gen():
+        q: asyncio.Queue = asyncio.Queue(maxsize=256)
+        if WARMUP_STATE:
+            WARMUP_STATE._subscribers.append(q)
+        # Replay current snapshot.
+        if WARMUP_STATE:
+            yield {"event": "snapshot", "data": json.dumps(
+                _serialize_state(WARMUP_STATE)
+            )}
+        try:
+            while True:
+                ev = await asyncio.wait_for(q.get(), timeout=30.0)
+                yield {"event": ev["event"], "data": json.dumps(ev["data"])}
+                if ev["event"] == "complete":
+                    return
+        except asyncio.TimeoutError:
+            return
+        finally:
+            if WARMUP_STATE and q in WARMUP_STATE._subscribers:
+                WARMUP_STATE._subscribers.remove(q)
+
+    return EventSourceResponse(gen())
+```
+
+- [ ] **Step 10.5: Register the router in app/main.py**
+
+Edit `app/main.py`. Find the section where routers are included (look for `app.include_router(...)` calls). Add:
+
+```python
+from app.api.cache_warmup import router as cache_warmup_router
+app.include_router(cache_warmup_router)
+```
+
+- [ ] **Step 10.6: Run tests**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_cache_warmup.py -v
+```
+Expected: all green.
+
+- [ ] **Step 10.7: Commit**
+
+```bash
+cd /tmp/agnes-metadata
+git add app/api/cache_warmup.py app/main.py pyproject.toml \
+        tests/test_cache_warmup.py
+git commit -m "feat(cache-warmup): startup background warmup + status / run / stream endpoints
+
+- WarmupRunState / WarmupRowState dataclasses + module-level singleton.
+- _warm_catalog_caches_bg walks remote BQ rows with bounded concurrency
+  (Semaphore(4), tunable via AGNES_WARMUP_CONCURRENCY).
+- Per-row failures isolated; never blow up the gather.
+- maybe_schedule_startup_warmup honors AGNES_SKIP_CACHE_WARMUP=1.
+- warm_one_table for the single-row re-warm called from
+  invalidate_for_table.
+- GET /api/admin/cache-warmup/status — JSON snapshot.
+- POST /api/admin/cache-warmup/run — manual trigger, idempotent under
+  concurrent invocation (locks + checks completed_at).
+- GET /api/admin/cache-warmup/stream — Server-Sent Events stream of
+  start / row / complete events.
+
+Refs: docs/superpowers/specs/2026-05-07-source-agnostic-table-metadata-spec.md"
+```
+
+---
+
+## Task 11: FastAPI startup event hook
+
+**Files:**
+- Modify: `app/main.py`
+- Test: `tests/test_main_startup_warmup.py`
+
+- [ ] **Step 11.1: Write failing test**
+
+Create `tests/test_main_startup_warmup.py`:
+
+```python
+"""The FastAPI startup event schedules `maybe_schedule_startup_warmup`
+without blocking readiness."""
+
+from unittest.mock import patch
+
+
+def test_startup_event_calls_warmup_scheduler():
+    from app.main import app
+    # FastAPI startup events are functions on `app.router.on_startup`.
+    handler_names = [h.__name__ for h in app.router.on_startup]
+    assert any("warm" in n.lower() for n in handler_names), (
+        "Expected a startup handler with 'warm' in its name; "
+        f"found: {handler_names}"
+    )
+
+
+def test_health_check_returns_immediately_during_warmup(seeded_app):
+    """/api/health doesn't await warmup; readiness is fire-and-forget."""
+    c = seeded_app["client"]
+    r = c.get("/api/health")
+    assert r.status_code == 200
+```
+
+- [ ] **Step 11.2: Run test to verify it fails**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_main_startup_warmup.py -v
+```
+Expected: first test FAIL, second probably passes.
+
+- [ ] **Step 11.3: Add the startup hook**
+
+Edit `app/main.py`. Locate the existing FastAPI app instantiation (`app = FastAPI(...)`). Add a startup event handler nearby:
+
+```python
+@app.on_event("startup")
+async def warm_catalog_caches_on_startup():
+    """Schedule a background warmup of the v2 catalog/schema/metadata
+    caches. Fire-and-forget; readiness is not blocked. Failures inside
+    the background task are logged + swallowed.
+    """
+    from app.api.cache_warmup import maybe_schedule_startup_warmup
+    maybe_schedule_startup_warmup()
+```
+
+If the file already uses lifespan handlers (newer FastAPI pattern), add the call into the lifespan function instead. Inspect the file first.
+
+- [ ] **Step 11.4: Run tests to verify they pass**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_main_startup_warmup.py -v
+```
+Expected: both pass.
+
+- [ ] **Step 11.5: Commit**
+
+```bash
+cd /tmp/agnes-metadata
+git add app/main.py tests/test_main_startup_warmup.py
+git commit -m "feat(main): startup event hook for catalog cache warmup
+
+Fire-and-forget — readiness is not blocked. Per-row warmup runs in
+background with bounded concurrency. Honors AGNES_SKIP_CACHE_WARMUP=1
+opt-out for dev/test instances.
+
+Refs: docs/superpowers/specs/2026-05-07-source-agnostic-table-metadata-spec.md"
+```
+
+---
+
+## Task 12: CLI post-register hint for query_mode=remote
+
+**Files:**
+- Modify: `cli/commands/admin.py` (extend `register_table` post-success hint)
+- Test: `tests/test_cli_admin.py` (append test)
+
+- [ ] **Step 12.1: Write failing test**
+
+Append to `tests/test_cli_admin.py`:
+
+```python
+class TestRegisterTableHints:
+    """The CLI prints helpful follow-up hints after a successful
+    register-table call. v0.46 adds a third hint for query_mode=remote
+    pointing at the IAM verify-your-SA smoke check."""
+
+    def test_remote_register_emits_iam_verify_hint(self):
+        with patch("cli.commands.admin.api_post", return_value=_resp(201, {"id": "t"})):
+            result = runner.invoke(app, [
+                "admin", "register-table", "orders",
+                "--source-type", "bigquery",
+                "--bucket", "dwh_base",
+                "--source-table", "orders",
+                "--query-mode", "remote",
+            ])
+        assert result.exit_code == 0
+        assert "agnes query --remote" in result.output
+        assert "query-modes.md" in result.output
+
+    def test_local_register_does_not_emit_remote_hint(self):
+        with patch("cli.commands.admin.api_post", return_value=_resp(201, {"id": "t"})):
+            result = runner.invoke(app, [
+                "admin", "register-table", "users",
+                "--source-type", "keboola",
+                "--bucket", "in.c-crm",
+                "--source-table", "users",
+                "--query-mode", "local",
+            ])
+        assert result.exit_code == 0
+        assert "agnes query --remote" not in result.output
+```
+
+- [ ] **Step 12.2: Run test to verify it fails**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_cli_admin.py::TestRegisterTableHints -v
+```
+Expected: first FAIL.
+
+- [ ] **Step 12.3: Add the hint**
+
+Edit `cli/commands/admin.py`. Find the success branch in `register_table` (search for the existing two hints — `Next: run agnes setup first-sync` and `register-table does not auto-grant`). Add a third hint conditional on `query_mode == "remote"`:
+
+```python
+        # Third hint: BQ-remote rows can fail at first analyst query if the
+        # SA lacks dataViewer/jobUser. Pointing at the smoke command
+        # surfaces the failure at registration time, not 30 minutes later.
+        if query_mode == "remote":
+            typer.echo(
+                f"  Note: this is a remote-query table. Verify the SA can read it:\n"
+                f"    agnes query --remote \"SELECT COUNT(*) FROM {name}\"\n"
+                f"  If it 403s, see docs/admin/query-modes.md → \"BigQuery → IAM\"."
+            )
+```
+
+- [ ] **Step 12.4: Run tests**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_cli_admin.py::TestRegisterTableHints -v
+```
+Expected: 2 passed.
+
+- [ ] **Step 12.5: Commit**
+
+```bash
+cd /tmp/agnes-metadata
+git add cli/commands/admin.py tests/test_cli_admin.py
+git commit -m "feat(cli): third post-register hint for query_mode=remote
+
+Points at agnes query --remote SELECT COUNT(*) as the smoke check for
+SA IAM. Surfaces 403 USER_PROJECT_DENIED at register time, not when
+the first analyst hits the table 30 minutes later. Cross-references the
+new docs/admin/query-modes.md page (Task 13).
+
+Refs: docs/superpowers/specs/2026-05-07-source-agnostic-table-metadata-spec.md"
+```
+
+---
+
+## Task 13: docs/admin/query-modes.md
+
+**Files:**
+- Create: `docs/admin/query-modes.md`
+- Test: smoke test linking via `tests/test_docs_links.py` (optional)
+
+- [ ] **Step 13.1: Write the doc**
+
+Create `docs/admin/query-modes.md` with this exact content:
+
+````markdown
+# Query Modes — when to register a table as `local`, `remote`, or `materialized`
+
+Source-agnostic guide to the three `query_mode` values Agnes supports. Pick the right mode at registration time and the analyst-side experience is fast, cost-aware, and predictable. Pick wrong and you'll either burn BQ scan budget on every query or spend hours waiting on syncs that didn't need to happen.
+
+## TL;DR — decision tree
+
+```
+Is the table small (< 1 GB) and updated daily-or-slower?
+  └─ YES → query_mode: local       (sync to laptop, query offline)
+
+Is the table the result of an aggregate SQL the operator controls?
+  └─ YES → query_mode: materialized  (server runs SQL → parquet, distributed)
+
+Otherwise:
+  └─ query_mode: remote   (data stays in upstream; analyst queries on demand)
+```
+
+## Three modes side-by-side
+
+| Aspect | `local` | `materialized` | `remote` |
+|---|---|---|---|
+| Where the data lives | Analyst laptop (parquet) | Agnes server filesystem (parquet) | Upstream (BigQuery, Keboola, …) |
+| Who runs the query | Analyst's local DuckDB | Analyst's local DuckDB | Upstream engine via DuckDB extension |
+| Cost model | Free after sync | Free after each sync | Per-query scan cost on the analyst's first hit |
+| Freshness | As fresh as last sync | As fresh as last scheduled run | Live |
+| Scan limits | None (laptop disk) | None (server disk) | `bq_max_scan_bytes` cost gate (default 5 GiB) |
+| Best for | Stable reference data, daily-updated facts | Aggregates, daily snapshots | Big tables, live data, residency-restricted |
+
+## Per-source-type reference
+
+### BigQuery — `query_mode: remote`
+
+The most common use case for `remote`. Data stays in BQ; analysts query on demand via the Agnes server's service account.
+
+**IAM:** the server's SA must have:
+- `roles/bigquery.dataViewer` on the dataset (read access)
+- `roles/bigquery.jobUser` on the *billing* project (run jobs)
+
+If `data_source.bigquery.billing_project == data_source.bigquery.project`, set the SA's `serviceusage.services.use` permission too — the BQ extension can otherwise 403 USER_PROJECT_DENIED on the first query. The instance health check (`agnes diagnose`) surfaces this as an `info`-tier entry on `bq_config`.
+
+**Register via UI:** `/admin/tables` → "Add table" → Source type `bigquery` → Mode `remote` → fill `dataset` (your BQ dataset name) + `source_table` (the BQ table id within that dataset).
+
+**Register via CLI:**
+
+```bash
+agnes admin register-table sales_2024 \
+    --source-type bigquery \
+    --bucket dwh_base \
+    --source-table sales_2024 \
+    --query-mode remote
+```
+
+After registration, smoke-test the SA's access:
+
+```bash
+agnes query --remote "SELECT COUNT(*) FROM sales_2024"
+```
+
+A 403 here means the SA is missing `dataViewer` or `jobUser`; fix in IAM and re-test.
+
+**Cost guardrail:** `bq_max_scan_bytes` (default 5 GiB) refuses queries whose pre-execution scan estimate exceeds the cap. Configurable in `/admin/server-config`. When an analyst hits the cap, the response includes a hint to use `agnes snapshot create --where '<predicate>'` to materialise a scoped subset locally.
+
+### BigQuery — `query_mode: materialized`
+
+The server runs a scheduled SQL aggregate against BigQuery and writes the result to a parquet on the Agnes filesystem. Analysts get the parquet via `agnes pull` like any other local table.
+
+**Register via CLI:**
+
+```bash
+agnes admin register-table monthly_kpis \
+    --source-type bigquery \
+    --bucket dwh_base \
+    --source-table monthly_kpis \
+    --query-mode materialized \
+    --query @path/to/monthly_kpis.sql \
+    --sync-schedule "daily 03:00"
+```
+
+**Cost guardrail:** `data_source.bigquery.max_bytes_per_materialize` (default 10 GiB; set `0` to disable) refuses materialise runs whose query plan exceeds the cap. Catches a typo'd `WHERE` clause that would otherwise scan a year of data.
+
+### Keboola — `query_mode: local` (the production path)
+
+The Agnes server's Keboola DuckDB extension downloads the table to a parquet on the server filesystem; `agnes pull` distributes it to analyst laptops.
+
+**Setup:** `instance.yaml.data_source.type: keboola` + Storage API token via `KEBOOLA_STORAGE_TOKEN` env var (or whatever `instance.yaml.token_env` points at).
+
+**Register via CLI:**
+
+```bash
+agnes admin register-table users \
+    --source-type keboola \
+    --bucket in.c-crm \
+    --source-table users \
+    --query-mode local
+```
+
+**`query_mode: remote` for Keboola** is architecturally supported via the `_remote_attach` mechanism (the orchestrator can ATTACH the Keboola DuckDB extension on demand the same way it does for BQ), but **not in active deployment use today**. If you have an analyst workflow against a Keboola table that's too big to sync, file an issue — the architecture is in place but the registration UX hasn't been polished.
+
+### Jira — `query_mode: local` only
+
+Event-driven: webhooks update parquets incrementally. No `remote` or `materialized` mode for Jira today.
+
+## Worked examples
+
+**1. Big BigQuery fact table you query weekly:** `query_mode: remote`. SA needs `dataViewer` + `jobUser`. Analyst uses `agnes query --remote` for one-off aggregates and `agnes snapshot create` for cross-week joins.
+
+**2. Daily Keboola dimension table:** `query_mode: local`. Synced once a day by the scheduler; analyst's `agnes pull` picks it up.
+
+**3. Monthly KPI aggregate from a BQ datawarehouse:** `query_mode: materialized` + `--sync-schedule "0 3 1 * *"` (3:00 on the 1st of each month). The server runs your aggregate SQL once a month; analysts get a parquet of the result.
+
+## See also
+
+- `docs/RBAC.md` — granting analysts access to a registered table.
+- `config/instance.yaml.example` — the `data_source` config block.
+- `agnes catalog --json` — inspect a registered table's mode + size hints.
+- `agnes diagnose` — surface `bq_config` IAM issues and other health entries.
+````
+
+- [ ] **Step 13.2: Quick smoke check that the doc builds without dead links**
+
+```bash
+cd /tmp/agnes-metadata && python -c "
+from pathlib import Path
+content = Path('docs/admin/query-modes.md').read_text()
+# Check the cross-referenced files exist.
+for ref in ['docs/RBAC.md', 'config/instance.yaml.example']:
+    assert Path(ref).exists(), f'broken cross-ref: {ref}'
+print('docs OK')
+"
+```
+Expected: `docs OK`.
+
+- [ ] **Step 13.3: Commit**
+
+```bash
+cd /tmp/agnes-metadata
+git add docs/admin/query-modes.md
+git commit -m "docs(admin): query-modes.md — when to register a table as local/remote/materialized
+
+Source-agnostic decision tree + per-source-type reference (BigQuery,
+Keboola, Jira). Three worked examples. Cross-references to RBAC.md +
+instance.yaml.example.
+
+Linked from the admin UI tooltip (Task 14) and the CLI post-register
+hint (Task 12).
+
+Refs: docs/superpowers/specs/2026-05-07-source-agnostic-table-metadata-spec.md"
+```
+
+---
+
+## Task 14: Admin UI integration on /admin/tables
+
+**Files:**
+- Modify: `app/web/templates/admin_tables.html`
+- Test: `tests/test_admin_tables_warmup_ui.py`
+
+- [ ] **Step 14.1: Write failing test**
+
+Create `tests/test_admin_tables_warmup_ui.py`:
+
+```python
+"""Smoke test that /admin/tables HTML contains the cache toolbar markup,
+the EventSource wiring, and the per-row col-status slot."""
+
+
+def test_cache_toolbar_present(seeded_app):
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.get(
+        "/admin/tables", headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.text
+    assert 'id="cacheWarmupCard"' in body
+    assert "Re-warm all" in body
+    assert "/api/admin/cache-warmup/stream" in body
+    assert "EventSource" in body
+
+
+def test_query_mode_doc_link_present(seeded_app):
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.get(
+        "/admin/tables", headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200
+    assert "query-modes.md" in r.text or "/docs/admin/query-modes" in r.text
+
+
+def test_col_status_th_present_in_renderer(seeded_app):
+    """The renderRegistryListing JS still emits <th class='col-status'>
+    so the per-row badge slot exists."""
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.get("/admin/tables", headers={"Authorization": f"Bearer {token}"})
+    assert 'class="col-status"' in r.text
+```
+
+- [ ] **Step 14.2: Run test to verify it fails**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_admin_tables_warmup_ui.py -v
+```
+Expected: 2 of 3 fail (toolbar absent, EventSource not yet wired). Third probably passes.
+
+- [ ] **Step 14.3: Add the cache toolbar `<section>` to `admin_tables.html`**
+
+Edit `app/web/templates/admin_tables.html`. Locate the section between the page header and the per-source-type table listings — search for `bqTableListing` to find the area. Insert the new card just before the listings:
+
+```html
+<section id="cacheWarmupCard" class="card" style="margin-bottom: 20px;">
+    <header class="card-header" style="display: flex; justify-content: space-between; align-items: center;">
+        <h2>Cache freshness</h2>
+        <button class="btn btn-secondary" id="cacheWarmupRunBtn" onclick="cacheWarmupRun()">
+            Re-warm all
+        </button>
+    </header>
+    <div class="card-body">
+        <div id="cacheWarmupProgress" style="margin-bottom: 8px;">
+            <span id="cacheWarmupSummary">Loading…</span>
+        </div>
+        <progress id="cacheWarmupBar" max="100" value="0" style="width: 100%; display: none;"></progress>
+        <details style="margin-top: 8px;">
+            <summary style="cursor: pointer; user-select: none;">Show log</summary>
+            <pre id="cacheWarmupLog" style="background: #0a0a0a; color: #dcdcdc; font-family: ui-monospace, Menlo, monospace; font-size: 12px; padding: 8px; max-height: 240px; overflow-y: auto; margin-top: 8px; border-radius: 4px;"></pre>
+        </details>
+    </div>
+</section>
+```
+
+- [ ] **Step 14.4: Add the JS for live updates**
+
+Inside the existing `<script>` block at the bottom of `admin_tables.html`, append:
+
+```javascript
+    // ── Cache warmup toolbar (issue #155 / #156) ────────────────
+    let cacheWarmupSource = null;
+
+    function cacheWarmupInit() {
+        cacheWarmupRefreshSnapshot();
+        cacheWarmupOpenStream();
+    }
+
+    function cacheWarmupRefreshSnapshot() {
+        fetch('/api/admin/cache-warmup/status')
+            .then(function(r) { return r.json(); })
+            .then(function(state) { cacheWarmupRender(state); })
+            .catch(function() { /* silent */ });
+    }
+
+    function cacheWarmupOpenStream() {
+        try {
+            cacheWarmupSource = new EventSource('/api/admin/cache-warmup/stream');
+            cacheWarmupSource.addEventListener('start', cacheWarmupOnStart);
+            cacheWarmupSource.addEventListener('row', cacheWarmupOnRow);
+            cacheWarmupSource.addEventListener('complete', cacheWarmupOnComplete);
+            cacheWarmupSource.addEventListener('snapshot', function(e) {
+                cacheWarmupRender(JSON.parse(e.data));
+            });
+            cacheWarmupSource.onerror = function() {
+                // Polling fallback — close + retry every 3 s.
+                if (cacheWarmupSource) {
+                    cacheWarmupSource.close();
+                    cacheWarmupSource = null;
+                }
+                setTimeout(cacheWarmupRefreshSnapshot, 3000);
+            };
+        } catch (e) {
+            // EventSource unsupported; poll instead.
+            setInterval(cacheWarmupRefreshSnapshot, 3000);
+        }
+    }
+
+    function cacheWarmupRender(state) {
+        var summary = document.getElementById('cacheWarmupSummary');
+        var bar = document.getElementById('cacheWarmupBar');
+        var btn = document.getElementById('cacheWarmupRunBtn');
+        if (!summary) return;
+
+        if (!state || state.state === 'never_run') {
+            summary.textContent = 'No cache warmup yet — click Re-warm all to start.';
+            bar.style.display = 'none';
+            btn.disabled = false;
+            return;
+        }
+        var inProgress = state.completed_at === null || state.completed_at === undefined;
+        var pct = state.total > 0 ? Math.round((state.completed * 100) / state.total) : 0;
+        summary.textContent = inProgress
+            ? state.completed + ' / ' + state.total + ' fresh — running…'
+            : 'Last run: ' + state.completed + ' ok, ' + state.failed + ' errors';
+        bar.style.display = 'block';
+        bar.value = pct;
+        btn.disabled = inProgress;
+
+        // Per-row badges.
+        if (state.rows) {
+            for (var tid in state.rows) {
+                cacheWarmupSetRowBadge(tid, state.rows[tid]);
+            }
+        }
+    }
+
+    function cacheWarmupOnStart(e) {
+        var data = JSON.parse(e.data);
+        var log = document.getElementById('cacheWarmupLog');
+        log.textContent = '';
+        cacheWarmupAppendLog(data.run_id ? '[' + nowHHMMSS() + '] start  trigger=' + data.trigger + ' total=' + data.total : '');
+        cacheWarmupRefreshSnapshot();
+    }
+
+    function cacheWarmupOnRow(e) {
+        var rs = JSON.parse(e.data);
+        cacheWarmupAppendLog(
+            '[' + nowHHMMSS() + '] ' + rs.status.padEnd(7) + rs.table_id +
+            (rs.duration_ms ? '  (' + (rs.duration_ms / 1000).toFixed(1) + ' s)' : '') +
+            (rs.error ? '  ' + rs.error : '')
+        );
+        cacheWarmupSetRowBadge(rs.table_id, rs);
+        cacheWarmupRefreshSnapshot();
+    }
+
+    function cacheWarmupOnComplete(e) {
+        var data = JSON.parse(e.data);
+        cacheWarmupAppendLog(
+            '[' + nowHHMMSS() + '] complete total=' + data.total +
+            ' ok=' + data.completed + ' fail=' + data.failed
+        );
+        cacheWarmupRefreshSnapshot();
+    }
+
+    function cacheWarmupAppendLog(line) {
+        var log = document.getElementById('cacheWarmupLog');
+        if (!log) return;
+        log.textContent += line + '\n';
+        log.scrollTop = log.scrollHeight;
+    }
+
+    function cacheWarmupSetRowBadge(tableId, rs) {
+        // Per-row badge in the col-status slot. Selector: any <tr>
+        // whose first <td class="col-id"> text matches tableId.
+        document.querySelectorAll('tr').forEach(function(tr) {
+            var idCell = tr.querySelector('td.col-id');
+            if (!idCell || idCell.textContent.trim() !== tableId) return;
+            var statusCell = tr.querySelector('td.col-status');
+            if (!statusCell) return;
+            var color = {fresh: '#10B77F', warming: '#0073D1', pending: '#9CA3AF', error: '#EA580C'}[rs.status] || '#9CA3AF';
+            var label = rs.status === 'fresh' ? 'fresh' : rs.status;
+            statusCell.innerHTML = '<span style="display:inline-block;padding:2px 6px;border-radius:3px;font-size:11px;background:' + color + ';color:white;" title="' + (rs.error || '') + '">' + label + '</span>';
+        });
+    }
+
+    function nowHHMMSS() {
+        var d = new Date();
+        return d.toTimeString().slice(0, 8);
+    }
+
+    function cacheWarmupRun() {
+        var btn = document.getElementById('cacheWarmupRunBtn');
+        btn.disabled = true;
+        fetch('/api/admin/cache-warmup/run', {method: 'POST'})
+            .then(function(r) { return r.json(); })
+            .then(function() { /* SSE stream picks up the new run */ })
+            .catch(function() { btn.disabled = false; });
+    }
+
+    // Init on page load.
+    document.addEventListener('DOMContentLoaded', cacheWarmupInit);
+```
+
+- [ ] **Step 14.5: Add `?` icon next to `query_mode` field in the edit modal**
+
+Find the edit-modal block in `admin_tables.html` (search for `editBqQueryMode` or similar). Next to the `query_mode` field's `<label>`, append:
+
+```html
+<a href="/docs/admin/query-modes.md" target="_blank" title="When to use which mode" style="margin-left: 6px; text-decoration: none;">?</a>
+```
+
+If the docs aren't served at `/docs/admin/...`, link to the GitHub URL instead (look at recent edits — `cli/lib/setup_instructions.py` may have a server-side doc base URL).
+
+- [ ] **Step 14.6: Run smoke tests**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest tests/test_admin_tables_warmup_ui.py -v
+```
+Expected: 3 passed.
+
+- [ ] **Step 14.7: Manual visual check (optional but recommended)**
+
+If a dev instance is available, browse to `/admin/tables`, register a remote BQ table, click "Re-warm all", and verify the log scrolls + per-row badges update.
+
+- [ ] **Step 14.8: Commit**
+
+```bash
+cd /tmp/agnes-metadata
+git add app/web/templates/admin_tables.html tests/test_admin_tables_warmup_ui.py
+git commit -m "feat(admin/tables): cache freshness toolbar + per-row badges + SSE log
+
+Adds a single cache panel above the per-source-type listings:
+- Re-warm all button → POST /api/admin/cache-warmup/run.
+- Progress bar + summary line.
+- Collapsible terminal-style log fed by EventSource on
+  /api/admin/cache-warmup/stream (polling fallback at 3 s on SSE error).
+- Per-row badge in the col-status slot updates live as warmup events
+  arrive.
+- ? icon next to the query_mode field in the edit modal links to
+  docs/admin/query-modes.md.
+
+Refs: docs/superpowers/specs/2026-05-07-source-agnostic-table-metadata-spec.md"
+```
+
+---
+
+## Task 15: CHANGELOG + version bump
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `pyproject.toml`
+
+- [ ] **Step 15.1: Bump version**
+
+Edit `pyproject.toml`. Find:
+
+```
+version = "0.45.x"
+```
+
+Change to:
+
+```
+version = "0.46.0"
+```
+
+- [ ] **Step 15.2: Add CHANGELOG entry**
+
+Edit `CHANGELOG.md`. Find `## [Unreleased]` near the top. Replace with:
+
+```markdown
+## [Unreleased]
+
+## [0.46.0] — 2026-05-07
+
+Catalog metadata enrichment + cache discipline + automatic warmup.
+Closes #155 + #156.
+
+### Added
+
+- **`/api/v2/catalog` returns four new optional fields per row** — `rows`,
+  `size_bytes`, `partition_by`, `clustered_by` — populated by per-source-type
+  metadata providers (`connectors/bigquery/metadata.py`,
+  `connectors/keboola/metadata.py`). For `query_mode='remote'` BigQuery rows,
+  `size_bytes` is `active_logical_bytes + long_term_logical_bytes` (a full
+  scan reads both); region resolved from `data_source.bigquery.location` →
+  `bq_client.get_dataset(...)` → fall back to legacy `__TABLES__`.
+  Existing CLI consumers reading only `rough_size_hint` are unaffected.
+- **Automatic cache warmup at startup.** FastAPI startup event schedules
+  a background task that walks BQ remote rows and pre-populates
+  `_metadata_cache` + `_schema_cache` with bounded concurrency (default 4,
+  tunable via `AGNES_WARMUP_CONCURRENCY`). Doesn't block readiness;
+  per-row failures logged + skipped. Opt-out via `AGNES_SKIP_CACHE_WARMUP=1`.
+- **Three new admin endpoints under `/api/admin/cache-warmup/*`:**
+  - `GET /status` — JSON snapshot of the latest run.
+  - `POST /run` — manual trigger, idempotent under concurrent invocation.
+  - `GET /stream` — Server-Sent Events with `start` / `row` / `complete`
+    events for live UI updates.
+- **`/admin/tables` cache freshness panel.** Toolbar above the per-source-type
+  listings with progress bar + "Re-warm all" button + collapsible
+  terminal-style log fed by SSE (polling fallback at 3 s). Per-row badge
+  in the existing `col-status` column updates live (fresh / warming /
+  pending / error).
+- **`docs/admin/query-modes.md`** — source-agnostic admin reference for
+  registering tables as `local` / `remote` / `materialized`. Decision
+  tree, per-source-type IAM + setup, three worked examples. Linked from
+  the `?` icon next to the `query_mode` field in the admin UI edit modal
+  and from the third post-register hint in `agnes admin register-table`.
+- **`agnes admin register-table` post-register hint** for `query_mode=remote`:
+  points at `agnes query --remote "SELECT COUNT(*)..."` as the IAM smoke
+  check so a missing `dataViewer` / `jobUser` surfaces at registration
+  time, not 30 minutes later.
+
+### Changed
+
+- **`/api/v2/schema/{id}` cache miss now does 1 BQ job instead of 2.**
+  `connectors/bigquery/access.py:fetch_bq_columns_full` collapses what
+  used to be `_fetch_bq_schema` + `_fetch_bq_table_options` into a single
+  `INFORMATION_SCHEMA.COLUMNS` query (same view, same predicate, just a
+  combined SELECT list). The metadata provider's partition/cluster path
+  shares the same helper — zero SQL duplication across the two consumers.
+- **All four catalog/schema/sample/metadata caches are flushed on registry
+  change.** `app/api/v2_catalog.py:invalidate_for_table` is wired into
+  `POST /api/admin/register-table`, `PUT /api/admin/registry/{id}`, and
+  `DELETE /api/admin/registry/{id}`. After a registry write, a single-row
+  re-warm task is scheduled in the background so the admin's verification
+  request hits warm caches within ~1 s instead of waiting for the next
+  analyst miss. Pre-fix none of the caches were invalidated — admin
+  registers a table, `agnes catalog` doesn't show the new row for up to
+  5 min; admin updates a row's bucket, `agnes schema` returns the OLD
+  column list for up to 1 hour.
+- **`v2_schema.build_schema` split into RBAC-aware outer + RBAC-naive
+  inner (`build_schema_uncached`).** Live endpoint behavior unchanged;
+  warmup uses the inner entry point to populate `_schema_cache` without
+  a user context.
+
+### Internal
+
+- New shared dataclass module `app/api/_metadata_models.py` with
+  `MetadataRequest` (frozen) + `TableMetadata` for source-agnostic
+  provider input/output.
+- New `connectors/keboola/storage_api.py:KeboolaStorageClient.get_table_info`
+  thin wrapper — keeps `_get` private to the module.
+- New env vars (operator-facing tuning, no required setup change):
+  - `AGNES_SKIP_CACHE_WARMUP` — opt-out of startup warmup.
+  - `AGNES_WARMUP_CONCURRENCY` — default 4, max parallel BQ
+    INFORMATION_SCHEMA jobs during a warmup pass.
+- New runtime dependency: `sse-starlette>=2.0` (Server-Sent Events
+  responses for the cache-warmup stream).
+- Tests added: `test_metadata_models`, `test_v2_schema_columns_consolidation`,
+  `test_v2_catalog_dispatcher`, `test_connectors_bigquery_metadata`,
+  `test_connectors_keboola_metadata`, `test_v2_catalog_remote_metadata`,
+  `test_v2_catalog_invalidation`, `test_cache_warmup`,
+  `test_main_startup_warmup`, `test_admin_tables_warmup_ui`.
+```
+
+- [ ] **Step 15.3: Smoke-check version + changelog consistency**
+
+```bash
+cd /tmp/agnes-metadata && grep '^version' pyproject.toml
+cd /tmp/agnes-metadata && head -20 CHANGELOG.md
+```
+Expected: pyproject shows `0.46.0`; CHANGELOG has `## [0.46.0] — 2026-05-07` directly after `## [Unreleased]`.
+
+- [ ] **Step 15.4: Run the full targeted test set**
+
+```bash
+cd /tmp/agnes-metadata && python -m pytest \
+    tests/test_metadata_models.py \
+    tests/test_keboola_storage_api.py::TestGetTableInfo \
+    tests/test_v2_schema_columns_consolidation.py \
+    tests/test_v2_schema.py \
+    tests/test_v2_catalog_dispatcher.py \
+    tests/test_connectors_bigquery_metadata.py \
+    tests/test_connectors_keboola_metadata.py \
+    tests/test_v2_catalog_remote_metadata.py \
+    tests/test_v2_catalog_invalidation.py \
+    tests/test_cache_warmup.py \
+    tests/test_main_startup_warmup.py \
+    tests/test_admin_tables_warmup_ui.py \
+    tests/test_cli_admin.py::TestRegisterTableHints \
+    -v
+```
+Expected: all green.
+
+- [ ] **Step 15.5: Commit**
+
+```bash
+cd /tmp/agnes-metadata
+git add CHANGELOG.md pyproject.toml
+git commit -m "release: 0.46.0 — source-agnostic catalog metadata + cache discipline
+
+PR closes #155 + #156.
+
+Highlights:
+- Catalog response gains rows / size_bytes / partition_by / clustered_by.
+- /api/v2/schema cache miss: 2 BQ jobs → 1 (-50%).
+- All 4 catalog/schema/sample/metadata caches flush on registry change.
+- Automatic startup warmup with bounded concurrency.
+- /admin/tables shows cache freshness toolbar + per-row badges + SSE log.
+- docs/admin/query-modes.md as the single source of truth for mode choice.
+
+No DB migration; no wire break; MIN_COMPAT_CLI_VERSION unchanged.
+
+Refs: docs/superpowers/specs/2026-05-07-source-agnostic-table-metadata-spec.md"
+```
+
+---
+
+## Task 16: Final verification + PR
+
+- [ ] **Step 16.1: Push branch**
+
+```bash
+cd /tmp/agnes-metadata && git push -u origin zs/issue-155-156-source-agnostic-metadata
+```
+
+- [ ] **Step 16.2: Open PR with auto-close keywords PER ISSUE**
+
+```bash
+gh pr create --title "release: 0.46.0 — source-agnostic catalog metadata + cache discipline" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Catalog enrichment for `query_mode='remote'` rows: rows + size_bytes + partition_by + clustered_by.
+- `/api/v2/schema` cache miss: 2 BQ jobs → 1 (-50%) via shared `fetch_bq_columns_full`.
+- All four catalog/schema/sample/metadata caches flush on registry change; single-row re-warm scheduled.
+- Automatic cache warmup at server startup; SSE-driven freshness toolbar on `/admin/tables`.
+
+Closes #155.
+Closes #156.
+
+## Test plan
+
+- [x] Targeted: 50+ unit + integration tests across 12 new test modules.
+- [x] No DB migration; no wire-break; MIN_COMPAT_CLI_VERSION unchanged.
+- [ ] Reviewer: register a remote BQ table, observe `/admin/tables` toolbar populates within 2 s.
+- [ ] Reviewer: trigger `Re-warm all`, verify SSE log scrolls and per-row badges update.
+- [ ] Reviewer: edit a registered row's bucket, verify `agnes schema <id>` returns updated columns immediately (no 1-hour staleness).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Per the user's `feedback_github_close_keyword_per_issue` memory: each issue gets its own `Closes #N` keyword on its own line. A list after one keyword only auto-closes the first.
+
+---
+
+## Self-Review
+
+After writing this plan, I checked it against the spec end-to-end:
+
+**Spec coverage:**
+- ✅ Provider pattern + dispatcher → Tasks 5, 6, 7
+- ✅ Identifier validation in dispatcher → Task 5
+- ✅ COLUMNS query consolidation → Task 3
+- ✅ `build_schema` RBAC/cache split → Task 4
+- ✅ v2_catalog wiring + 15-min metadata cache → Task 8
+- ✅ Unified `invalidate_for_table` → Task 9
+- ✅ Cache warmup framework + endpoints → Task 10
+- ✅ FastAPI startup hook → Task 11
+- ✅ CLI post-register hint → Task 12
+- ✅ docs/admin/query-modes.md → Task 13
+- ✅ Admin UI integration → Task 14
+- ✅ CHANGELOG + version bump → Task 15
+
+**Placeholder scan:** none of the "TBD", "TODO", "implement later" patterns. Every step has actual code or an exact command.
+
+**Type consistency:** `MetadataRequest` / `TableMetadata` / `WarmupRunState` / `WarmupRowState` field names referenced consistently across tasks. `fetch_bq_columns_full` signature consistent between Task 3 and Task 7.
+
+**One known nit:** Task 9's `_rewarm_one_row` references `cache_warmup.warm_one_table` which is defined in Task 10. The lazy import inside the function + outer try/except handles the during-development gap, but if a subagent runs Tasks 9 and 10 strictly in order without the lazy import, the test in Task 9 still passes because it patches `asyncio.create_task`. Documented in Task 9 step 9.3.
+
+Ready for execution.

--- a/docs/superpowers/specs/2026-05-07-source-agnostic-table-metadata-spec.md
+++ b/docs/superpowers/specs/2026-05-07-source-agnostic-table-metadata-spec.md
@@ -303,15 +303,23 @@ def _fetch_rows_and_size(bq, req: MetadataRequest) -> dict | None:
     """Return {rows, size_bytes} for a BQ table, or None on failure.
 
     Uses INFORMATION_SCHEMA.TABLE_STORAGE at REGION scope (the only
-    valid scope per live verification on prj-grp-foundryai-dev-7c37
-    2026-05-07 — see Open Question §1 in the spec). Falls back to
-    legacy __TABLES__ when region resolution fails.
+    valid scope per live verification 2026-05-07 — see Open Question §1).
+    Falls through to legacy __TABLES__ on TABLE_STORAGE failure (e.g.
+    operator typo'd the location config, region mismatch, IAM gap).
+
+    For VIEW-backed entries both views return no rows; caller gets
+    None which is the correct answer (a view has no inherent scan size).
     """
     location = _resolve_bq_location(bq, req)
     if location:
-        return _fetch_via_table_storage(bq, req, location)
-    # No region known and dataset.get() failed — last-resort fallback.
-    # Same row + size numbers, but loses multi-region portability.
+        result = _fetch_via_table_storage(bq, req, location)
+        if result is not None:
+            return result
+        # TABLE_STORAGE failed despite a configured location. Could be
+        # a typo (`us-central` vs `us-central1`), a multi-region dataset
+        # the operator misclassified, or a transient permission gap.
+        # Try __TABLES__ before giving up — same numbers, different
+        # IAM surface.
     return _fetch_via_legacy_tables(bq, req)
 
 
@@ -345,12 +353,24 @@ def _resolve_bq_location(bq, req: MetadataRequest) -> str | None:
 
 
 def _fetch_via_table_storage(bq, req: MetadataRequest, location: str) -> dict | None:
-    """Region-scoped INFORMATION_SCHEMA.TABLE_STORAGE — preferred path."""
+    """Region-scoped INFORMATION_SCHEMA.TABLE_STORAGE — preferred path.
+
+    `validate_quoted_identifier` accepts `us-central1`, `europe-west1`,
+    `EU`, `us` etc. (regex `^[a-zA-Z0-9_][a-zA-Z0-9_.\\-]{0,127}$` —
+    verified 2026-05-07). Refuses anything that could break out of the
+    backtick-quoted path.
+
+    The size_bytes reported is `active + long_term` logical bytes —
+    a full BQ scan reads both, so reporting only `active` undercounts
+    aged partitioned tables. See spec Open Question §1 for rationale.
+    """
+    from src.identifier_validation import validate_quoted_identifier
     if not validate_quoted_identifier(location, "BQ region"):
         return None
     try:
         bq_sql = (
-            f"SELECT total_rows, active_logical_bytes "
+            f"SELECT total_rows, "
+            f"IFNULL(active_logical_bytes, 0) + IFNULL(long_term_logical_bytes, 0) "
             f"FROM `{bq.projects.data}.region-{location}.INFORMATION_SCHEMA.TABLE_STORAGE` "
             f"WHERE table_schema = ? AND table_name = ?"
         )
@@ -366,7 +386,9 @@ def _fetch_via_table_storage(bq, req: MetadataRequest, location: str) -> dict | 
         )
         return None
     if row is None:
-        return None
+        return None  # row absent ⇒ entry is a VIEW, or table lives in
+                     # a different region than the configured one.
+                     # Caller falls through to __TABLES__.
     rows_, size_bytes = row
     return {
         "rows": int(rows_) if rows_ is not None else None,
@@ -417,9 +439,7 @@ Notes:
 import logging
 
 from app.api._metadata_models import MetadataRequest, TableMetadata
-from connectors.keboola.client import (
-    _resolve_keboola_url, _resolve_keboola_token,
-)  # see Token-resolution note below
+from connectors.keboola.client import KeboolaClient
 from connectors.keboola.storage_api import (
     KeboolaStorageClient, StorageApiError,
 )
@@ -428,15 +448,22 @@ logger = logging.getLogger(__name__)
 
 
 def fetch(req: MetadataRequest) -> TableMetadata | None:
-    url = _resolve_keboola_url()
-    token = _resolve_keboola_token()
-    if not url or not token:
+    # Reuse KeboolaClient's existing env-fallback path (KEBOOLA_STACK_URL
+    # + KEBOOLA_STORAGE_TOKEN env vars, mirrors instance.yaml token_env
+    # convention). We construct it just to read `.token` and `.url` —
+    # this is intentional; KeboolaClient.__init__ has no side effects
+    # beyond setting those two attributes (verified
+    # connectors/keboola/client.py:90-99). When a future refactor extracts
+    # `_resolve_keboola_credentials()` as a standalone helper, switch the
+    # provider to call that directly.
+    creds = KeboolaClient(token=None, url=None)
+    if not creds.url or not creds.token:
         return None  # not configured — same posture as BQ sentinel
 
     table_id = f"{req.bucket}.{req.source_table}"
     try:
-        client = KeboolaStorageClient(url=url, token=token)
-        info = client.get_table_info(table_id)  # NEW thin wrapper — see below
+        storage = KeboolaStorageClient(url=creds.url, token=creds.token)
+        info = storage.get_table_info(table_id)  # NEW thin wrapper — see below
     except (StorageApiError, ValueError) as e:
         logger.warning("Keboola metadata fetch failed for %s: %s", table_id, e)
         return None
@@ -450,12 +477,16 @@ def fetch(req: MetadataRequest) -> TableMetadata | None:
     )
 ```
 
-**Token resolution: reuse one path, do not invent a third.** `connectors/keboola/extractor.py` and `connectors/keboola/client.py` already resolve URL + token from a defined hierarchy:
+**Token resolution: reuse `KeboolaClient.__init__`'s existing env-fallback.** Verified at `connectors/keboola/client.py:90-99`:
 
-1. Env vars `KEBOOLA_STACK_URL` + `KEBOOLA_STORAGE_TOKEN` (or whatever `instance.yaml`'s `token_env` field points at).
-2. Fallback to `instance.yaml.data_source.keboola.{storage_url, token_env}`.
+```python
+def __init__(self, token: Optional[str] = None, url: Optional[str] = None):
+    ...
+    self.token = token or os.environ.get("KEBOOLA_STORAGE_TOKEN", "")
+    self.url = url or os.environ.get("KEBOOLA_STACK_URL", "")
+```
 
-The provider MUST call the existing helpers (`_resolve_keboola_url`, `_resolve_keboola_token` — names are placeholders; the implementation plan locks down whichever symbols actually ship). **Adding a third token-lookup path is rejected at review time.** The previous spec's `_get_storage_token()` "mirrors extractor.py" was hand-waving the wrong direction; the right move is `from connectors.keboola.client import the_existing_helper`.
+Constructing `KeboolaClient(token=None, url=None)` is a zero-side-effect way to inherit the same env-var hierarchy the rest of the codebase uses. **No third token-lookup path is invented.** A small future refactor could extract a standalone `_resolve_keboola_credentials()` helper that both `KeboolaClient.__init__` and this provider call directly; tracked as a low-priority follow-up nit, not a blocker.
 
 **`get_table_info(table_id)` — thin wrapper added to `KeboolaStorageClient` in this PR.** The previous spec called `client._get(f"/tables/{table_id}")` directly; that bleeds a `_`-private method out of the module and reviewers will (rightly) push back. One-line wrapper:
 
@@ -562,7 +593,7 @@ One conditional, mirrors the existing pattern. No new flag.
 
 - `connectors/bigquery/metadata.py` — `fetch(row)` returning `TableMetadata | None`.
 - `connectors/keboola/metadata.py` — same shape, Storage API path.
-- `connectors/_metadata_models.py` (or directly in each — TBD by reviewer; importing from a sibling `connectors/_models.py` is the cleanest, but pulls in a small refactor of how connectors are organised). Provisional location: a new `connectors/__init__.py` exposing `TableMetadata`. Per existing repo convention, I lean toward a top-level shared module since other dataclasses (e.g. `dataclass PullResult` in `cli/lib/pull.py`) live alongside their primary consumer.
+- `app/api/_metadata_models.py` — single shared module for `MetadataRequest` + `TableMetadata`. Lives under `app/api/` (not `connectors/`) because the primary consumer is `app/api/v2_catalog.py` and the providers (which sit one layer down in `connectors/`) import upward into the API layer rather than the reverse. This avoids the layering inversion of having `app/api/v2_catalog.py` import from `connectors/__init__.py`.
 - `tests/test_connectors_bigquery_metadata.py` — unit tests with mocked `bq.duckdb_session`.
 - `tests/test_connectors_keboola_metadata.py` — unit tests with mocked `KeboolaStorageClient`.
 - `tests/test_v2_catalog_remote_metadata.py` — integration test against the catalog endpoint with a registered remote row, mocked provider returning a `TableMetadata`. Verifies the response shape and the cache-bust path.
@@ -570,7 +601,7 @@ One conditional, mirrors the existing pattern. No new flag.
 ### Edited files
 
 - `app/api/v2_catalog.py` — rename `_materialized_size_hint` → `_size_hint_for_row`, add provider dispatch, add `_metadata_cache` (TTLCache, 15 min), extend response shape with the new fields. ~50 LOC delta.
-- `app/api/admin.py` — wire `_invalidate_metadata_cache(table_id)` into the success path of `register_table` and `update_table`. ~5 LOC.
+- `app/api/admin.py` — wire `v2_catalog.invalidate_for_table(table_id)` into the success path of `register_table`, `update_table`, and `unregister_table`. ~6 LOC.
 - `cli/commands/admin.py` — extend the post-register hint as above. ~5 LOC.
 - `app/web/templates/admin_tables.html` — `?` icon + doc link next to `query_mode`. ~10 LOC.
 
@@ -586,9 +617,14 @@ One conditional, mirrors the existing pattern. No new flag.
 
 | Layer | Coverage |
 |---|---|
-| Provider (BQ) | mocked `bq.duckdb_session().execute().fetchone()` returns a synthetic row → `fetch(row)` returns expected `TableMetadata`; `BqAccessError` → `None`; row missing `bucket` → `None`; query raises → `None` |
-| Provider (Keboola) | mocked `KeboolaStorageClient._get` returns `{rowsCount, dataSizeBytes, columns}` → `fetch(row)` returns expected metadata; missing token → `None`; `StorageApiError` → `None` |
-| Catalog endpoint | for a `query_mode='local'` row → existing parquet-stat path; for a `query_mode='remote'` BQ row → provider called, response has the new fields populated; cache-bust after `register_table` makes the next catalog request hit the provider again |
+| Provider (BQ) — happy path | mocked `bq.duckdb_session()` returns synthetic row → `fetch(req)` returns expected `TableMetadata` with `size_bytes = active + long_term` |
+| Provider (BQ) — sentinel | `bq.projects.data == ""` → returns `None` before any query, never imports `validate_quoted_identifier` |
+| Provider (BQ) — VIEW path | TABLE_STORAGE returns no rows, `__TABLES__` also returns no rows → `TableMetadata(rows=None, size_bytes=None, partition_by=<from COLUMNS>, clustered_by=<from COLUMNS>)`. Asserts the view-aware fall-through documented in §"View-backed remote tables" |
+| Provider (BQ) — region typo | location set to `"us-central"` (invalid) → `_fetch_via_table_storage` raises BQ "not found", `_fetch_rows_and_size` falls through to `_fetch_via_legacy_tables` → still returns rows + size |
+| Provider (BQ) — both paths fail | TABLE_STORAGE raises and `__TABLES__` raises → `_fetch_rows_and_size` returns `None`; `fetch()` still returns a `TableMetadata` with partition/cluster populated (only the size pieces are `None`) |
+| Provider (Keboola) | mocked `KeboolaStorageClient.get_table_info` returns `{rowsCount, dataSizeBytes}` → `fetch(req)` returns expected metadata; `KeboolaClient(token=None, url=None)` with empty env → `None`; `StorageApiError` → `None` |
+| Catalog endpoint | for a `query_mode='local'` row → existing parquet-stat path unchanged; for a `query_mode='remote'` BQ row → provider called, response has the new fields populated; cache hit returns cached metadata without re-calling provider |
+| Cache-bust | `register_table` flushes both `_table_rows_cache` and `_metadata_cache`; `update_table` same; `unregister_table` same. After bust, next catalog request reflects the new state immediately. |
 | `agnes catalog` CLI | smoke test that the new fields surface in `--json` output and don't break the text-mode renderer |
 | Sample endpoint | smoke test against a registered remote BQ row; verify it returns sample rows. If broken, separate fix path; not bundled in this PR's scope |
 
@@ -631,12 +667,16 @@ Three candidates were surveyed and tested against `audrius_test.product_inventor
 **Locked SQL for the BQ provider:**
 
 ```sql
-SELECT total_rows, active_logical_bytes
+SELECT
+  total_rows,
+  IFNULL(active_logical_bytes, 0) + IFNULL(long_term_logical_bytes, 0) AS total_logical_bytes
 FROM `<project>.region-<location>.INFORMATION_SCHEMA.TABLE_STORAGE`
 WHERE table_schema = ? AND table_name = ?
 ```
 
-Mapped to `TableMetadata` as `rows = total_rows`, `size_bytes = active_logical_bytes`. The `long_term_*` and `physical_bytes` variants are deliberately NOT exposed — they're storage-billing concepts the analyst doesn't act on; collapsing to a single number keeps the catalog response simple.
+Mapped to `TableMetadata` as `rows = total_rows`, `size_bytes = total_logical_bytes` (active + long-term). **The sum is correct for the cost-warning use case** — a full BQ table scan reads both partitions; reporting only `active_logical_bytes` would undercount on partitioned tables that have aged into long-term storage (≥ 90 days untouched), and the analyst's mental model of "this is a 200-GB table" includes long-term. The `physical_bytes` variants are NOT exposed — they're compression-aware storage billing, not scan-cost.
+
+**View-backed remote tables:** `INFORMATION_SCHEMA.TABLE_STORAGE` returns **no rows** for entries whose `table_type = 'VIEW'` (verified: TABLE_STORAGE only covers physical storage). For a `query_mode='remote'` row pointing at a VIEW, `_fetch_via_table_storage` returns `None`, and the legacy `__TABLES__` fallback also returns `None` for views. The final `TableMetadata` therefore has `rows=None, size_bytes=None` — which is **correct**: a view's scan cost depends on the underlying query, not on the view itself. The analyst Claude reads `null` and applies the existing CLAUDE.md guidance (*"treat as potentially large; use `agnes snapshot create --estimate` first"*). Partition + cluster metadata DOES surface for views via `INFORMATION_SCHEMA.COLUMNS` if the underlying tables are partitioned, so the response isn't entirely empty. Materialised views (`MATERIALIZED_VIEW`) DO appear in TABLE_STORAGE because they have stored bytes, so the path works for them out-of-the-box. Tested behavior, not theoretical: implementation plan includes a unit test that mocks TABLE_STORAGE returning empty for a view and asserts `TableMetadata(rows=None, size_bytes=None, partition_by=...)`.
 
 ### 1a. Where does `<region>` come from?
 

--- a/docs/superpowers/specs/2026-05-07-source-agnostic-table-metadata-spec.md
+++ b/docs/superpowers/specs/2026-05-07-source-agnostic-table-metadata-spec.md
@@ -189,30 +189,313 @@ The 15-minute TTL is a deliberate compromise:
 
 ### Unified cache invalidation
 
-The previous spec proposed `_invalidate_metadata_cache(table_id)` on register/update. **That alone is insufficient.** `app/api/v2_catalog.py:25` already runs a 5-minute `_table_rows_cache` over the registry rows themselves (the table list, before per-table metadata enrichment). On current main, that cache is **not** invalidated by `register_table` / `update_table` (verified: `admin.py:1037,1110,2771` only call `app.instance_config.reset_cache()`). An admin who registers a remote table immediately runs `agnes catalog` and sees no row at all for up to 5 minutes — not just missing size, missing the whole row. This is a pre-existing bug the new metadata cache would otherwise inherit.
+The previous spec proposed `_invalidate_metadata_cache(table_id)` on register/update. **That alone is insufficient.** Verified state on current main:
 
-Fix in this PR by introducing a single helper that owns both caches:
+| Cache | TTL | Cleared on registry change today? |
+|---|---|---|
+| `_table_rows_cache` (`v2_catalog.py:25`) | 300 s | ❌ no |
+| `_schema_cache` (`v2_schema.py:17`) | 3600 s (1 h) | ❌ no |
+| `_sample_cache` (`v2_sample.py:17`) | 3600 s (1 h) | ❌ no |
+
+`admin.py:1037,1110,2771` (the registry write paths) call only `app.instance_config.reset_cache()`. None of the four catalog/schema/sample/metadata caches are touched. The user-visible failures of this gap:
+
+- Admin registers a remote table → `agnes catalog` doesn't show the new row for up to 5 minutes.
+- Admin updates a row's `bucket` → `agnes schema <id>` returns the OLD column list for up to 1 hour.
+- Admin unregisters a table → `agnes describe <id>` keeps returning the OLD sample rows for up to 1 hour.
+
+Fix in this PR by introducing a single helper that owns all four caches:
 
 ```python
 # app/api/v2_catalog.py (addition)
 
 def invalidate_for_table(table_id: str) -> None:
-    """Drop both the registry-rows cache and the per-table metadata cache
-    so the next catalog request reflects the just-registered / updated /
-    unregistered row immediately. The catalog module owns this so admin.py
-    doesn't need to know which caches exist.
+    """Drop every per-table cache so the next /api/v2/* request reflects
+    the just-registered / updated / unregistered row immediately. Owned by
+    the catalog module so admin.py doesn't need to know which caches exist.
+
+    Imports v2_schema and v2_sample lazily — keeps catalog tests from
+    pulling in BQ-extension imports they don't need.
     """
-    _table_rows_cache.invalidate_all()  # whole-list cache; can't precisely invalidate one row
+    from app.api import v2_schema, v2_sample
+
+    _table_rows_cache.clear()  # whole-list cache; no per-row precision
     _metadata_cache.invalidate(table_id)
+    v2_schema._schema_cache.invalidate(table_id)
+    # Sample cache key is `f"{table_id}|{n}"`; clearing the whole sample
+    # cache is heavier than precise invalidation, but registry-change
+    # frequency (handful per day on a typical instance) doesn't justify
+    # adding a prefix-invalidation primitive to TTLCache. Acceptable.
+    v2_sample._sample_cache.clear()
 ```
 
 Wire it into `app/api/admin.py`:
 
 - `POST /api/admin/register-table` — call after the registry write succeeds, before returning.
 - `PUT /api/admin/registry/{id}` — call after the row update.
-- `DELETE /api/admin/registry/{id}` — call after unregister (otherwise an unregistered row keeps appearing in `agnes catalog` for up to 5 minutes; same UX bug, opposite direction).
+- `DELETE /api/admin/registry/{id}` — call after unregister (otherwise an unregistered row keeps appearing in `agnes catalog` and serving stale schema for up to 1 hour; same UX bug, opposite direction).
 
-Three call sites, one shared helper. Keeps cache knowledge in `v2_catalog.py` and out of `admin.py`.
+Three call sites, one shared helper. Keeps cache knowledge in `v2_catalog.py` and out of `admin.py`. The TTL values themselves are unchanged (1 h is fine when staleness is bounded by an explicit flush).
+
+### BQ COLUMNS query consolidation
+
+`v2_schema.py:_fetch_bq_schema` and `v2_schema.py:_fetch_bq_table_options` both query the same `INFORMATION_SCHEMA.COLUMNS` view with the same `WHERE table_name = ?` predicate; only the SELECT list differs. On a `_schema_cache` miss, that's **two BQ jobs back-to-back** for one logical request — wasteful on on-demand pricing where every job is billed.
+
+Consolidate into a single helper that returns one resultset; both consumers (the v2_schema endpoint AND the new BQ metadata provider's `_fetch_partition_cluster` path) call it:
+
+```python
+# connectors/bigquery/access.py (or a sibling module — see below)
+
+def fetch_bq_columns_full(
+    bq: BqAccess, dataset: str, table: str,
+) -> list[dict] | None:
+    """Single round-trip to INFORMATION_SCHEMA.COLUMNS pulling everything
+    both v2_schema and the metadata provider need. Returns one dict per
+    column; consumers project the fields they care about.
+
+    Best-effort: returns None on any failure. Sentinel-config early-return
+    on `not bq.projects.data`. Mirrors the validation discipline of the
+    individual functions it replaces.
+    """
+    if not bq.projects.data:
+        return None
+
+    if not (validate_quoted_identifier(bq.projects.data, "BQ project")
+            and validate_quoted_identifier(dataset, "BQ dataset")
+            and validate_quoted_identifier(table, "BQ source_table")):
+        return None
+
+    bq_sql = (
+        f"SELECT column_name, data_type, is_nullable, "
+        f"       is_partitioning_column, clustering_ordinal_position "
+        f"FROM `{bq.projects.data}.{dataset}.INFORMATION_SCHEMA.COLUMNS` "
+        f"WHERE table_name = ? ORDER BY ordinal_position"
+    )
+    try:
+        with bq.duckdb_session() as conn:
+            rows = conn.execute(
+                "SELECT * FROM bigquery_query(?, ?, ?)",
+                [bq.projects.billing, bq_sql, table],
+            ).fetchall()
+    except Exception as e:
+        logger.warning(
+            "BQ COLUMNS fetch failed for %s.%s.%s: %s",
+            bq.projects.data, dataset, table, e,
+        )
+        return None
+
+    return [
+        {
+            "name": r[0],
+            "type": r[1],
+            "nullable": (r[2] or "").upper() == "YES",
+            "is_partitioning_column": (r[3] or "").upper() == "YES",
+            "clustering_ordinal_position": r[4],
+        }
+        for r in rows
+    ]
+```
+
+Touchpoints on existing code:
+
+- **`v2_schema.py:_fetch_bq_schema`** — replaced by `[{"name", "type", "nullable", "description":""} for c in fetch_bq_columns_full(...)]`.
+- **`v2_schema.py:_fetch_bq_table_options`** — replaced by deriving `partition_by` (first row with `is_partitioning_column == True`) and `clustered_by` (rows with non-null `clustering_ordinal_position`, ordered by that position) from the same list.
+- **`connectors/bigquery/metadata.py:_fetch_partition_cluster`** (new) — same two derivations.
+- Net effect on `/api/v2/schema/{id}` cache miss: **2 BQ jobs → 1 BQ job**. ~50 % BQ-job reduction.
+
+Helper location: `connectors/bigquery/access.py` already exposes `BqAccess` to both consumers; appending the helper there avoids creating yet another module and keeps BQ specifics in the BQ connector. (Earlier draft proposed `app/api/_bq_helpers.py` but that's a worse fit — the function is connector-bound, not API-bound.)
+
+The consolidation is **independent of the metadata feature** in spirit but lands in the same PR because (a) the new metadata provider would otherwise add a third copy of the same SQL pattern, (b) the cache invalidation work touches the same `_schema_cache` the consolidation benefits from, and (c) splitting it would cost one extra round of CI + review.
+
+### Server-side automatic cache warmup
+
+In-process caches (the four flushed by `invalidate_for_table`) are empty after every container restart — a deploy, a rolling update, an OOM kill. The first analyst to call `agnes catalog` or `agnes schema <id>` after restart pays a cold-cache penalty: 1 BQ job per remote table for the catalog enrichment, plus 1 BQ job per `agnes schema` call. On a 30-table instance that's **30+ BQ jobs in the first analyst's first session, in burst**. Cost-wise it's negligible (INFORMATION_SCHEMA queries are <1 MB, $0.005/MB on-demand → $0.00015 for the whole burst). UX-wise it's a 2–6 second hiccup on the first catalog load. Operationally it's noise that confuses "is the new deploy slow?" with "is BQ slow?".
+
+The fix: warm the caches automatically at process startup, in the background, with bounded concurrency. The first analyst hits warm caches; the BQ burst is spread across the readiness-up-to-fully-warm window, not a single user's request.
+
+```python
+# app/main.py — addition to startup events
+
+@app.on_event("startup")
+async def warm_catalog_caches():
+    """Schedule a background warmup of the v2 catalog/schema/metadata caches.
+
+    Fire-and-forget — readiness is not blocked. Operators can disable via
+    `AGNES_SKIP_CACHE_WARMUP=1` in test/dev contexts. Failures inside the
+    background task are logged + swallowed; never escalate to startup
+    failure (a transient BQ outage at deploy time should not keep the
+    server from coming up at all).
+    """
+    if os.environ.get("AGNES_SKIP_CACHE_WARMUP") == "1":
+        return
+    asyncio.create_task(_warm_catalog_caches_bg())
+```
+
+```python
+# app/api/cache_warmup.py — new module
+
+@dataclass
+class WarmupRowState:
+    table_id: str
+    status: Literal["pending", "warming", "fresh", "error"]
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    duration_ms: int | None = None
+    error: str | None = None
+    last_warmed_at: datetime | None = None  # carries across runs
+
+
+@dataclass
+class WarmupRunState:
+    run_id: str
+    trigger: Literal["startup", "manual", "registry_change"]
+    started_at: datetime
+    completed_at: datetime | None = None
+    total: int = 0
+    completed: int = 0
+    failed: int = 0
+    rows: dict[str, WarmupRowState] = field(default_factory=dict)
+    # SSE subscribers attach to this; appended events are broadcast.
+    _subscribers: list[asyncio.Queue] = field(default_factory=list, repr=False)
+
+
+# Module-level singleton — survives across runs, holds the latest state.
+WARMUP_STATE: WarmupRunState | None = None
+
+
+async def _warm_catalog_caches_bg(trigger: str = "startup") -> None:
+    """Walk the registry, warm metadata + schema caches for every BQ remote
+    row with bounded concurrency. Errors are recorded per-row but never
+    propagate. Emits SSE events as rows complete.
+    """
+    global WARMUP_STATE
+    run_id = uuid4().hex[:8]
+    state = WarmupRunState(run_id=run_id, trigger=trigger, started_at=now())
+
+    # Snapshot registry — registry write during warmup is not coordinated;
+    # stale snapshot is fine because the cache-bust path will refresh
+    # whatever the warmup populated.
+    conn = get_system_db()
+    rows = TableRegistryRepository(conn).list_all()
+    remote = [
+        r for r in rows
+        if r.get("query_mode") == "remote" and r.get("source_type") == "bigquery"
+    ]
+    state.total = len(remote)
+    for r in remote:
+        state.rows[r["id"]] = WarmupRowState(table_id=r["id"], status="pending")
+    WARMUP_STATE = state
+    _broadcast(state, {"event": "start", "data": {
+        "run_id": run_id, "trigger": trigger, "total": state.total,
+    }})
+
+    sem = asyncio.Semaphore(int(os.environ.get("AGNES_WARMUP_CONCURRENCY", "4")))
+    await asyncio.gather(*(_warm_one(r, state, sem) for r in remote))
+
+    state.completed_at = now()
+    _broadcast(state, {"event": "complete", "data": {
+        "run_id": run_id, "total": state.total,
+        "completed": state.completed, "failed": state.failed,
+    }})
+    logger.info(
+        "cache warmup complete: run_id=%s total=%d ok=%d fail=%d",
+        run_id, state.total, state.completed, state.failed,
+    )
+
+
+async def _warm_one(row: dict, state: WarmupRunState, sem: asyncio.Semaphore) -> None:
+    async with sem:
+        rs = state.rows[row["id"]]
+        rs.status = "warming"
+        rs.started_at = now()
+        _broadcast(state, {"event": "row", "data": {**asdict(rs)}})
+        t0 = time.monotonic()
+        try:
+            # Warm metadata cache via the same path live requests use.
+            # _size_hint_for_row populates _metadata_cache as a side effect.
+            await asyncio.to_thread(_warm_metadata, row)
+            # Warm schema cache via the new RBAC-naive helper.
+            await asyncio.to_thread(_warm_schema, row)
+            rs.status = "fresh"
+            rs.last_warmed_at = now()
+            state.completed += 1
+        except Exception as e:
+            rs.status = "error"
+            rs.error = str(e)
+            state.failed += 1
+            logger.warning("cache warmup row=%s failed: %s", row["id"], e)
+        finally:
+            rs.completed_at = now()
+            rs.duration_ms = int((time.monotonic() - t0) * 1000)
+            _broadcast(state, {"event": "row", "data": {**asdict(rs)}})
+```
+
+The `build_schema` function in `v2_schema.py` currently mixes RBAC + cache + BQ work. Refactor splits it:
+
+- **`build_schema(conn, user, table_id, *, bq)`** — keeps RBAC + cache check at the top, then delegates to:
+- **`build_schema_uncached(conn, table_id, *, bq)`** — does the BQ work + cache write only. Warmup calls this directly with no user context. ~10-LOC extraction.
+
+### Status + control endpoints
+
+```python
+# app/api/cache_warmup.py — endpoints
+
+@router.get("/api/admin/cache-warmup/status")
+async def warmup_status(user: dict = Depends(require_admin)):
+    """Return the latest warmup state as JSON. For polling fallback when
+    SSE isn't available (e.g. behind a proxy that buffers)."""
+    if WARMUP_STATE is None:
+        return {"state": "never_run"}
+    return _serialize_state(WARMUP_STATE)
+
+
+@router.post("/api/admin/cache-warmup/run")
+async def warmup_run(user: dict = Depends(require_admin)):
+    """Manually trigger a warmup. Returns the new run_id immediately;
+    the run executes in the background. Idempotent: if a warmup is
+    already in progress, returns its run_id without starting another."""
+    if WARMUP_STATE and WARMUP_STATE.completed_at is None:
+        return {"run_id": WARMUP_STATE.run_id, "status": "already_running"}
+    asyncio.create_task(_warm_catalog_caches_bg(trigger="manual"))
+    return {"status": "started"}
+
+
+@router.get("/api/admin/cache-warmup/stream")
+async def warmup_stream(user: dict = Depends(require_admin)):
+    """Server-Sent Events stream of warmup events. UI consumes this for
+    realtime progress. Connection stays open for the lifetime of the
+    current run + 5 s grace, then closes; client reconnects on next run.
+
+    Event types: 'start', 'row', 'complete'. Each event is JSON.
+    """
+    return EventSourceResponse(_warmup_event_generator())
+```
+
+Three endpoints, all `require_admin`. `EventSourceResponse` is from `sse-starlette` (already a transitive dep; if not, ~3 KB additional install).
+
+### Cache-bust now also re-warms
+
+`invalidate_for_table` (defined above) flushes caches. After flushing, immediately enqueue a **single-row warmup** for the affected `table_id` so admins editing a registry row see fresh data within a couple of seconds rather than waiting for the next analyst to trigger a miss:
+
+```python
+def invalidate_for_table(table_id: str) -> None:
+    """... (existing flush logic) ..."""
+    # ... existing cache.clear() / .invalidate() calls ...
+
+    # Schedule a single-row re-warm in the background. Doesn't block the
+    # admin's HTTP response. Fire-and-forget; failures log + skip.
+    asyncio.create_task(_rewarm_one_row(table_id))
+```
+
+Effect: admin clicks "Save" in the edit modal → response returns in ~50 ms → 1-2 s later the warmup task has populated fresh metadata + schema caches → next `agnes catalog` request is warm. The admin doesn't see a "warming…" state because their edit doesn't call catalog/schema.
+
+### Operations env vars
+
+| Var | Default | Effect |
+|---|---|---|
+| `AGNES_SKIP_CACHE_WARMUP` | `0` | If `1`, the startup hook is a no-op. For dev / test instances. |
+| `AGNES_WARMUP_CONCURRENCY` | `4` | How many BQ INFORMATION_SCHEMA jobs to run in parallel. Bounded; raising this beyond 8 risks tripping BQ's 100-concurrent-job project quota on instances with 100+ tables. |
+
+No new instance.yaml knobs; warmup is unconditional in production, opt-out only.
 
 ### BQ provider implementation sketch
 
@@ -569,9 +852,68 @@ Outline:
 
 The doc is the single landing place for the question *"can / how do I register a $X table for $Y mode?"* — replaces the absent breadcrumb #156 calls out.
 
-### Admin UI — minimal change
+### Admin UI integration — `/admin/tables` only
 
-`app/web/templates/admin_tables.html` — add a `?` icon next to the `query_mode` selector linking to the new doc page. **No** redesign of the form, **no** inline guidance panel — adding a few hundred lines of UI copy here would bloat a 132-KB template that's already overdue for a structural pass. Tooltip + doc link is the right scope today. The form itself already has enough validation (#177's PUT/DELETE work, the materialised-mode source_query check, the BQ shape validator in `_validate_bigquery_register_payload`) that an admin who reads the doc can drive it.
+All visibility lives on the existing `/admin/tables` page. **No new admin pages.** The page already lists every registered table grouped by `source_type` (`bqTableListing` / `kbTableListing` / `jiraTableListing`) and renders rows via `renderRegistryListing(target, tables)`. The row markup already reserves an empty `<th class="col-status"></th>` column at the end — perfect slot for a cache-freshness badge with no schema-of-rendered-table change.
+
+Three additions to the page:
+
+**1. Cache toolbar** — a single card above the per-source-type listings, visible only when at least one BQ remote table is registered:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Cache freshness                            [Re-warm all]   │
+│                                                              │
+│  ●●●●●●●●●●○○○○○  21 / 30 fresh                              │
+│  Last completed run: 4 minutes ago (28 ok, 2 errors)         │
+│                                                              │
+│  [▾ Show log]                                                │
+└─────────────────────────────────────────────────────────────┘
+```
+
+When a run is in progress, the bar animates and `[Re-warm all]` is disabled. The "Show log" expand reveals a terminal-style scrolling area:
+
+```
+┌─ Warmup log — run f4d2bcae ───────────────────────────────┐
+│ 14:32:01  start   trigger=startup total=30                │
+│ 14:32:01  warming events_2024                             │
+│ 14:32:01  warming users_2024                              │
+│ 14:32:01  warming orders_2024                             │
+│ 14:32:01  warming sessions_2024                           │
+│ 14:32:02  fresh   events_2024  (1.2 s)                    │
+│ 14:32:02  warming products_2024                           │
+│ 14:32:02  fresh   users_2024   (1.4 s)                    │
+│ ...                                                       │
+│ 14:32:14  error   stale_table_v1  permission denied       │
+│ 14:32:18  complete  total=30 ok=28 fail=2                 │
+└───────────────────────────────────────────────────────────┘
+```
+
+The log is the SSE event stream rendered in chronological order. Auto-scrolls to bottom while a run is active; freezes when the run completes so the admin can scroll back.
+
+**2. Per-row cache badge in `col-status`** — populated from the WARMUP_STATE snapshot on page load and updated live from SSE:
+
+| Status | Badge |
+|---|---|
+| `fresh` (warmed within TTL) | ● green "fresh 4m" (with relative-time tooltip) |
+| `warming` (in current run) | ● blue spinner "warming…" |
+| `pending` (queued, not started) | ○ grey "queued" |
+| `error` (last run failed for this row) | ● red "error" (with tooltip showing `state.error`) |
+| not-warmed-yet OR cache TTL expired without re-warm | (empty cell) |
+
+For non-BQ-remote rows (Keboola local, Jira), the column stays empty — they don't go through the warmup path. This keeps the column visually quiet when there's nothing useful to say.
+
+**3. `?` icon next to the `query_mode` field** in the Add/Edit modal, linking to `docs/admin/query-modes.md`. The original "minimal admin UI" change. Survives unchanged.
+
+### Wiring details
+
+- **Initial state on page load:** call `GET /api/admin/cache-warmup/status` once, populate the toolbar + per-row badges from the response.
+- **Live updates:** open `EventSource("/api/admin/cache-warmup/stream")` after the initial render. Each event mutates the corresponding row badge + appends to the log. Reconnect logic is built into `EventSource` for free.
+- **SSE failure fallback:** if `EventSource.onerror` fires repeatedly (browser, proxy, content-security), fall back to polling `/status` every 3 s. Same code path, reads the same JSON shape.
+- **"Re-warm all" button:** `POST /api/admin/cache-warmup/run` — server schedules the run, response includes the new `run_id`. UI keeps watching the SSE stream; the new `start` event has the new `run_id` so the log section auto-clears the prior run's lines.
+- **Edit-modal cache flush hint:** when the admin saves an edit (existing `saveTableEdit` flow), the server's `invalidate_for_table` already triggers a single-row re-warm in the background. The UI doesn't need new copy here; the badge will update via SSE within 1-2 s.
+
+The toolbar + log fit in **one new `<section>` block** between the page header and the per-source-type table listings (`bqTableListing` etc.). Plus ~80 LOC of JS to render + bind. Plus the per-row badge addition in `renderRegistryListing` (~10 LOC).
 
 ### CLI hint at registration time
 
@@ -591,25 +933,39 @@ One conditional, mirrors the existing pattern. No new flag.
 
 ### New files
 
-- `connectors/bigquery/metadata.py` — `fetch(row)` returning `TableMetadata | None`.
+- `app/api/_metadata_models.py` — `MetadataRequest` + `TableMetadata` dataclasses. Lives under `app/api/` (not `connectors/`) — primary consumer is `app/api/v2_catalog.py`; providers in `connectors/` import upward into the API layer. Avoids layering inversion of `app/api/v2_catalog.py` importing from `connectors/__init__.py`.
+- `connectors/bigquery/metadata.py` — `fetch(req)` returning `TableMetadata | None`. Calls the new shared `fetch_bq_columns_full` helper for partition/cluster.
 - `connectors/keboola/metadata.py` — same shape, Storage API path.
-- `app/api/_metadata_models.py` — single shared module for `MetadataRequest` + `TableMetadata`. Lives under `app/api/` (not `connectors/`) because the primary consumer is `app/api/v2_catalog.py` and the providers (which sit one layer down in `connectors/`) import upward into the API layer rather than the reverse. This avoids the layering inversion of having `app/api/v2_catalog.py` import from `connectors/__init__.py`.
-- `tests/test_connectors_bigquery_metadata.py` — unit tests with mocked `bq.duckdb_session`.
-- `tests/test_connectors_keboola_metadata.py` — unit tests with mocked `KeboolaStorageClient`.
-- `tests/test_v2_catalog_remote_metadata.py` — integration test against the catalog endpoint with a registered remote row, mocked provider returning a `TableMetadata`. Verifies the response shape and the cache-bust path.
+- `app/api/cache_warmup.py` — `WarmupRunState` + `WarmupRowState` dataclasses, `_warm_catalog_caches_bg`, `_warm_one`, `_rewarm_one_row`, SSE generator, the three `/api/admin/cache-warmup/*` endpoints.
+- `tests/test_connectors_bigquery_metadata.py` — 5 unit cases (happy / sentinel / VIEW / region-typo / both-paths-fail).
+- `tests/test_connectors_keboola_metadata.py` — 3 unit cases (happy / unconfigured / api-error).
+- `tests/test_v2_catalog_remote_metadata.py` — integration test against the catalog endpoint; verifies response shape + cache hit/miss.
+- `tests/test_v2_catalog_invalidation.py` — verifies `invalidate_for_table` flushes all four caches and triggers single-row re-warm.
+- `tests/test_cache_warmup.py` — startup runs in background without blocking readiness; bounded concurrency; per-row failure isolated; SSE event stream shape; `/run` idempotency under concurrent invocation.
+- `tests/test_admin_tables_warmup_ui.py` — smoke test that `/admin/tables` HTML contains the cache toolbar markup, the per-row `col-status` slot, and the `EventSource` wiring.
 
 ### Edited files
 
-- `app/api/v2_catalog.py` — rename `_materialized_size_hint` → `_size_hint_for_row`, add provider dispatch, add `_metadata_cache` (TTLCache, 15 min), extend response shape with the new fields. ~50 LOC delta.
+- `app/api/v2_catalog.py` — rename `_materialized_size_hint` → `_size_hint_for_row`, add provider dispatch (`_metadata_provider_for`, `_build_metadata_request`), add `_metadata_cache` (TTLCache, 15 min), extend response shape with the new fields, add `invalidate_for_table` helper. ~80 LOC delta.
+- `app/api/v2_schema.py` — split `build_schema` into RBAC-checking outer + uncached inner (`build_schema_uncached`); replace `_fetch_bq_schema` + `_fetch_bq_table_options` with the shared `fetch_bq_columns_full` helper consumed by both schema response builder and the metadata provider's partition/cluster path. ~40 LOC delta (mostly refactor).
+- `connectors/bigquery/access.py` — append the `fetch_bq_columns_full(bq, dataset, table)` helper (single combined `INFORMATION_SCHEMA.COLUMNS` query). ~50 LOC.
+- `app/main.py` — register the `warm_catalog_caches` startup event hook. ~10 LOC.
 - `app/api/admin.py` — wire `v2_catalog.invalidate_for_table(table_id)` into the success path of `register_table`, `update_table`, and `unregister_table`. ~6 LOC.
-- `cli/commands/admin.py` — extend the post-register hint as above. ~5 LOC.
-- `app/web/templates/admin_tables.html` — `?` icon + doc link next to `query_mode`. ~10 LOC.
+- `cli/commands/admin.py` — extend the post-register hint with the BQ-remote IAM smoke-check pointer. ~5 LOC.
+- `app/web/templates/admin_tables.html` — new `<section id="cacheWarmupCard">` toolbar block, per-row badge in `renderRegistryListing`, `?` icon next to `query_mode` field in the edit modal, `EventSource` + polling-fallback JS. ~250 LOC delta in this template.
 
 ### Schema / DB / config
 
-**No schema migration.** All metadata is computed on demand from BigQuery / Keboola Storage API. We deliberately don't persist it (would add a bookkeeping problem — staleness, invalidation, schema bumps).
+**No schema migration.** All metadata is computed on demand from BigQuery / Keboola Storage API. Deliberately not persisted — adds a bookkeeping problem (staleness, invalidation, schema bumps) we don't need.
 
-**No new env vars.** All the required config (`data_source.bigquery.*`, `data_source.keboola.storage_*`) already exists for the connectors.
+**Two new env vars (both opt-out / tuning, no required setup change):**
+
+| Var | Default | Effect |
+|---|---|---|
+| `AGNES_SKIP_CACHE_WARMUP` | unset | If `1`, the FastAPI startup warmup hook is a no-op. For dev / test instances. |
+| `AGNES_WARMUP_CONCURRENCY` | `4` | How many BQ INFORMATION_SCHEMA jobs to run in parallel during a warmup run. Bounded; raising beyond 8 risks tripping BQ's 100-concurrent-job project quota on instances with 100+ tables. |
+
+The connector configs (`data_source.bigquery.*`, `data_source.keboola.storage_*`) already exist in `instance.yaml` and are not touched here.
 
 ---
 
@@ -624,9 +980,17 @@ One conditional, mirrors the existing pattern. No new flag.
 | Provider (BQ) — both paths fail | TABLE_STORAGE raises and `__TABLES__` raises → `_fetch_rows_and_size` returns `None`; `fetch()` still returns a `TableMetadata` with partition/cluster populated (only the size pieces are `None`) |
 | Provider (Keboola) | mocked `KeboolaStorageClient.get_table_info` returns `{rowsCount, dataSizeBytes}` → `fetch(req)` returns expected metadata; `KeboolaClient(token=None, url=None)` with empty env → `None`; `StorageApiError` → `None` |
 | Catalog endpoint | for a `query_mode='local'` row → existing parquet-stat path unchanged; for a `query_mode='remote'` BQ row → provider called, response has the new fields populated; cache hit returns cached metadata without re-calling provider |
-| Cache-bust | `register_table` flushes both `_table_rows_cache` and `_metadata_cache`; `update_table` same; `unregister_table` same. After bust, next catalog request reflects the new state immediately. |
-| `agnes catalog` CLI | smoke test that the new fields surface in `--json` output and don't break the text-mode renderer |
-| Sample endpoint | smoke test against a registered remote BQ row; verify it returns sample rows. If broken, separate fix path; not bundled in this PR's scope |
+| Cache-bust | `register_table` / `update_table` / `unregister_table` each flush all four caches (`_table_rows_cache`, `_metadata_cache`, `_schema_cache`, `_sample_cache`). After bust, next catalog/schema request reflects new state. Background re-warm task is scheduled for the affected `table_id` only. |
+| Cache warmup — startup | `warm_catalog_caches` startup hook runs in background without blocking `/api/health` readiness; warmup completes within `total × 200ms / concurrency` budget for synthetic 30-row registry. |
+| Cache warmup — failure isolation | one row's `_warm_one` raises; remaining rows still process; `WarmupRowState.error` is populated for the failed row only; final `state.failed == 1, state.completed == total - 1`. |
+| Cache warmup — bounded concurrency | with `AGNES_WARMUP_CONCURRENCY=2` and 30 rows, at most 2 `_warm_one` invocations run concurrently (assert via mock semaphore-tracked counter). |
+| Cache warmup — `/run` idempotency | calling `POST /api/admin/cache-warmup/run` twice in flight returns the same `run_id` on the second call without spawning a second background task. |
+| Cache warmup — registry-change rewarm | `invalidate_for_table(id)` schedules a single-row re-warm task; `WARMUP_STATE` is updated with that one row's progress. |
+| SSE stream | `GET /api/admin/cache-warmup/stream` yields `start` / `row` / `complete` events in JSON; events arrive within ~200 ms of state changes; client disconnect doesn't crash the producer. |
+| Status endpoint | `GET /api/admin/cache-warmup/status` returns the latest state (or `{"state": "never_run"}` before any run); reflects per-row state including `last_warmed_at` carried across runs. |
+| Admin UI smoke | `/admin/tables` HTML contains the cache toolbar `<section>`, the `EventSource` wiring, and the `col-status` per-row slot for BQ remote rows. (Doesn't run JS — just verifies the markup is present.) |
+| `agnes catalog` CLI | smoke test that the new fields surface in `--json` output and don't break the text-mode renderer. |
+| Sample endpoint | smoke test against a registered remote BQ row; verify it returns sample rows. If broken, separate fix path; not bundled in this PR's scope. |
 
 The new tests sit alongside `test_v2_catalog.py` (existing), `test_diagnose_billing.py` (existing — uses the same `seeded_app` BQ-mocking fixture).
 
@@ -723,17 +1087,21 @@ Reviewer flagged: when `bq_config` info-tier reports "BigQuery project not confi
 
 When this spec converts to a plan in `docs/superpowers/plans/`:
 
-0. ~~**Live BigQuery verification.**~~ ✅ Done 2026-05-07. Verified on `prj-grp-foundryai-dev-7c37` (us-central1) against `audrius_test.product_inventory`. Outcome locked in Open Question §1 + §1a + §1b. Chosen path: `<project>.region-<location>.INFORMATION_SCHEMA.TABLE_STORAGE`, region from `data_source.bigquery.location` with two fallback layers. Partition/cluster path inherits v2_schema's existing tested behavior (§2).
-1. **Shared models** — `app/api/_metadata_models.py` with `MetadataRequest` + `TableMetadata`. Pure dataclass module, no behavior. One commit, no tests beyond construction.
-2. **`KeboolaStorageClient.get_table_info` thin wrapper** — single function added to existing module + a unit test mocking the underlying `_get`. One commit.
-3. **Provider scaffold + dispatcher** — `app/api/v2_catalog.py:_metadata_provider_for` + `_build_metadata_request`. Stub providers in `connectors/<source>/metadata.py` returning `None`. Tests verify: dispatch returns the right callable per source_type; `_build_metadata_request` rejects bad identifiers; unknown source_type returns `None` callable.
-4. **Keboola provider** — real implementation backed by `KeboolaStorageClient.get_table_info`. Tests with mocked client returning canned `rowsCount`/`dataSizeBytes`; failure path returns `None`; unconfigured returns `None`.
-5. **BQ provider** — real implementation using the locked-in INFORMATION_SCHEMA view from step 0. Tests with mocked `bq.duckdb_session().execute().fetchall()`; partition + cluster path, rows + size path, sentinel early-return, error path, ingestion-time pseudo-column case (per step 0 verification).
-6. **v2_catalog wiring** — `_size_hint_for_row` rename, dispatch on `query_mode='remote'`, response shape extension (rows/size_bytes/partition_by/clustered_by fields), 15-min `_metadata_cache`. Tests verify the catalog response includes the new fields; cache hits don't re-call provider; cache miss after 15 min does.
-7. **Unified cache invalidation** — `v2_catalog.invalidate_for_table` helper + wiring into `admin.py:register_table` / `update_table` / `unregister_table`. Tests verify register/update/unregister all flush both caches; next catalog request shows the new state.
-8. **CLI post-register hint** — `cli/commands/admin.py:register_table` adds the third hint when `query_mode=remote`. CLI test asserts the line appears.
-9. **`docs/admin/query-modes.md`** — written end-to-end per the doc outline. Cross-references checked (RBAC.md, instance.yaml.example, BQ skill).
-10. **Admin UI tooltip** — `?` icon next to query_mode selector in `admin_tables.html`, links to the new doc page. ~10 LOC.
-11. **CHANGELOG + version bump** — `## [0.46.0] — YYYY-MM-DD`. Sections: Added (catalog response fields, query-modes doc), Changed (cache-invalidation behavior on register/update/unregister), Internal. Bump `pyproject.toml` to `0.46.0`. Minor (not patch) — new public catalog fields + new doc page.
+0. ~~**Live BigQuery verification.**~~ ✅ Done 2026-05-07. Outcome locked in Open Question §1 + §1a + §1b.
+1. **Shared models** — `app/api/_metadata_models.py` with `MetadataRequest` + `TableMetadata`. Pure dataclass module. One commit.
+2. **`KeboolaStorageClient.get_table_info` thin wrapper** — single function added + unit test mocking `_get`. One commit.
+3. **Combined COLUMNS helper** — `connectors/bigquery/access.py:fetch_bq_columns_full` (single query for column list + partition + cluster). Refactor `v2_schema._fetch_bq_schema` + `_fetch_bq_table_options` to call it; no behavior change for `/api/v2/schema/{id}` consumers. Existing schema-endpoint tests pass unchanged; new test asserts only one BQ job per cache miss (count `bigquery_query` invocations on the mocked session).
+4. **`build_schema` RBAC/cache split** — extract `build_schema_uncached(conn, table_id, *, bq)` containing the BQ work + cache write. `build_schema(...)` keeps the RBAC + cache-check at the top, then delegates. Existing endpoint behavior unchanged; new entry point is what warmup will call.
+5. **Provider scaffold + dispatcher** — `app/api/v2_catalog.py:_metadata_provider_for` + `_build_metadata_request`. Stub providers in `connectors/<source>/metadata.py` returning `None`. Tests verify dispatch + identifier rejection + unknown-source fall-through.
+6. **Keboola provider** — real `connectors/keboola/metadata.py:fetch` using `KeboolaStorageClient.get_table_info` + `KeboolaClient(token=None, url=None)` env-fallback. Tests cover happy / unconfigured / `StorageApiError`.
+7. **BQ provider** — real `connectors/bigquery/metadata.py:fetch` using `fetch_bq_columns_full` (step 3) for partition/cluster + `_fetch_via_table_storage` / `_fetch_via_legacy_tables` for rows+size + `_resolve_bq_location`. Tests cover the 5 cases from Test plan (happy / sentinel / VIEW / region-typo / both-paths-fail).
+8. **v2_catalog wiring** — `_size_hint_for_row` rename, dispatch on `query_mode='remote'`, response shape extension, 15-min `_metadata_cache`. Tests verify catalog response includes the new fields; cache hit/miss behavior; provider not dispatched for non-remote rows.
+9. **Unified cache invalidation** — `v2_catalog.invalidate_for_table` helper that flushes all four caches and schedules a single-row re-warm. Wired into `admin.py:register_table` / `update_table` / `unregister_table`. Tests verify all flushes + that the re-warm task is scheduled.
+10. **Cache warmup framework** — `app/api/cache_warmup.py` with `WarmupRunState` / `WarmupRowState` / `_warm_catalog_caches_bg` / `_warm_one`. The three `/api/admin/cache-warmup/{status,run,stream}` endpoints. SSE generator. Tests cover startup hook, bounded concurrency, failure isolation, idempotent `/run`, registry-change rewarm.
+11. **`app/main.py` startup hook** — register `warm_catalog_caches` event handler. Test verifies readiness is not blocked + warmup runs to completion in background. Honors `AGNES_SKIP_CACHE_WARMUP=1`.
+12. **CLI post-register hint** — `cli/commands/admin.py:register_table` adds the third hint when `query_mode=remote`. CLI test asserts the line appears.
+13. **`docs/admin/query-modes.md`** — written end-to-end per the doc outline. Cross-references checked (RBAC.md, instance.yaml.example, BQ skill).
+14. **Admin UI integration** — `admin_tables.html` cache toolbar `<section>`, per-row `col-status` badge, `EventSource` wiring + polling fallback, `?` icon on query_mode field. Smoke test asserts the markup is present.
+15. **CHANGELOG + version bump** — `## [0.46.0] — YYYY-MM-DD`. Sections: Added (catalog response fields, /api/admin/cache-warmup/*, automatic startup warmup, admin UI cache panel, query-modes doc), Changed (cache-invalidation on register/update/unregister; BQ schema endpoint now does 1 BQ job per cache miss instead of 2), Internal. Bump `pyproject.toml` to `0.46.0`. Minor — new public catalog fields, new admin endpoints, new doc page.
 
-Each step lands as one commit on the same branch. Reviewer can stop at any boundary if scope drifts.
+Each step lands as one commit on the same branch. Reviewer can stop at any boundary if scope drifts. Steps 1-2 are pure scaffolding; steps 3-4 are independent refactors that ship value on their own (50% BQ-job reduction); steps 5-9 are the metadata feature core; steps 10-11 are warmup infrastructure; step 14 is the operator-visible UI surface.

--- a/docs/superpowers/specs/2026-05-07-source-agnostic-table-metadata-spec.md
+++ b/docs/superpowers/specs/2026-05-07-source-agnostic-table-metadata-spec.md
@@ -1,0 +1,620 @@
+# Source-Agnostic Table Metadata for `agnes catalog`
+
+> **Status:** spec / design. Convert to an implementation plan in `docs/superpowers/plans/` once reviewed. Closes #155 + #156.
+
+**Goal:** Surface cost-relevant metadata for *every* registered table — regardless of `source_type` or `query_mode` — through `agnes catalog` and `agnes describe`. Right now the catalog response sets `rough_size_hint = None` for any non-local row, which means the analyst Claude has no guard against issuing a remote query against a 200-GB table. Plus give admins one canonical doc that explains when to register a table in each mode (BigQuery and Keboola today, future connectors tomorrow) so the option doesn't go undiscovered.
+
+**Why now:** the v0.45.0 easy-wins bundle left analyst-side cost discipline in good shape (BQ rewriter + cap-guard + `--remote` for views), and the v0.44.x bootstrap rework consolidated the analyst entrypoint on `agnes catalog` JSON. The remaining gap is on the *server*: catalog rows for remote tables still ship without size info, and there's no single connector-agnostic seam to add it. Issues #155 and #156 were filed against an older `data_description.md` / `schema.json` artifact pair that no longer exists; the same demand surfaces today against `agnes catalog`.
+
+**Non-goals:**
+
+- Profiling / column histograms for remote tables. That's a separate, much bigger piece of work (the original #155 third bullet) — `src/profiler.py` runs against a local parquet today, and lifting it to read from BigQuery is its own design conversation.
+- Dimension cardinality / `query_result_estimates`. Same reason — needs a profiler redesign.
+- Onboarding nudge ("hey, you have N tables, consider registering BQ remote ones"). Worth doing, but a separate UX call (admin dashboard empty-state, `agnes init` summary, or both) — out of scope here.
+- Generalising beyond BigQuery + Keboola. Jira / future connectors get a stub provider that returns `None`; not a polished surface yet.
+
+---
+
+## What already exists
+
+The pieces are 80% in place; this spec wires them up cleanly.
+
+### Catalog response (`/api/v2/catalog`)
+
+`app/api/v2_catalog.py:_materialized_size_hint` already sizes any table whose data is on the server's local filesystem (the `local` and `materialized` modes). For `remote`, it explicitly returns `None` with a TODO comment: *"size requires a BQ INFORMATION_SCHEMA round-trip; tracked separately"*. That's the gap.
+
+The function is also misnamed — it sizes more than just materialized rows. Will rename to `_size_hint_for_row` when restructuring.
+
+### Schema endpoint (`/api/v2/schema/{id}`)
+
+`app/api/v2_schema.py:_fetch_bq_table_options` (lines 85-140) already does a BQ INFORMATION_SCHEMA round-trip for partition + cluster info on a single table. The relevant body:
+
+```python
+# v2_schema.py:115-126 — DO NOT diverge from this shape; it's the template.
+with bq.duckdb_session() as conn:
+    bq_sql = (
+        f"SELECT column_name, is_partitioning_column, clustering_ordinal_position "
+        f"FROM `{bq.projects.data}.{dataset}.INFORMATION_SCHEMA.COLUMNS` "
+        f"WHERE table_name = ? "
+        f"ORDER BY clustering_ordinal_position NULLS LAST"
+    )
+    rows = conn.execute(
+        "SELECT * FROM bigquery_query(?, ?, ?)",
+        [bq.projects.billing, bq_sql, table],
+    ).fetchall()
+```
+
+Returns `{"partition_by": str | None, "clustered_by": list[str]}` or `{}`. Best-effort: errors degrade to empty dict, schema endpoint stays 200. The **load-bearing patterns** the new providers MUST mirror:
+
+1. **Sentinel-config early-return** — `if not bq.projects.data: return {}` on line 107, before any query construction. Keeps a Keboola-only deployment from blowing up on the first catalog call. Reasoning at `v2_schema.py:103-108`.
+2. **`validate_quoted_identifier` discipline** — every interpolated identifier (`bq.projects.data`, `dataset`, `table`) goes through `src.identifier_validation.validate_quoted_identifier` before f-stringing into the SQL (lines 110-113). Refuses unsafe identifiers by returning `{}`.
+3. **Positional `?` placeholders only** — `bigquery_query(?, ?, ?)` with 3 positional args: `[billing_project, inner_sql, *predicate_params]`. Inner BQ SQL uses `?` for predicates. **No `@named`-parameter syntax** — every existing call site (`extractor.py:204`, `v2_sample.py:52`, `v2_schema.py:124`) uses positional `?`; the BQ extension's named-param path is unverified in this codebase.
+4. **`try/except Exception → return {}` outer guard** — load-bearing per the function docstring (lines 93-99). The /schema endpoint must keep returning 200. Same applies to providers — never escalate to the catalog endpoint.
+
+This pattern is the prior-art template the new `metadata.py` providers replicate.
+
+### Sample endpoint (`/api/v2/sample/{id}`)
+
+`app/api/v2_sample.py` has a `bigquery` branch (line 86) that uses `bigquery_query` to fetch sample rows for remote BQ tables. **Already works**, in other words. Will verify with a smoke test in the implementation plan; if it works, no code change. (Issue #155's "agnes describe doesn't work on remote" claim is from May 1 — predates the rewriter / sample-endpoint work.)
+
+### Keboola Storage API wrapper
+
+`connectors/keboola/storage_api.py:KeboolaStorageClient` (landed in #190 today) exposes a generic `_get(path)` against `/v2/storage`. The Storage API's `GET /v2/storage/tables/{table_id}` returns `{rowsCount, dataSizeBytes, columns, primaryKey, ...}` — everything we need for a Keboola provider, no new HTTP plumbing required.
+
+Keboola tables are universally `query_mode='local'` in current deployments (a sync downloads the parquet), so the Keboola provider is mostly forward-looking. But the `_remote_attach` mechanism (`keboola.bucket.table` paths via the Keboola DuckDB extension) is architecturally supported and the docs page must reflect that.
+
+### BigQuery access
+
+`connectors/bigquery/access.py:get_bq_access()` returns a `BqAccess` with `duckdb_session()` — a DuckDB conn with the BigQuery extension preloaded. Same path `v2_schema._fetch_bq_table_options` already uses for INFORMATION_SCHEMA.
+
+### Caching infrastructure
+
+`app/api/v2_cache.py:TTLCache` is the existing TTL cache, already used by v2_catalog (`_table_rows_cache`, 5-min TTL). The new metadata cache plugs into the same primitive.
+
+---
+
+## Design
+
+### Provider pattern (source-agnostic seam)
+
+```
+connectors/
+  bigquery/
+    metadata.py      # NEW — INFORMATION_SCHEMA round-trip for BQ rows
+  keboola/
+    metadata.py      # NEW — GET /v2/storage/tables/{id} via storage_api
+  jira/
+    # no metadata.py — Jira tables are always query_mode='local',
+    # parquet stat path covers them.
+```
+
+Each provider exposes a single function. The contract is **narrow**: callers pass only the values the provider needs, never the whole registry row. This both stops the provider from accidentally reading fields the catalog doesn't intend it to, and gives the dispatcher one place to validate identifiers before calling.
+
+```python
+# app/api/_metadata_models.py — new shared module
+
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class MetadataRequest:
+    """Narrow input — the fields a metadata provider actually needs.
+
+    `bucket` and `source_table` are pre-validated by the dispatcher
+    (`validate_quoted_identifier`) before construction; the provider
+    can interpolate them into SQL/URL paths without re-checking.
+    """
+    table_id: str
+    bucket: str
+    source_table: str
+
+@dataclass
+class TableMetadata:
+    """Source-agnostic metadata bundle. Every field optional — providers
+    fill what they can cheaply get, callers tolerate Nones."""
+
+    rows: int | None = None
+    size_bytes: int | None = None
+    partition_by: str | None = None
+    clustered_by: list[str] | None = None
+    # Forward slots — populated when the provider grows. New fields here
+    # are non-breaking on existing CLI consumers (which today don't even
+    # render `rough_size_hint` — `grep -rn rough_size_hint cli/` is empty,
+    # confirming the additive-field claim).
+```
+
+```python
+# connectors/<source>/metadata.py
+
+def fetch(req: MetadataRequest) -> TableMetadata | None:
+    """Return metadata for a registered table. None on any failure
+    (network, permissions, sentinel-unconfigured connector); the caller
+    falls back to rough estimates or omits the field. Never raises."""
+```
+
+Dispatch from `app/api/v2_catalog.py` via a small registry:
+
+```python
+# app/api/v2_catalog.py (new helpers)
+
+from src.identifier_validation import validate_quoted_identifier
+
+def _metadata_provider_for(source_type: str):
+    """Lazy import — connector modules are heavy (import duckdb extensions,
+    google-cloud client, etc.). Loading them at request time keeps a
+    keboola-only deployment from paying the BQ import cost.
+    """
+    if source_type == "bigquery":
+        from connectors.bigquery import metadata as m
+        return m.fetch
+    if source_type == "keboola":
+        from connectors.keboola import metadata as m
+        return m.fetch
+    return None  # jira et al — no remote provider, fall through to parquet stat
+
+
+def _build_metadata_request(row: dict) -> MetadataRequest | None:
+    """Construct a validated MetadataRequest from a registry row. Returns
+    None when the row's identifiers don't pass validation — provider is
+    not dispatched. Mirrors the gate in v2_schema._fetch_bq_table_options:113."""
+    bucket = row.get("bucket") or ""
+    source_table = row.get("source_table") or row["id"]
+    if not (validate_quoted_identifier(bucket, "bucket")
+            and validate_quoted_identifier(source_table, "source_table")):
+        return None
+    return MetadataRequest(
+        table_id=row["id"], bucket=bucket, source_table=source_table,
+    )
+```
+
+The dispatch table is **two lines per connector**. Adding a future source (e.g. Snowflake) is a one-line registration plus a new `metadata.py`. Pre-validation means **identifier-injection guards live in one place** rather than being duplicated per provider.
+
+### When to call the provider
+
+`_size_hint_for_row(row)` (renamed from `_materialized_size_hint` — the rename is itself a fix; the existing function already handles `local` and `materialized`, the "materialized" in the name was misleading) becomes:
+
+1. If `query_mode in {"local", "materialized"}` → existing parquet-stat path on the data volume. Cheap.
+2. If `query_mode == "remote"` → call `_build_metadata_request(row)` (validates identifiers, returns None on bad shape) → dispatch to the provider → cache result by `(source_type, table_id)` for 15 minutes.
+3. Provider returns `None` or fails → return `None`, no escalation. The catalog response stays 200; the analyst Claude reads `null` and treats the size as unknown per existing CLAUDE.md guidance.
+
+The 15-minute TTL is a deliberate compromise:
+
+| TTL | Pro | Con |
+|---|---|---|
+| Per-request (no cache) | Always fresh | One INFORMATION_SCHEMA query per visible table per `agnes catalog` call. With 50 tables and 10 analysts hitting the dashboard, BQ quota burn adds up. |
+| 5 min (matches `_table_rows_cache`) | Already a configurable knob | Too short for a metric that barely changes hour-to-hour. |
+| **15 min** | Fresh enough for an analyst session, low enough that newly-registered tables show metrics within one coffee break | Slight lag for operators verifying registration. Mitigated by the unified cache-bust below. |
+| 1 hour | Less BQ traffic | Operators verifying `--query-mode remote` registration would see "unknown size" for too long. |
+
+**Negative-cache: NO.** Don't store a sentinel for failed lookups. The previous spec proposed a 60-second negative-cache TTL; reviewer correctly flagged the asymmetry as adding complexity without paying for itself. A failed BQ INFORMATION_SCHEMA call is cheap (one round-trip, metadata-only); a failed Keboola Storage API call is one HTTP GET. Worth re-trying on the next catalog request rather than building a parallel TTL system. If telemetry later shows a hot-loop (e.g. an instance permanently misconfigured but with admin watching the dashboard), revisit — until then, no negative cache.
+
+### Unified cache invalidation
+
+The previous spec proposed `_invalidate_metadata_cache(table_id)` on register/update. **That alone is insufficient.** `app/api/v2_catalog.py:25` already runs a 5-minute `_table_rows_cache` over the registry rows themselves (the table list, before per-table metadata enrichment). On current main, that cache is **not** invalidated by `register_table` / `update_table` (verified: `admin.py:1037,1110,2771` only call `app.instance_config.reset_cache()`). An admin who registers a remote table immediately runs `agnes catalog` and sees no row at all for up to 5 minutes — not just missing size, missing the whole row. This is a pre-existing bug the new metadata cache would otherwise inherit.
+
+Fix in this PR by introducing a single helper that owns both caches:
+
+```python
+# app/api/v2_catalog.py (addition)
+
+def invalidate_for_table(table_id: str) -> None:
+    """Drop both the registry-rows cache and the per-table metadata cache
+    so the next catalog request reflects the just-registered / updated /
+    unregistered row immediately. The catalog module owns this so admin.py
+    doesn't need to know which caches exist.
+    """
+    _table_rows_cache.invalidate_all()  # whole-list cache; can't precisely invalidate one row
+    _metadata_cache.invalidate(table_id)
+```
+
+Wire it into `app/api/admin.py`:
+
+- `POST /api/admin/register-table` — call after the registry write succeeds, before returning.
+- `PUT /api/admin/registry/{id}` — call after the row update.
+- `DELETE /api/admin/registry/{id}` — call after unregister (otherwise an unregistered row keeps appearing in `agnes catalog` for up to 5 minutes; same UX bug, opposite direction).
+
+Three call sites, one shared helper. Keeps cache knowledge in `v2_catalog.py` and out of `admin.py`.
+
+### BQ provider implementation sketch
+
+Two separate `bigquery_query()` calls, mirroring `v2_schema._fetch_bq_table_options` line-for-line. Same positional `?` binding, same identifier-validation discipline already enforced by the dispatcher, same sentinel-config early-return, same `try/except → None`. Combining them into one CTE was the previous spec's mistake — the codebase has zero precedent for multi-CTE BQ queries through `bigquery_query()`, the `LEFT JOIN ... ON TRUE` pattern made the empty-`cols` case yield `[NULL]` rather than `[]` (relied on coincidence to unwrap), and one extra round-trip on a 15-min-cached call site is not worth the risk.
+
+```python
+# connectors/bigquery/metadata.py
+
+import logging
+
+from app.api._metadata_models import MetadataRequest, TableMetadata
+from connectors.bigquery.access import BqAccessError, get_bq_access
+
+logger = logging.getLogger(__name__)
+
+
+def fetch(req: MetadataRequest) -> TableMetadata | None:
+    try:
+        bq = get_bq_access()
+    except BqAccessError:
+        return None
+
+    # Sentinel-config early-return — mirror v2_schema._fetch_bq_table_options:107.
+    # On a Keboola-only deployment, BqAccess is the sentinel and projects.data
+    # is empty. Returning None here keeps the catalog response clean (no
+    # mystery "size unknown" entries) and means the lazy-import rationale
+    # actually pays off — we don't run a query, we don't even build SQL.
+    if not bq.projects.data:
+        return None
+
+    # Identifier validation already done in the dispatcher
+    # (_build_metadata_request); req.bucket / req.source_table are safe
+    # to interpolate.
+    rows_size = _fetch_rows_and_size(bq, req)
+    part_clust = _fetch_partition_cluster(bq, req)
+    if rows_size is None and part_clust is None:
+        # Both queries failed — likely permissions or BQ down.
+        # Caller treats None as "unknown" and falls through to the existing
+        # null-size-hint contract.
+        return None
+
+    return TableMetadata(
+        rows=(rows_size or {}).get("rows"),
+        size_bytes=(rows_size or {}).get("size_bytes"),
+        partition_by=(part_clust or {}).get("partition_by"),
+        clustered_by=(part_clust or {}).get("clustered_by"),
+    )
+
+
+def _fetch_partition_cluster(bq, req: MetadataRequest) -> dict | None:
+    """Reuse the EXACT shape from v2_schema._fetch_bq_table_options:115-126.
+
+    We don't import the v2_schema helper directly because:
+    - It's marked private (leading underscore).
+    - Coupling the catalog provider to a sibling endpoint's internals
+      makes future refactors (e.g. v2_schema rewrite) ripple here.
+    The right move is one shared helper after a third caller appears;
+    until then, two co-located copies with this comment is cleaner than
+    a premature abstraction. (Tracked in "Out of scope".)
+    """
+    try:
+        bq_sql = (
+            f"SELECT column_name, is_partitioning_column, clustering_ordinal_position "
+            f"FROM `{bq.projects.data}.{req.bucket}.INFORMATION_SCHEMA.COLUMNS` "
+            f"WHERE table_name = ? "
+            f"ORDER BY clustering_ordinal_position NULLS LAST"
+        )
+        with bq.duckdb_session() as conn:
+            rows = conn.execute(
+                "SELECT * FROM bigquery_query(?, ?, ?)",
+                [bq.projects.billing, bq_sql, req.source_table],
+            ).fetchall()
+    except Exception as e:
+        logger.warning(
+            "BQ metadata partition/cluster fetch failed for %s.%s.%s: %s",
+            bq.projects.data, req.bucket, req.source_table, e,
+        )
+        return None
+    partition_by = next(
+        (r[0] for r in rows if (r[1] or "").upper() == "YES"),
+        None,
+    )
+    clustered_by = [r[0] for r in rows if r[2] is not None]
+    return {"partition_by": partition_by, "clustered_by": clustered_by}
+
+
+def _fetch_rows_and_size(bq, req: MetadataRequest) -> dict | None:
+    """Return {rows, size_bytes} for a BQ table, or None on failure.
+
+    *** EXACT INFORMATION_SCHEMA VIEW IS A PRE-IMPLEMENTATION OPEN
+    QUESTION (see Open Questions §1). Live BQ verification before
+    implementation freezes. ***
+
+    Candidates:
+
+    - **`<project>.<dataset>.INFORMATION_SCHEMA.TABLE_STORAGE`** —
+      preferred per Google's region-portable docs; reports
+      `total_rows` + `active_logical_bytes` + `long_term_logical_bytes`
+      + partition info. Works for BASE TABLE, VIEW (returns NULL bytes),
+      MATERIALIZED_VIEW. Region-qualified path is also legal as
+      `<project>.region-<region>.INFORMATION_SCHEMA.TABLE_STORAGE` and
+      may be needed for multi-region datasets. Requires
+      `bigquery.tables.get` on the table OR
+      `roles/bigquery.metadataViewer` on the dataset.
+    - `<project>.<dataset>.__TABLES__` (legacy) — has `row_count` +
+      `size_bytes` directly but is **per-dataset only**, doesn't
+      surface region-specific data, and is rumoured to be deprecated
+      in favour of TABLE_STORAGE. Avoid unless TABLE_STORAGE is
+      unavailable on the target instance.
+    - `__TABLES_SUMMARY__` — a SEPARATE legacy view (NOT the alias of
+      `__TABLES__` — distinct columns, common confusion). Don't use.
+
+    Implementation will hard-code one path; the open question is
+    *which*, decided by a one-day live test on the target BQ project.
+    """
+    raise NotImplementedError("see Open Questions §1 — verify on live BQ first")
+```
+
+Notes:
+
+- **Two queries, not one CTE.** Half the savings of a combined query (zero, since both round-trip the BQ jobs API at similar latency) for double the syntactic risk. Mirroring two well-tested patterns is the more conservative move on a metadata path.
+- **`bq.projects.billing` first arg, `bq.projects.data` in the SQL path.** Same as v2_schema. The billing project is who-pays-for-the-query; the data project is whose-tables-we-read.
+- **Partition/cluster path is verbatim copy of `_fetch_bq_table_options`:115-126.** If a follow-up PR consolidates the duplication into `app/api/_bq_helpers.py`, the consolidation can drop in without touching the provider's contract.
+- **Size/rows path is deliberately blocked** on the live-BQ open question so the implementer doesn't choose `__TABLES__` by default and ship the EU multi-region footgun.
+
+### Keboola provider implementation sketch
+
+```python
+# connectors/keboola/metadata.py
+
+import logging
+
+from app.api._metadata_models import MetadataRequest, TableMetadata
+from connectors.keboola.client import (
+    _resolve_keboola_url, _resolve_keboola_token,
+)  # see Token-resolution note below
+from connectors.keboola.storage_api import (
+    KeboolaStorageClient, StorageApiError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def fetch(req: MetadataRequest) -> TableMetadata | None:
+    url = _resolve_keboola_url()
+    token = _resolve_keboola_token()
+    if not url or not token:
+        return None  # not configured — same posture as BQ sentinel
+
+    table_id = f"{req.bucket}.{req.source_table}"
+    try:
+        client = KeboolaStorageClient(url=url, token=token)
+        info = client.get_table_info(table_id)  # NEW thin wrapper — see below
+    except (StorageApiError, ValueError) as e:
+        logger.warning("Keboola metadata fetch failed for %s: %s", table_id, e)
+        return None
+
+    return TableMetadata(
+        rows=info.get("rowsCount"),
+        size_bytes=info.get("dataSizeBytes"),
+        # Keboola has no BQ-style partition/cluster concept; primaryKey is
+        # conceptually different (uniqueness, not physical layout). Leave
+        # partition_by / clustered_by as None.
+    )
+```
+
+**Token resolution: reuse one path, do not invent a third.** `connectors/keboola/extractor.py` and `connectors/keboola/client.py` already resolve URL + token from a defined hierarchy:
+
+1. Env vars `KEBOOLA_STACK_URL` + `KEBOOLA_STORAGE_TOKEN` (or whatever `instance.yaml`'s `token_env` field points at).
+2. Fallback to `instance.yaml.data_source.keboola.{storage_url, token_env}`.
+
+The provider MUST call the existing helpers (`_resolve_keboola_url`, `_resolve_keboola_token` — names are placeholders; the implementation plan locks down whichever symbols actually ship). **Adding a third token-lookup path is rejected at review time.** The previous spec's `_get_storage_token()` "mirrors extractor.py" was hand-waving the wrong direction; the right move is `from connectors.keboola.client import the_existing_helper`.
+
+**`get_table_info(table_id)` — thin wrapper added to `KeboolaStorageClient` in this PR.** The previous spec called `client._get(f"/tables/{table_id}")` directly; that bleeds a `_`-private method out of the module and reviewers will (rightly) push back. One-line wrapper:
+
+```python
+# connectors/keboola/storage_api.py — addition
+
+def get_table_info(self, table_id: str) -> dict:
+    """GET /v2/storage/tables/{table_id} — full table metadata.
+
+    Storage API guarantees `rowsCount` + `dataSizeBytes` on success.
+    Other fields (`columns`, `primaryKey`, ...) are present but not
+    consumed today. Raises `StorageApiError` on 4xx/5xx.
+    """
+    return self._get(f"/tables/{table_id}")
+```
+
+Confirmed against existing call sites: `connectors/keboola/client.py:211-212,801-802` already destructure `rowsCount` and `dataSizeBytes` from the same endpoint. Test fixture `tests/test_admin_bq_register.py:1746` mocks the same shape. No surprises.
+
+### Catalog response shape — no breaking change
+
+Today's response per row:
+
+```jsonc
+{
+  "id": "orders",
+  "name": "orders",
+  "description": "...",
+  "source_type": "bigquery",
+  "query_mode": "remote",
+  "sql_flavor": "bigquery",
+  "where_examples": ["..."],
+  "fetch_via": "agnes snapshot create ...",
+  "rough_size_hint": null  // ← now populated for remote rows
+}
+```
+
+After:
+
+```jsonc
+{
+  // ... (all of the above) ...
+  "rough_size_hint": "large",            // size bucket — was null for remote
+  "rows": 12345678,                       // NEW — exact when known, null when not
+  "size_bytes": 4567890123,               // NEW — exact when known, null when not
+  "partition_by": "event_date",           // NEW — only for BQ, null otherwise
+  "clustered_by": ["country", "platform"] // NEW — only for BQ, null otherwise
+}
+```
+
+`rough_size_hint` keeps the existing bucket vocabulary (`small` / `medium` / `large` / `very_large`); the new exact fields are additive. Existing CLI consumers that read only `rough_size_hint` keep working unchanged.
+
+### `agnes describe` — verify, don't fix
+
+`/api/v2/sample/{id}` already has a BigQuery branch. Implementation plan includes a smoke test against a live BQ remote table; if it returns rows, **no code change**. If it doesn't, the fix is a 5-line `bigquery_query("SELECT * FROM ... LIMIT N")` along the same path as `v2_schema`. Don't pre-emptively scope-creep.
+
+CLI side (`agnes describe`) calls the v2 sample endpoint and renders rows — no per-source-type branching client-side. Nothing to change there.
+
+---
+
+## Documentation surface
+
+Single doc, one table-mode reference, future-proofs for new connectors.
+
+### `docs/admin/query-modes.md` (new)
+
+Outline:
+
+1. **Why three modes** — table comparing `local` vs `remote` vs `materialized` on (storage location, query path, cost model, freshness, scan limits).
+2. **Decision tree** — flowchart prose:
+   - Table updates daily and fits on a laptop (≤ 1 GB) → `local`
+   - Table updates frequently / live (intraday) → `remote`
+   - Table is the *result* of a daily SQL aggregate → `materialized`
+   - Table is too big to sync but rarely-queried (compliance/residency) → `remote`
+3. **Per-source-type reference**:
+   - **BigQuery** — IAM (`bigquery.dataViewer` + `bigquery.jobUser`), `billing_project` vs `project` distinction (cross-link to the `bq_config` info-tier health check from #178), `bq_max_scan_bytes` cost gate, registration via `agnes admin register-table --source-type bigquery --query-mode remote --bucket <dataset> --source-table <table>`, registration via UI.
+   - **Keboola** — Storage API token requirements, `local` is the path in production today, `remote` is architecturally supported via the Keboola DuckDB extension's `_remote_attach` mechanism but not in active deployment use. Includes a forward-looking note: *"If you have an analyst workflow against a Keboola table that's too big to sync, file an issue — the architecture is in place but the registration UX hasn't been polished."*
+   - **Jira** — event-driven ingestion, always `local`. Webhook setup pointer.
+4. **Three worked examples** (one per source type) — copy-paste CLI invocations.
+5. **Cross-references** — to `RBAC.md` (grants), to `instance.yaml.example` (config knobs), to the BQ skill in `docs/skills/`.
+
+The doc is the single landing place for the question *"can / how do I register a $X table for $Y mode?"* — replaces the absent breadcrumb #156 calls out.
+
+### Admin UI — minimal change
+
+`app/web/templates/admin_tables.html` — add a `?` icon next to the `query_mode` selector linking to the new doc page. **No** redesign of the form, **no** inline guidance panel — adding a few hundred lines of UI copy here would bloat a 132-KB template that's already overdue for a structural pass. Tooltip + doc link is the right scope today. The form itself already has enough validation (#177's PUT/DELETE work, the materialised-mode source_query check, the BQ shape validator in `_validate_bigquery_register_payload`) that an admin who reads the doc can drive it.
+
+### CLI hint at registration time
+
+`agnes admin register-table` already prints two post-success hints (the `Next: run agnes setup first-sync` and the `register-table does not auto-grant` notes). Add a third when `query_mode=remote` is registered:
+
+```
+Note: this is a remote-query table. Verify the SA can read it:
+  agnes query --remote "SELECT COUNT(*) FROM <id>"
+If it 403s, see docs/admin/query-modes.md → "BigQuery → IAM".
+```
+
+One conditional, mirrors the existing pattern. No new flag.
+
+---
+
+## Server-side changes
+
+### New files
+
+- `connectors/bigquery/metadata.py` — `fetch(row)` returning `TableMetadata | None`.
+- `connectors/keboola/metadata.py` — same shape, Storage API path.
+- `connectors/_metadata_models.py` (or directly in each — TBD by reviewer; importing from a sibling `connectors/_models.py` is the cleanest, but pulls in a small refactor of how connectors are organised). Provisional location: a new `connectors/__init__.py` exposing `TableMetadata`. Per existing repo convention, I lean toward a top-level shared module since other dataclasses (e.g. `dataclass PullResult` in `cli/lib/pull.py`) live alongside their primary consumer.
+- `tests/test_connectors_bigquery_metadata.py` — unit tests with mocked `bq.duckdb_session`.
+- `tests/test_connectors_keboola_metadata.py` — unit tests with mocked `KeboolaStorageClient`.
+- `tests/test_v2_catalog_remote_metadata.py` — integration test against the catalog endpoint with a registered remote row, mocked provider returning a `TableMetadata`. Verifies the response shape and the cache-bust path.
+
+### Edited files
+
+- `app/api/v2_catalog.py` — rename `_materialized_size_hint` → `_size_hint_for_row`, add provider dispatch, add `_metadata_cache` (TTLCache, 15 min), extend response shape with the new fields. ~50 LOC delta.
+- `app/api/admin.py` — wire `_invalidate_metadata_cache(table_id)` into the success path of `register_table` and `update_table`. ~5 LOC.
+- `cli/commands/admin.py` — extend the post-register hint as above. ~5 LOC.
+- `app/web/templates/admin_tables.html` — `?` icon + doc link next to `query_mode`. ~10 LOC.
+
+### Schema / DB / config
+
+**No schema migration.** All metadata is computed on demand from BigQuery / Keboola Storage API. We deliberately don't persist it (would add a bookkeeping problem — staleness, invalidation, schema bumps).
+
+**No new env vars.** All the required config (`data_source.bigquery.*`, `data_source.keboola.storage_*`) already exists for the connectors.
+
+---
+
+## Test plan
+
+| Layer | Coverage |
+|---|---|
+| Provider (BQ) | mocked `bq.duckdb_session().execute().fetchone()` returns a synthetic row → `fetch(row)` returns expected `TableMetadata`; `BqAccessError` → `None`; row missing `bucket` → `None`; query raises → `None` |
+| Provider (Keboola) | mocked `KeboolaStorageClient._get` returns `{rowsCount, dataSizeBytes, columns}` → `fetch(row)` returns expected metadata; missing token → `None`; `StorageApiError` → `None` |
+| Catalog endpoint | for a `query_mode='local'` row → existing parquet-stat path; for a `query_mode='remote'` BQ row → provider called, response has the new fields populated; cache-bust after `register_table` makes the next catalog request hit the provider again |
+| `agnes catalog` CLI | smoke test that the new fields surface in `--json` output and don't break the text-mode renderer |
+| Sample endpoint | smoke test against a registered remote BQ row; verify it returns sample rows. If broken, separate fix path; not bundled in this PR's scope |
+
+The new tests sit alongside `test_v2_catalog.py` (existing), `test_diagnose_billing.py` (existing — uses the same `seeded_app` BQ-mocking fixture).
+
+---
+
+## Migration / compatibility
+
+- **Wire-break: no.** Catalog response is additive. New fields default to `null` for sources without a provider; existing CLI consumers reading only `rough_size_hint` and `query_mode` are unaffected.
+- **`MIN_COMPAT_CLI_VERSION`** stays at `0.0.0`.
+- **BQ quota.** A typical instance with 30 remote tables sees one INFORMATION_SCHEMA query per table per 15-min window. INFORMATION_SCHEMA is metadata-only, doesn't bill against scan quota. Project-level concurrent-query quota is the only conceivable limit; with the 15-min cache it's not reachable.
+- **Keboola Storage API.** One `GET /tables/{id}` call per remote Keboola table per 15 min. Storage API has no public rate limit on metadata reads. Negligible.
+- **Performance.** First catalog call after a TTL expiry pays the round-trip cost (one BQ query + one Keboola GET). Subsequent calls within the window are sub-millisecond cache hits. Provider failures (network, permissions) are non-blocking — catalog response always returns within the existing latency budget.
+
+---
+
+## Out of scope (revisit later)
+
+- **Profile / column histograms / cardinality for remote tables.** Big lift, separate issue.
+- **`rough_size_hint` boundaries per source type.** A 5-GiB BQ table is "easy on remote" because of partition pruning; a 5-GiB Keboola table can't be remote at all. Bucket vocabulary is currently shared across sources; might want per-source thresholds eventually. Tracked as a follow-up nit.
+- **Provider plug-in registration via entry-points.** Currently the dispatch table is a hardcoded if-tree in `_metadata_provider_for`. If a future plugin API ships (#8), this becomes one line of registry boilerplate. Not worth pre-emptively building.
+- **Onboarding nudge** ("you have 0 remote tables, consider registering some BQ ones"). Worth doing — admin dashboard empty-state + `agnes init` summary footer line — but a UX call separate from this metadata work. Followup issue after this lands.
+
+---
+
+## Open questions
+
+### 1. Which BigQuery view exposes row count + size? **(Blocks implementation; needs live BQ verification.)**
+
+Three candidates surveyed; one needs a live test on the target instance to lock in:
+
+| View | Pros | Cons |
+|---|---|---|
+| `<project>.<dataset>.INFORMATION_SCHEMA.TABLE_STORAGE` | Region-portable; reports `total_rows` + `active_logical_bytes` + `long_term_logical_bytes` separately; partition-aware; works on BASE TABLE / VIEW (NULL bytes for views) / MATERIALIZED_VIEW | Requires `bigquery.tables.get` on the table OR `roles/bigquery.metadataViewer` on the dataset; per-region path may be needed for multi-region datasets (`<project>.region-<region>.INFORMATION_SCHEMA.TABLE_STORAGE`) |
+| `<project>.<dataset>.__TABLES__` (legacy) | Per-dataset, single query, zero cost | Doesn't surface region-specific data; rumoured to be deprecated; same IAM as `INFORMATION_SCHEMA.TABLES`; not partition-aware |
+| `__TABLES_SUMMARY__` | n/a | A SEPARATE legacy view with its own column set — frequently confused with `__TABLES__` (the previous spec called it an alias, **wrong**). Don't use. |
+
+**Verification protocol:** the live-BQ test runs all three on a real registered table on a target instance, captures the actual columns + values, and the spec's implementation step 0 records the chosen view + path before any code lands. Test SQL stubs:
+
+```sql
+-- Candidate A — region-qualified TABLE_STORAGE
+SELECT total_rows, active_logical_bytes, long_term_logical_bytes,
+       active_physical_bytes, long_term_physical_bytes
+FROM `<proj>.region-<region>.INFORMATION_SCHEMA.TABLE_STORAGE`
+WHERE table_schema = '<dataset>' AND table_name = '<table>';
+
+-- Candidate B — dataset-qualified TABLE_STORAGE
+SELECT total_rows, active_logical_bytes, long_term_logical_bytes
+FROM `<proj>.<dataset>.INFORMATION_SCHEMA.TABLE_STORAGE`
+WHERE table_name = '<table>';
+
+-- Candidate C — legacy __TABLES__
+SELECT row_count, size_bytes
+FROM `<proj>.<dataset>.__TABLES__`
+WHERE table_id = '<table>';
+```
+
+Lock the choice before implementation step 1 begins. Document the outcome in this section before the spec ships.
+
+### 2. Ingestion-time partitioning pseudo-columns
+
+For tables partitioned by ingestion time (BQ's `_PARTITIONTIME` / `_PARTITIONDATE` pseudo-columns), `INFORMATION_SCHEMA.COLUMNS` may or may not surface them as `is_partitioning_column='YES'` rows — Google's docs are unclear and the answer differs by region. **Verify in the same live BQ test.** If the pseudo-column appears: provider returns `partition_by="_PARTITIONTIME"`; analyst Claude can use that in `--where`. If it doesn't appear: provider returns `partition_by=None` and the analyst falls back to scan-byte cap-guard (existing behavior). Both branches need a unit test.
+
+### 3. Cache key shape
+
+`(source_type, table_id)` vs `(source_type, bucket, source_table)`. Today `table_id` is unique within a registry, so they're equivalent. If two registry rows ever pointed at the same upstream table (local-mode for sync + remote-mode for ad-hoc), keying by tuple would dedupe the BQ call. **Provisional answer: `table_id`.** Duplicate-target case is hypothetical; KISS until somebody registers it.
+
+### 4. `fetch_via` hint differentiation
+
+Currently catalog says `agnes snapshot create <id>` for any non-local row. With the new size hint, the catalog could differentiate per bucket: `small`/`medium` → `agnes query --remote "..."`; `large`/`very_large` → `agnes snapshot create <id> --where '<predicate>'`. **Lean yes** — one-line conditional, surfaces actionable advice the analyst Claude already follows manually. Codify in implementation plan.
+
+### 5. `--no-metadata` flag on `agnes catalog`?
+
+**No** — the cache amortises the work, an opt-out is more knob than the operator needs. Reconsider only if telemetry shows real load.
+
+### 6. `bq_config` health-check coordination
+
+Reviewer flagged: when `bq_config` info-tier reports "BigQuery project not configured" (`app/api/health.py:64-66`), the metadata provider currently silently returns `None` rather than agreeing with the health check. Both signals exist; they should be consistent. **Resolved in design above** — provider's sentinel-config early-return (`if not bq.projects.data: return None`) reads the same `BqAccess.projects.data` truthy check that drives the health entry. They can't disagree because they share state. No code coordination needed.
+
+---
+
+## Implementation order
+
+When this spec converts to a plan in `docs/superpowers/plans/`:
+
+0. **Live BigQuery verification.** *Before any code.* Run the three Open Question §1 candidate queries against a real registered remote table on a target instance. Capture actual column names, value ranges, IAM behavior, and ingestion-time partitioning pseudo-column presence (Open Question §2). Update Open Question §1 + §2 in this spec with the outcomes; lock the chosen view + path. Without this step the BQ provider is half-blind. Estimated: 30 min with credentials in hand.
+1. **Shared models** — `app/api/_metadata_models.py` with `MetadataRequest` + `TableMetadata`. Pure dataclass module, no behavior. One commit, no tests beyond construction.
+2. **`KeboolaStorageClient.get_table_info` thin wrapper** — single function added to existing module + a unit test mocking the underlying `_get`. One commit.
+3. **Provider scaffold + dispatcher** — `app/api/v2_catalog.py:_metadata_provider_for` + `_build_metadata_request`. Stub providers in `connectors/<source>/metadata.py` returning `None`. Tests verify: dispatch returns the right callable per source_type; `_build_metadata_request` rejects bad identifiers; unknown source_type returns `None` callable.
+4. **Keboola provider** — real implementation backed by `KeboolaStorageClient.get_table_info`. Tests with mocked client returning canned `rowsCount`/`dataSizeBytes`; failure path returns `None`; unconfigured returns `None`.
+5. **BQ provider** — real implementation using the locked-in INFORMATION_SCHEMA view from step 0. Tests with mocked `bq.duckdb_session().execute().fetchall()`; partition + cluster path, rows + size path, sentinel early-return, error path, ingestion-time pseudo-column case (per step 0 verification).
+6. **v2_catalog wiring** — `_size_hint_for_row` rename, dispatch on `query_mode='remote'`, response shape extension (rows/size_bytes/partition_by/clustered_by fields), 15-min `_metadata_cache`. Tests verify the catalog response includes the new fields; cache hits don't re-call provider; cache miss after 15 min does.
+7. **Unified cache invalidation** — `v2_catalog.invalidate_for_table` helper + wiring into `admin.py:register_table` / `update_table` / `unregister_table`. Tests verify register/update/unregister all flush both caches; next catalog request shows the new state.
+8. **CLI post-register hint** — `cli/commands/admin.py:register_table` adds the third hint when `query_mode=remote`. CLI test asserts the line appears.
+9. **`docs/admin/query-modes.md`** — written end-to-end per the doc outline. Cross-references checked (RBAC.md, instance.yaml.example, BQ skill).
+10. **Admin UI tooltip** — `?` icon next to query_mode selector in `admin_tables.html`, links to the new doc page. ~10 LOC.
+11. **CHANGELOG + version bump** — `## [0.46.0] — YYYY-MM-DD`. Sections: Added (catalog response fields, query-modes doc), Changed (cache-invalidation behavior on register/update/unregister), Internal. Bump `pyproject.toml` to `0.46.0`. Minor (not patch) — new public catalog fields + new doc page.
+
+Each step lands as one commit on the same branch. Reviewer can stop at any boundary if scope drifts.

--- a/docs/superpowers/specs/2026-05-07-source-agnostic-table-metadata-spec.md
+++ b/docs/superpowers/specs/2026-05-07-source-agnostic-table-metadata-spec.md
@@ -302,41 +302,112 @@ def _fetch_partition_cluster(bq, req: MetadataRequest) -> dict | None:
 def _fetch_rows_and_size(bq, req: MetadataRequest) -> dict | None:
     """Return {rows, size_bytes} for a BQ table, or None on failure.
 
-    *** EXACT INFORMATION_SCHEMA VIEW IS A PRE-IMPLEMENTATION OPEN
-    QUESTION (see Open Questions §1). Live BQ verification before
-    implementation freezes. ***
-
-    Candidates:
-
-    - **`<project>.<dataset>.INFORMATION_SCHEMA.TABLE_STORAGE`** —
-      preferred per Google's region-portable docs; reports
-      `total_rows` + `active_logical_bytes` + `long_term_logical_bytes`
-      + partition info. Works for BASE TABLE, VIEW (returns NULL bytes),
-      MATERIALIZED_VIEW. Region-qualified path is also legal as
-      `<project>.region-<region>.INFORMATION_SCHEMA.TABLE_STORAGE` and
-      may be needed for multi-region datasets. Requires
-      `bigquery.tables.get` on the table OR
-      `roles/bigquery.metadataViewer` on the dataset.
-    - `<project>.<dataset>.__TABLES__` (legacy) — has `row_count` +
-      `size_bytes` directly but is **per-dataset only**, doesn't
-      surface region-specific data, and is rumoured to be deprecated
-      in favour of TABLE_STORAGE. Avoid unless TABLE_STORAGE is
-      unavailable on the target instance.
-    - `__TABLES_SUMMARY__` — a SEPARATE legacy view (NOT the alias of
-      `__TABLES__` — distinct columns, common confusion). Don't use.
-
-    Implementation will hard-code one path; the open question is
-    *which*, decided by a one-day live test on the target BQ project.
+    Uses INFORMATION_SCHEMA.TABLE_STORAGE at REGION scope (the only
+    valid scope per live verification on prj-grp-foundryai-dev-7c37
+    2026-05-07 — see Open Question §1 in the spec). Falls back to
+    legacy __TABLES__ when region resolution fails.
     """
-    raise NotImplementedError("see Open Questions §1 — verify on live BQ first")
+    location = _resolve_bq_location(bq, req)
+    if location:
+        return _fetch_via_table_storage(bq, req, location)
+    # No region known and dataset.get() failed — last-resort fallback.
+    # Same row + size numbers, but loses multi-region portability.
+    return _fetch_via_legacy_tables(bq, req)
+
+
+def _resolve_bq_location(bq, req: MetadataRequest) -> str | None:
+    """Return the BQ region (e.g. "us-central1") for the dataset, or None.
+
+    Resolution order:
+      1. instance.yaml `data_source.bigquery.location` (the common case;
+         operators with a single-region BQ deployment set this once).
+      2. google-cloud-bigquery REST: `client.get_dataset(dataset_id).location`.
+         Cached at the dispatcher (TBD — likely a small TTL dict on
+         `(project, dataset) → location`).
+      3. None → caller falls back to legacy __TABLES__.
+    """
+    # Implementation detail; see app.instance_config.get_value lookup.
+    from app.instance_config import get_value
+    cfg_location = (get_value("data_source.bigquery.location") or "").strip()
+    if cfg_location:
+        return cfg_location
+    try:
+        ds = bq.bigquery_client().get_dataset(
+            f"{bq.projects.data}.{req.bucket}"
+        )
+        return ds.location
+    except Exception as e:
+        logger.warning(
+            "BQ dataset.get failed for %s.%s — falling back to __TABLES__: %s",
+            bq.projects.data, req.bucket, e,
+        )
+        return None
+
+
+def _fetch_via_table_storage(bq, req: MetadataRequest, location: str) -> dict | None:
+    """Region-scoped INFORMATION_SCHEMA.TABLE_STORAGE — preferred path."""
+    if not validate_quoted_identifier(location, "BQ region"):
+        return None
+    try:
+        bq_sql = (
+            f"SELECT total_rows, active_logical_bytes "
+            f"FROM `{bq.projects.data}.region-{location}.INFORMATION_SCHEMA.TABLE_STORAGE` "
+            f"WHERE table_schema = ? AND table_name = ?"
+        )
+        with bq.duckdb_session() as conn:
+            row = conn.execute(
+                "SELECT * FROM bigquery_query(?, ?, ?, ?)",
+                [bq.projects.billing, bq_sql, req.bucket, req.source_table],
+            ).fetchone()
+    except Exception as e:
+        logger.warning(
+            "BQ TABLE_STORAGE fetch failed for %s.%s.%s: %s",
+            bq.projects.data, req.bucket, req.source_table, e,
+        )
+        return None
+    if row is None:
+        return None
+    rows_, size_bytes = row
+    return {
+        "rows": int(rows_) if rows_ is not None else None,
+        "size_bytes": int(size_bytes) if size_bytes is not None else None,
+    }
+
+
+def _fetch_via_legacy_tables(bq, req: MetadataRequest) -> dict | None:
+    """Last-resort dataset-scoped __TABLES__ — works without region."""
+    try:
+        bq_sql = (
+            f"SELECT row_count, size_bytes "
+            f"FROM `{bq.projects.data}.{req.bucket}.__TABLES__` "
+            f"WHERE table_id = ?"
+        )
+        with bq.duckdb_session() as conn:
+            row = conn.execute(
+                "SELECT * FROM bigquery_query(?, ?, ?)",
+                [bq.projects.billing, bq_sql, req.source_table],
+            ).fetchone()
+    except Exception as e:
+        logger.warning(
+            "BQ __TABLES__ fetch failed for %s.%s.%s: %s",
+            bq.projects.data, req.bucket, req.source_table, e,
+        )
+        return None
+    if row is None:
+        return None
+    rows_, size_bytes = row
+    return {
+        "rows": int(rows_) if rows_ is not None else None,
+        "size_bytes": int(size_bytes) if size_bytes is not None else None,
+    }
 ```
 
 Notes:
 
-- **Two queries, not one CTE.** Half the savings of a combined query (zero, since both round-trip the BQ jobs API at similar latency) for double the syntactic risk. Mirroring two well-tested patterns is the more conservative move on a metadata path.
+- **Two queries, not one CTE.** Forced by BQ schema: TABLE_STORAGE is region-scoped, COLUMNS is dataset-scoped, they live at different fully-qualified paths and cannot share a query. Live-verified 2026-05-07 (Open Question §1).
 - **`bq.projects.billing` first arg, `bq.projects.data` in the SQL path.** Same as v2_schema. The billing project is who-pays-for-the-query; the data project is whose-tables-we-read.
 - **Partition/cluster path is verbatim copy of `_fetch_bq_table_options`:115-126.** If a follow-up PR consolidates the duplication into `app/api/_bq_helpers.py`, the consolidation can drop in without touching the provider's contract.
-- **Size/rows path is deliberately blocked** on the live-BQ open question so the implementer doesn't choose `__TABLES__` by default and ship the EU multi-region footgun.
+- **Region resolution prefers config over discovery.** `instance.yaml.data_source.bigquery.location` is already a documented knob; reading it from `app.instance_config.get_value` avoids a per-dataset round-trip in the common case (single-region deployments). The `bq_client.get_dataset(...)` fallback handles the rare multi-region or unset-config case; the `__TABLES__` fallback handles the rarer SA-can-query-but-not-`bigquery.datasets.get` case.
 
 ### Keboola provider implementation sketch
 
@@ -546,41 +617,49 @@ The new tests sit alongside `test_v2_catalog.py` (existing), `test_diagnose_bill
 
 ## Open questions
 
-### 1. Which BigQuery view exposes row count + size? **(Blocks implementation; needs live BQ verification.)**
+### 1. Which BigQuery view exposes row count + size? **RESOLVED — verified live on `prj-grp-foundryai-dev-7c37` 2026-05-07.**
 
-Three candidates surveyed; one needs a live test on the target instance to lock in:
+Three candidates were surveyed and tested against `audrius_test.product_inventory` (25-row table in us-central1). Outcome:
 
-| View | Pros | Cons |
+| View | Status | Notes |
 |---|---|---|
-| `<project>.<dataset>.INFORMATION_SCHEMA.TABLE_STORAGE` | Region-portable; reports `total_rows` + `active_logical_bytes` + `long_term_logical_bytes` separately; partition-aware; works on BASE TABLE / VIEW (NULL bytes for views) / MATERIALIZED_VIEW | Requires `bigquery.tables.get` on the table OR `roles/bigquery.metadataViewer` on the dataset; per-region path may be needed for multi-region datasets (`<project>.region-<region>.INFORMATION_SCHEMA.TABLE_STORAGE`) |
-| `<project>.<dataset>.__TABLES__` (legacy) | Per-dataset, single query, zero cost | Doesn't surface region-specific data; rumoured to be deprecated; same IAM as `INFORMATION_SCHEMA.TABLES`; not partition-aware |
-| `__TABLES_SUMMARY__` | n/a | A SEPARATE legacy view with its own column set — frequently confused with `__TABLES__` (the previous spec called it an alias, **wrong**). Don't use. |
+| **`<project>.region-<region>.INFORMATION_SCHEMA.TABLE_STORAGE`** | ✅ **chosen** | Returns `total_rows`, `active_logical_bytes`, `long_term_logical_bytes`, `active_physical_bytes`, `long_term_physical_bytes`. Filter via `WHERE table_schema='<dataset>' AND table_name='<table>'`. Confirmed `active_logical_bytes` matches legacy `__TABLES__.size_bytes` byte-for-byte (2407 == 2407). |
+| `<project>.<dataset>.INFORMATION_SCHEMA.TABLE_STORAGE` | ❌ doesn't exist | `bq query` returns "Not found: Dataset prj-grp-foundryai-dev-7c37:audrius_test.INFORMATION_SCHEMA was not found in location us-central1". TABLE_STORAGE is region-scoped only. |
+| `<project>.<dataset>.__TABLES__` (legacy) | ⚠️ fallback only | Works (`row_count=25, size_bytes=2407`), but per-dataset (no multi-region) and rumoured to be deprecated. Use only if region resolution fails. |
+| `__TABLES_SUMMARY__` | n/a | Separate legacy view, distinct columns. **Not** an alias of `__TABLES__` (the original spec was wrong on this). Don't use. |
 
-**Verification protocol:** the live-BQ test runs all three on a real registered table on a target instance, captures the actual columns + values, and the spec's implementation step 0 records the chosen view + path before any code lands. Test SQL stubs:
+**Locked SQL for the BQ provider:**
 
 ```sql
--- Candidate A — region-qualified TABLE_STORAGE
-SELECT total_rows, active_logical_bytes, long_term_logical_bytes,
-       active_physical_bytes, long_term_physical_bytes
-FROM `<proj>.region-<region>.INFORMATION_SCHEMA.TABLE_STORAGE`
-WHERE table_schema = '<dataset>' AND table_name = '<table>';
-
--- Candidate B — dataset-qualified TABLE_STORAGE
-SELECT total_rows, active_logical_bytes, long_term_logical_bytes
-FROM `<proj>.<dataset>.INFORMATION_SCHEMA.TABLE_STORAGE`
-WHERE table_name = '<table>';
-
--- Candidate C — legacy __TABLES__
-SELECT row_count, size_bytes
-FROM `<proj>.<dataset>.__TABLES__`
-WHERE table_id = '<table>';
+SELECT total_rows, active_logical_bytes
+FROM `<project>.region-<location>.INFORMATION_SCHEMA.TABLE_STORAGE`
+WHERE table_schema = ? AND table_name = ?
 ```
 
-Lock the choice before implementation step 1 begins. Document the outcome in this section before the spec ships.
+Mapped to `TableMetadata` as `rows = total_rows`, `size_bytes = active_logical_bytes`. The `long_term_*` and `physical_bytes` variants are deliberately NOT exposed — they're storage-billing concepts the analyst doesn't act on; collapsing to a single number keeps the catalog response simple.
+
+### 1a. Where does `<region>` come from?
+
+**Primary:** `data_source.bigquery.location` in `instance.yaml` (already a documented config knob — see `config/instance.yaml.example:116`). Operators with a single-region BQ deployment (the common case) set this once; provider reads it.
+
+**Fallback:** if `location` is unset and the dataset's region can't be inferred, the provider tries `bq_client.get_dataset(dataset_id).location` via the existing google-cloud-bigquery REST client (one cached round-trip per dataset). If that also fails (e.g. the SA lacks `bigquery.datasets.get`), the provider falls back to legacy `__TABLES__` which is dataset-scoped and doesn't need region knowledge — at the cost of losing the region-portable property.
+
+The dispatch order is: **`instance.yaml.location` → `bq_client.get_dataset` → legacy `__TABLES__`**. Most deployments hit the first; the rest have a graceful path.
+
+### 1b. Why two queries, not one CTE
+
+The original spec proposed a single combined CTE. After live verification this is **architecturally impossible**: TABLE_STORAGE lives at *region* scope (`<project>.region-<region>.INFORMATION_SCHEMA.TABLE_STORAGE`); COLUMNS lives at *dataset* scope (`<project>.<dataset>.INFORMATION_SCHEMA.COLUMNS`). They cannot be joined inside a single `bigquery_query()` call — different fully-qualified paths require separate queries. Two round-trips is forced, not a preference.
 
 ### 2. Ingestion-time partitioning pseudo-columns
 
-For tables partitioned by ingestion time (BQ's `_PARTITIONTIME` / `_PARTITIONDATE` pseudo-columns), `INFORMATION_SCHEMA.COLUMNS` may or may not surface them as `is_partitioning_column='YES'` rows — Google's docs are unclear and the answer differs by region. **Verify in the same live BQ test.** If the pseudo-column appears: provider returns `partition_by="_PARTITIONTIME"`; analyst Claude can use that in `--where`. If it doesn't appear: provider returns `partition_by=None` and the analyst falls back to scan-byte cap-guard (existing behavior). Both branches need a unit test.
+**RESOLVED — defer to existing v2_schema behavior, no new code.**
+
+The original concern: for tables partitioned by ingestion time (BQ's `_PARTITIONTIME` / `_PARTITIONDATE` pseudo-columns), `INFORMATION_SCHEMA.COLUMNS` may or may not surface them as `is_partitioning_column='YES'`. Live verification could not be completed — the SA on `prj-grp-foundryai-dev-7c37` doesn't have visibility into a partitioned table that's also reachable for testing. But this is **not a blocker** because:
+
+1. The new BQ provider's partition/cluster path is a **verbatim copy** of `v2_schema._fetch_bq_table_options:115-126`, which has been running in production for months. Whatever its behavior is on ingestion-time-partitioned tables, the metadata provider will produce identical output — and the `/api/v2/schema` endpoint already serves that output to analysts today without complaints.
+2. The fallback contract is well-defined: provider returns `partition_by=None` if no row matches `is_partitioning_column='YES'`. Analyst Claude treats `null` as "no usable partition pruning" and falls back to the BQ cap-guard. No corruption mode.
+
+If a follow-up issue surfaces with ingestion-time partitioning specifically, the fix is one-line in v2_schema and the metadata provider inherits it.
 
 ### 3. Cache key shape
 
@@ -604,7 +683,7 @@ Reviewer flagged: when `bq_config` info-tier reports "BigQuery project not confi
 
 When this spec converts to a plan in `docs/superpowers/plans/`:
 
-0. **Live BigQuery verification.** *Before any code.* Run the three Open Question §1 candidate queries against a real registered remote table on a target instance. Capture actual column names, value ranges, IAM behavior, and ingestion-time partitioning pseudo-column presence (Open Question §2). Update Open Question §1 + §2 in this spec with the outcomes; lock the chosen view + path. Without this step the BQ provider is half-blind. Estimated: 30 min with credentials in hand.
+0. ~~**Live BigQuery verification.**~~ ✅ Done 2026-05-07. Verified on `prj-grp-foundryai-dev-7c37` (us-central1) against `audrius_test.product_inventory`. Outcome locked in Open Question §1 + §1a + §1b. Chosen path: `<project>.region-<location>.INFORMATION_SCHEMA.TABLE_STORAGE`, region from `data_source.bigquery.location` with two fallback layers. Partition/cluster path inherits v2_schema's existing tested behavior (§2).
 1. **Shared models** — `app/api/_metadata_models.py` with `MetadataRequest` + `TableMetadata`. Pure dataclass module, no behavior. One commit, no tests beyond construction.
 2. **`KeboolaStorageClient.get_table_info` thin wrapper** — single function added to existing module + a unit test mocking the underlying `_get`. One commit.
 3. **Provider scaffold + dispatcher** — `app/api/v2_catalog.py:_metadata_provider_for` + `_build_metadata_request`. Stub providers in `connectors/<source>/metadata.py` returning `None`. Tests verify: dispatch returns the right callable per source_type; `_build_metadata_request` rejects bad identifiers; unknown source_type returns `None` callable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ dependencies = [
     # directly via `requests` — no SDK dependency on the data-path side. The
     # SDK stays for the metadata reads.
     "kbcstorage>=0.9.0",
+    "sse-starlette>=2.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.46.5"
+version = "0.47.0"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,19 @@ def _reset_module_caches():
         _q._quota_singleton = None
     except ImportError:
         pass
+    try:
+        from app.api import v2_catalog as _vc
+        _vc._table_rows_cache.clear()
+        _vc._metadata_cache.clear()
+    except (ImportError, AttributeError):
+        pass
     yield
+    try:
+        from app.api import v2_catalog as _vc
+        _vc._table_rows_cache.clear()
+        _vc._metadata_cache.clear()
+    except (ImportError, AttributeError):
+        pass
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,11 +87,21 @@ def _reset_module_caches():
         _vc._metadata_cache.clear()
     except (ImportError, AttributeError):
         pass
+    try:
+        import app.api.cache_warmup as _cw
+        _cw.WARMUP_STATE = None
+    except (ImportError, AttributeError):
+        pass
     yield
     try:
         from app.api import v2_catalog as _vc
         _vc._table_rows_cache.clear()
         _vc._metadata_cache.clear()
+    except (ImportError, AttributeError):
+        pass
+    try:
+        import app.api.cache_warmup as _cw
+        _cw.WARMUP_STATE = None
     except (ImportError, AttributeError):
         pass
 

--- a/tests/test_admin_tables_warmup_ui.py
+++ b/tests/test_admin_tables_warmup_ui.py
@@ -1,0 +1,35 @@
+"""Smoke test that /admin/tables HTML contains the cache toolbar markup,
+the EventSource wiring, and the per-row col-status slot."""
+
+
+def test_cache_toolbar_present(seeded_app):
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.get(
+        "/admin/tables", headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.text
+    assert 'id="cacheWarmupCard"' in body
+    assert "Re-warm all" in body
+    assert "/api/admin/cache-warmup/stream" in body
+    assert "EventSource" in body
+
+
+def test_query_mode_doc_link_present(seeded_app):
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.get(
+        "/admin/tables", headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200
+    assert "query-modes" in r.text  # link to docs/admin/query-modes.md or rendered URL
+
+
+def test_col_status_th_present_in_renderer(seeded_app):
+    """The renderRegistryListing JS still emits <th class='col-status'>
+    so the per-row badge slot exists."""
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.get("/admin/tables", headers={"Authorization": f"Bearer {token}"})
+    assert 'col-status' in r.text

--- a/tests/test_cache_warmup.py
+++ b/tests/test_cache_warmup.py
@@ -4,6 +4,7 @@ import asyncio
 from unittest.mock import patch
 
 import pytest
+from app.api.cache_warmup import WarmupRunState
 
 
 def test_warmup_run_state_starts_empty():
@@ -67,7 +68,7 @@ def test_run_endpoint_starts_warmup(seeded_app, monkeypatch):
     monkeypatch.setattr(cache_warmup, "WARMUP_STATE", None)
     # Patch the actual warmup so the test doesn't run a real one.
     monkeypatch.setattr(cache_warmup, "_warm_catalog_caches_bg",
-                        lambda trigger="manual": _async_noop())
+                        lambda trigger="manual", state=None: _async_noop())
 
     c = seeded_app["client"]
     token = seeded_app["admin_token"]
@@ -76,6 +77,30 @@ def test_run_endpoint_starts_warmup(seeded_app, monkeypatch):
         headers={"Authorization": f"Bearer {token}"},
     )
     assert r.status_code == 200
+
+
+def test_run_endpoint_returns_run_id_not_none(seeded_app, monkeypatch):
+    """POST /run returns a non-null run_id even when the bg task hasn't
+    started running yet (no race between create_task and the handler return)."""
+    from app.api import cache_warmup
+
+    async def fake_bg(trigger="manual", state=None):
+        await asyncio.sleep(0.01)  # don't actually warm
+
+    monkeypatch.setattr(cache_warmup, "WARMUP_STATE", None)
+    monkeypatch.setattr(cache_warmup, "_warm_catalog_caches_bg", fake_bg)
+
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.post(
+        "/api/admin/cache-warmup/run",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "started"
+    assert body["run_id"] is not None
+    assert len(body["run_id"]) == 8  # uuid4 hex prefix
 
 
 async def _async_noop():

--- a/tests/test_cache_warmup.py
+++ b/tests/test_cache_warmup.py
@@ -3,7 +3,6 @@
 import asyncio
 from unittest.mock import patch
 
-import pytest
 from app.api.cache_warmup import WarmupRunState
 
 
@@ -24,9 +23,12 @@ def test_warmup_skips_when_env_set(monkeypatch):
     mock_bg.assert_not_called()
 
 
-@pytest.mark.asyncio
-async def test_warmup_runs_one_per_remote_row(monkeypatch):
-    """`_warm_catalog_caches_bg` calls `_warm_one` once per remote row."""
+def test_warmup_runs_one_per_remote_row(monkeypatch):
+    """`_warm_catalog_caches_bg` calls `_warm_one` once per remote row.
+
+    Uses asyncio.run rather than @pytest.mark.asyncio to match the
+    convention in this repo (see tests/test_selective_gzip.py).
+    """
     from app.api import cache_warmup
 
     # Stub the registry to return 3 remote BQ rows + 1 local row.
@@ -42,7 +44,7 @@ async def test_warmup_runs_one_per_remote_row(monkeypatch):
 
     monkeypatch.setattr(cache_warmup, "_list_remote_rows", lambda: fake_rows)
     monkeypatch.setattr(cache_warmup, "_warm_one", fake_warm_one)
-    await cache_warmup._warm_catalog_caches_bg(trigger="manual")
+    asyncio.run(cache_warmup._warm_catalog_caches_bg(trigger="manual"))
 
     assert sorted(warmed) == ["r1", "r2", "r3"]
 

--- a/tests/test_cache_warmup.py
+++ b/tests/test_cache_warmup.py
@@ -1,0 +1,82 @@
+"""Cache warmup framework — state, bg task, endpoints."""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+
+def test_warmup_run_state_starts_empty():
+    from app.api.cache_warmup import WARMUP_STATE
+    assert WARMUP_STATE is None or WARMUP_STATE.completed_at is not None
+
+
+def test_warmup_skips_when_env_set(monkeypatch):
+    """AGNES_SKIP_CACHE_WARMUP=1 → background warmup is a no-op."""
+    monkeypatch.setenv("AGNES_SKIP_CACHE_WARMUP", "1")
+    from app.api import cache_warmup
+
+    # When the env opt-out is set, maybe_schedule_startup_warmup must
+    # NOT call _warm_catalog_caches_bg.
+    with patch.object(cache_warmup, "_warm_catalog_caches_bg") as mock_bg:
+        cache_warmup.maybe_schedule_startup_warmup()
+    mock_bg.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_warmup_runs_one_per_remote_row(monkeypatch):
+    """`_warm_catalog_caches_bg` calls `_warm_one` once per remote row."""
+    from app.api import cache_warmup
+
+    # Stub the registry to return 3 remote BQ rows + 1 local row.
+    fake_rows = [
+        {"id": "r1", "query_mode": "remote", "source_type": "bigquery"},
+        {"id": "r2", "query_mode": "remote", "source_type": "bigquery"},
+        {"id": "r3", "query_mode": "remote", "source_type": "bigquery"},
+    ]
+    warmed = []
+
+    async def fake_warm_one(row, state, sem):
+        warmed.append(row["id"])
+
+    monkeypatch.setattr(cache_warmup, "_list_remote_rows", lambda: fake_rows)
+    monkeypatch.setattr(cache_warmup, "_warm_one", fake_warm_one)
+    await cache_warmup._warm_catalog_caches_bg(trigger="manual")
+
+    assert sorted(warmed) == ["r1", "r2", "r3"]
+
+
+def test_status_endpoint_before_first_run(seeded_app, monkeypatch):
+    """GET /status returns {state: never_run} before any warmup."""
+    from app.api import cache_warmup
+    monkeypatch.setattr(cache_warmup, "WARMUP_STATE", None)
+
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.get(
+        "/api/admin/cache-warmup/status",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200
+    assert r.json() == {"state": "never_run"}
+
+
+def test_run_endpoint_starts_warmup(seeded_app, monkeypatch):
+    """POST /run schedules a warmup and returns 200."""
+    from app.api import cache_warmup
+    monkeypatch.setattr(cache_warmup, "WARMUP_STATE", None)
+    # Patch the actual warmup so the test doesn't run a real one.
+    monkeypatch.setattr(cache_warmup, "_warm_catalog_caches_bg",
+                        lambda trigger="manual": _async_noop())
+
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    r = c.post(
+        "/api/admin/cache-warmup/run",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200
+
+
+async def _async_noop():
+    return None

--- a/tests/test_cache_warmup.py
+++ b/tests/test_cache_warmup.py
@@ -105,5 +105,50 @@ def test_run_endpoint_returns_run_id_not_none(seeded_app, monkeypatch):
     assert len(body["run_id"]) == 8  # uuid4 hex prefix
 
 
+def test_list_remote_rows_filters_to_bigquery_source_type(monkeypatch):
+    """Devin Review #1 regression: `_list_remote_rows` previously returned
+    every `query_mode='remote'` row regardless of `source_type`. The downstream
+    `_warm_schema_sync` always calls `get_bq_access()`, so a non-BQ remote row
+    (hypothetical today, plausible as connectors expand) would crash the
+    warmup pass.
+
+    Fix: filter on `source_type == 'bigquery'` in `_list_remote_rows` so the
+    BQ-only warmup path only sees rows it can handle. Rows from other sources
+    are simply skipped — they'll grow their own warmup paths as needed."""
+    from app.api import cache_warmup
+
+    fake_rows = [
+        {"id": "bq_remote", "query_mode": "remote", "source_type": "bigquery"},
+        {"id": "kbc_remote", "query_mode": "remote", "source_type": "keboola"},
+        {"id": "bq_local", "query_mode": "local", "source_type": "bigquery"},
+        {"id": "future_remote", "query_mode": "remote", "source_type": "snowflake"},
+        {"id": "bq_remote2", "query_mode": "remote", "source_type": "bigquery"},
+    ]
+
+    class FakeRepo:
+        def __init__(self, conn):
+            pass
+
+        def list_all(self):
+            return fake_rows
+
+    class FakeConn:
+        def close(self):
+            pass
+
+    monkeypatch.setattr(
+        "src.repositories.table_registry.TableRegistryRepository", FakeRepo,
+    )
+    monkeypatch.setattr(
+        "src.db.get_system_db", lambda: FakeConn(),
+    )
+
+    result = cache_warmup._list_remote_rows()
+    ids = sorted(r["id"] for r in result)
+    assert ids == ["bq_remote", "bq_remote2"], (
+        f"only remote+bigquery rows should be warmed, got {ids}"
+    )
+
+
 async def _async_noop():
     return None

--- a/tests/test_cli_admin.py
+++ b/tests/test_cli_admin.py
@@ -264,6 +264,37 @@ class TestUpdateTable:
         assert result.exit_code == 1
 
 
+class TestRegisterTableHints:
+    """The CLI prints helpful follow-up hints after a successful
+    register-table call. v0.46 adds a third hint for query_mode=remote
+    pointing at the IAM verify-your-SA smoke check."""
+
+    def test_remote_register_emits_iam_verify_hint(self):
+        with patch("cli.commands.admin.api_post", return_value=_resp(201, {"id": "t"})):
+            result = runner.invoke(app, [
+                "admin", "register-table", "orders",
+                "--source-type", "bigquery",
+                "--bucket", "dwh_base",
+                "--source-table", "orders",
+                "--query-mode", "remote",
+            ])
+        assert result.exit_code == 0
+        assert "agnes query --remote" in result.output
+        assert "query-modes.md" in result.output
+
+    def test_local_register_does_not_emit_remote_hint(self):
+        with patch("cli.commands.admin.api_post", return_value=_resp(201, {"id": "t"})):
+            result = runner.invoke(app, [
+                "admin", "register-table", "users",
+                "--source-type", "keboola",
+                "--bucket", "in.c-crm",
+                "--source-table", "users",
+                "--query-mode", "local",
+            ])
+        assert result.exit_code == 0
+        assert "agnes query --remote" not in result.output
+
+
 def test_admin_set_role_returns_hardfail():
     """v19: `agnes admin set-role` was removed. Calling it must hard-fail
     with a non-zero exit code and a message pointing at the replacement

--- a/tests/test_connectors_bigquery_metadata.py
+++ b/tests/test_connectors_bigquery_metadata.py
@@ -57,13 +57,24 @@ def _bq_with_session(table_storage_rows=None, columns_rows=None,
     return bq
 
 
+def _location_get_value(*keys, default=None):
+    """Mock for `app.instance_config.get_value` matching its multi-positional
+    signature. Returns 'us-central1' for the BQ location key, default otherwise.
+    Regression-anchored to Devin Review #1: the prior buggy single-string call
+    silently dropped the configured location; this fixture intentionally
+    requires the correct ('data_source', 'bigquery', 'location') tuple."""
+    if keys == ("data_source", "bigquery", "location"):
+        return "us-central1"
+    return default
+
+
 def test_happy_path_returns_full_metadata(req, monkeypatch):
     """TABLE_STORAGE returns rows+size, COLUMNS returns partition+cluster."""
     from connectors.bigquery import metadata
 
     monkeypatch.setattr(
         "connectors.bigquery.metadata.get_value",
-        lambda key, default=None: "us-central1" if "location" in key else default,
+        _location_get_value,
         raising=False,
     )
 
@@ -100,7 +111,7 @@ def test_view_path_returns_metadata_with_null_rows_size(req, monkeypatch):
     from connectors.bigquery import metadata
     monkeypatch.setattr(
         "connectors.bigquery.metadata.get_value",
-        lambda key, default=None: "us-central1" if "location" in key else default,
+        _location_get_value,
         raising=False,
     )
     bq = _bq_with_session(
@@ -121,9 +132,15 @@ def test_view_path_returns_metadata_with_null_rows_size(req, monkeypatch):
 def test_region_typo_falls_through_to_legacy_tables(req, monkeypatch):
     """TABLE_STORAGE raises (typo'd region) → fall through to __TABLES__."""
     from connectors.bigquery import metadata
+
+    def typo_get_value(*keys, default=None):
+        if keys == ("data_source", "bigquery", "location"):
+            return "us-central"  # typo!
+        return default
+
     monkeypatch.setattr(
         "connectors.bigquery.metadata.get_value",
-        lambda key, default=None: "us-central" if "location" in key else default,  # typo!
+        typo_get_value,
         raising=False,
     )
     bq = _bq_with_session(
@@ -143,7 +160,7 @@ def test_both_paths_fail_returns_metadata_with_partition_only(req, monkeypatch):
     from connectors.bigquery import metadata
     monkeypatch.setattr(
         "connectors.bigquery.metadata.get_value",
-        lambda key, default=None: "us-central1" if "location" in key else default,
+        _location_get_value,
         raising=False,
     )
     bq = _bq_with_session(
@@ -157,6 +174,65 @@ def test_both_paths_fail_returns_metadata_with_partition_only(req, monkeypatch):
     assert result.rows is None
     assert result.size_bytes is None
     assert result.partition_by == "event_date"
+
+
+def test_location_config_uses_multi_positional_get_value_args(req, monkeypatch):
+    """Devin Review #1 regression: `get_value` was called with a single
+    dot-separated string `'data_source.bigquery.location'`, but the function
+    iterates over separate positional keys — so the call always returned None
+    and the BQ location config was never read.
+
+    This test records every call to `get_value` and asserts that the location
+    lookup goes through the correct multi-positional form
+    (`'data_source', 'bigquery', 'location'`)."""
+    from connectors.bigquery import metadata
+
+    calls: list[tuple] = []
+
+    def recording_get_value(*keys, default=None):
+        calls.append(keys)
+        if keys == ("data_source", "bigquery", "location"):
+            return "europe-west1"
+        return default
+
+    monkeypatch.setattr(
+        "connectors.bigquery.metadata.get_value",
+        recording_get_value,
+        raising=False,
+    )
+
+    captured: dict = {}
+
+    def execute(outer_sql, params):
+        if "TABLE_STORAGE" in (params[1] if len(params) > 1 else ""):
+            captured["table_storage_sql"] = params[1]
+            return MagicMock(fetchone=lambda: (5, 10))
+        return MagicMock(fetchall=lambda: [], fetchone=lambda: None)
+
+    bq = MagicMock()
+    bq.projects.data = "data-proj"
+    bq.projects.billing = "billing-proj"
+    session = MagicMock()
+    session.execute.side_effect = execute
+    cm = MagicMock()
+    cm.__enter__.return_value = session
+    cm.__exit__.return_value = False
+    bq.duckdb_session.return_value = cm
+
+    with patch("connectors.bigquery.metadata.get_bq_access", return_value=bq):
+        metadata.fetch(req)
+
+    # The fix: `get_value("data_source", "bigquery", "location")` must appear.
+    assert ("data_source", "bigquery", "location") in calls, (
+        f"expected ('data_source','bigquery','location') tuple in get_value "
+        f"calls, got: {calls}"
+    )
+    # And the configured location must reach the TABLE_STORAGE SQL — proving
+    # the value was actually consumed, not just looked up.
+    assert "region-europe-west1" in captured.get("table_storage_sql", ""), (
+        f"location config was not propagated to BQ SQL: "
+        f"{captured.get('table_storage_sql', '<no SQL captured>')}"
+    )
 
 
 def test_bq_access_error_returns_none(req):

--- a/tests/test_connectors_bigquery_metadata.py
+++ b/tests/test_connectors_bigquery_metadata.py
@@ -62,7 +62,7 @@ def test_happy_path_returns_full_metadata(req, monkeypatch):
     from connectors.bigquery import metadata
 
     monkeypatch.setattr(
-        "app.instance_config.get_value",
+        "connectors.bigquery.metadata.get_value",
         lambda key, default=None: "us-central1" if "location" in key else default,
         raising=False,
     )
@@ -99,7 +99,7 @@ def test_view_path_returns_metadata_with_null_rows_size(req, monkeypatch):
     partition + cluster from COLUMNS still surface."""
     from connectors.bigquery import metadata
     monkeypatch.setattr(
-        "app.instance_config.get_value",
+        "connectors.bigquery.metadata.get_value",
         lambda key, default=None: "us-central1" if "location" in key else default,
         raising=False,
     )
@@ -122,7 +122,7 @@ def test_region_typo_falls_through_to_legacy_tables(req, monkeypatch):
     """TABLE_STORAGE raises (typo'd region) → fall through to __TABLES__."""
     from connectors.bigquery import metadata
     monkeypatch.setattr(
-        "app.instance_config.get_value",
+        "connectors.bigquery.metadata.get_value",
         lambda key, default=None: "us-central" if "location" in key else default,  # typo!
         raising=False,
     )
@@ -142,7 +142,7 @@ def test_both_paths_fail_returns_metadata_with_partition_only(req, monkeypatch):
     """Both TABLE_STORAGE and __TABLES__ fail → rows/size None, partition still fills."""
     from connectors.bigquery import metadata
     monkeypatch.setattr(
-        "app.instance_config.get_value",
+        "connectors.bigquery.metadata.get_value",
         lambda key, default=None: "us-central1" if "location" in key else default,
         raising=False,
     )

--- a/tests/test_connectors_bigquery_metadata.py
+++ b/tests/test_connectors_bigquery_metadata.py
@@ -1,0 +1,170 @@
+"""BigQuery metadata provider — 5 paths from spec test plan:
+happy / sentinel / VIEW / region-typo / both-paths-fail."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.api._metadata_models import MetadataRequest, TableMetadata
+
+
+@pytest.fixture
+def req():
+    return MetadataRequest(
+        table_id="orders", bucket="dwh_base", source_table="orders_2024",
+    )
+
+
+def _bq_with_session(table_storage_rows=None, columns_rows=None,
+                     table_storage_raises=None, columns_raises=None,
+                     legacy_tables_rows=None, legacy_tables_raises=None,
+                     projects_data="data-proj", projects_billing="billing-proj"):
+    """Mock `BqAccess` whose `duckdb_session()` returns a context manager
+    routing `.execute(...)` based on the inner SQL string."""
+    bq = MagicMock()
+    bq.projects.data = projects_data
+    bq.projects.billing = projects_billing
+
+    def execute(outer_sql, params):
+        inner_sql = params[1] if len(params) > 1 else ""
+        if "TABLE_STORAGE" in inner_sql:
+            if table_storage_raises:
+                raise table_storage_raises
+            return MagicMock(
+                fetchone=lambda: table_storage_rows[0] if table_storage_rows else None,
+                fetchall=lambda: table_storage_rows or [],
+            )
+        if "INFORMATION_SCHEMA.COLUMNS" in inner_sql:
+            if columns_raises:
+                raise columns_raises
+            return MagicMock(
+                fetchall=lambda: columns_rows or [],
+            )
+        if "__TABLES__" in inner_sql:
+            if legacy_tables_raises:
+                raise legacy_tables_raises
+            return MagicMock(
+                fetchone=lambda: legacy_tables_rows[0] if legacy_tables_rows else None,
+            )
+        raise AssertionError(f"unexpected SQL: {inner_sql[:80]}")
+
+    session = MagicMock()
+    session.execute.side_effect = execute
+    cm = MagicMock()
+    cm.__enter__.return_value = session
+    cm.__exit__.return_value = False
+    bq.duckdb_session.return_value = cm
+    return bq
+
+
+def test_happy_path_returns_full_metadata(req, monkeypatch):
+    """TABLE_STORAGE returns rows+size, COLUMNS returns partition+cluster."""
+    from connectors.bigquery import metadata
+
+    monkeypatch.setattr(
+        "app.instance_config.get_value",
+        lambda key, default=None: "us-central1" if "location" in key else default,
+        raising=False,
+    )
+
+    bq = _bq_with_session(
+        table_storage_rows=[(1234567, 5_000_000)],
+        columns_rows=[
+            ("event_date", "DATE", "NO", "YES", None),
+            ("country", "STRING", "YES", "NO", 1),
+            ("user_id", "STRING", "NO", "NO", None),
+        ],
+    )
+    with patch("connectors.bigquery.metadata.get_bq_access", return_value=bq):
+        result = metadata.fetch(req)
+    assert result == TableMetadata(
+        rows=1234567,
+        size_bytes=5_000_000,
+        partition_by="event_date",
+        clustered_by=["country"],
+    )
+
+
+def test_sentinel_unconfigured_returns_none_no_query(req):
+    """`bq.projects.data == ''` → return None before any query."""
+    from connectors.bigquery import metadata
+    bq = _bq_with_session(projects_data="")
+    with patch("connectors.bigquery.metadata.get_bq_access", return_value=bq):
+        assert metadata.fetch(req) is None
+    bq.duckdb_session.assert_not_called()
+
+
+def test_view_path_returns_metadata_with_null_rows_size(req, monkeypatch):
+    """VIEW: TABLE_STORAGE empty + __TABLES__ empty → rows/size = None;
+    partition + cluster from COLUMNS still surface."""
+    from connectors.bigquery import metadata
+    monkeypatch.setattr(
+        "app.instance_config.get_value",
+        lambda key, default=None: "us-central1" if "location" in key else default,
+        raising=False,
+    )
+    bq = _bq_with_session(
+        table_storage_rows=[],   # view → no row
+        legacy_tables_rows=[],   # view also absent from __TABLES__
+        columns_rows=[
+            ("event_date", "DATE", "NO", "YES", None),
+        ],
+    )
+    with patch("connectors.bigquery.metadata.get_bq_access", return_value=bq):
+        result = metadata.fetch(req)
+    assert result is not None
+    assert result.rows is None
+    assert result.size_bytes is None
+    assert result.partition_by == "event_date"
+
+
+def test_region_typo_falls_through_to_legacy_tables(req, monkeypatch):
+    """TABLE_STORAGE raises (typo'd region) → fall through to __TABLES__."""
+    from connectors.bigquery import metadata
+    monkeypatch.setattr(
+        "app.instance_config.get_value",
+        lambda key, default=None: "us-central" if "location" in key else default,  # typo!
+        raising=False,
+    )
+    bq = _bq_with_session(
+        table_storage_raises=RuntimeError("Not found: ..."),
+        legacy_tables_rows=[(100, 2048)],
+        columns_rows=[("event_date", "DATE", "NO", "YES", None)],
+    )
+    with patch("connectors.bigquery.metadata.get_bq_access", return_value=bq):
+        result = metadata.fetch(req)
+    assert result is not None
+    assert result.rows == 100
+    assert result.size_bytes == 2048
+
+
+def test_both_paths_fail_returns_metadata_with_partition_only(req, monkeypatch):
+    """Both TABLE_STORAGE and __TABLES__ fail → rows/size None, partition still fills."""
+    from connectors.bigquery import metadata
+    monkeypatch.setattr(
+        "app.instance_config.get_value",
+        lambda key, default=None: "us-central1" if "location" in key else default,
+        raising=False,
+    )
+    bq = _bq_with_session(
+        table_storage_raises=RuntimeError("BQ down"),
+        legacy_tables_raises=RuntimeError("BQ still down"),
+        columns_rows=[("event_date", "DATE", "NO", "YES", None)],
+    )
+    with patch("connectors.bigquery.metadata.get_bq_access", return_value=bq):
+        result = metadata.fetch(req)
+    assert result is not None
+    assert result.rows is None
+    assert result.size_bytes is None
+    assert result.partition_by == "event_date"
+
+
+def test_bq_access_error_returns_none(req):
+    """get_bq_access() raises BqAccessError → return None gracefully."""
+    from connectors.bigquery import metadata
+    from connectors.bigquery.access import BqAccessError
+    with patch(
+        "connectors.bigquery.metadata.get_bq_access",
+        side_effect=BqAccessError("not_configured", "not configured"),
+    ):
+        assert metadata.fetch(req) is None

--- a/tests/test_connectors_keboola_metadata.py
+++ b/tests/test_connectors_keboola_metadata.py
@@ -1,0 +1,75 @@
+"""Keboola metadata provider — happy + unconfigured + api-error paths."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.api._metadata_models import MetadataRequest, TableMetadata
+
+
+@pytest.fixture
+def req():
+    return MetadataRequest(
+        table_id="orders", bucket="in.c-crm", source_table="orders",
+    )
+
+
+def test_happy_path_returns_populated_metadata(req, monkeypatch):
+    from connectors.keboola import metadata
+    # KeboolaClient(token=None, url=None) reads env vars; pretend they're set.
+    monkeypatch.setenv("KEBOOLA_STACK_URL", "https://connection.keboola.com")
+    monkeypatch.setenv("KEBOOLA_STORAGE_TOKEN", "tok")
+
+    with patch("connectors.keboola.metadata.KeboolaStorageClient") as MockStorage:
+        instance = MockStorage.return_value
+        instance.get_table_info.return_value = {
+            "rowsCount": 1234,
+            "dataSizeBytes": 500_000,
+            "primaryKey": ["id"],
+        }
+        result = metadata.fetch(req)
+
+    assert result == TableMetadata(
+        rows=1234,
+        size_bytes=500_000,
+        partition_by=None,
+        clustered_by=None,
+    )
+
+
+def test_returns_none_when_unconfigured(req, monkeypatch):
+    """No KEBOOLA_STACK_URL / KEBOOLA_STORAGE_TOKEN env → return None."""
+    from connectors.keboola import metadata
+    monkeypatch.delenv("KEBOOLA_STACK_URL", raising=False)
+    monkeypatch.delenv("KEBOOLA_STORAGE_TOKEN", raising=False)
+    assert metadata.fetch(req) is None
+
+
+def test_returns_none_on_storage_api_error(req, monkeypatch):
+    """`StorageApiError` from get_table_info → log + return None."""
+    from connectors.keboola import metadata
+    from connectors.keboola.storage_api import StorageApiError
+    monkeypatch.setenv("KEBOOLA_STACK_URL", "https://x.keboola.com")
+    monkeypatch.setenv("KEBOOLA_STORAGE_TOKEN", "tok")
+
+    with patch("connectors.keboola.metadata.KeboolaStorageClient") as MockStorage:
+        instance = MockStorage.return_value
+        instance.get_table_info.side_effect = StorageApiError(
+            "404 not found", status=404, body={},
+        )
+        assert metadata.fetch(req) is None
+
+
+def test_table_id_uses_bucket_dot_source_table(req, monkeypatch):
+    """Storage API path is `<bucket>.<source_table>`."""
+    from connectors.keboola import metadata
+    monkeypatch.setenv("KEBOOLA_STACK_URL", "https://x.keboola.com")
+    monkeypatch.setenv("KEBOOLA_STORAGE_TOKEN", "tok")
+
+    with patch("connectors.keboola.metadata.KeboolaStorageClient") as MockStorage:
+        instance = MockStorage.return_value
+        instance.get_table_info.return_value = {
+            "rowsCount": 0, "dataSizeBytes": 0,
+        }
+        metadata.fetch(req)
+        instance.get_table_info.assert_called_once_with("in.c-crm.orders")

--- a/tests/test_keboola_storage_api.py
+++ b/tests/test_keboola_storage_api.py
@@ -518,3 +518,45 @@ class TestParquetPath:
         }, dest)
 
         assert dest.read_bytes() == b"PAR1\x00\x00\x00binary"
+
+
+# ---- get_table_info --------------------------------------------------------
+
+class TestGetTableInfo:
+    """`get_table_info` is a thin wrapper around the existing _get path
+    so the metadata provider doesn't have to bleed `_get` out of the
+    module (#155)."""
+
+    def test_calls_storage_api_with_table_id(self, monkeypatch):
+        from connectors.keboola.storage_api import KeboolaStorageClient
+
+        captured = {}
+
+        def fake_get(self, path, **kwargs):
+            captured["path"] = path
+            return {"rowsCount": 100, "dataSizeBytes": 4096}
+
+        monkeypatch.setattr(KeboolaStorageClient, "_get", fake_get)
+
+        client = KeboolaStorageClient(
+            url="https://connection.keboola.com", token="tok"
+        )
+        info = client.get_table_info("in.c-orders.events")
+        assert captured["path"] == "/tables/in.c-orders.events"
+        assert info["rowsCount"] == 100
+        assert info["dataSizeBytes"] == 4096
+
+    def test_propagates_storage_api_error(self, monkeypatch):
+        from connectors.keboola.storage_api import (
+            KeboolaStorageClient, StorageApiError,
+        )
+
+        def fake_get(self, path, **kwargs):
+            raise StorageApiError("404 not found", status=404, body={})
+
+        monkeypatch.setattr(KeboolaStorageClient, "_get", fake_get)
+
+        client = KeboolaStorageClient(url="https://x", token="tok")
+        import pytest
+        with pytest.raises(StorageApiError):
+            client.get_table_info("missing.table")

--- a/tests/test_main_startup_warmup.py
+++ b/tests/test_main_startup_warmup.py
@@ -1,0 +1,31 @@
+"""The FastAPI startup hook schedules cache warmup."""
+
+from unittest.mock import patch
+
+
+def test_startup_handler_calls_warmup_scheduler():
+    """A startup handler in app.main calls maybe_schedule_startup_warmup."""
+    from app.main import app
+
+    # FastAPI startup events live on app.router.on_startup OR are
+    # registered via lifespan. Either way, we should be able to verify
+    # the scheduler is called.
+    handlers = list(app.router.on_startup)
+    handler_names = [getattr(h, "__name__", "?") for h in handlers]
+    # Either: a named handler that calls warmup, OR a lifespan that does.
+    has_warmup = any("warm" in n.lower() for n in handler_names)
+    if not has_warmup:
+        # Lifespan path — check for the lifespan fn
+        lifespan = getattr(app.router, "lifespan_context", None)
+        assert lifespan is not None, (
+            "Expected a startup handler (or lifespan) that calls "
+            "cache_warmup.maybe_schedule_startup_warmup. "
+            f"Found on_startup: {handler_names}"
+        )
+
+
+def test_health_check_succeeds_immediately(seeded_app):
+    """/api/health doesn't await warmup; readiness is fire-and-forget."""
+    c = seeded_app["client"]
+    r = c.get("/api/health")
+    assert r.status_code == 200

--- a/tests/test_metadata_models.py
+++ b/tests/test_metadata_models.py
@@ -1,0 +1,39 @@
+"""Sanity tests for the shared metadata dataclasses."""
+
+from app.api._metadata_models import MetadataRequest, TableMetadata
+
+
+def test_metadata_request_constructs():
+    req = MetadataRequest(
+        table_id="orders", bucket="dwh_base", source_table="orders_2024",
+    )
+    assert req.table_id == "orders"
+    assert req.bucket == "dwh_base"
+    assert req.source_table == "orders_2024"
+
+
+def test_metadata_request_is_frozen():
+    """Frozen so cache keys derived from a request are stable."""
+    req = MetadataRequest(table_id="x", bucket="b", source_table="t")
+    import dataclasses
+    try:
+        req.bucket = "other"
+    except dataclasses.FrozenInstanceError:
+        return
+    raise AssertionError("MetadataRequest should be frozen")
+
+
+def test_table_metadata_all_fields_optional():
+    tm = TableMetadata()
+    assert tm.rows is None
+    assert tm.size_bytes is None
+    assert tm.partition_by is None
+    assert tm.clustered_by is None
+
+
+def test_table_metadata_partial_population():
+    tm = TableMetadata(rows=100, size_bytes=2048)
+    assert tm.rows == 100
+    assert tm.size_bytes == 2048
+    assert tm.partition_by is None
+    assert tm.clustered_by is None

--- a/tests/test_v2_catalog_dispatcher.py
+++ b/tests/test_v2_catalog_dispatcher.py
@@ -1,0 +1,71 @@
+"""Dispatch + identifier-validation gate for the source-agnostic
+metadata providers."""
+
+from app.api._metadata_models import MetadataRequest
+
+
+def test_dispatcher_returns_bq_provider_for_bigquery():
+    from app.api.v2_catalog import _metadata_provider_for
+    from connectors.bigquery import metadata as bq_meta
+    fn = _metadata_provider_for("bigquery")
+    assert fn is bq_meta.fetch
+
+
+def test_dispatcher_returns_keboola_provider_for_keboola():
+    from app.api.v2_catalog import _metadata_provider_for
+    from connectors.keboola import metadata as kb_meta
+    fn = _metadata_provider_for("keboola")
+    assert fn is kb_meta.fetch
+
+
+def test_dispatcher_returns_none_for_unknown_source():
+    from app.api.v2_catalog import _metadata_provider_for
+    assert _metadata_provider_for("jira") is None
+    assert _metadata_provider_for("") is None
+    assert _metadata_provider_for("snowflake") is None
+
+
+def test_build_metadata_request_for_valid_row():
+    from app.api.v2_catalog import _build_metadata_request
+    req = _build_metadata_request({
+        "id": "orders",
+        "bucket": "dwh_base",
+        "source_table": "orders_2024",
+    })
+    assert isinstance(req, MetadataRequest)
+    assert req.table_id == "orders"
+    assert req.bucket == "dwh_base"
+    assert req.source_table == "orders_2024"
+
+
+def test_build_metadata_request_rejects_unsafe_bucket():
+    from app.api.v2_catalog import _build_metadata_request
+    req = _build_metadata_request({
+        "id": "x",
+        "bucket": "evil`; DROP--",
+        "source_table": "t",
+    })
+    assert req is None
+
+
+def test_build_metadata_request_falls_back_to_id_when_source_table_missing():
+    """Some legacy Keboola registry rows have empty source_table; the row id
+    is the table name in that case (mirrors v2_schema:168 behavior)."""
+    from app.api.v2_catalog import _build_metadata_request
+    req = _build_metadata_request({
+        "id": "orders",
+        "bucket": "in.c-crm",
+        "source_table": "",
+    })
+    assert req is not None
+    assert req.source_table == "orders"
+
+
+def test_stub_providers_return_none():
+    """Providers don't have their real bodies yet — stubs return None
+    so the catalog endpoint stays 200 while we wire the rest."""
+    from connectors.bigquery import metadata as bq_meta
+    from connectors.keboola import metadata as kb_meta
+    req = MetadataRequest(table_id="x", bucket="b", source_table="t")
+    assert bq_meta.fetch(req) is None
+    assert kb_meta.fetch(req) is None

--- a/tests/test_v2_catalog_invalidation.py
+++ b/tests/test_v2_catalog_invalidation.py
@@ -1,0 +1,99 @@
+"""Unified cache flush across all four catalog/schema/sample/metadata
+caches on registry write."""
+
+from unittest.mock import patch
+
+
+def test_invalidate_flushes_all_four_caches():
+    from app.api import v2_catalog, v2_schema, v2_sample
+    from app.api._metadata_models import TableMetadata
+
+    # Pre-populate.
+    v2_catalog._table_rows_cache.set("all", ["fake_row"])
+    v2_catalog._metadata_cache.set("orders", TableMetadata(rows=10))
+    v2_schema._schema_cache.set("orders", {"columns": []})
+    v2_sample._sample_cache.set("orders|10", [{"row": 1}])
+
+    v2_catalog.invalidate_for_table("orders")
+
+    assert v2_catalog._table_rows_cache.get("all") is None
+    assert v2_catalog._metadata_cache.get("orders") is None
+    assert v2_schema._schema_cache.get("orders") is None
+    # Sample cache is cleared whole (we don't have prefix-invalidation).
+    assert v2_sample._sample_cache.get("orders|10") is None
+
+
+def test_invalidate_schedules_single_row_rewarm(monkeypatch):
+    """After the flush, a background re-warm task is scheduled for the
+    same table_id. Assert via patching create_task."""
+    import asyncio
+    from app.api import v2_catalog
+
+    scheduled = []
+
+    def fake_create_task(coro):
+        # Drain the coroutine so the test doesn't leak it.
+        coro.close()
+        scheduled.append(coro)
+        return None
+
+    # Simulate a running event loop so the create_task branch is reached.
+    monkeypatch.setattr(asyncio, "get_running_loop", lambda: object())
+    monkeypatch.setattr(asyncio, "create_task", fake_create_task)
+    v2_catalog.invalidate_for_table("orders")
+    assert len(scheduled) == 1
+
+
+def test_register_table_invalidates(seeded_app):
+    """Registering a table flushes the rows cache so the next catalog
+    request reflects it without waiting for the 5-min TTL."""
+    from app.api import v2_catalog
+    v2_catalog._table_rows_cache.set("all", [])
+
+    client = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+    client.post("/api/admin/register-table", json={
+        "name": "new_t",
+        "source_type": "keboola",
+        "bucket": "in.c-x",
+        "source_table": "t",
+        "query_mode": "local",
+    }, headers=headers)
+    assert v2_catalog._table_rows_cache.get("all") is None
+
+
+def test_update_table_invalidates(seeded_app):
+    from app.api import v2_catalog
+    client = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    client.post("/api/admin/register-table", json={
+        "name": "u_t",
+        "source_type": "keboola",
+        "bucket": "in.c-x",
+        "source_table": "t",
+        "query_mode": "local",
+    }, headers=headers)
+    v2_catalog._table_rows_cache.set("all", ["pre-update"])
+    client.put("/api/admin/registry/u_t", json={"description": "new"}, headers=headers)
+    assert v2_catalog._table_rows_cache.get("all") is None
+
+
+def test_unregister_table_invalidates(seeded_app):
+    from app.api import v2_catalog
+    client = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    client.post("/api/admin/register-table", json={
+        "name": "d_t",
+        "source_type": "keboola",
+        "bucket": "in.c-x",
+        "source_table": "t",
+        "query_mode": "local",
+    }, headers=headers)
+    v2_catalog._table_rows_cache.set("all", ["pre-delete"])
+    client.delete("/api/admin/registry/d_t", headers=headers)
+    assert v2_catalog._table_rows_cache.get("all") is None

--- a/tests/test_v2_catalog_remote_metadata.py
+++ b/tests/test_v2_catalog_remote_metadata.py
@@ -1,0 +1,137 @@
+"""Catalog endpoint integration: per-table metadata enrichment for
+remote rows."""
+
+from unittest.mock import patch
+
+from app.api._metadata_models import TableMetadata
+
+
+def _register_table(seeded_app, **kwargs):
+    """Register a table into the test DB using TableRegistryRepository."""
+    from src.db import get_system_db
+    from src.repositories.table_registry import TableRegistryRepository
+    conn = get_system_db()
+    try:
+        repo = TableRegistryRepository(conn)
+        # `name` defaults to `id` if not supplied
+        name = kwargs.pop("name", kwargs.get("id"))
+        repo.register(name=name, **kwargs)
+    finally:
+        conn.close()
+
+
+def test_remote_row_includes_metadata_fields(seeded_app, monkeypatch):
+    """Catalog response for a query_mode='remote' BQ row carries the four
+    new fields populated by the provider."""
+    # Reset catalog row cache so this test's registered table is visible.
+    from app.api import v2_catalog
+    v2_catalog._table_rows_cache.clear()
+    v2_catalog._metadata_cache.clear()
+
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+
+    fake_meta = TableMetadata(
+        rows=10000, size_bytes=2_000_000,
+        partition_by="event_date", clustered_by=["country", "platform"],
+    )
+
+    _register_table(
+        seeded_app,
+        id="orders", source_type="bigquery", bucket="dwh_base",
+        source_table="orders_2024", query_mode="remote",
+    )
+
+    with patch(
+        "connectors.bigquery.metadata.fetch", return_value=fake_meta,
+    ):
+        r = c.get(
+            "/api/v2/catalog",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert r.status_code == 200, r.text
+    tables = r.json()["tables"]
+    orders = next(t for t in tables if t["id"] == "orders")
+    assert orders["rows"] == 10000
+    assert orders["size_bytes"] == 2_000_000
+    assert orders["partition_by"] == "event_date"
+    assert orders["clustered_by"] == ["country", "platform"]
+    # Existing fields still present.
+    assert orders["query_mode"] == "remote"
+
+
+def test_local_row_unaffected_by_provider_dispatch(seeded_app):
+    """query_mode='local' rows take the parquet-stat path; provider not called."""
+    from app.api import v2_catalog
+    v2_catalog._table_rows_cache.clear()
+    v2_catalog._metadata_cache.clear()
+
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    _register_table(
+        seeded_app,
+        id="users", source_type="keboola", bucket="in.c-crm",
+        source_table="users", query_mode="local",
+    )
+
+    with patch("connectors.keboola.metadata.fetch") as mock_fetch:
+        r = c.get(
+            "/api/v2/catalog",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert r.status_code == 200, r.text
+    mock_fetch.assert_not_called()
+
+
+def test_provider_failure_returns_null_metadata(seeded_app):
+    """Provider returns None → row appears with null new fields, not
+    a 500. Catalog endpoint must stay 200."""
+    from app.api import v2_catalog
+    v2_catalog._table_rows_cache.clear()
+    v2_catalog._metadata_cache.clear()
+
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    _register_table(
+        seeded_app,
+        id="broken", source_type="bigquery", bucket="dwh_base",
+        source_table="broken_t", query_mode="remote",
+    )
+
+    with patch(
+        "connectors.bigquery.metadata.fetch", return_value=None,
+    ):
+        r = c.get(
+            "/api/v2/catalog",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert r.status_code == 200, r.text
+    tables = r.json()["tables"]
+    broken = next(t for t in tables if t["id"] == "broken")
+    assert broken["rows"] is None
+    assert broken["size_bytes"] is None
+    assert broken["partition_by"] is None
+    assert broken["clustered_by"] is None
+
+
+def test_cache_hit_does_not_call_provider_twice(seeded_app):
+    """First call invokes provider; second within 15 min hits cache."""
+    from app.api import v2_catalog
+    v2_catalog._table_rows_cache.clear()
+    v2_catalog._metadata_cache.clear()
+
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+    _register_table(
+        seeded_app,
+        id="orders", source_type="bigquery", bucket="dwh_base",
+        source_table="orders_2024", query_mode="remote",
+    )
+
+    fake_meta = TableMetadata(rows=1, size_bytes=2)
+    with patch(
+        "connectors.bigquery.metadata.fetch", return_value=fake_meta,
+    ) as mock_fetch:
+        c.get("/api/v2/catalog", headers={"Authorization": f"Bearer {token}"})
+        c.get("/api/v2/catalog", headers={"Authorization": f"Bearer {token}"})
+    assert mock_fetch.call_count == 1

--- a/tests/test_v2_catalog_remote_metadata.py
+++ b/tests/test_v2_catalog_remote_metadata.py
@@ -114,6 +114,48 @@ def test_provider_failure_returns_null_metadata(seeded_app):
     assert broken["clustered_by"] is None
 
 
+def test_zero_size_bytes_reports_small_not_unknown(seeded_app):
+    """Devin Review #1 regression: `if cached.size_bytes:` is falsy when
+    `size_bytes == 0` (genuinely empty table) — that wrongly emitted
+    `rough_size_hint=None` ("unknown") instead of `"small"` (the bucket
+    `_bucket_size(0)` returns).
+
+    Fix in `_size_hint_for_row`: distinguish "size known to be zero" from
+    "size is unknown" with `is not None`."""
+    from app.api import v2_catalog
+    v2_catalog._table_rows_cache.clear()
+    v2_catalog._metadata_cache.clear()
+
+    c = seeded_app["client"]
+    token = seeded_app["admin_token"]
+
+    fake_meta = TableMetadata(
+        rows=0, size_bytes=0, partition_by=None, clustered_by=[],
+    )
+
+    _register_table(
+        seeded_app,
+        id="empty_t", source_type="bigquery", bucket="dwh_base",
+        source_table="empty_t", query_mode="remote",
+    )
+
+    with patch(
+        "connectors.bigquery.metadata.fetch", return_value=fake_meta,
+    ):
+        r = c.get(
+            "/api/v2/catalog",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert r.status_code == 200, r.text
+    tables = r.json()["tables"]
+    empty = next(t for t in tables if t["id"] == "empty_t")
+    # The whole point of this test: 0 bytes is NOT "unknown".
+    assert empty["size_bytes"] == 0
+    assert empty["rough_size_hint"] == "small", (
+        f"size_bytes=0 should bucket to 'small', got {empty['rough_size_hint']}"
+    )
+
+
 def test_cache_hit_does_not_call_provider_twice(seeded_app):
     """First call invokes provider; second within 15 min hits cache."""
     from app.api import v2_catalog

--- a/tests/test_v2_schema.py
+++ b/tests/test_v2_schema.py
@@ -331,3 +331,47 @@ class TestBqAccessErrors:
         assert captured["billing_project"] == "billing-proj"
         # FROM clause uses data project (where INFORMATION_SCHEMA.COLUMNS lives)
         assert "`data-proj.ds.INFORMATION_SCHEMA.COLUMNS`" in captured["bq_sql"]
+
+
+class TestBuildSchemaUncached:
+    """The uncached entry point exists for warmup, which has no user
+    context. RBAC + cache check live in `build_schema`; the BQ work +
+    cache write live in `build_schema_uncached`."""
+
+    def test_uncached_function_exists_and_does_not_take_user(self):
+        """Signature: build_schema_uncached(conn, table_id, *, bq)"""
+        from app.api.v2_schema import build_schema_uncached
+        import inspect
+        sig = inspect.signature(build_schema_uncached)
+        params = list(sig.parameters)
+        assert "user" not in params, (
+            "build_schema_uncached should NOT require a user — that's "
+            "the whole point of the split (warmup has no user)."
+        )
+        assert "table_id" in params
+        assert "bq" in params
+
+    def test_build_schema_delegates_to_uncached(self, monkeypatch):
+        """build_schema should call build_schema_uncached after RBAC+cache check."""
+        from app.api import v2_schema
+
+        called_with = {}
+        def fake_uncached(conn, table_id, *, bq):
+            called_with["table_id"] = table_id
+            return {"table_id": table_id, "columns": []}
+
+        monkeypatch.setattr(v2_schema, "build_schema_uncached", fake_uncached)
+        # Bypass the cache + RBAC for this assertion — both are tested elsewhere.
+        monkeypatch.setattr(v2_schema._schema_cache, "get", lambda k, default=None: None)
+        monkeypatch.setattr(v2_schema, "can_access_table", lambda u, tid, c: True)
+
+        # Synthetic registry row.
+        from unittest.mock import MagicMock
+        repo_mock = MagicMock()
+        repo_mock.get.return_value = {"id": "x", "source_type": "bigquery"}
+        monkeypatch.setattr(v2_schema, "TableRegistryRepository", lambda c: repo_mock)
+
+        v2_schema.build_schema(
+            conn=MagicMock(), user={"id": "u"}, table_id="x", bq=MagicMock(),
+        )
+        assert called_with["table_id"] == "x"

--- a/tests/test_v2_schema.py
+++ b/tests/test_v2_schema.py
@@ -356,8 +356,9 @@ class TestBuildSchemaUncached:
         from app.api import v2_schema
 
         called_with = {}
-        def fake_uncached(conn, table_id, *, bq):
+        def fake_uncached(conn, table_id, *, bq, row=None):
             called_with["table_id"] = table_id
+            called_with["row"] = row
             return {"table_id": table_id, "columns": []}
 
         monkeypatch.setattr(v2_schema, "build_schema_uncached", fake_uncached)
@@ -375,3 +376,22 @@ class TestBuildSchemaUncached:
             conn=MagicMock(), user={"id": "u"}, table_id="x", bq=MagicMock(),
         )
         assert called_with["table_id"] == "x"
+
+    def test_uncached_raises_notfound_for_unregistered_table(self):
+        """Warmup-direct call against an unregistered id raises NotFound,
+        not FileNotFoundError or other surprise."""
+        from app.api.v2_schema import build_schema_uncached, NotFound
+        from unittest.mock import MagicMock
+
+        conn = MagicMock()
+        repo_mock = MagicMock()
+        repo_mock.get.return_value = None
+        # Patch the repo lookup the same way the implementation imports it.
+        import app.api.v2_schema as v2_schema_mod
+        original = v2_schema_mod.TableRegistryRepository
+        v2_schema_mod.TableRegistryRepository = lambda c: repo_mock
+        try:
+            with pytest.raises(NotFound):
+                build_schema_uncached(conn, "nonexistent", bq=MagicMock())
+        finally:
+            v2_schema_mod.TableRegistryRepository = original

--- a/tests/test_v2_schema_columns_consolidation.py
+++ b/tests/test_v2_schema_columns_consolidation.py
@@ -1,0 +1,111 @@
+"""Asserts that /api/v2/schema/{id} for a BQ row makes exactly ONE
+bigquery_query() call on cache miss, down from two pre-#155.
+
+Counts via a side-effect tracker on the mocked DuckDB session.
+"""
+
+from unittest.mock import MagicMock, patch
+import pytest
+
+
+def _mock_duckdb_session_returning(rows):
+    """Build a context-manager mock that returns `rows` on .fetchall().
+
+    Exposes `call_count` on the returned mock for assertion.
+    """
+    session = MagicMock()
+    session.execute.return_value.fetchall.return_value = rows
+    cm = MagicMock()
+    cm.__enter__.return_value = session
+    cm.__exit__.return_value = False
+    return cm, session
+
+
+def test_fetch_bq_columns_full_is_single_query():
+    """The new shared helper makes exactly ONE call to bigquery_query."""
+    from connectors.bigquery.access import fetch_bq_columns_full
+
+    bq = MagicMock()
+    bq.projects.data = "data-proj"
+    bq.projects.billing = "billing-proj"
+    cm, session = _mock_duckdb_session_returning([
+        ("event_date", "DATE", "NO", "YES", None),
+        ("country", "STRING", "YES", "NO", 1),
+        ("user_id", "STRING", "NO", "NO", None),
+    ])
+    bq.duckdb_session.return_value = cm
+
+    rows = fetch_bq_columns_full(bq, "dwh_base", "events")
+    assert len(rows) == 3
+    # Exactly one bigquery_query() call — no second round-trip.
+    assert session.execute.call_count == 1
+    first_call = session.execute.call_args_list[0]
+    # Outer wrapper SQL is bigquery_query(?, ?, ?)
+    assert "bigquery_query" in first_call.args[0]
+    # Inner BQ SQL pulls all five columns we need at once.
+    inner_sql = first_call.args[1][1]
+    assert "column_name" in inner_sql
+    assert "data_type" in inner_sql
+    assert "is_nullable" in inner_sql
+    assert "is_partitioning_column" in inner_sql
+    assert "clustering_ordinal_position" in inner_sql
+
+
+def test_fetch_bq_columns_full_returns_dicts():
+    """Each row is a dict with the documented keys."""
+    from connectors.bigquery.access import fetch_bq_columns_full
+
+    bq = MagicMock()
+    bq.projects.data = "data-proj"
+    bq.projects.billing = "billing-proj"
+    cm, _ = _mock_duckdb_session_returning([
+        ("event_date", "DATE", "NO", "YES", None),
+    ])
+    bq.duckdb_session.return_value = cm
+
+    rows = fetch_bq_columns_full(bq, "dwh_base", "events")
+    assert rows == [{
+        "name": "event_date",
+        "type": "DATE",
+        "nullable": False,
+        "is_partitioning_column": True,
+        "clustering_ordinal_position": None,
+    }]
+
+
+def test_fetch_bq_columns_full_returns_none_when_unconfigured():
+    """Sentinel BqAccess (data project empty) → return None, no query."""
+    from connectors.bigquery.access import fetch_bq_columns_full
+
+    bq = MagicMock()
+    bq.projects.data = ""  # sentinel
+    rows = fetch_bq_columns_full(bq, "dwh_base", "events")
+    assert rows is None
+    bq.duckdb_session.assert_not_called()
+
+
+def test_fetch_bq_columns_full_returns_none_on_unsafe_identifier():
+    """Refuses to interpolate identifiers that fail validation."""
+    from connectors.bigquery.access import fetch_bq_columns_full
+
+    bq = MagicMock()
+    bq.projects.data = "data-proj"
+    rows = fetch_bq_columns_full(bq, "evil`; DROP--", "events")
+    assert rows is None
+    bq.duckdb_session.assert_not_called()
+
+
+def test_fetch_bq_columns_full_returns_none_on_query_error():
+    """BQ failure → log + None; never raises."""
+    from connectors.bigquery.access import fetch_bq_columns_full
+
+    bq = MagicMock()
+    bq.projects.data = "data-proj"
+    bq.projects.billing = "billing-proj"
+    cm = MagicMock()
+    cm.__enter__.return_value.execute.side_effect = RuntimeError("BQ down")
+    cm.__exit__.return_value = False
+    bq.duckdb_session.return_value = cm
+
+    rows = fetch_bq_columns_full(bq, "dwh_base", "events")
+    assert rows is None


### PR DESCRIPTION
## Summary

- Catalog enrichment for `query_mode='remote'` rows: `rows`, `size_bytes`, `partition_by`, `clustered_by` per table (BQ + Keboola providers).
- `/api/v2/schema/{id}` cache miss: 2 BQ jobs → 1 (-50%) via shared `fetch_bq_columns_full`.
- All four catalog/schema/sample/metadata caches flush on registry change; single-row re-warm scheduled.
- Automatic cache warmup at server startup (bounded concurrency, opt-out via `AGNES_SKIP_CACHE_WARMUP=1`).
- SSE-driven freshness toolbar on `/admin/tables` with progress bar, log, and per-row badge.
- New admin doc `docs/admin/query-modes.md` — single source of truth on `local` / `remote` / `materialized` choice.

Closes #155.
Closes #156.

## Test plan

- [x] 65+ targeted tests pass across 11 new test modules + 3 modified ones.
- [x] No DB migration; no wire-break; `MIN_COMPAT_CLI_VERSION` unchanged.
- [ ] Reviewer: register a remote BQ table via `/admin/tables`, observe the toolbar populates within ~2 s and the per-row badge transitions warming → fresh.
- [ ] Reviewer: trigger `Re-warm all`, verify SSE log scrolls and `cacheWarmupBar` progresses.
- [ ] Reviewer: edit a registered row's bucket, verify `agnes schema <id>` returns updated columns immediately (no 1-hour staleness).
- [ ] Reviewer: confirm `agnes admin register-table --query-mode remote` prints the new IAM-smoke-check hint.

## Notable design decisions

- BigQuery `INFORMATION_SCHEMA.TABLE_STORAGE` is the only valid scope for size+rows (verified live 2026-05-07; dataset-scoped doesn't exist). Region resolved from `instance.yaml.data_source.bigquery.location` → `bq.client().get_dataset(...)` → fall back to legacy `__TABLES__`.
- VIEW handling: TABLE_STORAGE returns no rows for views, fall through to `__TABLES__` (also empty) → `TableMetadata(rows=None, size_bytes=None, partition_by=..., clustered_by=...)`. Null size signals analyst Claude to apply existing CLAUDE.md guidance.
- `size_bytes` is `active_logical_bytes + long_term_logical_bytes` — full BQ scan reads both; reporting only active undercounts aged partitioned tables.
- Source-agnostic provider seam: per-source `connectors/<source>/metadata.py:fetch(MetadataRequest)`; dispatcher in `app/api/v2_catalog.py:_metadata_provider_for` lazily imports per source_type so a Keboola-only deployment doesn't pay the BQ-extension import cost.
- Warmup non-blocking: FastAPI `lifespan` schedules `asyncio.create_task(_warm_catalog_caches_bg)` before `yield`. Per-row failures isolated.

## Out of scope

- Profile / column histograms / dimension cardinality for remote tables (separate issue).
- Onboarding nudge ("you have 0 remote tables, consider registering some BQ ones") — separate UX call.
- Provider plug-in registration via entry-points (the dispatch table is a hardcoded if-tree today; one line per future source).

## Release

Bumps `pyproject.toml` 0.46.1 → 0.47.0 (main shipped 0.46.0 + 0.46.1 during this PR — see commit `d98976ec`). New CHANGELOG section under `## [0.47.0] — 2026-05-07`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->