### PR TITLE
Flea-market edit feature with version history (schema v37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,48 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   `claude plugin marketplace update`, no plugin install/update side
   effects.
 
+- **Flea-market entity edit feature with version history (schema v38).**
+  Owner + admin can now edit a store entity from a real Edit page at
+  `/marketplace/flea/{id}/edit` (replaces the prior "coming soon"
+  placeholder). Editable fields: display name, description, category,
+  video URL, cover photo, and an optional new bundle. Type is locked
+  (400 `type_locked` on change attempt). Display-name change renames
+  the on-disk slug for both the live `plugin/` dir and the version
+  dir, mirroring the rename-on-archive flow.
+
+  Each bundle update creates a new version: bytes bake into
+  `${DATA_DIR}/store/<id>/versions/v<N+1>/plugin/`, run the standard
+  guardrails pipeline. **Deferred promotion:** the live `plugin/` dir
+  and `entity.version_no` stay at the prior approved version through
+  the LLM review window, so existing installers keep receiving the
+  previously approved bundle while the new version is being
+  validated. Promotion (live swap + version_no/version/file_size
+  bump) happens only on LLM approval; if the new version is blocked,
+  installers continue serving the prior approved version
+  indefinitely. The entity row carries `version_no` (current served
+  index) and `version_history` JSON (append-only per-version
+  metadata: hash, sha256, size, submission_id, created_at,
+  created_by). Existing entities backfill to v1 with a single-entry
+  history seeded from the row's current `version` hash.
+
+  **Block-while-pending:** an in-flight LLM review blocks any further
+  edit with 409 `prior_version_pending`. Owner waits ~5-30s; the
+  detail page Edit button renders disabled in the same window.
+
+  **Rollback:** new endpoint `POST /api/store/entities/{id}/versions/{n}/restore`
+  (owner + admin) copies a prior version's bundle forward as
+  v<max+1> and re-runs guardrails. Forward-only history — the
+  original row keeps its verdict; the new copy gets a fresh one.
+  Detail page renders a Versions card with restore buttons for
+  owner/admin only.
+
+  **Admin queue** gains a `v#` column (with "current" badge) and a
+  separate Hash column. Submission detail page surfaces Version +
+  Bundle hash rows. Activity timeline splits into per-submission +
+  entity-wide cards so admins can tell version-scoped events apart
+  from entity-wide ones; entity-wide rows render `vN` chips when the
+  audit row's params reference a version.
+
 ### Changed
 
 - **SessionStart marketplace hook is now read-only.** The hook installed

--- a/app/api/store.py
+++ b/app/api/store.py
@@ -1303,19 +1303,24 @@ async def update_entity(
     * **Type is locked** — passing ``type`` that differs from the
       stored row returns 400 ``type_locked``. Replacing one form
       factor with another is a fresh upload, not an edit.
-    * **Display-name change** is allowed — triggers a slug rename in
-      the live bundle (mirrors the rename-on-archive flow). Existing
-      installers see the plugin renamed on next sync.
+    * **Display-name change** is allowed. Without a bundle change it
+      flips the live slug immediately (mirrors rename-on-archive).
+      Combined with a bundle change the rename is deferred — only the
+      staged version dir is renamed; live keeps the prior slug until
+      promotion, so existing installers never see a slug≠content pair
+      mid-review.
     * **Bundle change** creates a new version: bake into
       ``versions/v<N+1>/plugin/``, run guardrails, on approval copy
       to the live ``plugin/`` dir + bump ``version_no`` + append
       ``version_history``. The prior version dir stays so rollback
       can copy it forward.
-    * **Block-while-pending**: an in-flight LLM review (the entity's
-      ``visibility_status='pending'`` AND the latest submission has
-      ``status IN ('pending_inline','pending_llm')``) blocks any
-      further edit with 409 ``prior_version_pending``. Owner waits
-      for the verdict; the detail page auto-refreshes.
+    * **Block-while-pending**: gates on the latest submission's status
+      directly (``status IN ('pending_inline','pending_llm')``),
+      independent of ``visibility_status``. Under deferred promotion
+      v2+ edits leave the entity ``approved`` through the LLM review
+      window, so a visibility-only check would never fire. Returns 409
+      ``prior_version_pending``; owner waits for the verdict; the
+      detail page auto-refreshes.
     * **Metadata-only edit** (no ``file`` posted) skips the bundle
       pipeline and the version bump.
     """

--- a/app/api/store.py
+++ b/app/api/store.py
@@ -637,6 +637,62 @@ def _write_synth_plugin_json(
     )
 
 
+def _swap_live_to_version(entity_id: str, version_no: int) -> bool:
+    """Replace the live ``plugin/`` dir with a copy of the named
+    version's contents. Used by the guardrails-disabled promote path
+    (no LLM review) and by the runner's approval branch.
+
+    Sequence (close the visible-gap window the naive
+    rename-then-copytree had):
+      1. copytree the source version into a sibling staging dir
+         ``plugin.staging-XXX/``. Live ``plugin/`` is NOT touched
+         while the multi-MB copy runs — concurrent readers see the
+         prior bundle the whole time.
+      2. rename live ``plugin/`` → ``plugin.backup-XXX/`` (atomic).
+      3. rename staging → ``plugin/`` (atomic).
+      4. rmtree backup.
+    On step-3 failure, rename backup back to ``plugin/``. Returns
+    ``True`` on success.
+    """
+    source = _entity_dir(entity_id) / "versions" / f"v{version_no}" / "plugin"
+    if not source.is_dir():
+        logger.error(
+            "_swap_live_to_version: source missing for entity %s v%d at %s",
+            entity_id, version_no, source,
+        )
+        return False
+    live = _plugin_dir(entity_id)
+    staging = live.with_name(f"plugin.staging-{os.urandom(4).hex()}")
+    if staging.exists():
+        shutil.rmtree(staging, ignore_errors=True)
+    # Step 1: copy into staging while live keeps serving the prior
+    # bundle. Multi-MB copy doesn't expose a missing-live window.
+    shutil.copytree(source, staging)
+
+    backup: Optional[Path] = None
+    try:
+        if live.exists():
+            backup = live.with_name(f"plugin.backup-{os.urandom(4).hex()}")
+            os.rename(live, backup)
+        # Step 3: atomic rename — same-FS, fast.
+        os.rename(staging, live)
+    except OSError:
+        # Restore backup if the rename mid-way failed.
+        if staging.exists():
+            shutil.rmtree(staging, ignore_errors=True)
+        if backup is not None and backup.exists():
+            try:
+                if live.exists():
+                    shutil.rmtree(live, ignore_errors=True)
+                os.rename(backup, live)
+            except OSError:
+                pass
+        raise
+    if backup is not None:
+        shutil.rmtree(backup, ignore_errors=True)
+    return True
+
+
 def _rename_baked_tree(
     *,
     type_: str,
@@ -1075,6 +1131,15 @@ async def create_entity(
         )
         version = compute_entity_version(plugin_dir)
 
+        # v37: also seed versions/v1/plugin/ so the restore endpoint
+        # can copy v1 bytes forward later. Same content as the live
+        # plugin/ dir; cheap copy.
+        v1_plugin = _entity_dir(entity_id) / "versions" / "v1" / "plugin"
+        v1_plugin.parent.mkdir(parents=True, exist_ok=True)
+        if v1_plugin.exists():
+            shutil.rmtree(v1_plugin, ignore_errors=True)
+        shutil.copytree(plugin_dir, v1_plugin)
+
         # ---- Guardrail pipeline ------------------------------------------
         #
         # Inline checks (manifest, static security, quality+templating)
@@ -1222,6 +1287,8 @@ async def update_entity(
     entity_id: str,
     background_tasks: BackgroundTasks,
     file: Optional[UploadFile] = File(None),
+    name: Optional[str] = Form(None),
+    type: Optional[str] = Form(None),  # noqa: A002
     description: Optional[str] = Form(None),
     category: Optional[str] = Form(None),
     video_url: Optional[str] = Form(None),
@@ -1229,6 +1296,29 @@ async def update_entity(
     user: dict = Depends(get_current_user),
     conn: duckdb.DuckDBPyConnection = Depends(_get_db),
 ):
+    """Edit a flea-market entity. Owner or admin.
+
+    v37 edit feature semantics:
+
+    * **Type is locked** — passing ``type`` that differs from the
+      stored row returns 400 ``type_locked``. Replacing one form
+      factor with another is a fresh upload, not an edit.
+    * **Display-name change** is allowed — triggers a slug rename in
+      the live bundle (mirrors the rename-on-archive flow). Existing
+      installers see the plugin renamed on next sync.
+    * **Bundle change** creates a new version: bake into
+      ``versions/v<N+1>/plugin/``, run guardrails, on approval copy
+      to the live ``plugin/`` dir + bump ``version_no`` + append
+      ``version_history``. The prior version dir stays so rollback
+      can copy it forward.
+    * **Block-while-pending**: an in-flight LLM review (the entity's
+      ``visibility_status='pending'`` AND the latest submission has
+      ``status IN ('pending_inline','pending_llm')``) blocks any
+      further edit with 409 ``prior_version_pending``. Owner waits
+      for the verdict; the detail page auto-refreshes.
+    * **Metadata-only edit** (no ``file`` posted) skips the bundle
+      pipeline and the version bump.
+    """
     repo = StoreEntitiesRepository(conn)
     entity = repo.get(entity_id)
     if not entity:
@@ -1236,32 +1326,90 @@ async def update_entity(
     if entity["owner_user_id"] != user["id"] and not is_user_admin(user["id"], conn):
         raise HTTPException(status_code=403, detail="not_owner")
 
+    # Type is immutable — reject change attempts up front.
+    if type is not None and type != entity["type"]:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "type_locked",
+                "message": "Cannot change a flea entity's type. "
+                           "Upload a new entity instead.",
+            },
+        )
+
+    # Block-while-pending: an in-flight review must complete (or be
+    # reaped) before another version can be uploaded. Metadata-only
+    # edits are also blocked for UX consistency — one rule for the
+    # owner instead of "metadata yes / bundle no".
+    #
+    # Gate on the latest submission's status DIRECTLY, NOT on
+    # entity.visibility_status. With deferred promotion (v37), v2+
+    # edits keep the entity at 'approved' through the LLM review
+    # window, so a visibility-only check would never fire and
+    # concurrent PUTs could race-create overlapping version dirs
+    # (each baking its own versions/v<N+1>/plugin/ which the runner
+    # would then sequentially promote — violates the "single in-flight
+    # version per entity" invariant).
+    latest_sub = StoreSubmissionsRepository(conn).latest_for_entity(entity_id)
+    if latest_sub and latest_sub.get("status") in (
+        "pending_inline", "pending_llm",
+    ):
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "prior_version_pending",
+                "message": "A previous edit is still under review. "
+                           "Wait for the verdict to finish before "
+                           "submitting another change.",
+                "submission_id": latest_sub.get("id"),
+            },
+        )
+
     if category and not is_valid_category(category):
         raise HTTPException(status_code=400, detail="invalid_category")
 
     video_url = _validate_video_url(video_url)
 
+    # Display-name change handled at the end (after bundle bake) so the
+    # rename can target the version-bumped or current bundle dir.
+    rename_to: Optional[str] = None
+    if name is not None and name.strip() and name.strip() != entity["name"]:
+        new_name = name.strip()
+        if not _NAME_RE.match(new_name):
+            raise HTTPException(status_code=400, detail="invalid_name_format")
+        # Same-owner conflict (skip archived which already freed slot).
+        if repo.get_by_owner_and_name(
+            entity["owner_user_id"], new_name, exclude_archived=True,
+        ):
+            raise HTTPException(status_code=409, detail="conflict_owner_name")
+        # Cross-owner suffix — must be globally unique post-rename.
+        new_suffixed = suffixed_name(new_name, entity["owner_username"])
+        if _suffixed_already_taken(
+            conn, new_suffixed, exclude_entity_id=entity_id,
+            exclude_archived=True,
+        ):
+            raise HTTPException(status_code=409, detail="conflict_global_suffix")
+        rename_to = new_name
+
     new_version: Optional[str] = None
     new_size: Optional[int] = None
     inline_after_update: Optional[InlineResult] = None
+    new_version_dir: Optional[Path] = None  # set when bundle uploaded
+    new_version_no: Optional[int] = None
     if file is not None:
-        # PUT atomicity: bake the new bundle into a staging dir alongside
-        # the live one, run checks against the staging copy, then atomic-
-        # rename onto the live path on success. Pre-fix, the bake wrote
-        # directly into the live `plugin/` dir BEFORE checks ran — a
-        # concurrent GET during the window saw partial / unverified
-        # content. Staging closes that window: failed checks leave the
-        # live tree byte-for-byte intact.
+        # PUT atomicity + version history: bake the new bundle into the
+        # versioned dir ``versions/v<N+1>/plugin/`` and run checks
+        # there. On approval the live ``plugin/`` dir is replaced with
+        # a copy of the new version's contents — prior versions stay on
+        # disk so rollback can copy them forward.
         tmp, size = await _stream_to_temp(file, MAX_ZIP_SIZE, suffix=".zip")
         tmp.close()
         scratch = Path(tempfile.mkdtemp(prefix="agnes_store_"))
-        # Sibling of the live `plugin/` dir so the eventual rename is on
-        # the same filesystem (atomic on POSIX). Random suffix in case
-        # multiple PUTs land back-to-back.
         existing_plugin = _plugin_dir(entity_id)
-        staging_plugin = existing_plugin.with_name(
-            f"plugin.staging-{os.urandom(4).hex()}",
-        )
+        new_version_no = int(entity.get("version_no") or 1) + 1
+        version_root = _entity_dir(entity_id) / "versions" / f"v{new_version_no}"
+        staging_plugin = version_root / "plugin"
+        new_version_dir = version_root  # exposed to outer scope
         backup_plugin: Optional[Path] = None  # set if the swap starts
         try:
             try:
@@ -1330,41 +1478,36 @@ async def update_entity(
                     },
                 )
 
-            # Checks passed — swap staging onto live. Three steps:
-            # rename live → backup, rename staging → live, rmtree backup.
-            # If the second rename fails, restore by renaming backup
-            # back. Same-FS rename is atomic on POSIX.
-            if existing_plugin.exists():
-                backup_plugin = existing_plugin.with_name(
-                    f"plugin.backup-{os.urandom(4).hex()}",
-                )
-                os.rename(existing_plugin, backup_plugin)
-            try:
-                os.rename(staging_plugin, existing_plugin)
-            except OSError:
-                # Restore live from backup if the swap failed mid-way.
-                if backup_plugin is not None and backup_plugin.exists():
-                    try:
-                        os.rename(backup_plugin, existing_plugin)
-                    except OSError:
-                        pass
-                raise
-            # Live now points at the new bundle; drop the backup copy.
-            if backup_plugin is not None:
-                shutil.rmtree(backup_plugin, ignore_errors=True)
-                backup_plugin = None
+            # Checks passed — but DO NOT swap live yet. Live ``plugin/``
+            # keeps serving the prior approved version to existing
+            # installers via marketplace.zip / .git until the LLM
+            # verdict approves the new bundle. Promotion (copy version
+            # → live + bump entity.version_no/version/file_size)
+            # happens after approval — see runner.run_llm_review or the
+            # immediate promote when guardrails are disabled below.
+            #
+            # If guardrails are disabled (no API key), we promote
+            # synchronously after the submission row is created. The
+            # only contract installers care about is "live always
+            # serves an approved version"; with guardrails off every
+            # accepted submission is implicitly approved.
         finally:
             shutil.rmtree(scratch, ignore_errors=True)
-            # If staging never made it through the swap (failed check or
-            # exception), remove it.
-            if staging_plugin.exists():
-                shutil.rmtree(staging_plugin, ignore_errors=True)
-            # If a swap failed leaving the backup orphaned without a
-            # restore, leave it on disk for the operator to recover —
-            # better to log and inspect than silently drop.
+            # The version dir IS the source of truth — don't remove it
+            # on failure paths. But if the bundle was rejected before
+            # the swap (failed inline check raised 422), the version
+            # dir is incomplete: the row hasn't been bumped yet, the
+            # bytes are blocked-only forensics. Decision: keep the
+            # version dir for the admin to download via the
+            # submission's bundle download endpoint, but mark the
+            # row's version_history WITHOUT this incomplete entry
+            # (we never called append_version on the failed path).
+            # The version dir at versions/v<N+1>/plugin/ stays orphan
+            # on disk linked from the submission row's hash — admin
+            # can still inspect.
             if backup_plugin is not None and backup_plugin.exists():
                 logger.error(
-                    "PUT atomic-swap left orphan backup at %s — "
+                    "PUT version-swap left orphan backup at %s — "
                     "operator should reconcile manually",
                     backup_plugin,
                 )
@@ -1380,34 +1523,105 @@ async def update_entity(
                 pass
         photo_rel = await _save_photo(photo, entity_id)
 
+    # Apply name change.
+    #
+    # Two cases:
+    #
+    # 1. Metadata-only edit (no new bundle): rename the LIVE plugin
+    #    dir immediately so consumers pick up the new slug on next
+    #    sync. No bundle bytes change; v_no stays at the current.
+    #
+    # 2. Bundle change (file is not None): the new bundle is staged
+    #    in versions/v<N+1>/plugin/ and live still serves the prior
+    #    approved version through the LLM review window. Renaming
+    #    live now would produce a slug-vs-content mismatch (live
+    #    holds prior bytes under the new slug + frontmatter).
+    #    Instead, rename ONLY the version dir; promotion copies the
+    #    renamed contents onto live atomically when the LLM approves.
+    #    On block, neither live nor the slug changed — installers
+    #    keep serving the prior bundle under the prior slug.
+    if rename_to is not None:
+        owner_username = entity["owner_username"]
+        old_suffix = suffixed_name(entity["name"], owner_username)
+        new_suffix = suffixed_name(rename_to, owner_username)
+
+        if file is None:
+            # Metadata-only rename — flip live now.
+            try:
+                _rename_baked_tree(
+                    type_=entity["type"],
+                    plugin_dir=_plugin_dir(entity_id),
+                    old_suffix=old_suffix,
+                    new_suffix=new_suffix,
+                    description=description if description is not None else entity.get("description"),
+                )
+            except Exception:
+                logger.exception(
+                    "rename_baked_tree failed during metadata-only "
+                    "edit for entity %s", entity_id,
+                )
+                raise HTTPException(status_code=500, detail="rename_failed")
+        elif new_version_dir is not None:
+            # Bundle change — defer live rename. Apply ONLY to the
+            # staged version dir; live + frontmatter inside it stay
+            # at the prior slug until promotion copies the renamed
+            # version dir over live.
+            try:
+                _rename_baked_tree(
+                    type_=entity["type"],
+                    plugin_dir=new_version_dir / "plugin",
+                    old_suffix=old_suffix,
+                    new_suffix=new_suffix,
+                    description=description if description is not None else entity.get("description"),
+                )
+            except Exception:
+                # Surface the failure rather than silently swallow —
+                # otherwise the version dir would carry stale slug
+                # and a future promotion would copy the wrong contents
+                # to live.
+                logger.exception(
+                    "rename_baked_tree failed for version dir %s",
+                    new_version_dir,
+                )
+                raise HTTPException(
+                    status_code=500, detail="version_rename_failed",
+                )
+
+    # Metadata-only column updates (name, description, category, photo,
+    # video) — never bundle-derived (version / file_size) because the
+    # new version isn't promoted to current until the LLM approves.
     repo.update(
         entity_id,
+        name=rename_to,
         description=description,
         category=category,
-        version=new_version,
         photo_path=photo_rel,
         video_url=video_url,
-        file_size=new_size,
     )
 
-    # Re-run the LLM review whenever the bundle bytes changed. New
-    # version = new submission row; visibility flips back to 'pending'
-    # until the review approves the new tree. Description-only / photo-
-    # only edits don't re-trigger.
-    if file is not None:
+    # Bundle change → record a new version + maybe promote.
+    #
+    # Critical invariant: existing installers keep getting the prior
+    # approved version through the LLM review window. We do this by
+    # NOT pre-swapping the live ``plugin/`` dir and NOT flipping
+    # ``visibility_status`` to 'pending'. The new bundle stays in its
+    # version dir; the LLM reads it from there. Promotion (live swap +
+    # version_no/version/file_size bump) happens only when the LLM
+    # approves — see runner.run_llm_review's approval branch. With
+    # guardrails disabled the path collapses: submission lands at
+    # 'approved' and we promote synchronously below.
+    if file is not None and new_version_no is not None and new_version_dir is not None:
         guardrails_on = get_guardrails_enabled()
-        if guardrails_on:
-            repo.set_visibility(entity_id, "pending")
         subs_repo = StoreSubmissionsRepository(conn)
-        # Compute sha256 for the accepted re-upload so the submission row
-        # carries forensics for retry-chain correlation.
         from src.store_guardrails.bundle_meta import compute_bundle_meta
-        accepted_meta = compute_bundle_meta(_plugin_dir(entity_id))
+        # Hash the NEW version dir, not live (which still holds the
+        # prior approved bytes during a guardrails-on edit).
+        accepted_meta = compute_bundle_meta(new_version_dir / "plugin")
         sub_id = subs_repo.create(
             submitter_id=user["id"],
             submitter_email=user.get("email"),
             type=entity["type"],
-            name=entity["name"],
+            name=rename_to or entity["name"],
             version=new_version,
             status="approved" if not guardrails_on else "pending_llm",
             entity_id=entity_id,
@@ -1416,22 +1630,235 @@ async def update_entity(
             file_size=accepted_meta.file_size,
             bundle_sha256=accepted_meta.sha256,
         )
+        # Record the new version in history (no promotion). Promotion
+        # depends on the LLM verdict — runner.run_llm_review does it.
+        appended_n = repo.append_version_history(
+            entity_id,
+            version_hash=new_version,
+            sha256=accepted_meta.sha256,
+            size=accepted_meta.file_size,
+            submission_id=sub_id,
+            created_by=user["id"],
+        )
         _audit(
             conn, user["id"],
             "store.submission.accepted" if guardrails_on else "store.submission.approved",
             sub_id, {"entity_id": entity_id, "on": "update",
+                     "version_no": appended_n,
                      "guardrails_enabled": guardrails_on},
         )
         if guardrails_on:
-            _schedule_llm_review(background_tasks, sub_id, _plugin_dir(entity_id))
+            # Live remains at prior approved bundle. LLM reviews the
+            # new version dir; runner promotes on approval.
+            _schedule_llm_review(
+                background_tasks, sub_id, new_version_dir / "plugin",
+            )
+        else:
+            # Guardrails off → implicit approval. Promote inline:
+            # update entity columns + swap live to new version.
+            repo.promote_version(entity_id, appended_n)
+            _swap_live_to_version(entity_id, appended_n)
 
+    # Use the freshly-appended version number when a bundle change
+    # produced one, falling back to the planned new_version_no for
+    # metadata-only edits. Pre-fix the entity audit referenced the
+    # planned `new_version_no = entity.version_no + 1` while the
+    # submission audit referenced `appended_n = max(history.n) + 1`;
+    # under any history skew between those two values the audits
+    # would diverge. Read the actually-appended n.
+    audit_version_no: Optional[int] = None
+    if file is not None and new_version_dir is not None:
+        # `appended_n` is in scope inside the branch that creates it,
+        # but we're outside that branch here — re-derive by reading
+        # the entity's latest history entry, which append_version_history
+        # just wrote.
+        latest_row = repo.get(entity_id) or {}
+        history = latest_row.get("version_history") or []
+        if history:
+            try:
+                audit_version_no = max(int(e.get("n") or 0) for e in history)
+            except (TypeError, ValueError):
+                audit_version_no = new_version_no
+        else:
+            audit_version_no = new_version_no
     _audit(
         conn,
         user["id"],
         "store.entity.update",
         entity_id,
-        {"version": new_version, "rebuilt": file is not None},
+        {"version": new_version, "version_no": audit_version_no,
+         "rebuilt": file is not None,
+         "renamed_to": rename_to},
     )
+    _invalidate_etag()
+    return _entity_to_response(conn, repo.get(entity_id))  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Restore — POST /api/store/entities/{id}/versions/{version_no}/restore
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/entities/{entity_id}/versions/{version_no}/restore",
+    response_model=StoreEntityResponse,
+)
+async def restore_version(
+    entity_id: str,
+    version_no: int,
+    background_tasks: BackgroundTasks,
+    user: dict = Depends(get_current_user),
+    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
+):
+    """Roll back to a prior version. Owner or admin.
+
+    Creates a NEW version (`v<max+1>`) by copying the bundle bytes
+    from `versions/v<N>/plugin/`, then runs the standard guardrails
+    pipeline so today's rules apply (rules tighten over time —
+    pre-approved bundles re-validate at restore time).
+
+    The original `version_no` row in ``version_history`` keeps its
+    own verdict; the new copy gets a fresh one. Forward-only history
+    — no deletes from version_history.
+
+    Refuses while a prior version is under review (same
+    ``prior_version_pending`` 409 as PUT).
+    """
+    repo = StoreEntitiesRepository(conn)
+    entity = repo.get(entity_id)
+    if not entity:
+        raise HTTPException(status_code=404, detail="entity_not_found")
+    if entity["owner_user_id"] != user["id"] and not is_user_admin(user["id"], conn):
+        raise HTTPException(status_code=403, detail="not_owner")
+
+    # Block while pending — same gate as PUT. Gate on submission
+    # status directly so v2+ deferred-promotion edits don't slip
+    # through the visibility check.
+    latest_sub = StoreSubmissionsRepository(conn).latest_for_entity(entity_id)
+    if latest_sub and latest_sub.get("status") in (
+        "pending_inline", "pending_llm",
+    ):
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "prior_version_pending",
+                "message": "A previous edit is still under review. "
+                           "Wait for the verdict before restoring.",
+                "submission_id": latest_sub.get("id"),
+            },
+        )
+
+    # Locate the source version dir.
+    source_dir = (
+        _entity_dir(entity_id) / "versions" / f"v{version_no}" / "plugin"
+    )
+    if not source_dir.is_dir():
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "code": "version_not_found",
+                "version_no": version_no,
+            },
+        )
+    if int(version_no) == int(entity.get("version_no") or 1):
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "already_current",
+                "version_no": version_no,
+            },
+        )
+
+    # Copy source → new version dir, run guardrails, swap live.
+    new_version_no = int(entity.get("version_no") or 1) + 1
+    target_root = _entity_dir(entity_id) / "versions" / f"v{new_version_no}"
+    target_plugin = target_root / "plugin"
+    if target_plugin.exists():
+        shutil.rmtree(target_plugin, ignore_errors=True)
+    target_root.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(source_dir, target_plugin)
+
+    new_version = compute_entity_version(target_plugin)
+    inline = run_inline_checks(
+        target_plugin,
+        type_=entity["type"],
+        description=entity.get("description"),
+    )
+    if not inline.passed:
+        from src.store_guardrails.bundle_meta import compute_bundle_meta
+        rejected_meta = compute_bundle_meta(target_plugin)
+        subs_repo = StoreSubmissionsRepository(conn)
+        sub_id = subs_repo.create(
+            submitter_id=user["id"],
+            submitter_email=user.get("email"),
+            type=entity["type"],
+            name=entity["name"],
+            version=new_version,
+            status="blocked_inline",
+            entity_id=entity_id,
+            inline_checks=inline.to_response_dict(),
+            file_size=rejected_meta.file_size,
+            bundle_sha256=rejected_meta.sha256,
+        )
+        _audit(
+            conn, user["id"], "store.submission.blocked_inline",
+            sub_id,
+            {"entity_id": entity_id, "on": "restore",
+             "restored_from_version_no": version_no,
+             "sha256": rejected_meta.sha256,
+             "file_size": rejected_meta.file_size},
+        )
+        # Live tree untouched. Version dir kept for forensic download.
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "submission_blocked",
+                "submission_id": sub_id,
+                "entity_id": entity_id,
+                "checks": inline.to_response_dict(),
+            },
+        )
+
+    # Inline checks passed. DO NOT swap live yet — same invariant as
+    # the PUT edit path: existing installers keep getting the prior
+    # approved version through the LLM review window. Promotion (live
+    # swap + version_no/version/file_size bump) waits on LLM approval.
+    guardrails_on = get_guardrails_enabled()
+    from src.store_guardrails.bundle_meta import compute_bundle_meta
+    accepted_meta = compute_bundle_meta(target_plugin)
+    subs_repo = StoreSubmissionsRepository(conn)
+    sub_id = subs_repo.create(
+        submitter_id=user["id"],
+        submitter_email=user.get("email"),
+        type=entity["type"],
+        name=entity["name"],
+        version=new_version,
+        status="approved" if not guardrails_on else "pending_llm",
+        entity_id=entity_id,
+        inline_checks=inline.to_response_dict(),
+        file_size=accepted_meta.file_size,
+        bundle_sha256=accepted_meta.sha256,
+    )
+    appended_n = repo.append_version_history(
+        entity_id,
+        version_hash=new_version,
+        sha256=accepted_meta.sha256,
+        size=accepted_meta.file_size,
+        submission_id=sub_id,
+        created_by=user["id"],
+    )
+    _audit(
+        conn, user["id"], "store.entity.restore", entity_id,
+        {"restored_from_version_no": version_no,
+         "new_version_no": appended_n,
+         "submission_id": sub_id},
+    )
+    if guardrails_on:
+        _schedule_llm_review(background_tasks, sub_id, target_plugin)
+    else:
+        repo.promote_version(entity_id, appended_n)
+        _swap_live_to_version(entity_id, appended_n)
+
     _invalidate_etag()
     return _entity_to_response(conn, repo.get(entity_id))  # type: ignore[arg-type]
 

--- a/app/web/router.py
+++ b/app/web/router.py
@@ -1073,6 +1073,53 @@ async def store_new(
     return templates.TemplateResponse(request, "store_upload.html", ctx)
 
 
+@router.get("/marketplace/flea/{entity_id}/edit", response_class=HTMLResponse)
+async def store_edit(
+    entity_id: str,
+    request: Request,
+    user: dict = Depends(get_current_user),
+    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
+):
+    """Edit page for a flea-market entity (v37 edit feature).
+
+    Owner or admin only. Pre-fills metadata + lets the submitter
+    optionally upload a new bundle (creates v<N+1>). Skipping the
+    bundle field updates only metadata. Edit is blocked while a
+    prior version is under review — the form surfaces a banner and
+    disables Save in that case (the API gate also enforces 409
+    server-side).
+    """
+    from app.auth.access import is_user_admin
+    from src.repositories.store_entities import StoreEntitiesRepository
+    from src.repositories.store_submissions import StoreSubmissionsRepository
+    from src.store_categories import STORE_CATEGORIES
+
+    entity = StoreEntitiesRepository(conn).get(entity_id)
+    if not entity:
+        raise HTTPException(status_code=404, detail="entity_not_found")
+    is_admin = is_user_admin(user["id"], conn)
+    if entity["owner_user_id"] != user["id"] and not is_admin:
+        # Same 404-no-leak as _enforce_visibility — strangers don't
+        # learn of the entity's existence.
+        raise HTTPException(status_code=404, detail="entity_not_found")
+
+    pending_sub = None
+    if entity.get("visibility_status") == "pending":
+        latest = StoreSubmissionsRepository(conn).latest_for_entity(entity_id)
+        if latest and latest.get("status") in ("pending_inline", "pending_llm"):
+            pending_sub = latest
+
+    ctx = _build_context(
+        request, user=user,
+        entity=entity,
+        is_admin=is_admin,
+        is_owner=entity["owner_user_id"] == user["id"],
+        categories=list(STORE_CATEGORIES),
+        pending_sub=pending_sub,
+    )
+    return templates.TemplateResponse(request, "store_edit.html", ctx)
+
+
 # Legacy /store/{id} detail surface removed in v32+. The unified
 # /marketplace/flea/{id} is the canonical detail page. All in-tree
 # callers (store_upload redirect, my_ai_stack card, store_listing
@@ -1148,6 +1195,22 @@ async def marketplace_flea_detail(
     if (is_owner or is_admin) and entity.get("visibility_status") != "approved":
         quarantine_sub = StoreSubmissionsRepository(conn).latest_for_entity(entity_id)
 
+    # v37: even when entity is 'approved' (deferred promotion path —
+    # existing installers continue receiving the prior version),
+    # owner/admin needs to see if there's an edit-review in flight so
+    # the Edit button can lock + a small status surfaces. Look it up
+    # separately from quarantine_sub to keep the banner partial's
+    # gates intact.
+    edit_in_flight = False
+    if (is_owner or is_admin):
+        latest = (
+            StoreSubmissionsRepository(conn).latest_for_entity(entity_id)
+        )
+        if latest and latest.get("status") in (
+            "pending_inline", "pending_llm",
+        ):
+            edit_in_flight = True
+
     common = dict(
         source="flea",
         entity=entity,
@@ -1155,6 +1218,7 @@ async def marketplace_flea_detail(
         is_owner=is_owner,
         is_admin=is_admin,
         quarantine_sub=quarantine_sub,
+        edit_in_flight=edit_in_flight,
     )
 
     if entity["type"] == "plugin":
@@ -1603,11 +1667,23 @@ async def admin_store_submission_detail_page(
     # Verdict (sub.status) is immutable forensic record; lifecycle
     # (entity.visibility_status) reflects current state — see plan
     # "Admin Submissions Filter: Use Entity Visibility, Not Denormalized Status".
+    # Also derive submission_version_no by matching sub.version (hash)
+    # against the entity's version_history (v37 edit feature).
     entity_visibility_status = None
+    entity_version_no = None
+    submission_version_no = None
     if sub.get("entity_id"):
         ent = StoreEntitiesRepository(conn).get(sub["entity_id"])
         if ent:
             entity_visibility_status = ent.get("visibility_status")
+            entity_version_no = ent.get("version_no")
+            for entry in (ent.get("version_history") or []):
+                try:
+                    if entry.get("hash") == sub.get("version"):
+                        submission_version_no = int(entry.get("n"))
+                        break
+                except (TypeError, ValueError):
+                    continue
 
     other_count = StoreSubmissionsRepository(conn).count_for_submitter(
         sub["submitter_id"], exclude_id=submission_id,
@@ -1639,31 +1715,56 @@ async def admin_store_submission_detail_page(
     #     (creation, hard delete). entity_id stays on submission
     #     rows even after hard delete (tombstone), so the linkage
     #     survives — see mark_deleted_for_entity.
-    resources = [
+    submission_resources = [
         f"store_submission:{submission_id}",
         f"store_entity:{submission_id}",
         submission_id,
     ]
+    submission_audit_rows = AuditRepository(conn).query_for_resources(
+        submission_resources, limit=100,
+    )
+    entity_audit_rows: list = []
     if sub.get("entity_id"):
-        resources.append(f"store_entity:{sub['entity_id']}")
-    audit_rows = AuditRepository(conn).query_for_resources(resources, limit=100)
+        entity_audit_rows = AuditRepository(conn).query_for_resources(
+            [f"store_entity:{sub['entity_id']}"], limit=100,
+        )
+        # Drop entity-scoped rows that are actually submission audits for
+        # OTHER versions of the same entity (the helper writes them at
+        # resource=store_entity:{sub_id} for ALL submissions). Keep only
+        # rows whose action is a true entity-scoped event so admins see
+        # entity lifecycle (archive / install / delete) here without
+        # other versions' verdict noise leaking in.
+        entity_audit_rows = [
+            r for r in entity_audit_rows
+            if not (r.get("action") or "").startswith("store.submission.")
+        ]
     actor_cache: dict = {}
-    for row in audit_rows:
-        uid = row.get("user_id")
-        if not uid:
-            row["actor_email"] = ""
-            continue
-        if uid not in actor_cache:
-            urow = user_repo.get_by_id(uid)
-            actor_cache[uid] = (urow or {}).get("email") or uid
-        row["actor_email"] = actor_cache[uid]
+
+    def _resolve_actor(rows):
+        for row in rows:
+            uid = row.get("user_id")
+            if not uid:
+                row["actor_email"] = ""
+                continue
+            if uid not in actor_cache:
+                urow = user_repo.get_by_id(uid)
+                actor_cache[uid] = (urow or {}).get("email") or uid
+            row["actor_email"] = actor_cache[uid]
+    _resolve_actor(submission_audit_rows)
+    _resolve_actor(entity_audit_rows)
+    # Combine for back-compat with the existing template var name.
+    audit_rows = submission_audit_rows
 
     ctx = _build_context(
         request, user=user,
         sub=sub, other_count=other_count,
         override_email=override_email,
         audit_rows=audit_rows,
+        submission_audit_rows=submission_audit_rows,
+        entity_audit_rows=entity_audit_rows,
         entity_visibility_status=entity_visibility_status,
+        entity_version_no=entity_version_no,
+        submission_version_no=submission_version_no,
     )
     return templates.TemplateResponse(request, "admin_store_submission_detail.html", ctx)
 

--- a/app/web/templates/_flea_versions.html
+++ b/app/web/templates/_flea_versions.html
@@ -1,0 +1,152 @@
+{# Versions card — owner + admin only.
+
+   Renders entity.version_history (oldest-first) reversed so newest
+   appears at top. Each row gets:
+     * version label (vN, "current" badge for the active one)
+     * short hash + size + created_at
+     * Restore button (owner + admin) for non-current versions
+     * Download button (admin only) — links to admin submission bundle
+
+   Required scope:
+     entity         — store_entities row carrying version_no + version_history
+     is_owner       — bool
+     is_admin       — bool
+
+   Self-guards on visibility (only renders for owner/admin) and on
+   history length (>= 1). Plain entities created post-v37 always have
+   at least a v1 entry.
+#}
+
+{% if (is_owner or is_admin) and entity and entity.version_history and entity.version_history|length >= 1 %}
+<style>
+  .versions-card {
+    margin: 16px 0; padding: 14px 18px; background: var(--surface, #fff);
+    border: 1px solid var(--border, #e5e7eb); border-radius: 10px;
+    font-size: 13px;
+  }
+  .versions-card h3 {
+    margin: 0 0 10px 0; font-size: 14px; font-weight: 600;
+    color: var(--text, #111827);
+  }
+  .versions-card table { width: 100%; border-collapse: collapse; }
+  .versions-card th, .versions-card td {
+    text-align: left; padding: 6px 10px; border-bottom: 1px solid var(--border-light, #f3f4f6);
+    vertical-align: middle;
+  }
+  .versions-card th {
+    font-size: 11px; text-transform: uppercase; letter-spacing: 0.4px;
+    color: var(--text-secondary, #6b7280); font-weight: 500;
+  }
+  .versions-card .vn { font-weight: 600; }
+  .versions-card .current-badge {
+    display: inline-block; padding: 1px 6px; border-radius: 999px;
+    background: #d1fae5; color: #065f46; font-size: 10px;
+    font-weight: 600; text-transform: uppercase; letter-spacing: 0.3px;
+    margin-left: 6px;
+  }
+  .versions-card code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 11px; background: rgba(0,0,0,0.04); padding: 1px 4px; border-radius: 3px;
+  }
+  .versions-card button.restore {
+    padding: 4px 10px; border-radius: 5px;
+    border: 1px solid var(--border, #d1d5db); background: var(--surface, #fff);
+    font-size: 12px; cursor: pointer;
+  }
+  .versions-card button.restore:hover { background: var(--surface-muted, #f9fafb); }
+  .versions-card button.restore:disabled { opacity: 0.5; cursor: not-allowed; }
+</style>
+
+<div class="versions-card">
+  <h3>Versions ({{ entity.version_history|length }})</h3>
+  <table>
+    <thead>
+      <tr>
+        <th>Version</th>
+        <th>Hash</th>
+        <th>Size</th>
+        <th>Created</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      {# Render newest-first. Build a reversed list in Jinja. #}
+      {% set ordered = entity.version_history | sort(attribute='n', reverse=true) %}
+      {% for v in ordered %}
+      <tr>
+        <td class="vn">
+          v{{ v.n }}
+          {% if v.n == entity.version_no %}<span class="current-badge">current</span>{% endif %}
+        </td>
+        <td><code>{{ v.hash[:12] if v.hash else '—' }}</code></td>
+        <td>
+          {%- if v.size is not none -%}
+            {%- if v.size < 1024 -%}{{ v.size }} B
+            {%- elif v.size < 1048576 -%}{{ "%.1f"|format(v.size / 1024) }} KB
+            {%- else -%}{{ "%.1f"|format(v.size / 1048576) }} MB
+            {%- endif -%}
+          {%- else -%}—{%- endif -%}
+        </td>
+        <td style="white-space: nowrap; color: var(--text-secondary, #6b7280);">
+          {{ v.created_at[:10] if v.created_at else '' }}
+        </td>
+        <td>
+          {% if v.n != entity.version_no %}
+          <button class="restore" type="button"
+                  data-version-no="{{ v.n }}"
+                  onclick="restoreVersion({{ v.n }})">
+            Restore
+          </button>
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<script>
+async function restoreVersion(versionNo) {
+  const currentVersionNo = {{ entity.version_no | tojson }};
+  const ok = confirm(
+    `Restore version ${versionNo}?\n\n` +
+    `This will create a new version (v${currentVersionNo + 1}) with v${versionNo}'s ` +
+    `bundle and re-run security checks. The current version stays in history.`
+  );
+  if (!ok) return;
+  const r = await fetch(
+    `/api/store/entities/{{ entity.id }}/versions/${versionNo}/restore`,
+    {method: 'POST', credentials: 'same-origin'}
+  );
+  if (r.ok) {
+    window.location.reload();
+    return;
+  }
+  let msg = 'Restore failed.';
+  try {
+    const j = await r.json();
+    if (j.detail) {
+      const code = j.detail.code || '';
+      if (code === 'submission_blocked') {
+        // Land on detail to see the blocked banner.
+        const eid = j.detail.entity_id || '{{ entity.id }}';
+        window.location = `/marketplace/flea/${eid}`;
+        return;
+      }
+      if (code === 'prior_version_pending') {
+        msg = 'A previous edit is still under review. Wait for the verdict before restoring.';
+      } else if (code === 'version_not_found') {
+        msg = 'That version is no longer on disk.';
+      } else if (code === 'already_current') {
+        msg = 'Already on that version.';
+      } else if (typeof j.detail === 'object') {
+        msg = `Restore failed: ${code || JSON.stringify(j.detail)}`;
+      } else {
+        msg = `Restore failed: ${j.detail}`;
+      }
+    }
+  } catch (_) {}
+  alert(msg);
+}
+</script>
+{% endif %}

--- a/app/web/templates/_quarantine_banner.html
+++ b/app/web/templates/_quarantine_banner.html
@@ -49,6 +49,16 @@
 
 <div class="vis-banner {{ bcls }}">
   {% if st == 'pending_llm' or st == 'pending_inline' or st == 'pending' %}
+    {% set _is_edit_review = entity.version_no and entity.version_no > 1 %}
+    {% if _is_edit_review %}
+    <h3>⟳ Version {{ entity.version_no }} under review</h3>
+    <div>
+      Your edit is being checked. The previously approved version
+      (v{{ entity.version_no - 1 }}) keeps serving to existing
+      installers until v{{ entity.version_no }} passes review. The
+      page refreshes automatically when the verdict lands.
+    </div>
+    {% else %}
     <h3>⟳ Under review</h3>
     <div>
       Your submission is being checked. It is hidden from the public
@@ -56,6 +66,7 @@
       refreshes automatically when the verdict lands — usually a few
       seconds.
     </div>
+    {% endif %}
 
   {% elif st == 'blocked_inline' %}
     <h3>⚠ Quarantined — automated checks failed</h3>

--- a/app/web/templates/admin_store_submission_detail.html
+++ b/app/web/templates/admin_store_submission_detail.html
@@ -172,6 +172,25 @@
         </dd>
       </div>
       <div>
+        <dt>Version</dt>
+        <dd>
+          {%- if submission_version_no -%}
+            <strong>v{{ submission_version_no }}</strong>
+            {%- if entity_version_no and entity_version_no == submission_version_no %}
+            <span class="badge approved" style="margin-left: 6px;">current</span>
+            {%- elif entity_version_no %}
+            <span style="font-size: 11px; color: var(--text-secondary, #9ca3af); margin-left: 6px;">superseded — current is v{{ entity_version_no }}</span>
+            {%- endif %}
+          {%- else -%}
+            <span class="empty-msg">— (legacy or hash not in history)</span>
+          {%- endif -%}
+        </dd>
+      </div>
+      <div>
+        <dt>Bundle hash</dt>
+        <dd>{% if sub.version %}<code style="font-size:12px;">{{ sub.version }}</code>{% else %}<span class="empty-msg">—</span>{% endif %}</dd>
+      </div>
+      <div>
         <dt>Submitter</dt>
         <dd><a href="/admin/store/submissions?submitter={{ sub.submitter_id }}">{{ sub.submitter_email or sub.submitter_id }}</a></dd>
       </div>
@@ -191,7 +210,19 @@
       </div>
       <div>
         <dt>Reviewed by model</dt>
-        <dd>{{ sub.reviewed_by_model or "—" }}</dd>
+        <dd>
+          {%- if sub.reviewed_by_model -%}
+            <code style="font-size: 12px;">{{ sub.reviewed_by_model }}</code>
+          {%- elif sub.status in ['pending_llm', 'pending_inline'] -%}
+            <span class="empty-msg">⟳ in flight</span>
+          {%- elif sub.status == 'blocked_inline' -%}
+            <span class="empty-msg">— (inline-blocked, LLM skipped)</span>
+          {%- elif sub.status == 'approved' -%}
+            <span class="empty-msg">— (guardrails disabled or no API key)</span>
+          {%- else -%}
+            <span class="empty-msg">—</span>
+          {%- endif -%}
+        </dd>
       </div>
       <div>
         <dt>Entity ID</dt>
@@ -265,39 +296,73 @@
   {% endif %}
 
   {# ── Activity timeline ───────────────────────────────────────────────────── #}
-  {% if audit_rows %}
-  <div class="det-card">
-    <h2>Activity timeline</h2>
-    <p style="font-size: 12px; color: var(--text-secondary, #6b7280); margin: 0 0 8px 0;">
-      Every recorded action on this submission + linked entity, newest first.
-      Use this to confirm a verdict is fresh (e.g. the timestamp on the latest
-      <code>store.submission.rescan</code> row matches the time you clicked Rescan).
-    </p>
+  {# v37 split: per-submission events surface here. Entity-wide events
+     (archive / install / hard-delete) — which apply to ALL versions of
+     this entity — surface in the separate "Entity activity" card below
+     so admin can tell version-scoped from entity-scoped at a glance. #}
+  {% macro _render_timeline(rows) %}
     <ul class="timeline">
-      {% for row in audit_rows %}
+      {% for row in rows %}
       <li>
         <span class="ts">{{ row.timestamp.strftime("%Y-%m-%d %H:%M:%S") if row.timestamp else "" }}</span>
         <span>
           <span class="action">{{ row.action }}</span>
+          {# Inline `vN` chip when the audit's params reference a
+             specific version_no — makes it clear in the entity-wide
+             timeline which version each event applied to. #}
+          {% if row.params and row.params is mapping and row.params.version_no %}
+            <span class="badge approved" style="margin-left: 4px; font-size: 9px;">v{{ row.params.version_no }}</span>
+          {% endif %}
           {% if row.actor_email %}<span class="actor"> · {{ row.actor_email }}</span>{% endif %}
           {% if row.params and row.params is mapping %}
             {% if row.params.outcome %}<span class="actor"> · → {{ row.params.outcome }}</span>{% endif %}
             {% if row.params.risk_level %}<span class="actor"> · risk={{ row.params.risk_level }}</span>{% endif %}
             {% if row.params.reason %}<span class="actor"> · "{{ row.params.reason[:80] }}"</span>{% endif %}
+            {% if row.params.renamed_to %}<span class="actor"> · → {{ row.params.renamed_to }}</span>{% endif %}
+            {% if row.params.restored_from_version_no %}<span class="actor"> · from v{{ row.params.restored_from_version_no }}</span>{% endif %}
           {% endif %}
         </span>
         <span class="relative" data-rel-since="{{ row.timestamp.isoformat() if row.timestamp else '' }}">just now</span>
       </li>
       {% endfor %}
     </ul>
+  {% endmacro %}
+
+  {% if submission_audit_rows %}
+  <div class="det-card">
+    <h2>Activity timeline{% if submission_version_no %} <span class="badge approved" style="font-size:9px;">v{{ submission_version_no }}</span>{% endif %}</h2>
+    <p style="font-size: 12px; color: var(--text-secondary, #6b7280); margin: 0 0 8px 0;">
+      Recorded actions for THIS submission row only — accept / verdict /
+      rescan / override / retry / bundle download. Use this to confirm a
+      verdict is fresh (timestamp on the latest <code>store.submission.rescan</code>
+      row matches the time you clicked Rescan).
+    </p>
+    {{ _render_timeline(submission_audit_rows) }}
+  </div>
+  {% endif %}
+
+  {% if entity_audit_rows %}
+  <div class="det-card">
+    <h2>Entity activity (all versions)</h2>
+    <p style="font-size: 12px; color: var(--text-secondary, #6b7280); margin: 0 0 8px 0;">
+      Entity-wide events that apply to every version of this entity —
+      creation, archive, install / uninstall, hard delete. Same content
+      shows on every submission for this entity by design.
+    </p>
+    {{ _render_timeline(entity_audit_rows) }}
   </div>
   {% endif %}
 
   {# ── Inline checks ───────────────────────────────────────────────────────── #}
+  {# Each ``det-card`` below renders verdict data scoped to THIS
+     submission row (i.e. one specific version). Section headers get
+     a ``vN`` chip when ``submission_version_no`` is known so admin
+     never confuses one version's verdict for another's. #}
   {% set ic = sub.inline_checks or {} %}
+  {% macro _vchip() %}{% if submission_version_no %}<span class="badge approved" style="margin-left:6px;font-size:9px;">v{{ submission_version_no }}</span>{% endif %}{% endmacro %}
 
   <div class="det-card">
-    <h2>Manifest check {% if ic.manifest %}<span class="badge {{ ic.manifest.status or 'pass' }}">{{ ic.manifest.status or 'pass' }}</span>{% endif %}</h2>
+    <h2>Manifest check{{ _vchip() }} {% if ic.manifest %}<span class="badge {{ ic.manifest.status or 'pass' }}">{{ ic.manifest.status or 'pass' }}</span>{% endif %}</h2>
     {% if ic.manifest and ic.manifest.issues %}
       <ul class="issues">
         {% for issue in ic.manifest.issues %}<li><code>{{ issue }}</code></li>{% endfor %}
@@ -308,7 +373,7 @@
   </div>
 
   <div class="det-card">
-    <h2>Static security scan {% if ic.static_security %}<span class="badge {{ ic.static_security.status or 'pass' }}">{{ ic.static_security.status or 'pass' }}</span>{% endif %}</h2>
+    <h2>Static security scan{{ _vchip() }} {% if ic.static_security %}<span class="badge {{ ic.static_security.status or 'pass' }}">{{ ic.static_security.status or 'pass' }}</span>{% endif %}</h2>
     {% if ic.static_security and ic.static_security.findings %}
     <table class="sub-table">
       <thead>
@@ -332,7 +397,7 @@
   </div>
 
   <div class="det-card">
-    <h2>Quality + templating {% if ic.quality %}<span class="badge {{ ic.quality.status or 'pass' }}">{{ ic.quality.status or 'pass' }}</span>{% endif %}</h2>
+    <h2>Quality + templating{{ _vchip() }} {% if ic.quality %}<span class="badge {{ ic.quality.status or 'pass' }}">{{ ic.quality.status or 'pass' }}</span>{% endif %}</h2>
     {% if ic.quality %}
       <div style="font-size: 13px; color: var(--text-secondary, #6b7280); margin-bottom: 8px;">
         Template placeholders found: <strong>{{ ic.quality.template_placeholders or 0 }}</strong>
@@ -352,7 +417,7 @@
 
   {# ── LLM review ──────────────────────────────────────────────────────────── #}
   <div class="det-card">
-    <h2>LLM security review
+    <h2>LLM security review{{ _vchip() }}
       {% if sub.llm_findings and sub.llm_findings.risk_level %}
       <span class="badge {{ sub.llm_findings.risk_level }}">{{ sub.llm_findings.risk_level }}</span>
       {% endif %}

--- a/app/web/templates/admin_store_submissions.html
+++ b/app/web/templates/admin_store_submissions.html
@@ -241,7 +241,8 @@
           <th>{{ sort_link("created_at", "When") }}</th>
           <th>Submitter</th>
           <th>Type / {{ sort_link("name", "name") }}</th>
-          <th>Version</th>
+          <th title="Human version index (v1, v2, …) derived from the entity's version_history. Hash shown below.">v#</th>
+          <th>Hash</th>
           <th>{{ sort_link("status", "Status") }}</th>
           <th>{{ sort_link("file_size", "Size") }}</th>
           <th>Findings</th>
@@ -260,7 +261,17 @@
             <span style="color: var(--text-secondary, #6b7280); font-size: 11px;">{{ s.type }}</span>
             <strong>{{ s.name | store_display_name }}</strong>
           </td>
-          <td>{{ s.version or "" }}</td>
+          <td style="white-space: nowrap; font-variant-numeric: tabular-nums;">
+            {%- if s.version_no -%}
+              <strong>v{{ s.version_no }}</strong>
+              {%- if s.entity_version_no and s.entity_version_no == s.version_no %}
+              <span style="display:inline-block;padding:1px 5px;margin-left:4px;border-radius:999px;background:#d1fae5;color:#065f46;font-size:9px;font-weight:600;text-transform:uppercase;letter-spacing:0.3px;">current</span>
+              {%- endif %}
+            {%- else -%}
+              <span style="color: var(--text-secondary, #9ca3af);">—</span>
+            {%- endif -%}
+          </td>
+          <td><code style="font-size:11px;">{{ s.version[:12] if s.version else "" }}</code></td>
           <td><span class="badge {{ s.status }}">{{ s.status }}</span></td>
           <td style="white-space: nowrap; font-variant-numeric: tabular-nums; color: var(--text-secondary, #6b7280);">{{ fmt_size(s.file_size) }}</td>
           <td class="findings">

--- a/app/web/templates/marketplace_item_detail.html
+++ b/app/web/templates/marketplace_item_detail.html
@@ -415,10 +415,17 @@
     }
   </style>
   <div class="owner-actions">
+    {% if edit_in_flight %}
     <a href="#" aria-disabled="true"
-       title="Edit flow lands in a follow-up — for now, re-upload to update.">
-      Edit (coming soon)
+       title="Wait for the in-flight review to finish before editing.">
+      Edit (review in flight)
     </a>
+    {% else %}
+    <a href="/marketplace/flea/{{ entity.id }}/edit"
+       title="Edit metadata or upload a new version.">
+      Edit
+    </a>
+    {% endif %}
     {# Same v35 delete UX as the plugin detail page — see comment there. #}
     {% if is_admin %}
       {% if entity.visibility_status == 'approved' %}
@@ -464,6 +471,9 @@
       </button>
     {% endif %}
   </div>
+
+  {% include "_flea_versions.html" %}
+
   <script>
   (function(){
     const root = document.getElementById('root');

--- a/app/web/templates/marketplace_plugin_detail.html
+++ b/app/web/templates/marketplace_plugin_detail.html
@@ -419,10 +419,23 @@
     }
   </style>
   <div class="owner-actions">
-    <a href="#" id="owner-edit-btn" aria-disabled="true"
-       title="Edit flow lands in a follow-up — for now, re-upload to update.">
-      Edit (coming soon)
+    {# v37 edit feature: Edit lands a real page. Disabled while a
+       prior version is under review (server-side 409 also enforces).
+       edit_in_flight is set by the router whenever the latest
+       submission is pending_inline / pending_llm — even if the
+       entity stayed at visibility='approved' (deferred-promotion
+       path so existing installers keep receiving the prior bundle). #}
+    {% if edit_in_flight %}
+    <a href="#" aria-disabled="true"
+       title="Wait for the in-flight review to finish before editing.">
+      Edit (review in flight)
     </a>
+    {% else %}
+    <a href="/marketplace/flea/{{ entity.id }}/edit"
+       title="Edit metadata or upload a new version.">
+      Edit
+    </a>
+    {% endif %}
     {# v35 delete UX: Archive (soft) is the primary path. Owner sees
        Archive only when the entity is approved or already archived
        (re-archive is a no-op, but no point exposing). Admin gets
@@ -480,6 +493,8 @@
     {% endif %}
   </div>
   {% endif %}
+
+  {% include "_flea_versions.html" %}
 
   <div class="hero">
     <div class="crumbs">

--- a/app/web/templates/store_edit.html
+++ b/app/web/templates/store_edit.html
@@ -1,0 +1,303 @@
+{% extends "base.html" %}
+{% block title %}Edit {{ entity.name | store_display_name }} — {{ config.INSTANCE_NAME }}{% endblock %}
+
+{% block content %}
+<style>
+  .edit-back { font-size: 13px; color: var(--text-secondary, #6b7280); text-decoration: none; }
+  .edit-back:hover { color: var(--text, #111827); text-decoration: underline; }
+
+  h1.edit-title { margin: 8px 0 16px 0; font-size: 22px; font-weight: 600; }
+  .field { margin-bottom: 18px; }
+  .field-label {
+    display: block; font-size: 13px; font-weight: 500;
+    color: var(--text, #111827); margin-bottom: 6px;
+  }
+  .field-help {
+    font-size: 12px; color: var(--text-secondary, #6b7280); margin-top: 4px;
+  }
+  .field-help.warn { color: #92400e; }
+
+  input[type=text], textarea, select {
+    width: 100%; padding: 8px 10px;
+    border: 1px solid var(--border, #d1d5db); border-radius: 6px;
+    font-size: 14px; font-family: inherit;
+    background: var(--surface, #fff);
+  }
+  textarea { min-height: 80px; resize: vertical; }
+
+  .file-drop {
+    display: flex; align-items: center; gap: 12px;
+    padding: 16px; border-radius: 8px;
+    border: 2px dashed var(--border, #d1d5db); background: var(--surface-muted, #f9fafb);
+    cursor: pointer;
+  }
+  .file-drop input[type=file] { display: none; }
+  .file-drop:hover { border-color: var(--primary, #0073D1); background: #fff; }
+  .file-drop.is-dragover { border-color: var(--primary, #0073D1); background: #eff6ff; }
+  .file-drop .icon { font-size: 24px; }
+  .file-drop .file-info .label { font-size: 13px; font-weight: 500; }
+  .file-drop .file-info .meta { font-size: 12px; color: var(--text-secondary, #6b7280); }
+  .file-drop button {
+    margin-left: auto; padding: 6px 12px; border-radius: 6px;
+    border: 1px solid var(--border, #d1d5db); background: var(--surface, #fff);
+    font-size: 13px; cursor: pointer;
+  }
+
+  .actions { display: flex; gap: 8px; margin-top: 20px; align-items: center; }
+  .btn-primary {
+    padding: 8px 18px; border-radius: 6px; border: none;
+    background: var(--primary, #0073D1); color: white;
+    font-size: 14px; font-weight: 500; cursor: pointer;
+  }
+  .btn-primary:disabled { background: var(--border, #d1d5db); cursor: not-allowed; }
+  .btn-link {
+    padding: 8px 12px; color: var(--text-secondary, #6b7280); text-decoration: none;
+    font-size: 14px;
+  }
+
+  .pending-banner {
+    margin: 12px 0 16px 0; padding: 14px 18px; border-radius: 10px;
+    background: #fef3c7; color: #92400e; border: 1px solid #fde68a; font-size: 14px;
+  }
+  .pending-banner h3 { margin: 0 0 6px 0; font-size: 15px; }
+
+  .banner {
+    padding: 12px 16px; border-radius: 8px; margin-bottom: 16px;
+    font-size: 13px; line-height: 1.5; display: flex; align-items: flex-start; gap: 10px;
+  }
+  /* `display: flex` above overrides the user-agent default rule for
+     [hidden] (display:none); force it back so the empty banner stays
+     out of the layout until showError() unhides it. */
+  .banner[hidden] { display: none !important; }
+  .banner.error { background: #fef2f2; color: #b91c1c; border: 1px solid #fecaca; }
+  .banner > span { white-space: pre-wrap; }
+</style>
+
+<div class="page-shell">
+  <p style="margin: 8px 0;">
+    <a class="edit-back" href="/marketplace/flea/{{ entity.id }}">← Back to detail</a>
+  </p>
+  <h1 class="edit-title">Edit · {{ entity.type }} · {{ entity.name | store_display_name }}</h1>
+
+  {% if pending_sub %}
+  <div class="pending-banner">
+    <h3>⟳ A previous edit is still under review</h3>
+    <div>
+      Submission <code>{{ pending_sub.id[:8] }}</code> is being checked
+      ({{ pending_sub.status }}). Edits are temporarily disabled until
+      the verdict lands. The detail page auto-refreshes when it does.
+    </div>
+  </div>
+  {% endif %}
+
+  <div id="banner" class="banner error" hidden>
+    <span class="ico">!</span><span id="banner-text"></span>
+  </div>
+
+  <form id="edit-form">
+    <div class="field">
+      <label class="field-label" for="f-name">Display name</label>
+      <input id="f-name" name="name" type="text" value="{{ entity.name | store_display_name }}"
+             pattern="^[a-z][a-z0-9-]{0,63}$"
+             {% if pending_sub %}disabled{% endif %}>
+      <div class="field-help warn">
+        ⚠ Changing the name renames the plugin slug for existing
+        installers. They'll see the plugin renamed on their next sync
+        and may need to re-add it to their stack.
+      </div>
+    </div>
+
+    <div class="field">
+      <label class="field-label" for="f-description">Description</label>
+      <textarea id="f-description" name="description" maxlength="1000"
+                {% if pending_sub %}disabled{% endif %}>{{ entity.description or "" }}</textarea>
+    </div>
+
+    <div class="field">
+      <label class="field-label" for="f-category">Category</label>
+      <select id="f-category" name="category"
+              {% if pending_sub %}disabled{% endif %}>
+        <option value="">— none —</option>
+        {% for cat in categories %}
+        <option value="{{ cat }}" {% if cat == entity.category %}selected{% endif %}>{{ cat }}</option>
+        {% endfor %}
+      </select>
+    </div>
+
+    <div class="field">
+      <label class="field-label" for="f-video">Video URL <span style="color:var(--text-secondary,#6b7280);font-weight:400;">(optional)</span></label>
+      <input id="f-video" name="video_url" type="text"
+             value="{{ entity.video_url or '' }}" placeholder="https://..."
+             {% if pending_sub %}disabled{% endif %}>
+    </div>
+
+    <div class="field">
+      <label class="field-label">Cover photo</label>
+      <div class="file-drop" id="photo-drop">
+        <div class="icon">🖼</div>
+        <div class="file-info">
+          <div class="label" id="photo-label">
+            {% if entity.photo_path %}Replace existing photo{% else %}No photo{% endif %}
+          </div>
+          <div class="meta">JPG, PNG, WebP · Max 5 MB</div>
+        </div>
+        <input type="file" id="photo" accept="image/jpeg,image/png,image/webp"
+               {% if pending_sub %}disabled{% endif %}>
+        <button type="button" id="photo-pick" {% if pending_sub %}disabled{% endif %}>Choose</button>
+      </div>
+    </div>
+
+    <hr style="border:none;border-top:1px solid var(--border-light, #e5e7eb); margin: 20px 0;">
+
+    <div class="field">
+      <label class="field-label">Upload new version <span style="color:var(--text-secondary,#6b7280);font-weight:400;">(optional)</span></label>
+      <div class="file-drop" id="zip-drop">
+        <div class="icon">📦</div>
+        <div class="file-info">
+          <div class="label" id="zip-label">No file selected</div>
+          <div class="meta" id="zip-meta">
+            Skip to update only the metadata above. Uploading creates
+            v{{ (entity.version_no or 1) + 1 }} and re-runs guardrails.
+          </div>
+        </div>
+        <input type="file" id="zip" accept=".zip"
+               {% if pending_sub %}disabled{% endif %}>
+        <button type="button" id="zip-pick" {% if pending_sub %}disabled{% endif %}>Choose file</button>
+      </div>
+      <div class="field-help">
+        Current version: <strong>v{{ entity.version_no or 1 }}</strong>
+        ({{ entity.version[:12] if entity.version else "—" }}).
+        Prior versions remain on disk and can be restored from the
+        detail page's <em>Versions</em> section.
+      </div>
+    </div>
+
+    <div class="actions">
+      <button type="submit" class="btn-primary" id="save-btn"
+              {% if pending_sub %}disabled{% endif %}>Save</button>
+      <a href="/marketplace/flea/{{ entity.id }}" class="btn-link">Cancel</a>
+    </div>
+  </form>
+</div>
+
+<script>
+const ENTITY_ID = {{ entity.id|tojson }};
+const banner = document.getElementById('banner');
+const bannerText = document.getElementById('banner-text');
+function showError(msg) {
+  banner.className = 'banner error';
+  bannerText.textContent = msg;
+  banner.hidden = false;
+}
+function clearBanner() { banner.hidden = true; }
+
+function humanizeError(detail) {
+  if (!detail) return 'Save failed.';
+  if (typeof detail === 'object') {
+    const code = detail.code || '';
+    if (code === 'submission_blocked') {
+      const lines = ['New version blocked by automated checks.'];
+      const inline = (detail.checks?.static_security?.findings) || [];
+      for (const f of inline.slice(0, 5)) {
+        lines.push('• ' + (f.file || '?') + ':' + (f.line || '?') + ' — ' + (f.reason || f.category || ''));
+      }
+      lines.push('');
+      lines.push('Fix the issues and re-upload, or open the detail page to see the full report.');
+      return lines.join('\n');
+    }
+    if (code === 'prior_version_pending') {
+      return 'A previous edit is still under review. Wait for the verdict before saving.';
+    }
+    if (code === 'type_locked') {
+      return 'Cannot change the entity type. Upload a new entity if you need a different form factor.';
+    }
+    if (code === 'conflict_owner_name') return 'You already have a plugin with that name.';
+    if (code === 'conflict_global_suffix') return 'That name conflicts with another user\'s plugin slug.';
+    if (code === 'invalid_name_format') return 'Name must be lowercase letters / digits / hyphens, starting with a letter.';
+    if (code) return 'Save failed: ' + code;
+    try { return 'Save failed: ' + JSON.stringify(detail); } catch (_) { return 'Save failed.'; }
+  }
+  return 'Save failed: ' + String(detail);
+}
+
+// File picker wiring (no double-click bug — div, not label).
+function wireDropZone(dropEl, fileInput, pickBtn, labelEl, validate) {
+  if (!dropEl) return;
+  pickBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    fileInput.click();
+  });
+  dropEl.addEventListener('click', (e) => {
+    if (e.target.tagName !== 'BUTTON') fileInput.click();
+  });
+  fileInput.addEventListener('change', () => {
+    const f = fileInput.files[0];
+    if (!f) return;
+    const err = validate ? validate(f) : null;
+    if (err) { showError(err); fileInput.value = ''; return; }
+    if (labelEl) labelEl.textContent = f.name + ' (' + Math.round(f.size / 1024) + ' KB)';
+    dropEl.classList.add('is-dragover');
+  });
+}
+
+wireDropZone(
+  document.getElementById('zip-drop'),
+  document.getElementById('zip'),
+  document.getElementById('zip-pick'),
+  document.getElementById('zip-label'),
+  (f) => f.size > 50 * 1024 * 1024 ? 'ZIP too large (max 50 MB).' : null,
+);
+wireDropZone(
+  document.getElementById('photo-drop'),
+  document.getElementById('photo'),
+  document.getElementById('photo-pick'),
+  document.getElementById('photo-label'),
+  (f) => f.size > 5 * 1024 * 1024 ? 'Photo too large (max 5 MB).' : null,
+);
+
+document.getElementById('edit-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  clearBanner();
+  const saveBtn = document.getElementById('save-btn');
+  saveBtn.disabled = true;
+  saveBtn.textContent = 'Saving…';
+  try {
+    const fd = new FormData();
+    const name = document.getElementById('f-name').value.trim();
+    if (name) fd.append('name', name);
+    fd.append('description', document.getElementById('f-description').value);
+    fd.append('category', document.getElementById('f-category').value);
+    fd.append('video_url', document.getElementById('f-video').value);
+    const zip = document.getElementById('zip').files[0];
+    if (zip) fd.append('file', zip);
+    const photo = document.getElementById('photo').files[0];
+    if (photo) fd.append('photo', photo);
+
+    const r = await fetch(`/api/store/entities/${ENTITY_ID}`, {
+      method: 'PUT', body: fd, credentials: 'same-origin',
+    });
+    if (r.ok) {
+      window.location = `/marketplace/flea/${ENTITY_ID}`;
+      return;
+    }
+    let msg = 'Save failed.';
+    try {
+      const j = await r.json();
+      const eid = j?.detail?.entity_id;
+      if (eid && j.detail.code === 'submission_blocked') {
+        // Land on detail to see the banner.
+        window.location = `/marketplace/flea/${eid}`;
+        return;
+      }
+      if (j.detail) msg = humanizeError(j.detail);
+    } catch (_) {}
+    showError(msg);
+  } catch (err) {
+    showError(String(err));
+  } finally {
+    saveBtn.disabled = false;
+    saveBtn.textContent = 'Save';
+  }
+});
+</script>
+{% endblock %}

--- a/src/db.py
+++ b/src/db.py
@@ -40,7 +40,7 @@ def _maybe_instrument(con, db_tag: str):
 
 _SAFE_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,63}$")
 
-SCHEMA_VERSION = 37
+SCHEMA_VERSION = 38
 
 _SYSTEM_SCHEMA = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -535,6 +535,15 @@ CREATE TABLE IF NOT EXISTS store_entities (
                       CHECK (visibility_status IN ('pending','approved','hidden','archived')),
     archived_at       TIMESTAMP,
     archived_by       VARCHAR,
+    -- v37: flea-market edit feature. version_no tracks the current
+    -- version index (1-based); version_history is an append-only JSON
+    -- array of past version metadata. Bundle bytes for each version
+    -- live on disk under ${DATA_DIR}/store/<id>/versions/v<N>/plugin/
+    -- so rollback can copy them forward; the live `plugin/` dir is
+    -- always a copy of the current version. See
+    -- StoreEntitiesRepository.append_version + restore endpoint.
+    version_no        INTEGER NOT NULL DEFAULT 1,
+    version_history   JSON DEFAULT '[]',
     created_at        TIMESTAMP DEFAULT current_timestamp,
     updated_at        TIMESTAMP DEFAULT current_timestamp,
     UNIQUE (owner_user_id, name)
@@ -2390,6 +2399,73 @@ _V35_TO_V36_MIGRATIONS = [
 ]
 
 
+# v37→v38: flea-market entity edit feature with version history.
+#
+# (Originally drafted as v37; renumbered after rebase onto main where
+# v37 is taken by the curated marketplace enrichment migration.)
+#
+# Adds two columns to store_entities so an owner editing their plugin
+# accumulates an append-only history rather than overwriting the prior
+# bundle:
+#
+#   * version_no INTEGER  — current version index (1-based). Bumps on
+#     every approved bundle update; metadata-only edits don't bump.
+#   * version_history JSON — array of past version metadata entries:
+#       [{"n", "hash", "sha256", "size", "submission_id",
+#         "created_at", "created_by"}, …]
+#     Each row's bundle bytes live on disk under
+#     ``${DATA_DIR}/store/<eid>/versions/v<N>/plugin/`` so rollback can
+#     copy them forward.
+#
+# Backfill: existing rows get version_no=1 and a single-entry
+# version_history populated from the row's current ``version`` (hash)
+# + ``file_size`` so post-migration entities surface as v1 in the UI.
+# created_at backfilled from the entity row; submission_id is best-
+# effort (we look up the most recent submission_id for the entity_id
+# if any exists, else NULL).
+_V37_TO_V38_MIGRATIONS = [
+    # Defensive: minimal partial-state DBs from earlier migrations may
+    # be missing columns the backfill UPDATE below references. Add
+    # them idempotently first. Real post-v29 DBs already have these;
+    # this is a no-op there. Keeps the recovery path through
+    # `tests/test_db_schema_version.py::test_v32_db_with_partial_v35_recovers_through_full_ladder`
+    # intact when walking from v32 fixture forward.
+    "ALTER TABLE store_entities ADD COLUMN IF NOT EXISTS version VARCHAR",
+    "ALTER TABLE store_entities ADD COLUMN IF NOT EXISTS file_size BIGINT",
+    "ALTER TABLE store_entities ADD COLUMN IF NOT EXISTS created_at TIMESTAMP",
+    # DuckDB ALTER doesn't accept "NOT NULL DEFAULT" together — split:
+    # ADD nullable + DEFAULT, backfill nulls, then SET NOT NULL.
+    "ALTER TABLE store_entities ADD COLUMN IF NOT EXISTS version_no INTEGER DEFAULT 1",
+    "UPDATE store_entities SET version_no = 1 WHERE version_no IS NULL",
+    "ALTER TABLE store_entities ALTER COLUMN version_no SET NOT NULL",
+    "ALTER TABLE store_entities ADD COLUMN IF NOT EXISTS version_history JSON DEFAULT '[]'",
+    # Backfill: synthesize a v1 entry from existing columns when the
+    # history is empty. Idempotent — re-running on a populated row
+    # is a no-op because the WHERE filters on empty/NULL history.
+    """
+    UPDATE store_entities SET version_history = json_array(
+        json_object(
+            'n',  1,
+            'hash', version,
+            'sha256', NULL,
+            'size', file_size,
+            'submission_id', (
+                SELECT id FROM store_submissions
+                 WHERE entity_id = store_entities.id
+                 ORDER BY created_at DESC
+                 LIMIT 1
+            ),
+            'created_at', CAST(created_at AS VARCHAR),
+            'created_by', owner_user_id
+        )
+    )
+    WHERE version_history IS NULL
+       OR version_history = '[]'
+       OR json_array_length(version_history) = 0
+    """,
+]
+
+
 _V33_TO_V34_MIGRATIONS = [
     # DuckDB blocks DROP COLUMN while indexes reference the table
     # ("Dependency Error: Cannot alter entry … because there are entries
@@ -2776,6 +2852,9 @@ def _ensure_schema(conn: duckdb.DuckDBPyConnection) -> None:
                     conn.execute(sql)
             if current < 37:
                 for sql in _V36_TO_V37_MIGRATIONS:
+                    conn.execute(sql)
+            if current < 38:
+                for sql in _V37_TO_V38_MIGRATIONS:
                     conn.execute(sql)
             conn.execute(
                 "UPDATE schema_version SET version = ?, applied_at = current_timestamp",

--- a/src/repositories/store_entities.py
+++ b/src/repositories/store_entities.py
@@ -32,6 +32,15 @@ class StoreEntitiesRepository:
                     d[k] = []
             elif v is None:
                 d[k] = []
+        # v37: version_history is a JSON array of past version metadata.
+        v = d.get("version_history")
+        if isinstance(v, str):
+            try:
+                d["version_history"] = json.loads(v) if v else []
+            except (ValueError, TypeError):
+                d["version_history"] = []
+        elif v is None:
+            d["version_history"] = []
         return d
 
     def create(
@@ -52,21 +61,66 @@ class StoreEntitiesRepository:
         visibility_status: str = "pending",
     ) -> Dict[str, Any]:
         now = datetime.now(timezone.utc)
+        # v37: seed version_history with the v1 entry on create so the
+        # edit feature's append_version always has a baseline to build
+        # on. submission_id is filled in by the API layer post-INSERT
+        # via update_history_submission_id when the submission row is
+        # created.
+        v1_entry = {
+            "n": 1,
+            "hash": version,
+            "sha256": None,
+            "size": int(file_size) if file_size else None,
+            "submission_id": None,
+            "created_at": now.isoformat(),
+            "created_by": owner_user_id,
+        }
         self.conn.execute(
             """INSERT INTO store_entities
                 (id, owner_user_id, owner_username, type, name, description,
                  category, version, photo_path, video_url, doc_paths,
                  file_size, install_count, visibility_status,
+                 version_no, version_history,
                  created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?)""",
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, 1, ?, ?, ?)""",
             [
                 id, owner_user_id, owner_username, type, name, description,
                 category, version, photo_path, video_url,
                 json.dumps(doc_paths or []),
-                int(file_size), visibility_status, now, now,
+                int(file_size), visibility_status,
+                json.dumps([v1_entry]),
+                now, now,
             ],
         )
         return self.get(id)  # type: ignore[return-value]
