### PR TITLE
release: 0.49.1 — /home onboarding rework + memory admin gate + admin_email + folded connectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.49.1] — 2026-05-11
+
 ### Added
 
 - **`instance.admin_email` operator config knob** (env `AGNES_INSTANCE_ADMIN_EMAIL` > YAML `instance.admin_email` > unset). When set, the `/home` Google Workspace connector tile renders an "Email admin" mailto button so analysts whose operator hasn't pre-provisioned a shared OAuth app can request one without leaving the workspace. Empty default cleanly hides the button.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -524,6 +524,26 @@ Customer-specific automation, hostnames, and identities live in private infra re
 
 **If you find yourself opening a PR without a CHANGELOG entry, stop and add one before requesting review.** Reviewers should bounce PRs that touch user-visible behavior without a changelog update — same way they'd bounce a PR with no test changes for new logic.
 
+## Release-cut belongs to the PR — non-negotiable
+
+**The version bump + CHANGELOG rename + new empty `[Unreleased]` are the LAST commit on the PR that earned the version. Never a standalone follow-up PR.**
+
+When a PR lands the only `[Unreleased]` content (or is the last in a queue of in-flight feature PRs), the release-cut MUST ship as part of the same merge. Standalone release-cut PRs add review-overhead PRs to history with no behavior change of their own and pollute `git log` with the worst kind of churn — bookkeeping commits separated from the work that earned them.
+
+**Mandatory checklist before approving / enabling auto-merge on ANY PR:**
+
+1. **Stop.** Will this PR land alone in `[Unreleased]` (no other in-flight PRs queued behind it)?
+2. **If yes**, the release-cut is REQUIRED in the same PR before merge. BEFORE pushing the final commit:
+   - Bump `pyproject.toml` to `X.Y.Z`
+   - Rename `## [Unreleased]` → `## [X.Y.Z] — YYYY-MM-DD`, add a new empty `## [Unreleased]` on top
+   - Either squash these into the consolidation commit OR add as a separate `release: X.Y.Z` commit on the same branch
+3. **THEN** push, approve, enable auto-merge.
+4. After auto-merge fires: tag `vX.Y.Z` against the merge commit + create a GitHub Release. Done — one PR, one merge, one release.
+
+**Failure mode to avoid:** enabling auto-merge on the feature PR thinking "I'll add the release-cut after." Auto-merge fires faster than the second commit lands. The window closes; the only fix is a standalone release-cut PR — exactly what this rule prohibits.
+
+**Acceptable standalone release-cut** (rare): only when `[Unreleased]` accumulated bullets from MULTIPLE already-merged PRs AND no further behavior-change PR is queued — i.e. the cut is the only outstanding work and there's no PR to attach it to.
+
 ## Run tests before every push — non-negotiable
 
 **Before `git push`, run the full pytest suite locally.** CI runs the same command (`.github/workflows/ci.yml:29` → `pytest tests/ -v --tb=short -n auto`); a failure that surfaces in CI was discoverable in 90 seconds locally. Pushing first and watching CI fail wastes operator time, slows the PR, and trains everyone to ignore CI badges.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.49.0"
+version = "0.49.1"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"


### PR DESCRIPTION
## Summary

Standalone release-cut for v0.49.1. The behavior change shipping in this release was #243; the cut couldn't be appended to it because the squash + merge happened before this commit could land on top.

- Bumps `pyproject.toml` 0.49.0 → 0.49.1
- Renames CHANGELOG `[Unreleased]` → `[0.49.1] — 2026-05-11` + adds new empty `[Unreleased]` on top
- **NEW: hard-rule in `CLAUDE.md` — "Release-cut belongs to the PR — non-negotiable"** with a mandatory checklist before approving / enabling auto-merge on any PR. This rule prevents standalone release-cut PRs like this one from happening again. The failure mode is documented (enabling auto-merge on the feature PR thinking "I'll add the release-cut after"; auto-merge fires faster). The acceptable-standalone case is also documented (cut accumulated bullets from multiple already-merged PRs with no further behavior-change PR queued).

Tag `v0.49.1` + GitHub Release follow once this merges.

## Test plan

- [ ] CI green
- [ ] Tag pushed against merge commit
- [ ] GitHub Release created with prose summary of #243
