### PR TITLE
release: 0.49.0 — session capture queue + private session feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.49.0] — 2026-05-11
+
 ### Fixed (PR #242 follow-ups)
 
 - **`/agnes-private` legacy-scan gap closed (David #8 from PR review).**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.48.0"
+version = "0.49.0"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"


### PR DESCRIPTION
## Summary

Standalone release-cut for v0.49.0 (only behavior-change PR since v0.48.0 was #242, which already merged before this could be appended).

- Bumps \`pyproject.toml\` 0.48.0 → 0.49.0
- Renames CHANGELOG \`[Unreleased]\` → \`[0.49.0] — 2026-05-11\` + adds new empty \`[Unreleased]\` on top

Tag \`v0.49.0\` + GitHub Release follow once this merges.

## Test plan

- [ ] CI green
- [ ] Tag pushed against merge commit
- [ ] GitHub Release created with prose summary of #242
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->