+
+    def update_history_submission_id(
+        self, id: str, version_no: int, submission_id: str,
+    ) -> None:
+        """Backfill the ``submission_id`` field on a version_history
+        entry once the submission row has been written. Used by the
+        upload + edit endpoints to link version → submission verdict
+        without requiring a two-phase write that would race with the
+        v1 seed in ``create``.
+        """
+        row = self.get(id)
+        if row is None:
+            return
+        history = list(row.get("version_history") or [])
+        changed = False
+        for entry in history:
+            try:
+                if int(entry.get("n")) == int(version_no):
+                    entry["submission_id"] = submission_id
+                    changed = True
+                    break
+            except (TypeError, ValueError):
+                continue
+        if changed:
+            self.conn.execute(
+                "UPDATE store_entities SET version_history = ? WHERE id = ?",
+                [json.dumps(history), id],
+            )
 
     def set_visibility(self, id: str, status: str) -> None:
         """Flip visibility_status on a submission's resolution.
@@ -243,10 +297,141 @@ class StoreEntitiesRepository:
         )
         return {"original_name": original, "new_name": new_name}
 
+    def append_version_history(
+        self,
+        id: str,
+        *,
+        version_hash: str,
+        sha256: Optional[str],
+        size: Optional[int],
+        submission_id: Optional[str],
+        created_by: str,
+    ) -> int:
+        """Append a new version entry to ``version_history`` and return
+        its ``n`` value. **Does NOT promote** — entity row's
+        ``version_no`` / ``version`` / ``file_size`` stay at the
+        previous current.
+
+        Used by the PUT edit path + restore endpoint to record that a
+        new version exists in history (with its verdict) without
+        affecting what installers see. Promotion happens separately
+        once the LLM approves: see :meth:`promote_version`.
+        """
+        row = self.get(id)
+        if row is None:
+            raise ValueError(f"entity not found: {id!r}")
+        history = list(row.get("version_history") or [])
+        # Pick the next n above the largest existing entry. Defaults to
+        # 1 for empty history (shouldn't happen post-v37 since create()
+        # seeds v1, but defensive).
+        max_n = max((int(e.get("n") or 0) for e in history), default=0)
+        new_n = max_n + 1
+        now = datetime.now(timezone.utc)
+        history.append({
+            "n": new_n,
+            "hash": version_hash,
+            "sha256": sha256,
+            "size": int(size) if size is not None else None,
+            "submission_id": submission_id,
+            "created_at": now.isoformat(),
+            "created_by": created_by,
+        })
+        self.conn.execute(
+            "UPDATE store_entities SET version_history = ?, updated_at = ? WHERE id = ?",
+            [json.dumps(history), now, id],
+        )
+        return new_n
+
+    def promote_version(self, id: str, version_no: int) -> bool:
+        """Promote a version_history entry to current.
+
+        Looks up the ``n=version_no`` entry in the entity's
+        ``version_history`` and copies its ``hash``/``size`` onto the
+        entity row's ``version_no`` / ``version`` / ``file_size``.
+        Returns ``True`` on success, ``False`` when the entry is
+        missing.
+
+        Caller is responsible for swapping the on-disk live
+        ``plugin/`` dir from the matching version dir
+        (``versions/v<version_no>/plugin/``).
+        """
+        row = self.get(id)
+        if row is None:
+            return False
+        target = None
+        for entry in (row.get("version_history") or []):
+            try:
+                if int(entry.get("n")) == int(version_no):
+                    target = entry
+                    break
+            except (TypeError, ValueError):
+                continue
+        if target is None:
+            return False
+        size = target.get("size")
+        self.conn.execute(
+            """UPDATE store_entities
+                  SET version_no = ?,
+                      version = ?,
+                      file_size = ?,
+                      updated_at = ?
+                WHERE id = ?""",
+            [int(version_no), target.get("hash"),
+             int(size) if size is not None else row.get("file_size"),
+             datetime.now(timezone.utc), id],
+        )
+        return True
+
+    # Back-compat alias — old callers still call append_version.
+    # Kept as the PUT-equivalent shorthand: append + promote in one
+    # step. Used by code paths where we want immediate promotion
+    # (guardrails disabled, or test-only flows).
+    def append_version(
+        self,
+        id: str,
+        *,
+        version_hash: str,
+        sha256: Optional[str],
+        size: Optional[int],
+        submission_id: Optional[str],
+        created_by: str,
+    ) -> int:
+        """Append + promote in one shot. New code paths should call
+        :meth:`append_version_history` and :meth:`promote_version`
+        separately so they can defer promotion until an LLM verdict
+        approves the new version."""
+        n = self.append_version_history(
+            id,
+            version_hash=version_hash,
+            sha256=sha256,
+            size=size,
+            submission_id=submission_id,
+            created_by=created_by,
+        )
+        self.promote_version(id, n)
+        return n
+
+    def get_version(
+        self, id: str, version_no: int,
+    ) -> Optional[Dict[str, Any]]:
+        """Return the version_history entry for the given version_no, or
+        ``None`` if the entity / version is unknown."""
+        row = self.get(id)
+        if row is None:
+            return None
+        for entry in (row.get("version_history") or []):
+            try:
+                if int(entry.get("n")) == int(version_no):
+                    return entry
+            except (TypeError, ValueError):
+                continue
+        return None
+
     def update(
         self,
         id: str,
         *,
+        name: Optional[str] = None,
         description: Optional[str] = None,
         category: Optional[str] = None,
         version: Optional[str] = None,
@@ -257,9 +442,16 @@ class StoreEntitiesRepository:
     ) -> Optional[Dict[str, Any]]:
         """Partial update — only the supplied columns change. Returns the
         updated row, or None if no row matched.
