### PR TITLE
fix(duckdb): CHECKPOINT on shutdown + 60s compose grace to prevent WAL corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -542,6 +542,14 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 - Schema bumped v28 → v29 → v30. New tests: news repository (14), sanitizer (20), API (8), web (5), CLI (14) — 61 total — plus updated home/auth/template tests for the shared-shell architecture. CLAUDE.md "Run tests before every push" section codifies `pytest tests/ -n auto -q` as non-negotiable before each push.
 
+### Fixed (system DB shutdown)
+
+- **`close_system_db()` now CHECKPOINTs before closing the system DB connection**, so the WAL flushes into `system.duckdb` and the file is left in a clean state across `docker compose up -d` recreate windows. Previously, a SIGKILL after the default 10s `stop_grace_period` could leave a populated `.wal` that the next process must replay on open; if the next image carried a different DuckDB version, replay could trip an internal assertion (`Failure while replaying WAL ... GetDefaultDatabase with no default database set`) and 500 every authed request until the WAL file was manually removed. CHECKPOINT is best-effort with operator-visible logging — `WARNING` on failure, `DEBUG` on success.
+
+### Changed (compose grace)
+
+- **`docker-compose.yml` `stop_grace_period: 60s`** on the `app` and `scheduler` services (was Docker's 10s default). Gives uvicorn time to drain in-flight requests + run the new shutdown CHECKPOINT before SIGKILL. Healthy `docker compose down` is unaffected (services still stop as soon as their lifespan exits).
+
 ## [0.47.4] — 2026-05-08
 
 ### Fixed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,14 @@ services:
     mem_limit: 4g
     mem_reservation: 1g
     cpus: 2.0
+    # Default 10s is too short for graceful uvicorn shutdown — under load,
+    # in-flight requests + DuckDB CHECKPOINT (see lifespan in app/main.py)
+    # need more headroom. SIGKILL mid-WAL-write produces a corrupt
+    # system.duckdb.wal that the next image's DuckDB version cannot replay
+    # ("Failure while replaying WAL ... GetDefaultDatabase with no default
+    # database set"), 500-ing every authed request until WAL is removed.
+    # Observed on foundryai-dev-vrysanek 2026-05-05 during auto-upgrade.
+    stop_grace_period: 60s
 
   # One-shot: run extractor then rebuild orchestrator views
   extract:
@@ -78,6 +86,9 @@ services:
     restart: unless-stopped
     mem_limit: 2g
     cpus: 1.0
+    # Match app service — scheduler holds DuckDB connections too; same
+    # WAL-corruption risk on SIGKILL during recreate.
+    stop_grace_period: 60s
 
   telegram-bot:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,9 @@ services:
     # system.duckdb.wal that the next image's DuckDB version cannot replay
     # ("Failure while replaying WAL ... GetDefaultDatabase with no default
     # database set"), 500-ing every authed request until WAL is removed.
-    # Observed on foundryai-dev-vrysanek 2026-05-05 during auto-upgrade.
+    # Hits hardest during a Docker image upgrade window where the new
+    # image's DuckDB version differs from the old container's, since
+    # WAL replay across versions trips on internal assertions.
     stop_grace_period: 60s
 
   # One-shot: run extractor then rebuild orchestrator views

--- a/src/db.py
+++ b/src/db.py
@@ -2924,8 +2924,7 @@ def close_system_db() -> None:
     the next process is a different DuckDB version (image upgrade
     window), replay can hit internal assertions like
     ``Failure while replaying WAL ... GetDefaultDatabase with no default
-    database set`` — observed on foundryai-dev-vrysanek 2026-05-05 —
-    and the app 500s on every authed request.
+    database set`` and the app 500s on every authed request.
 
     CHECKPOINT is best-effort: if it raises (locked, disk full, etc.)
     we still proceed to close — the recovery path in ``_try_open_system_db``

--- a/src/db.py
+++ b/src/db.py
@@ -2914,9 +2914,29 @@ def get_schema_version(conn: duckdb.DuckDBPyConnection) -> int:
 
 
 def close_system_db() -> None:
-    """Close the shared system DB connection. Called on app shutdown."""
+    """Close the shared system DB connection. Called on app shutdown.
+
+    CHECKPOINT before close so the WAL flushes into ``system.duckdb`` and
+    the file is left in a clean state. If we skip this and the process
+    later gets SIGKILL'd (e.g. Docker's default 10s stop_grace_period
+    expires during ``docker compose up -d`` recreate), DuckDB leaves a
+    populated ``.wal`` that the next process must replay on open. When
+    the next process is a different DuckDB version (image upgrade
+    window), replay can hit internal assertions like
+    ``Failure while replaying WAL ... GetDefaultDatabase with no default
+    database set`` — observed on foundryai-dev-vrysanek 2026-05-05 —
+    and the app 500s on every authed request.
+
+    CHECKPOINT is best-effort: if it raises (locked, disk full, etc.)
+    we still proceed to close — the recovery path in ``_try_open_system_db``
+    plus the longer ``stop_grace_period`` in compose are the safety nets.
+    """
     global _system_db_conn, _system_db_path
     if _system_db_conn:
+        try:
+            _system_db_conn.execute("CHECKPOINT")
+        except Exception:
+            pass
         try:
             _system_db_conn.close()
         except Exception:

--- a/src/db.py
+++ b/src/db.py
@@ -2935,11 +2935,16 @@ def close_system_db() -> None:
     if _system_db_conn:
         try:
             _system_db_conn.execute("CHECKPOINT")
-        except Exception:
-            pass
+            logger.debug("close_system_db: CHECKPOINT ok")
+        except Exception as exc:
+            # Log + proceed — CHECKPOINT failure is not fatal (recovery path
+            # in _try_open_system_db handles a dirty WAL on next open), but
+            # we want operators to see WHY the safety net was needed if a
+            # WAL-replay failure does surface later.
+            logger.warning("close_system_db: CHECKPOINT failed (%s); proceeding to close", exc)
         try:
             _system_db_conn.close()
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("close_system_db: close raised (%s); ignoring", exc)
         _system_db_conn = None
         _system_db_path = None


### PR DESCRIPTION
## Summary

- `close_system_db()` now runs `CHECKPOINT` before `close()` so the WAL flushes into `system.duckdb` on graceful shutdown.
- `app` and `scheduler` services in `docker-compose.yml` get `stop_grace_period: 60s` (was Docker default 10s).

## Why

Auto-upgrade SIGKILL'd the app container mid-WAL-write on `foundryai-dev-vrysanek` 2026-05-05. The new image's DuckDB then could not replay the WAL and hit:

```
INTERNAL Error: Failure while replaying WAL file "/data/state/system.duckdb.wal":
Calling DatabaseManager::GetDefaultDatabase with no default database set
```

Every authed request 500'd at `app/auth/dependencies.py::_get_db -> src/db.py::get_system_db -> duckdb.connect()` until the WAL was removed manually.

`dockerd` journal confirmed the kill chain:

```
May 05 15:47:47 ... "Container failed to exit within 10s of signal 15 - using the force"
                    container=cfc70c6b48...
```

i.e. `agnes-auto-upgrade.timer` (5-min image-pull tick) called `docker compose up -d`, which sent SIGTERM, app stayed busy past Docker's default 10s stop grace, dockerd SIGKILL'd. WAL had unchecpointed ops at the moment of kill.

DuckDB tolerates SIGKILL only if next open uses the same binary version. Image swap during dirty WAL = WAL-replay assertion class.

## Why this fix and not others

`_try_open_system_db()` already exists at `src/db.py:556` as a recovery path — restores from `system.duckdb.pre-migrate` on WAL-replay failures. But that snapshot is only written by the migration ladder, so non-migration WAL corruption (e.g. just a busy CHECKPOINT-less shutdown) has no fallback.

Two-layer defense:

1. **CHECKPOINT in `close_system_db`** — primary. Empty WAL → SIGKILL after this point is safe regardless of next binary's DuckDB version.
2. **`stop_grace_period: 60s`** — backstop. Gives uvicorn + lifespan room to actually run the new CHECKPOINT under load before Docker SIGKILLs.

Both are needed: layer 1 fixes the data-correctness bug, layer 2 ensures layer 1 actually runs.

## Class risk

All 8 Caddy-fronted Agnes VMs run `agnes-auto-upgrade.timer` with the old 10s grace + uncheckpointed close. Latent until the next image-rebuild's DuckDB version drift hits an in-flight write window. After this PR merges, fixes auto-deploy on each VM within 5 minutes via the existing auto-upgrade tick (compose files re-fetched; container recreated when image digest moves with the new image carrying the patched `close_system_db`).

## Out of scope

- DuckDB version pinning in `pyproject.toml` (`duckdb>=0.9.0` is too loose) — separate concern, follow-up issue.
- Pre-`up -d` `docker exec ... CHECKPOINT` in `agnes-auto-upgrade.sh` — overlaps with layer 1; would only help if lifespan failed silently. Skipping unless layer 1+2 prove insufficient.
- `Caddyfile.new` mv error observed in `agnes-auto-upgrade.service` journal on the affected VM 2026-05-07 20:25:02 — that script path doesn't appear in main; likely from a stale `.worktrees/` deploy. Separate.

## Test plan

- [ ] Smoke: local `docker compose up -d`, kick a write, `docker compose stop` → confirm `system.duckdb.wal` is empty (or absent) post-stop.
- [ ] Compose validates: `docker compose config --quiet` (run locally; passes).
- [ ] Python compiles: `python -m py_compile src/db.py` (passes).
- [ ] Full app test suite via CI.
- [ ] After merge: monitor first auto-upgrade tick on `foundryai-dev-vrysanek` and other Caddy VMs for graceful shutdown (no `"Container failed to exit within 10s"` in `journalctl -u docker.service`).