+
+        ``name`` change is allowed (v37 edit feature). The caller is
+        responsible for collision checks BEFORE invoking this method
+        (per-owner UNIQUE + global suffix uniqueness) and for
+        renaming the on-disk skill/agent/plugin slug to match.
         """
         sets: List[str] = []
         params: List[Any] = []
+        if name is not None:
+            sets.append("name = ?"); params.append(name)
         if description is not None:
             sets.append("description = ?"); params.append(description)
         if category is not None:

--- a/src/repositories/store_submissions.py
+++ b/src/repositories/store_submissions.py
@@ -376,7 +376,10 @@ class StoreSubmissionsRepository:
         order = "ASC" if (sort_order or "desc").lower() == "asc" else "DESC"
 
         sql = (
-            f"SELECT s.*, e.visibility_status AS entity_visibility_status "
+            f"SELECT s.*, "
+            f"  e.visibility_status AS entity_visibility_status, "
+            f"  e.version_history   AS entity_version_history, "
+            f"  e.version_no        AS entity_version_no "
             f"FROM store_submissions s "
             f"LEFT JOIN store_entities e ON e.id = s.entity_id "
             f"{where} "
@@ -388,4 +391,28 @@ class StoreSubmissionsRepository:
             return [], int(total)
         columns = [d[0] for d in self.conn.description]
         items = [self._row_to_dict(columns, r) for r in rows]
+        # Derive ``version_no`` for each row by matching the submission's
+        # version hash against the entity's version_history. Surfaces a
+        # human-friendly v1/v2/v3 label in the admin queue + detail page
+        # (the raw ``s.version`` is the hash). Falls back to None when
+        # the entity is gone (hard-deleted) or the hash isn't in history.
+        for item in items:
+            history = item.get("entity_version_history")
+            if isinstance(history, str):
+                try:
+                    history = json.loads(history) if history else []
+                except (ValueError, TypeError):
+                    history = []
+            elif history is None:
+                history = []
+            item["entity_version_history"] = history
+            item["version_no"] = None
+            sub_hash = item.get("version")
+            for entry in history:
+                try:
+                    if entry.get("hash") == sub_hash:
+                        item["version_no"] = int(entry.get("n"))
+                        break
+                except (TypeError, ValueError):
+                    continue
         return items, int(total)

--- a/src/store_guardrails/runner.py
+++ b/src/store_guardrails/runner.py
@@ -201,43 +201,95 @@ def run_llm_review(
                 llm_findings=verdict,
                 reviewed_by_model=model,
             )
-            applied = True
+            # Two outcomes are possible AND independent here:
+            #
+            # 1. Initial-upload (v1) approval flips visibility from
+            #    'pending' to 'approved'. set_visibility_if_pending
+            #    returns True. No promotion (v1 IS current).
+            #
+            # 2. v2+ edit/restore approval doesn't flip visibility
+            #    (entity already 'approved' under deferred-promotion).
+            #    set_visibility_if_pending returns False. We MUST
+            #    still promote — copy the new version dir to live +
+            #    bump entity.version_no/version/file_size.
+            #
+            # 3. Admin archived the row mid-flight: visibility =
+            #    'archived'. set_visibility_if_pending returns False
+            #    AND we must NOT promote. Detect via the row's
+            #    current visibility, not via the flip's return value.
+            #
+            # The flip's return value alone can't distinguish (2)
+            # from (3). Inspect the row's actual state to decide.
+            visibility_flipped = False
+            promoted_to: Optional[int] = None
+            superseded_reason: Optional[str] = None
             if entity_id:
-                # BG-task race guard: only flip when the entity is still
-                # in the review window (pending/hidden). If an admin
-                # archived the row while the LLM was thinking, leave it
-                # archived — the admin's decision wins.
-                applied = ents_repo.set_visibility_if_pending(
+                visibility_flipped = ents_repo.set_visibility_if_pending(
                     entity_id, "approved",
                 )
-            if applied:
-                audit.log(
-                    user_id=submitter_id,
-                    action="store.submission.approved",
-                    resource=f"store_submission:{submission_id}",
-                    params={"risk_level": verdict.get("risk_level"),
-                            "model": model},
-                    result="ok",
-                )
-            else:
-                # Surface the skipped flip so an operator triaging the
-                # admin queue understands why an "approved" verdict
-                # didn't publish the entity.
-                current = (ents_repo.get(entity_id) or {}).get(
-                    "visibility_status",
-                )
+                ent_row = ents_repo.get(entity_id) or {}
+                current_visibility = ent_row.get("visibility_status")
+                # Only promote when the entity is actually in a
+                # serve-able state. Archive / hidden-by-admin paths
+                # leave alone.
+                if current_visibility == "approved":
+                    sub_row = subs_repo.get(submission_id) or {}
+                    sub_hash = sub_row.get("version")
+                    target_version_no = None
+                    for entry in (ent_row.get("version_history") or []):
+                        if entry.get("hash") == sub_hash:
+                            try:
+                                target_version_no = int(entry.get("n"))
+                            except (TypeError, ValueError):
+                                target_version_no = None
+                            break
+                    if (target_version_no is not None
+                            and target_version_no != int(ent_row.get("version_no") or 0)):
+                        if ents_repo.promote_version(entity_id, target_version_no):
+                            try:
+                                from app.api.store import _swap_live_to_version
+                                _swap_live_to_version(entity_id, target_version_no)
+                                promoted_to = target_version_no
+                            except Exception:
+                                logger.exception(
+                                    "promote_version live swap failed for entity %s v%d",
+                                    entity_id, target_version_no,
+                                )
+                else:
+                    # Entity left the serve-able states between BG
+                    # task start + verdict-write. Record so admin
+                    # triaging the queue sees why an "approved"
+                    # verdict didn't change the live state.
+                    superseded_reason = (
+                        f"entity left review window before LLM verdict "
+                        f"landed (current visibility: {current_visibility})"
+                    )
+
+            # Audit the verdict + the action taken.
+            if superseded_reason:
                 audit.log(
                     user_id=submitter_id,
                     action="store.submission.bg_verdict_skipped",
                     resource=f"store_submission:{submission_id}",
                     params={
                         "attempted_verdict": "approved",
-                        "current_visibility": current,
-                        "reason": "entity left review window before "
-                                  "LLM verdict landed (admin action)",
+                        "reason": superseded_reason,
                         "model": model,
                     },
                     result="skipped",
+                )
+            else:
+                audit.log(
+                    user_id=submitter_id,
+                    action="store.submission.approved",
+                    resource=f"store_submission:{submission_id}",
+                    params={
+                        "risk_level": verdict.get("risk_level"),
+                        "model": model,
+                        "visibility_flipped": visibility_flipped,
+                        "promoted_to_version_no": promoted_to,
+                    },
+                    result="ok",
                 )
         else:
             subs_repo.update_status(
@@ -246,8 +298,17 @@ def run_llm_review(
                 llm_findings=verdict,
                 reviewed_by_model=model,
             )
-            # Entity stays at visibility_status='pending' — invisible in
-            # the flea browse for non-admins. Admin can override.
+            # On block, entity state depends on which path triggered
+            # this submission:
+            #
+            # - Initial v1 upload: visibility='pending' (invisible to
+            #   non-admins). Admin can override.
+            # - v2+ edit / restore (deferred promotion): entity stays
+            #   'approved' at the prior version. Existing installers
+            #   keep receiving the previously approved bundle; nothing
+            #   to roll back. The submission row carries the verdict
+            #   so admin can Override + publish if the block was a
+            #   false positive.
             audit.log(
                 user_id=submitter_id,
                 action="store.submission.blocked_llm",

--- a/tests/test_db_schema_version.py
+++ b/tests/test_db_schema_version.py
@@ -50,17 +50,27 @@ def test_schema_version_is_37():
     #            in the visibility gates. Value-list invariant remains
     #            enforced application-side (DuckDB ADD CHECK on existing
     #            column not supported).
-    # v36 → v37 (this PR): curated marketplace enrichment from
+    # v36 → v37: curated marketplace enrichment from
     #            `.claude-plugin/agnes-metadata.json` plus mandatory curator
     #            identity on marketplace_registry. Adds curator_name +
     #            curator_email to marketplace_registry, and
     #            cover_photo_url + video_url + doc_links to
     #            marketplace_plugins.
-    assert SCHEMA_VERSION == 37
+    # v37 → v38 (this PR): flea-market edit feature with version
+    #            history. Adds store_entities.version_no INTEGER and
+    #            version_history JSON. Each new bundle upload via
+    #            PUT bumps version_no and appends to version_history;
+    #            metadata-only edits don't bump. Existing rows backfill
+    #            to version_no=1 with a single-entry history seeded
+    #            from the row's current `version` (hash). Bundle bytes
+    #            for each version live on disk under
+    #            ${DATA_DIR}/store/<id>/versions/v<N>/plugin/.
+    assert SCHEMA_VERSION == 38
 
 
 def test_v37_marketplace_curator_columns(tmp_path):
-    """Fresh install reaches v37 with the new marketplace columns present."""
+    """Fresh install reaches the current schema with the v37 marketplace
+    columns present."""
     db_path = tmp_path / "system.duckdb"
     conn = duckdb.connect(str(db_path))
     _ensure_schema(conn)
@@ -87,9 +97,10 @@ def test_v37_marketplace_curator_columns(tmp_path):
     conn.close()
 
 
-def test_v36_db_migrates_to_v37(tmp_path):
-    """Pre-existing v36 DB (with the v36 schema) upgrades cleanly to v37 without
-    losing existing marketplace_registry / marketplace_plugins rows."""
+def test_v36_db_migrates_to_current(tmp_path):
+    """Pre-existing v36 DB upgrades cleanly through v37 (curator
+    enrichment) and v38 (flea edit version history) without losing
+    existing rows."""
     db_path = tmp_path / "system.duckdb"
     conn = duckdb.connect(str(db_path))
 
@@ -128,7 +139,7 @@ def test_v36_db_migrates_to_v37(tmp_path):
     _ensure_schema(conn)
     assert get_schema_version(conn) == SCHEMA_VERSION
 
-    # New columns exist and existing rows preserved with NULL enrichment.
+    # v37 enrichment columns exist; existing rows preserved with NULL.
     row = conn.execute(
         "SELECT curator_name, curator_email FROM marketplace_registry "
         "WHERE id = 'legacy'"

--- a/tests/test_store_entity_versions.py
+++ b/tests/test_store_entity_versions.py
@@ -1,0 +1,1000 @@
+"""v37 flea-market edit feature with version history.
+
+Covers:
+* Bundle update bumps version_no + appends version_history entry.
+* Metadata-only edit doesn't bump version.
+* Type change rejected with 400 type_locked.
+* Block-while-pending: 409 prior_version_pending.
+* Display name change renames the on-disk slug for live + version dirs.
+* Restore copies a prior version forward as v<max+1>; live + history
+  reflect the new version; original version row keeps its own verdict.
+* Restore re-runs guardrails (blocked path leaves live untouched).
+* Versions card on detail page renders for owner/admin only.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+from argon2 import PasswordHasher
+from fastapi.testclient import TestClient
+
+from app.utils import get_store_dir
+from src.db import close_system_db, get_system_db
+from src.repositories.store_entities import StoreEntitiesRepository
+from src.repositories.users import UserRepository
+
+
+@pytest.fixture
+def web_client(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("TESTING", "1")
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-min-32-characters!!")
+    (tmp_path / "state").mkdir()
+    (tmp_path / "analytics").mkdir()
+    (tmp_path / "extracts").mkdir()
+    close_system_db()
+    from app.main import create_app
+    app = create_app()
+    yield TestClient(app)
+    close_system_db()
+
+
+def _create_user(client, email, password="UserPass1!"):
+    ph = PasswordHasher()
+    conn = get_system_db()
+    user_id = email.split("@")[0]
+    UserRepository(conn).create(
+        id=user_id, email=email, name=user_id, password_hash=ph.hash(password),
+    )
+    conn.close()
+    r = client.post("/auth/token", json={"email": email, "password": password})
+    assert r.status_code == 200, r.text
+    return user_id, {"access_token": r.json()["access_token"]}
+
+
+def _create_admin(client, email="admin-edit@x.com"):
+    from tests.helpers.auth import grant_admin
+    user_id, cookies = _create_user(client, email, password="AdminPass1!")
+    conn = get_system_db()
+    grant_admin(conn, user_id)
+    conn.close()
+    return user_id, cookies
+
+
+def _make_skill_zip(skill_name: str, body: str = "Body. " * 30) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(
+            f"{skill_name}/SKILL.md",
+            f"---\nname: {skill_name}\ndescription: A clean test skill for the edit feature.\n---\n\n"
+            + body,
+        )
+    return buf.getvalue()
+
+
+def _make_eval_skill_zip(skill_name: str) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(
+            f"{skill_name}/SKILL.md",
+            f"---\nname: {skill_name}\ndescription: A bad test skill.\n---\n\n"
+            + ("Body. " * 30),
+        )
+        zf.writestr(f"{skill_name}/run.sh", "#!/bin/sh\neval $1\n")
+    return buf.getvalue()
+
+
+def _upload_clean(client, cookies, name="ed1"):
+    r = client.post(
+        "/api/store/entities",
+        files={"file": ("s.zip", _make_skill_zip(name), "application/zip")},
+        data={"type": "skill"}, cookies=cookies,
+    )
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+class TestEditFeature:
+    def test_metadata_only_edit_no_version_bump(self, web_client):
+        owner_id, owner_cookies = _create_user(web_client, "metaowner@x.com")
+        eid = _upload_clean(web_client, owner_cookies, name="metaedit")
+
+        r = web_client.put(
+            f"/api/store/entities/{eid}",
+            data={"description": "Updated description text"},
+            cookies=owner_cookies,
+        )
+        assert r.status_code == 200, r.text
+
+        conn = get_system_db()
+        entity = StoreEntitiesRepository(conn).get(eid)
+        conn.close()
+        assert entity["description"] == "Updated description text"
+        assert entity["version_no"] == 1
+        assert len(entity["version_history"]) == 1
+
+    def test_bundle_edit_bumps_version_and_appends_history(self, web_client):
+        owner_id, owner_cookies = _create_user(web_client, "bundleowner@x.com")
+        eid = _upload_clean(web_client, owner_cookies, name="bundleedit")
+
+        # PUT with new bundle bytes.
+        new_zip = _make_skill_zip("bundleedit", body="V2 body. " * 30)
+        r = web_client.put(
+            f"/api/store/entities/{eid}",
+            files={"file": ("v2.zip", new_zip, "application/zip")},
+            cookies=owner_cookies,
+        )
+        assert r.status_code == 200, r.text
+
+        conn = get_system_db()
+        entity = StoreEntitiesRepository(conn).get(eid)
+        conn.close()
+        assert entity["version_no"] == 2
+        assert len(entity["version_history"]) == 2
+        v1, v2 = entity["version_history"]
+        assert v1["n"] == 1
+        assert v2["n"] == 2
+        assert v2["hash"] != v1["hash"], "v2 hash must differ from v1"
+
+    def test_type_change_rejected(self, web_client):
+        owner_id, owner_cookies = _create_user(web_client, "typeowner@x.com")
+        eid = _upload_clean(web_client, owner_cookies, name="typelock")
+        r = web_client.put(
+            f"/api/store/entities/{eid}",
+            data={"type": "agent"},
+            cookies=owner_cookies,
+        )
+        assert r.status_code == 400, r.text
+        assert r.json()["detail"]["code"] == "type_locked"
+
+    def test_block_while_prior_pending_409(self, web_client):
+        """Manually flip the entity to visibility=pending + create a
+        pending submission, then attempt edit → 409."""
+        from src.repositories.store_submissions import StoreSubmissionsRepository
+        owner_id, owner_cookies = _create_user(web_client, "blockowner@x.com")
+        eid = _upload_clean(web_client, owner_cookies, name="blockpending")
+
+        conn = get_system_db()
+        # Force pending state.
+        conn.execute(
+            "UPDATE store_entities SET visibility_status = 'pending' WHERE id = ?",
+            [eid],
+        )
+        StoreSubmissionsRepository(conn).create(
+            submitter_id=owner_id, submitter_email="blockowner@x.com",
+            type="skill", name="blockpending", version="2.0.0",
+            status="pending_llm", entity_id=eid,
+            inline_checks={"manifest": {"status": "pass"}},
+        )
+        conn.close()
+
+        r = web_client.put(
+            f"/api/store/entities/{eid}",
+            data={"description": "Trying to edit"},
+            cookies=owner_cookies,
+        )
+        assert r.status_code == 409, r.text
+        assert r.json()["detail"]["code"] == "prior_version_pending"
+
+    def test_name_change_renames_baked_slug(self, web_client):
+        owner_id, owner_cookies = _create_user(web_client, "renameowner@x.com")
+        eid = _upload_clean(web_client, owner_cookies, name="oldname")
+
+        r = web_client.put(
+            f"/api/store/entities/{eid}",
+            data={"name": "newname"},
+            cookies=owner_cookies,
+        )
+        assert r.status_code == 200, r.text
+
+        conn = get_system_db()
+        entity = StoreEntitiesRepository(conn).get(eid)
+        conn.close()
+        assert entity["name"] == "newname"
+
+        plugin_dir = Path(get_store_dir()) / eid / "plugin"
+        new_skill_dir = plugin_dir / "skills" / "newname-by-renameowner"
+        old_skill_dir = plugin_dir / "skills" / "oldname-by-renameowner"
+        assert new_skill_dir.is_dir(), "renamed slug missing on disk"
+        assert not old_skill_dir.exists(), "old slug must be gone"
+
+
+class TestRestoreVersion:
+    def test_restore_creates_new_version_with_old_bundle(self, web_client):
+        owner_id, owner_cookies = _create_user(web_client, "restoreowner@x.com")
+        eid = _upload_clean(web_client, owner_cookies, name="restoreme")
+
+        # Edit to v2.
+        v2_zip = _make_skill_zip("restoreme", body="VERSION-2-BODY " * 20)
+        r = web_client.put(
+            f"/api/store/entities/{eid}",
+            files={"file": ("v2.zip", v2_zip, "application/zip")},
+            cookies=owner_cookies,
+        )
+        assert r.status_code == 200, r.text
+
+        # Capture v1 + v2 hashes from history.
+        conn = get_system_db()
+        entity = StoreEntitiesRepository(conn).get(eid)
+        conn.close()
+        v1_hash = entity["version_history"][0]["hash"]
+        v2_hash = entity["version_history"][1]["hash"]
+        assert v1_hash != v2_hash
+
+        # Restore v1 → creates v3 with v1's bundle hash.
+        r = web_client.post(
+            f"/api/store/entities/{eid}/versions/1/restore",
+            cookies=owner_cookies,
+        )
+        assert r.status_code == 200, r.text
+
+        conn = get_system_db()
+        entity = StoreEntitiesRepository(conn).get(eid)
+        conn.close()
+        assert entity["version_no"] == 3
+        assert len(entity["version_history"]) == 3
+        v3 = entity["version_history"][2]
+        assert v3["n"] == 3
+        assert v3["hash"] == v1_hash, (
+            "restored bundle should hash identically to v1 — same bytes"
+        )
+
+    def test_restore_already_current_400(self, web_client):
+        owner_id, owner_cookies = _create_user(web_client, "alreadyowner@x.com")
+        eid = _upload_clean(web_client, owner_cookies, name="already")
+        r = web_client.post(
+            f"/api/store/entities/{eid}/versions/1/restore",
+            cookies=owner_cookies,
+        )
+        assert r.status_code == 400, r.text
+        assert r.json()["detail"]["code"] == "already_current"
+
+    def test_restore_unknown_version_404(self, web_client):
+        owner_id, owner_cookies = _create_user(web_client, "unknownver@x.com")
+        eid = _upload_clean(web_client, owner_cookies, name="ukver")
+        r = web_client.post(
+            f"/api/store/entities/{eid}/versions/99/restore",
+            cookies=owner_cookies,
+        )
+        assert r.status_code == 404, r.text
+        assert r.json()["detail"]["code"] == "version_not_found"
+
+    def test_non_owner_non_admin_cannot_restore(self, web_client):
+        owner_id, owner_cookies = _create_user(web_client, "owrestore@x.com")
+        eid = _upload_clean(web_client, owner_cookies, name="ownedver")
+        v2 = _make_skill_zip("ownedver", body="v2 " * 30)
+        web_client.put(
+            f"/api/store/entities/{eid}",
+            files={"file": ("v2.zip", v2, "application/zip")},
+            cookies=owner_cookies,
+        )
+
+        _, snoop_cookies = _create_user(web_client, "snoopver@x.com")
+        r = web_client.post(
+            f"/api/store/entities/{eid}/versions/1/restore",
+            cookies=snoop_cookies,
+        )
+        assert r.status_code in (403, 404), r.text
+
+
+class TestEditPage:
+    def test_edit_page_renders_for_owner(self, web_client):
+        owner_id, owner_cookies = _create_user(web_client, "editpage@x.com")
+        eid = _upload_clean(web_client, owner_cookies, name="editrender")
+        r = web_client.get(
+            f"/marketplace/flea/{eid}/edit", cookies=owner_cookies,
+        )
+        assert r.status_code == 200
+        assert "edit-form" in r.text
+        assert "editrender" in r.text
+
+    def test_edit_page_404_for_non_owner(self, web_client):
+        owner_id, owner_cookies = _create_user(web_client, "owneredit@x.com")
+        eid = _upload_clean(web_client, owner_cookies, name="snoopedit")
+        _, snoop_cookies = _create_user(web_client, "snoopedit@x.com")
+        r = web_client.get(
+            f"/marketplace/flea/{eid}/edit", cookies=snoop_cookies,
+        )
+        assert r.status_code == 404
+
+    def test_versions_card_renders_for_owner(self, web_client):
+        owner_id, owner_cookies = _create_user(web_client, "vowner@x.com")
+        eid = _upload_clean(web_client, owner_cookies, name="vcard")
+        r = web_client.get(
+            f"/marketplace/flea/{eid}", cookies=owner_cookies,
+        )
+        assert r.status_code == 200
+        assert "versions-card" in r.text
+        assert "Versions (1)" in r.text
+
+    def test_versions_card_hidden_for_non_owner(self, web_client):
+        owner_id, owner_cookies = _create_user(web_client, "vowner2@x.com")
+        eid = _upload_clean(web_client, owner_cookies, name="vhide")
+        _, other_cookies = _create_user(web_client, "vother@x.com")
+        r = web_client.get(
+            f"/marketplace/flea/{eid}", cookies=other_cookies,
+        )
+        assert r.status_code == 200
+        assert "versions-card" not in r.text
+
+
+class TestInstallerAlwaysGetsLatestApproved:
+    """Critical contract: existing installers continue receiving the
+    last APPROVED version through the review window of a new edit, and
+    NEVER receive an unapproved version. If the new version is blocked,
+    they keep the prior approved one. If approved, they advance.
+
+    Implemented via deferred promotion: PUT/restore append the new
+    version to history at status='pending_llm' but DO NOT swap live
+    or bump entity.version_no. runner.run_llm_review's approval branch
+    promotes; on block, nothing changes.
+    """
+
+    def _install_as_user(self, web_client, owner_cookies, eid):
+        """Install as a separate consumer user, return their list_for_user
+        rows post-install (mirrors what marketplace.zip serves)."""
+        from src.repositories.user_store_installs import UserStoreInstallsRepository
+        installer_id, installer_cookies = _create_user(web_client, "installer@x.com")
+        r = web_client.post(
+            f"/api/store/entities/{eid}/install",
+            cookies=installer_cookies,
+        )
+        assert r.status_code == 200, r.text
+        return installer_id, installer_cookies
+
+    def test_pending_review_does_not_break_existing_installer(self, web_client, monkeypatch):
+        """Initial upload runs with guardrails OFF (lands approved).
+        Then we flip guardrails ON and PUT a new bundle. The new
+        version should defer promotion: existing installer must
+        continue seeing v1 + entity.version_no=1, not get hidden by a
+        flipped visibility or a half-promoted live dir."""
+        from app import instance_config as ic
+        # Stub LLM scheduling so the BG path never actually runs.
+        monkeypatch.setattr(
+            "app.api.store._schedule_llm_review",
+            lambda *a, **kw: None,
+        )
+
+        owner_id, owner_cookies = _create_user(web_client, "stickyowner@x.com")
+        # Phase 1: guardrails OFF → initial upload lands approved.
+        eid = _upload_clean(web_client, owner_cookies, name="sticky")
+        # Capture v1 hash + size baseline.
+        conn = get_system_db()
+        ent = StoreEntitiesRepository(conn).get(eid)
+        v1_hash = ent["version"]
+        v1_size = ent["file_size"]
+        conn.close()
+
+        # Install as a different user.
+        installer_id, _ = self._install_as_user(web_client, owner_cookies, eid)
+
+        # Phase 2: flip guardrails ON for the PUT call. Now an edit
+        # defers promotion until LLM approves.
+        # Patch where update_entity looks it up — `from app.instance_config
+        # import get_guardrails_enabled` binds the symbol into app.api.store,
+        # so patching the source module isn't enough.
+        monkeypatch.setattr("app.api.store.get_guardrails_enabled", lambda: True)
+
+        # PUT a new bundle. Guardrails on → submission lands at
+        # pending_llm; promotion deferred.
+        v2_zip = _make_skill_zip("sticky", body="V2 BODY " * 30)
+        r = web_client.put(
+            f"/api/store/entities/{eid}",
+            files={"file": ("v2.zip", v2_zip, "application/zip")},
+            cookies=owner_cookies,
+        )
+        assert r.status_code == 200, r.text
+
+        # Installer's list_for_user must STILL see entity with v1 hash
+        # + size + visibility='approved'. The pending edit must not
+        # have hidden the entity from them.
+        from src.repositories.user_store_installs import UserStoreInstallsRepository
+        conn = get_system_db()
+        installs = UserStoreInstallsRepository(conn).list_for_user(installer_id)
+        ids = {r["id"] for r in installs}
+        assert eid in ids, (
+            "installer lost access to the entity during the LLM "
+            "review window — list_for_user filter excluded it"
+        )
+        row = next(r for r in installs if r["id"] == eid)
+        assert row["version"] == v1_hash, (
+            f"installer should still get v1 hash {v1_hash[:8]} but "
+            f"got {row['version'][:8]}"
+        )
+        assert row["file_size"] == v1_size, "size shouldn't change pre-promotion"
+        assert row["visibility_status"] == "approved", (
+            "entity must stay 'approved' through the review window so "
+            "existing installers continue serving"
+        )
+
+        # Entity row's version_no must NOT have bumped yet.
+        ent = StoreEntitiesRepository(conn).get(eid)
+        conn.close()
+        assert ent["version_no"] == 1, (
+            f"version_no must stay 1 during pending review; got {ent['version_no']}"
+        )
+        # But version_history MUST have v2 entry tracked (with the
+        # new hash) so admin can see what's in flight.
+        history_n = [int(e["n"]) for e in ent["version_history"]]
+        assert 2 in history_n, "v2 entry must be in history despite no promotion"
+
+    def test_blocked_new_version_keeps_installer_on_prior(self, web_client, monkeypatch):
+        """Mock the LLM to BLOCK the v2 review. Installer must keep
+        v1; entity.version_no must stay at 1; live plugin/ must hold
+        v1's bytes."""
+        from app import instance_config as ic
+
+        # Mock the runner's LLM call to return a high-risk verdict.
+        def mock_review_bundle(*args, **kwargs):
+            return {
+                "risk_level": "high",
+                "summary": "mock block",
+                "findings": [{"severity": "high", "category": "test",
+                              "file": "x", "explanation": "mock"}],
+                "template_placeholders_found": 0,
+                "reviewed_by_model": "mock-model",
+                "error": None,
+            }
+
+        monkeypatch.setattr(
+            "src.store_guardrails.llm_review.review_bundle",
+            mock_review_bundle,
+        )
+
+        # Phase 1: initial upload guardrails OFF.
+        owner_id, owner_cookies = _create_user(web_client, "blockowner@x.com")
+        eid = _upload_clean(web_client, owner_cookies, name="blocksticky")
+        # Phase 2: switch guardrails ON before PUT.
+        # Patch where update_entity looks it up — `from app.instance_config
+        # import get_guardrails_enabled` binds the symbol into app.api.store,
+        # so patching the source module isn't enough.
+        monkeypatch.setattr("app.api.store.get_guardrails_enabled", lambda: True)
+        conn = get_system_db()
+        v1_hash = StoreEntitiesRepository(conn).get(eid)["version"]
+        conn.close()
+
+        installer_id, _ = self._install_as_user(web_client, owner_cookies, eid)
+
+        # Edit. Inline checks pass; LLM mocked to block.
+        v2_zip = _make_skill_zip("blocksticky", body="v2-content " * 30)
+        # Run the LLM synchronously by calling runner directly after
+        # the PUT (the BG task may not have fired in TestClient).
+        r = web_client.put(
+            f"/api/store/entities/{eid}",
+            files={"file": ("v2.zip", v2_zip, "application/zip")},
+            cookies=owner_cookies,
+        )
+        assert r.status_code == 200, r.text
+
+        # Find the just-created submission + run runner against it.
+        from src.repositories.store_submissions import StoreSubmissionsRepository
+        from src.store_guardrails.runner import run_llm_review
+        from app.utils import get_store_dir
+        conn = get_system_db()
+        sub_id = StoreSubmissionsRepository(conn).latest_for_entity(eid)["id"]
+        conn.close()
+        run_llm_review(
+            sub_id,
+            plugin_dir=Path(get_store_dir()) / eid / "versions" / "v2" / "plugin",
+            conn_factory=get_system_db,
+            api_key_loader=lambda: "sk-test",
+            model_loader=lambda: "claude-haiku-4-5-20251001",
+        )
+
+        # Installer must STILL see v1.
+        from src.repositories.user_store_installs import UserStoreInstallsRepository
+        conn = get_system_db()
+        installs = UserStoreInstallsRepository(conn).list_for_user(installer_id)
+        ent = StoreEntitiesRepository(conn).get(eid)
+        conn.close()
+
+        row = next(r for r in installs if r["id"] == eid)
+        assert row["version"] == v1_hash, (
+            f"after v2 blocked, installer must still get v1 hash; got {row['version'][:8]}"
+        )
+        assert ent["version_no"] == 1, (
+            f"version_no must stay at 1 after a blocked verdict; got {ent['version_no']}"
+        )
+
+    def test_approved_new_version_promotes_to_installer(self, web_client):
+        """Default test path: guardrails OFF → guardrails-disabled
+        promote-inline branch fires immediately. Installer's next
+        list_for_user reflects v2."""
+        owner_id, owner_cookies = _create_user(web_client, "promoowner@x.com")
+        eid = _upload_clean(web_client, owner_cookies, name="promosticky")
+        conn = get_system_db()
+        v1_hash = StoreEntitiesRepository(conn).get(eid)["version"]
+        conn.close()
+
+        installer_id, _ = self._install_as_user(web_client, owner_cookies, eid)
+
+        v2_zip = _make_skill_zip("promosticky", body="promo-v2 " * 30)
+        r = web_client.put(
+            f"/api/store/entities/{eid}",
+            files={"file": ("v2.zip", v2_zip, "application/zip")},
+            cookies=owner_cookies,
+        )
+        assert r.status_code == 200, r.text
+
+        # Installer should now see v2 hash.
+        from src.repositories.user_store_installs import UserStoreInstallsRepository
+        conn = get_system_db()
+        installs = UserStoreInstallsRepository(conn).list_for_user(installer_id)
+        ent = StoreEntitiesRepository(conn).get(eid)
+        conn.close()
+
+        assert ent["version_no"] == 2
+        row = next(r for r in installs if r["id"] == eid)
+        assert row["version"] != v1_hash, "installer should advance to v2"
+
+
+class TestAdminAccess:
+    """Admin can edit + restore on entities they don't own (parity with
+    the existing admin override path)."""
+
+    def test_admin_can_edit_non_owned_entity_metadata(self, web_client):
+        owner_id, owner_cookies = _create_user(web_client, "adminedit-owner@x.com")
+        eid = _upload_clean(web_client, owner_cookies, name="adminedit")
+        _, admin_cookies = _create_admin(web_client)
+        r = web_client.put(
+            f"/api/store/entities/{eid}",
+            data={"description": "moderated by admin"},
+            cookies=admin_cookies,
+        )
+        assert r.status_code == 200, r.text
+        conn = get_system_db()
+        ent = StoreEntitiesRepository(conn).get(eid)
+        conn.close()
+        assert ent["description"] == "moderated by admin"
+        assert ent["version_no"] == 1
+
+    def test_admin_can_restore_non_owned_entity(self, web_client):
+        owner_id, owner_cookies = _create_user(web_client, "adminrestore-owner@x.com")
+        eid = _upload_clean(web_client, owner_cookies, name="adminrestore")
+        v2 = _make_skill_zip("adminrestore", body="v2 " * 30)
+        web_client.put(
+            f"/api/store/entities/{eid}",
+            files={"file": ("v2.zip", v2, "application/zip")},
+            cookies=owner_cookies,
+        )
+        _, admin_cookies = _create_admin(web_client)
+        r = web_client.post(
+            f"/api/store/entities/{eid}/versions/1/restore",
+            cookies=admin_cookies,
+        )
+        assert r.status_code == 200, r.text
+        conn = get_system_db()
+        ent = StoreEntitiesRepository(conn).get(eid)
+        conn.close()
+        assert ent["version_no"] == 3
+
+
+class TestRestoreDeferredPromotion:
+    """Restore endpoint mirrors PUT semantics: live + version_no stay
+    on prior current until LLM approves the restored copy."""
+
+    def test_restore_with_guardrails_on_does_not_promote_until_approved(
+        self, web_client, monkeypatch,
+    ):
+        """Owner restores v1 → restored bytes baked into v3 dir.
+        Until LLM approves, live + version_no stay at v2."""
+        owner_id, owner_cookies = _create_user(web_client, "restoreowner-defer@x.com")
+        eid = _upload_clean(web_client, owner_cookies, name="restoredefer")
+        v2 = _make_skill_zip("restoredefer", body="v2 " * 30)
+        web_client.put(
+            f"/api/store/entities/{eid}",
+            files={"file": ("v2.zip", v2, "application/zip")},
+            cookies=owner_cookies,
+        )
+        # v2 promoted (guardrails off). Now flip on for the restore.
+        monkeypatch.setattr("app.api.store.get_guardrails_enabled", lambda: True)
+        monkeypatch.setattr(
+            "app.api.store._schedule_llm_review",
+            lambda *a, **kw: None,
+        )
+        r = web_client.post(
+            f"/api/store/entities/{eid}/versions/1/restore",
+            cookies=owner_cookies,
+        )
+        assert r.status_code == 200, r.text
+        conn = get_system_db()
+        ent = StoreEntitiesRepository(conn).get(eid)
+        conn.close()
+        # version_no must STAY at 2 until LLM approves the v3 (restored)
+        # copy. version_history has 3 entries; current is still 2.
+        assert ent["version_no"] == 2, (
+            f"restore must defer promotion when guardrails on; "
+            f"version_no={ent['version_no']}"
+        )
+        history_n = sorted([int(e["n"]) for e in ent["version_history"]])
+        assert history_n == [1, 2, 3]
+
+
+class TestEditPageBanner:
+    """Detail page banner during pending edit review must surface
+    the version under review + the prior version still serving."""
+
+    def test_banner_shows_version_n_under_review(self, web_client, monkeypatch):
+        from src.repositories.store_submissions import StoreSubmissionsRepository
+        owner_id, owner_cookies = _create_user(web_client, "bannerowner@x.com")
+        eid = _upload_clean(web_client, owner_cookies, name="bannerver")
+
+        # Switch guardrails on; stub LLM scheduler so v2 stays pending.
+        monkeypatch.setattr("app.api.store.get_guardrails_enabled", lambda: True)
+        monkeypatch.setattr(
+            "app.api.store._schedule_llm_review",
+            lambda *a, **kw: None,
+        )
+
+        v2 = _make_skill_zip("bannerver", body="v2 " * 30)
+        web_client.put(
+            f"/api/store/entities/{eid}",
+            files={"file": ("v2.zip", v2, "application/zip")},
+            cookies=owner_cookies,
+        )
+        # v2 review pending. visibility on entity stays approved (per
+        # the deferred-promotion fix). But banner partial reads sub
+        # status — for an in-flight edit submission the banner won't
+        # render unless visibility != approved. Lock the scenario:
+        # ensure entity stays at version_no=1 + visibility approved.
+        conn = get_system_db()
+        ent = StoreEntitiesRepository(conn).get(eid)
+        sub = StoreSubmissionsRepository(conn).latest_for_entity(eid)
+        conn.close()
+        assert ent["version_no"] == 1
+        assert ent["visibility_status"] == "approved"
+        assert sub["status"] == "pending_llm"
+
+        # Detail page renders. Banner partial only fires when
+        # visibility_status != approved, so for a deferred-edit case
+        # the marketplace detail does NOT render the quarantine
+        # banner — that's correct UX (consumers see the entity as
+        # approved and operational). Owner-facing review status
+        # surfaces via the Edit button being disabled.
+        r = web_client.get(
+            f"/marketplace/flea/{eid}", cookies=owner_cookies,
+        )
+        assert r.status_code == 200
+        # Edit button should reflect the in-flight review (locked).
+        assert "review in flight" in r.text or "Edit (review in flight)" in r.text
+
+
+class TestAuditLogPerVersion:
+    """Each edit / restore writes audit rows carrying the version_no
+    in params, so the entity timeline can attribute events to the
+    right version."""
+
+    def test_edit_audit_carries_version_no(self, web_client):
+        from src.repositories.audit import AuditRepository
+        owner_id, owner_cookies = _create_user(web_client, "auditver@x.com")
+        eid = _upload_clean(web_client, owner_cookies, name="auditver")
+        v2 = _make_skill_zip("auditver", body="v2 " * 30)
+        web_client.put(
+            f"/api/store/entities/{eid}",
+            files={"file": ("v2.zip", v2, "application/zip")},
+            cookies=owner_cookies,
+        )
+
+        conn = get_system_db()
+        rows = AuditRepository(conn).query_for_resources(
+            [f"store_entity:{eid}"], limit=20,
+        )
+        conn.close()
+        # store.entity.update event for the edit must carry version_no
+        # in its params.
+        update_rows = [r for r in rows if r.get("action") == "store.entity.update"]
+        assert update_rows, "missing store.entity.update audit"
+        assert any(
+            (r.get("params") or {}).get("version_no") == 2
+            for r in update_rows
+        ), "update audit must carry version_no=2 in params"
+
+    def test_restore_audit_carries_versions(self, web_client):
+        from src.repositories.audit import AuditRepository
+        owner_id, owner_cookies = _create_user(web_client, "auditrestore@x.com")
+        eid = _upload_clean(web_client, owner_cookies, name="auditrest")
+        v2 = _make_skill_zip("auditrest", body="v2 " * 30)
+        web_client.put(
+            f"/api/store/entities/{eid}",
+            files={"file": ("v2.zip", v2, "application/zip")},
+            cookies=owner_cookies,
+        )
+        web_client.post(
+            f"/api/store/entities/{eid}/versions/1/restore",
+            cookies=owner_cookies,
+        )
+
+        conn = get_system_db()
+        rows = AuditRepository(conn).query_for_resources(
+            [f"store_entity:{eid}"], limit=20,
+        )
+        conn.close()
+        restore_rows = [r for r in rows if r.get("action") == "store.entity.restore"]
+        assert restore_rows, "missing store.entity.restore audit"
+        params = restore_rows[0].get("params") or {}
+        assert params.get("restored_from_version_no") == 1
+        assert params.get("new_version_no") == 3
+
+
+class TestPRReviewFixes:
+    """Locks in the fixes called out in the PR #239 review."""
+
+    def test_block_while_pending_fires_for_v2_edit_under_deferred_promotion(
+        self, web_client, monkeypatch,
+    ):
+        """#1 — v2+ edit during in-flight LLM review must 409 even
+        though entity.visibility_status is still 'approved'."""
+        from src.repositories.store_submissions import StoreSubmissionsRepository
+        owner_id, owner_cookies = _create_user(web_client, "blockv2@x.com")
+        eid = _upload_clean(web_client, owner_cookies, name="blockv2")
+
+        # Switch guardrails on for the edit so promotion defers.
+        monkeypatch.setattr("app.api.store.get_guardrails_enabled", lambda: True)
+        monkeypatch.setattr(
+            "app.api.store._schedule_llm_review",
+            lambda *a, **kw: None,
+        )
+
+        v2 = _make_skill_zip("blockv2", body="v2 " * 30)
+        r = web_client.put(
+            f"/api/store/entities/{eid}",
+            files={"file": ("v2.zip", v2, "application/zip")},
+            cookies=owner_cookies,
+        )
+        assert r.status_code == 200, r.text
+
+        # Entity should remain at 'approved' visibility — v2 in flight.
+        conn = get_system_db()
+        ent = StoreEntitiesRepository(conn).get(eid)
+        sub = StoreSubmissionsRepository(conn).latest_for_entity(eid)
+        conn.close()
+        assert ent["visibility_status"] == "approved"
+        assert sub["status"] == "pending_llm"
+
+        # Second concurrent edit MUST be blocked.
+        v3 = _make_skill_zip("blockv2", body="v3 " * 30)
+        r = web_client.put(
+            f"/api/store/entities/{eid}",
+            files={"file": ("v3.zip", v3, "application/zip")},
+            cookies=owner_cookies,
+        )
+        assert r.status_code == 409, r.text
+        assert r.json()["detail"]["code"] == "prior_version_pending"
+
+    def test_name_change_with_bundle_does_not_rename_live_until_promote(
+        self, web_client, monkeypatch,
+    ):
+        """#2 — name + bundle in same PUT must NOT rename live until
+        the LLM approves and promotion runs. Existing installer keeps
+        getting the prior bundle under the prior slug."""
+        from app.utils import get_store_dir
+        owner_id, owner_cookies = _create_user(web_client, "rename-defer@x.com")
+        eid = _upload_clean(web_client, owner_cookies, name="origname")
+
+        plugin_dir = Path(get_store_dir()) / eid / "plugin"
+        old_skill_dir = plugin_dir / "skills" / "origname-by-rename-defer"
+        assert old_skill_dir.is_dir()
+
+        # Enable guardrails so promotion defers.
+        monkeypatch.setattr("app.api.store.get_guardrails_enabled", lambda: True)
+        monkeypatch.setattr(
+            "app.api.store._schedule_llm_review",
+            lambda *a, **kw: None,
+        )
+
+        v2 = _make_skill_zip("origname", body="v2 " * 30)
+        r = web_client.put(
+            f"/api/store/entities/{eid}",
+            files={"file": ("v2.zip", v2, "application/zip")},
+            data={"name": "newname"},
+            cookies=owner_cookies,
+        )
+        assert r.status_code == 200, r.text
+
+        # Live skill dir MUST still hold the old slug — promotion
+        # hasn't fired since we stubbed _schedule_llm_review.
+        assert old_skill_dir.is_dir(), (
+            "live skill dir was renamed before LLM approval — "
+            "violates deferred-promotion contract"
+        )
+        new_skill_dir = plugin_dir / "skills" / "newname-by-rename-defer"
+        assert not new_skill_dir.exists(), (
+            "live shouldn't have the renamed slug yet"
+        )
+        # Version dir HAS been renamed (so promotion will land on the
+        # new slug).
+        v2_dir = (
+            Path(get_store_dir()) / eid / "versions" / "v2" / "plugin"
+            / "skills" / "newname-by-rename-defer"
+        )
+        assert v2_dir.is_dir(), "version dir should carry the new slug"
+
+    def test_v2_approval_logs_approved_not_skipped(
+        self, web_client, monkeypatch,
+    ):
+        """#3 — v2+ approvals must log store.submission.approved, NOT
+        store.submission.bg_verdict_skipped. Pre-fix the runner used
+        the visibility-flip return value to gate the audit; under
+        deferred promotion v2+ never flips visibility (already
+        'approved'), so the wrong audit was emitted."""
+        from src.repositories.audit import AuditRepository
+        from src.repositories.store_submissions import StoreSubmissionsRepository
+        from src.store_guardrails.runner import run_llm_review
+        from app.utils import get_store_dir
+
+        owner_id, owner_cookies = _create_user(web_client, "auditv2@x.com")
+        eid = _upload_clean(web_client, owner_cookies, name="auditv2")
+
+        # Enable guardrails for the edit. Stub LLM scheduler so we
+        # control when the runner fires.
+        monkeypatch.setattr("app.api.store.get_guardrails_enabled", lambda: True)
+        monkeypatch.setattr(
+            "app.api.store._schedule_llm_review",
+            lambda *a, **kw: None,
+        )
+        # Mock the LLM call to return a safe verdict.
+        monkeypatch.setattr(
+            "src.store_guardrails.llm_review.review_bundle",
+            lambda *a, **kw: {
+                "risk_level": "safe", "summary": "ok",
+                "findings": [], "template_placeholders_found": 0,
+                "reviewed_by_model": "mock", "error": None,
+            },
+        )
+
+        v2 = _make_skill_zip("auditv2", body="v2 " * 30)
+        web_client.put(
+            f"/api/store/entities/{eid}",
+            files={"file": ("v2.zip", v2, "application/zip")},
+            cookies=owner_cookies,
+        )
+
+        # Manually fire the runner against the v2 dir.
+        conn = get_system_db()
+        sub_id = StoreSubmissionsRepository(conn).latest_for_entity(eid)["id"]
+        conn.close()
+        run_llm_review(
+            sub_id,
+            plugin_dir=Path(get_store_dir()) / eid / "versions" / "v2" / "plugin",
+            conn_factory=get_system_db,
+            api_key_loader=lambda: "sk-test",
+            model_loader=lambda: "claude-haiku-4-5-20251001",
+        )
+
+        # Audit log must contain store.submission.approved with
+        # promoted_to_version_no=2; NO bg_verdict_skipped.
+        conn = get_system_db()
+        rows = AuditRepository(conn).query_for_resources(
+            [f"store_submission:{sub_id}"], limit=20,
+        )
+        conn.close()
+        actions = [r.get("action") for r in rows]
+        assert "store.submission.approved" in actions, (
+            f"v2 approval missing approved audit; got {actions}"
+        )
+        assert "store.submission.bg_verdict_skipped" not in actions, (
+            f"v2 approval should NOT log bg_verdict_skipped; got {actions}"
+        )
+        approved_row = next(
+            r for r in rows if r.get("action") == "store.submission.approved"
+        )
+        params = approved_row.get("params") or {}
+        assert params.get("promoted_to_version_no") == 2
+
+    def test_bg_verdict_skipped_when_admin_archives_during_review(
+        self, web_client, monkeypatch,
+    ):
+        """Negative: when admin DOES archive mid-review, the runner
+        correctly logs bg_verdict_skipped (not approved)."""
+        from src.repositories.audit import AuditRepository
+        from src.repositories.store_submissions import StoreSubmissionsRepository
+        from src.repositories.store_entities import StoreEntitiesRepository
+        from src.store_guardrails.runner import run_llm_review
+        from app.utils import get_store_dir
+
+        owner_id, owner_cookies = _create_user(web_client, "archmid@x.com")
+        eid = _upload_clean(web_client, owner_cookies, name="archmid")
+
+        monkeypatch.setattr("app.api.store.get_guardrails_enabled", lambda: True)
+        monkeypatch.setattr(
+            "app.api.store._schedule_llm_review",
+            lambda *a, **kw: None,
+        )
+        monkeypatch.setattr(
+            "src.store_guardrails.llm_review.review_bundle",
+            lambda *a, **kw: {
+                "risk_level": "safe", "summary": "ok",
+                "findings": [], "template_placeholders_found": 0,
+                "reviewed_by_model": "mock", "error": None,
+            },
+        )
+
+        v2 = _make_skill_zip("archmid", body="v2 " * 30)
+        web_client.put(
+            f"/api/store/entities/{eid}",
+            files={"file": ("v2.zip", v2, "application/zip")},
+            cookies=owner_cookies,
+        )
+
+        # Admin archives BEFORE runner fires.
+        conn = get_system_db()
+        StoreEntitiesRepository(conn).archive(eid, by_user_id="admin-x")
+        sub_id = StoreSubmissionsRepository(conn).latest_for_entity(eid)["id"]
+        conn.close()
+
+        run_llm_review(
+            sub_id,
+            plugin_dir=Path(get_store_dir()) / eid / "versions" / "v2" / "plugin",
+            conn_factory=get_system_db,
+            api_key_loader=lambda: "sk-test",
+            model_loader=lambda: "claude-haiku-4-5-20251001",
+        )
+
+        conn = get_system_db()
+        rows = AuditRepository(conn).query_for_resources(
+            [f"store_submission:{sub_id}"], limit=20,
+        )
+        conn.close()
+        actions = [r.get("action") for r in rows]
+        assert "store.submission.bg_verdict_skipped" in actions, (
+            f"archive-during-review must log bg_verdict_skipped; got {actions}"
+        )
+        assert "store.submission.approved" not in actions, (
+            f"archive-during-review must NOT log approved; got {actions}"
+        )
+
+
+class TestAdminQueueShowsVersion:
+    def test_admin_queue_shows_v_no_after_name(self, web_client):
+        """v# column derives version_no from entity.version_history by
+        matching submission.version (hash) against the entry hashes."""
+        owner_id, owner_cookies = _create_user(web_client, "vqowner@x.com")
+        eid = _upload_clean(web_client, owner_cookies, name="vqcol")
+        v2 = _make_skill_zip("vqcol", body="v2 body. " * 20)
+        web_client.put(
+            f"/api/store/entities/{eid}",
+            files={"file": ("v2.zip", v2, "application/zip")},
+            cookies=owner_cookies,
+        )
+
+        _, admin_cookies = _create_admin(web_client)
+        r = web_client.get(
+            "/api/admin/store/submissions", cookies=admin_cookies,
+        )
+        assert r.status_code == 200
+        items = {it["name"]: it for it in r.json()["items"]}
+        assert "vqcol" in items
+        # version_no derived for the v2 row should be 2.
+        # The list returns rows newest-first; pick the v2 (current).
+        v2_row = next(
+            it for it in r.json()["items"]
+            if it.get("entity_id") == eid and it.get("version_no") == 2
+        )
+        assert v2_row["version_no"] == 2
+        assert v2_row["entity_version_no"] == 2
+
+    def test_admin_detail_shows_version_no(self, web_client):
+        """Detail page renders v# under the Status / Entity-lifecycle
+        block + a separate Bundle hash row."""
+        from src.repositories.store_submissions import StoreSubmissionsRepository
+        owner_id, owner_cookies = _create_user(web_client, "vdowner@x.com")
+        eid = _upload_clean(web_client, owner_cookies, name="vdrow")
+
+        conn = get_system_db()
+        sub_id = StoreSubmissionsRepository(conn).latest_for_entity(eid)["id"]
+        conn.close()
+
+        _, admin_cookies = _create_admin(web_client)
+        r = web_client.get(
+            f"/admin/store/submissions/{sub_id}", cookies=admin_cookies,
+        )
+        assert r.status_code == 200
+        body = r.text
+        assert "<dt>Version</dt>" in body
+        assert "<dt>Bundle hash</dt>" in body
+        assert "v1" in body


### PR DESCRIPTION
## Summary

Real edit page for flea-market entities, replacing the "Edit (coming soon)" placeholder. Each bundle update creates a new version; prior versions persist on disk for rollback.

## What's in the box

**Schema v37**
- `store_entities.version_no INTEGER NOT NULL DEFAULT 1` — current version index.
- `store_entities.version_history JSON DEFAULT '[]'` — append-only metadata for each version.
- Backfill: existing rows seeded with v1 from the row's current `version` hash.

**Edit page** (`/marketplace/flea/{id}/edit`, owner + admin only)
- Pre-filled metadata: name, description, category, video URL, cover photo.
- Optional bundle re-upload — creates v<N+1>.
- Type is locked (400 `type_locked`).
- Block-while-pending: form disabled + 409 `prior_version_pending` during in-flight review.

**Versioning** on `PUT /api/store/entities/{id}`
- New bundle bakes into `${DATA_DIR}/store/<id>/versions/v<N+1>/plugin/`.
- Guardrails run on the new version dir (atomic — failed checks leave live untouched).
- On approval: live `plugin/` dir copied from version dir; `version_no` bumps; `version_history` appends.
- Initial create now also seeds `versions/v1/plugin/` so restore can copy v1 forward.
- Display-name change renames on-disk slug for both live + version dirs (reuses rename-on-archive helper).

**Restore** — `POST /api/store/entities/{id}/versions/{n}/restore` (owner + admin)
- Copies vN bundle forward as v<max+1>; re-runs guardrails.
- Forward-only history. Original vN row keeps its verdict.
- 404 `version_not_found` / 400 `already_current` / 409 `prior_version_pending`.

**UI**
- Versions card on plugin + item detail templates (`_flea_versions.html` partial) — owner/admin only, newest-first, current badge, Restore button on non-current rows.
- Edit button on detail page replaces "Edit (coming soon)"; disabled with tooltip during pending review.
- Quarantine banner copy adapts for v<N+1> review window: *"Version 4 under review — v3 keeps serving to existing installers"*.

## Test plan
- [x] 13 new tests in `tests/test_store_entity_versions.py`:
  - metadata-only edit no version bump
  - bundle edit bumps version + appends history
  - type change rejected
  - block-while-pending → 409
  - name change renames slug on disk
  - restore creates new version with old bundle hash
  - restore already-current → 400
  - restore unknown version → 404
  - non-owner non-admin can't restore
  - edit page 200 for owner / 404 for non-owner
  - versions card renders for owner / hidden for non-owner
- [x] 151 tests green across the guardrails + edit suites.
- [x] Migration v36 → v37 is idempotent + backfill verified.

## Risks
- **Storage cost**: each version persists its own bundle. ~bundle-size per version per entity. No prune yet — admin can hard-delete the entity to free everything; per-version pruning is a follow-up if disk usage grows.
- **Consumer-side rename on display-name change**: same trade-off as rename-on-archive. Existing installers re-resolve under the new slug on next sync.
- **Forward-only history on restore**: restored bundle re-validates against today's rules. If a bundle was approved at v3 but today's static-scan would flag it, restore lands as `blocked_inline` and live stays at the previous current.