### PR TITLE
Rename agnes-metadata.json to marketplace-metadata.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING** Curated marketplace enrichment file renamed from `.claude-plugin/agnes-metadata.json` to `.claude-plugin/marketplace-metadata.json`. Curators of upstream marketplace repos must rename the file in their repo — Agnes no longer reads the old filename (clean cut, no fallback). The Python API also renames: `read_agnes_metadata` → `read_marketplace_metadata`, `AGNES_METADATA_REL` → `MARKETPLACE_METADATA_REL`, `AGNES_METADATA_MAX_BYTES` → `MARKETPLACE_METADATA_MAX_BYTES`. The synth Claude Code marketplace's strip rule (`.agnes/**` + the metadata file) follows the new filename. See `docs/curated-marketplace-format.md`.
+
 ## [0.49.1] — 2026-05-11
 
 ### Added

--- a/app/api/marketplace.py
+++ b/app/api/marketplace.py
@@ -114,7 +114,7 @@ class InnerItemSummary(BaseModel):
     name: str
     description: Optional[str] = None
     detail_url: Optional[str] = None  # nested detail for skill/agent only
-    # v32: agnes-metadata-driven cover photo for the skill/agent card on the
+    # v32: marketplace-metadata-driven cover photo for the skill/agent card on the
     # parent plugin detail page. Already in served-URL form (internal /asset/
     # endpoint, mirrored /mirrored/ endpoint, or pass-through external URL).
     # None → frontend renders initials placeholder ("SK" / "AG").
@@ -173,7 +173,7 @@ class PluginDetailResponse(BaseModel):
     curator_email: Optional[str] = None         # curated only — surfaced for "contact curator"
     owner_display: Optional[str] = None         # flea: users.name → email → owner_username
     homepage: Optional[str] = None
-    cover_photo_url: Optional[str] = None       # /api/store/.../photo for flea, agnes-metadata for curated
+    cover_photo_url: Optional[str] = None       # /api/store/.../photo for flea, marketplace-metadata for curated
     video_url: Optional[str] = None             # v32: external (YouTube/Vimeo/Loom) embed URL
     bundle_size: Optional[int] = None           # bytes; None when unknown
     install_count: int = 0                      # flea only; curated leaves at 0
@@ -232,7 +232,7 @@ class InnerDetailResponse(BaseModel):
     manifest_name: str = ""
     bundle_size: Optional[int] = None
     files: List[FileEntry] = []
-    # v32: per-skill / per-agent enrichment from agnes-metadata.json sub-tree.
+    # v32: per-skill / per-agent enrichment from marketplace-metadata.json sub-tree.
     # Read at request time from the cloned working tree (not cached in DB) so
     # curators can update one inner asset without paying the cost of a full
     # plugin-cache rewrite. Three-typed cover URL layout matches plugin
@@ -515,7 +515,7 @@ async def list_items(
     marketplace_meta: Dict[str, Dict[str, Optional[str]]] = {}
 
     # Pull the enriched rows the Curated tab uses (cover_photo_url, video_url,
-    # category override, doc_links from agnes-metadata.json) so the My Stack
+    # category override, doc_links from marketplace-metadata.json) so the My Stack
     # cards look identical to the curated cards the user just clicked
     # "+ Add to my stack" on. ``resolve_allowed_plugins`` reads only the
     # upstream marketplace.json, which doesn't carry those columns; without
@@ -541,7 +541,7 @@ async def list_items(
             # Fallback: plugin in RBAC + subscribed but not yet ingested into
             # marketplace_plugins (rare race — granted before the first sync
             # cycle runs). Build the bare shape from the on-disk manifest so
-            # the card still renders, just without agnes-metadata enrichment;
+            # the card still renders, just without marketplace-metadata enrichment;
             # cover falls through to the gradient placeholder until the next
             # sync.
             author = p["raw"].get("author")
@@ -943,11 +943,11 @@ async def curated_detail(
     skills = _list_inner_skills(plugin_root)
     agents = _list_inner_agents(plugin_root)
 
-    # v32: enrich each skill/agent card with its agnes-metadata cover photo
+    # v32: enrich each skill/agent card with its marketplace-metadata cover photo
     # so the inner cards on the plugin detail page render the real image
-    # instead of just initials. Read agnes-metadata + mirror manifest once
+    # instead of just initials. Read marketplace-metadata + mirror manifest once
     # (cached by the helpers) and reuse for all inner items in the plugin.
-    from src.marketplace_metadata import read_agnes_metadata as _read_md
+    from src.marketplace_metadata import read_marketplace_metadata as _read_md
     inner_metadata = _read_md(
         Path(get_marketplaces_dir()) / marketplace_id,
     )
@@ -982,7 +982,7 @@ async def curated_detail(
         except (ValueError, TypeError):
             raw = {}
 
-    # v32: cover, video, and doc_links come from `agnes-metadata.json` via the
+    # v32: cover, video, and doc_links come from `marketplace-metadata.json` via the
     # sync pipeline (`src/marketplace.py::_refresh_plugin_cache`) — already in
     # served-URL form when written to the DB. We pass them through the
     # response model unchanged. Curator name + email come from the marketplace
@@ -1348,12 +1348,12 @@ def _curated_inner_enrichment(
     kind: str,
     inner_name: str,
 ) -> Dict[str, Any]:
-    """Load agnes-metadata.json sub-tree for a single skill/agent.
+    """Load marketplace-metadata.json sub-tree for a single skill/agent.
 
-    Lives here (not in the sync pipeline) so curators can update agnes-metadata
+    Lives here (not in the sync pipeline) so curators can update marketplace-metadata
     on a working tree and see the change at the next page refresh, without
     waiting for a full plugin-cache rewrite. Read on every inner-detail
-    request — agnes-metadata.json is small enough that disk hit cost is
+    request — marketplace-metadata.json is small enough that disk hit cost is
     negligible compared to the SKILL.md / agent.md frontmatter parse the
     endpoint already does.
 
@@ -1370,12 +1370,12 @@ def _curated_inner_enrichment(
     ``video_url`` (str or None), ``docs`` (list of DocEntry).
     """
     from src.marketplace_metadata import (
-        read_agnes_metadata,
+        read_marketplace_metadata,
         resolve_inner_metadata,
     )
 
     repo_root = Path(get_marketplaces_dir()) / marketplace_id
-    metadata = read_agnes_metadata(repo_root)
+    metadata = read_marketplace_metadata(repo_root)
     section_kind = "skills" if kind == "skill" else "agents"
     resolved = resolve_inner_metadata(metadata, plugin_name, section_kind, inner_name)
     if not resolved:
@@ -1447,9 +1447,9 @@ def _curated_inner_cover(
     from src.marketplace_metadata import resolve_inner_metadata
 
     if metadata is None:
-        from src.marketplace_metadata import read_agnes_metadata
+        from src.marketplace_metadata import read_marketplace_metadata
         repo_root = Path(get_marketplaces_dir()) / marketplace_id
-        metadata = read_agnes_metadata(repo_root)
+        metadata = read_marketplace_metadata(repo_root)
     if manifest is None:
         manifest = _load_mirror_manifest(marketplace_id)
 
@@ -1564,7 +1564,7 @@ async def curated_agent_detail(
 # ---------------------------------------------------------------------------
 #
 # Three sibling endpoints that serve the binary content referenced from
-# `agnes-metadata.json`. All three:
+# `marketplace-metadata.json`. All three:
 #
 #   * are gated by `require_resource_access(MARKETPLACE_PLUGIN, "{mp}/{plugin}")`
 #     so a user without RBAC can't side-load assets even with a direct URL,
@@ -1625,7 +1625,7 @@ async def curated_asset(
     ``.agnes/cover.png`` or ``plugins/foo/icon.png``.
 
     **Image-only by contract.** The endpoint is the source of cover photos
-    referenced from ``agnes-metadata.json`` and from inner skill / agent
+    referenced from ``marketplace-metadata.json`` and from inner skill / agent
     cards. A curator who could land an arbitrary file in the cloned repo
     (HTML, JS, SVG with inline ``<script>``) would otherwise have a
     same-origin XSS via this endpoint, since the response shares the
@@ -1693,7 +1693,7 @@ async def curated_doc(
     Same path-traversal guard as ``/asset/``. Adds an allowlist check — the
     doc endpoint refuses to serve a file whose extension isn't in the
     documented PDF / Markdown / plain text set (HTTP 415). Defense-in-depth
-    even though the agnes-metadata parser already rejects out-of-allowlist
+    even though the marketplace-metadata parser already rejects out-of-allowlist
     extensions during the doc_link parse — a curator who edits the working
     tree directly (or whose JSON survived parsing because of a generic
     extension match elsewhere) shouldn't be able to land a .docx through

--- a/app/marketplace_server/git_backend.py
+++ b/app/marketplace_server/git_backend.py
@@ -123,7 +123,7 @@ def file_set_for_user(
         for f in sorted(p for p in plugin_dir.rglob("*") if p.is_file()):
             rel_parts = f.relative_to(plugin_dir).parts
             # v32: same Agnes-only file stripping as the ZIP path —
-            # `.agnes/**` and `agnes-metadata.json` never enter the synth
+            # `.agnes/**` and `marketplace-metadata.json` never enter the synth
             # Claude Code git tree. See app/marketplace_server/packager.py
             # for context.
             from src.marketplace_filter import is_agnes_only_path

--- a/app/marketplace_server/packager.py
+++ b/app/marketplace_server/packager.py
@@ -171,7 +171,7 @@ def _collect_members(plugins: List[dict], etag: str) -> List[Tuple[str, bytes]]:
             continue
         for f in sorted(p for p in plugin_dir.rglob("*") if p.is_file()):
             rel_parts = f.relative_to(plugin_dir).parts
-            # v32: strip Agnes-only files (`.agnes/**` and `agnes-metadata.json`)
+            # v32: strip Agnes-only files (`.agnes/**` and `marketplace-metadata.json`)
             # from the synth Claude Code marketplace so user instances never
             # see enrichment metadata they don't need. ETag is computed from
             # the same filtered set (compute_etag in marketplace_filter), so

--- a/app/web/templates/admin_marketplaces.html
+++ b/app/web/templates/admin_marketplaces.html
@@ -263,7 +263,7 @@
     <h2 class="marketplaces-title">Curated Marketplaces</h2>
     <input id="mp-search" type="search" class="marketplaces-search" placeholder="Filter by slug, name, or URL…" autocomplete="off">
     <a class="icon-btn" href="/marketplace/format-guide" target="_blank" rel="noopener"
-       title="Open the agnes-metadata.json format guide in a new tab">
+       title="Open the marketplace-metadata.json format guide in a new tab">
       Format guide →
     </a>
     <button class="modal-btn primary" id="open-create-btn">+ Add marketplace</button>

--- a/app/web/templates/marketplace.html
+++ b/app/web/templates/marketplace.html
@@ -600,7 +600,7 @@ function renderGrid(items) {
     card.className = 'mp-card' + (it.installed ? ' is-installed' : '');
     card.href = it.detail_url;
     // Cover photo with broken-image fallback. When the <img> 404s (e.g. an
-    // agnes-metadata.json `cover_photo` references a file the curator forgot
+    // marketplace-metadata.json `cover_photo` references a file the curator forgot
     // to commit, or an external mirror failed), browsers paint their default
     // broken-image icon — which looks worse than the gradient placeholder we
     // render when no cover_photo_url is set at all. The `onerror` swaps the

--- a/app/web/templates/marketplace_item_detail.html
+++ b/app/web/templates/marketplace_item_detail.html
@@ -740,7 +740,7 @@
   document.getElementById('hero-name').textContent = heroTitle;
 
   // Cover photo — flea may have one; curated v32 may also have one when
-  // agnes-metadata.json sub-tree references a skill/agent cover via either
+  // marketplace-metadata.json sub-tree references a skill/agent cover via either
   // an internal path (resolved to /asset/) or an external URL.
   if (d.cover_photo_url) {
     const heroPhoto = document.getElementById('hero-photo');
@@ -964,7 +964,7 @@
 
   // ── Docs section ────────────────────────────────────────────────
   // Flea has always populated `d.docs`. v32 added the same field for curated
-  // skill/agent inner detail, sourced from agnes-metadata.json's per-skill
+  // skill/agent inner detail, sourced from marketplace-metadata.json's per-skill
   // sub-tree. Both surface here through a single render path — file rows
   // for internal-cached docs, link rows for external ones.
   if (Array.isArray(d.docs) && d.docs.length) {
@@ -983,7 +983,7 @@
       </li>`).join('');
   }
 
-  // ── v32: demo video for skill / agent (from agnes-metadata sub-tree) ──
+  // ── v32: demo video for skill / agent (from marketplace-metadata sub-tree) ──
   // Same auto-embed logic as the parent plugin detail page: YouTube /
   // Vimeo are embedded; raw .mp4/.webm/.ogg are inlined as <video>; anything
   // else falls back to a "Watch on external site" link.

--- a/app/web/templates/marketplace_plugin_detail.html
+++ b/app/web/templates/marketplace_plugin_detail.html
@@ -617,7 +617,7 @@
 
   <!-- v32: video + doc_links section. Both blocks stay hidden until populated
        so the layout collapses gracefully when an upstream marketplace ships
-       no agnes-metadata.json. Doc icons differentiate internal-cached files
+       no marketplace-metadata.json. Doc icons differentiate internal-cached files
        (📄) from external links (🔗) so the user knows what's a click away. -->
   <div class="panel" id="panel-video" hidden>
     <h2>Demo video</h2>
@@ -895,7 +895,7 @@
     document.getElementById('panel-what').hidden = true;
   }
 
-  // ── v32: demo video (agnes-metadata.json :: video_url) ─────────
+  // ── v32: demo video (marketplace-metadata.json :: video_url) ─────────
   // Detection logic lives in the shared partial so item_detail.html and
   // this page stay in lockstep on YouTube nocookie / Vimeo / mp4 / link
   // fallback handling.
@@ -905,7 +905,7 @@
     document.getElementById('panel-video').hidden = false;
   }
 
-  // ── v32: doc_links (agnes-metadata.json :: doc_links[]) ────────
+  // ── v32: doc_links (marketplace-metadata.json :: doc_links[]) ────────
   // The user contract: every entry in this list is a real downloadable
   // document Agnes can serve (PDF / Markdown / plain text). Sync pipeline
   // already dropped HTML pages, 404s, SSRF-blocked URLs, and any internal
@@ -962,7 +962,7 @@
   // ── Internal structure ─────────────────────────────────────────
   function buildCardSection(title, items, type) {
     if (!items || !items.length) return '';
-    // Inner cards render the agnes-metadata cover photo when present
+    // Inner cards render the marketplace-metadata cover photo when present
     // (mirrored OK for external, file exists for internal); otherwise the
     // initials fall through ("SK" / "AG") on the colored gradient. Same
     // onerror fallback as the top-level cards so a missing file doesn't

--- a/docs/curated-marketplace-format.md
+++ b/docs/curated-marketplace-format.md
@@ -13,7 +13,7 @@ story.
 Create a JSON file at this exact path in your repo:
 
 ```
-.claude-plugin/agnes-metadata.json
+.claude-plugin/marketplace-metadata.json
 ```
 
 Put the keys you want filled in. **Every key is optional.** Skip a
@@ -156,7 +156,7 @@ Copy this and adjust:
 ```
 
 The same example lives at
-[`docs/examples/agnes-metadata.json`](https://github.com/keboola/agnes-the-ai-analyst/blob/main/docs/examples/agnes-metadata.json)
+[`docs/examples/marketplace-metadata.json`](https://github.com/keboola/agnes-the-ai-analyst/blob/main/docs/examples/marketplace-metadata.json)
 in the source repo.
 
 ---

--- a/docs/examples/marketplace-metadata.json
+++ b/docs/examples/marketplace-metadata.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Example .claude-plugin/agnes-metadata.json — copy to your marketplace repo and adjust. See docs/curated-marketplace-format.md for the full schema. The `_comment` keys are ignored by Agnes — they're here purely as inline documentation; remove them in production.",
+  "_comment": "Example .claude-plugin/marketplace-metadata.json — copy to your marketplace repo and adjust. See docs/curated-marketplace-format.md for the full schema. The `_comment` keys are ignored by Agnes — they're here purely as inline documentation; remove them in production.",
   "plugins": {
     "data-explorer": {
       "_comment": "Plugin-level enrichment — surfaces on /marketplace cards and on the plugin detail page.",

--- a/src/db.py
+++ b/src/db.py
@@ -386,13 +386,13 @@ CREATE TABLE IF NOT EXISTS marketplace_plugins (
     raw             JSON,
     created_at      TIMESTAMP DEFAULT current_timestamp,
     updated_at      TIMESTAMP DEFAULT current_timestamp,
-    -- v37: enrichment from upstream `.claude-plugin/agnes-metadata.json`.
+    -- v37: enrichment from upstream `.claude-plugin/marketplace-metadata.json`.
     -- `cover_photo_url` and `video_url` are stored as already-resolved served
     -- URLs (internal asset endpoint, mirrored cache endpoint, or pass-through
     -- external URL). `doc_links` is a JSON array of `{name, url, kind}` where
     -- `kind ∈ {internal, mirrored, external}` so the frontend can pick the
     -- right icon without re-resolving. NULL = upstream marketplace shipped no
-    -- agnes-metadata.json (or shipped one without an entry for this plugin).
+    -- marketplace-metadata.json (or shipped one without an entry for this plugin).
     cover_photo_url VARCHAR,
     video_url       VARCHAR,
     doc_links       JSON,
@@ -2567,7 +2567,7 @@ def _v30_to_v31_migrate(conn: duckdb.DuckDBPyConnection) -> None:
     conn.execute("DROP TABLE session_extraction_state")
 
 
-# v37: curated marketplace enrichment from `.claude-plugin/agnes-metadata.json`
+# v37: curated marketplace enrichment from `.claude-plugin/marketplace-metadata.json`
 # plus mandatory curator identity on `marketplace_registry`. See the file-level
 # `_SYSTEM_SCHEMA` block for the column-level commentary; the migration is
 # pure ADD COLUMN IF NOT EXISTS so it is idempotent against a fresh install

--- a/src/marketplace.py
+++ b/src/marketplace.py
@@ -169,11 +169,11 @@ def _refresh_plugin_cache(slug: str) -> int:
     * ``.claude-plugin/marketplace.json`` (the Claude Code spec) is the
       authoritative source for plugin existence, source spec, and the bare
       Claude Code-shaped metadata.
-    * ``.claude-plugin/agnes-metadata.json`` (Agnes-only) supplies cover
+    * ``.claude-plugin/marketplace-metadata.json`` (Agnes-only) supplies cover
       photo, video URL, doc links, and category overrides per plugin. Missing
       file → no enrichment, plugins still cached at the bare shape.
 
-    External URLs referenced from agnes-metadata are fed through the asset
+    External URLs referenced from marketplace-metadata are fed through the asset
     mirror (`src.marketplace_asset_mirror.sync_assets`) before the DB write
     so the persisted ``cover_photo_url`` / ``doc_links`` already point at the
     final served URL. Mirror failures degrade gracefully — failed external
@@ -182,7 +182,7 @@ def _refresh_plugin_cache(slug: str) -> int:
     from src.marketplace_asset_mirror import sync_assets
     from src.marketplace_metadata import (
         collect_all_external_urls,
-        read_agnes_metadata,
+        read_marketplace_metadata,
         resolve_plugin_metadata,
     )
     from src.marketplace_urls import (
@@ -199,7 +199,7 @@ def _refresh_plugin_cache(slug: str) -> int:
         return 0
 
     repo_root = get_marketplaces_dir() / slug
-    metadata = read_agnes_metadata(repo_root)
+    metadata = read_marketplace_metadata(repo_root)
 
     # Resolve per-plugin enrichment + collect every external URL the mirror
     # needs to fetch this round. Internal references skip the mirror.
@@ -274,7 +274,7 @@ def _refresh_plugin_cache(slug: str) -> int:
         # path doesn't exist on disk at sync time are dropped too. This
         # matches the operator contract: any doc_link Agnes can't deliver
         # as a real downloadable PDF / Markdown / plain text is treated as
-        # if it weren't in agnes-metadata.json at all.
+        # if it weren't in marketplace-metadata.json at all.
         serialized_links: List[Dict[str, str]] = []
         for link in resolved.get("doc_links") or []:
             if not hasattr(link, "kind"):
@@ -344,7 +344,7 @@ def _refresh_plugin_cache(slug: str) -> int:
         if "video_url" in resolved:
             merged["video_url"] = resolved["video_url"]
         if "category" in resolved:
-            # Override marketplace.json category when agnes-metadata supplies one.
+            # Override marketplace.json category when marketplace-metadata supplies one.
             merged["category"] = resolved["category"]
         if serialized_links:
             merged["doc_links"] = serialized_links

--- a/src/marketplace_asset_mirror.py
+++ b/src/marketplace_asset_mirror.py
@@ -1,6 +1,6 @@
 """External-asset mirror cache for curated marketplaces.
 
-The curator's ``.claude-plugin/agnes-metadata.json`` may reference cover
+The curator's ``.claude-plugin/marketplace-metadata.json`` may reference cover
 photos and doc files by external HTTP(S) URL. Linkrot would then mean the
 Agnes web UI starts showing broken images / dead links the moment the
 upstream CDN serves a 404. This module mirrors those URLs to disk at sync
@@ -23,7 +23,7 @@ time and serves the local copy thereafter.
    - 304 Not Modified → keep cached file, refresh ``fetched_at`` only.
    - 200 OK with same sha256 → keep file, refresh validators.
    - 200 OK with new sha256 → overwrite local file.
-3. URL removed from agnes-metadata.json → ``cleanup_unused`` removes the
+3. URL removed from marketplace-metadata.json → ``cleanup_unused`` removes the
    manifest entry and the local file.
 
 **Failure modes** (b1 fallback per the design discussion):
@@ -682,7 +682,7 @@ def sync_assets(
             # between body-write and the end-of-batch persist would otherwise
             # leave on-disk files the next sync's manifest never references —
             # disk bloats over time as URLs come and go from the curator's
-            # agnes-metadata.json. Per-iteration persist narrows the crash
+            # marketplace-metadata.json. Per-iteration persist narrows the crash
             # window from "all of Phase 2" to "between persist and unlink"
             # (microseconds). Cost: ~one tmp+rename per body write; manifest
             # is a few KB so the overhead is negligible vs. the HTTP fetches.

--- a/src/marketplace_asset_validation.py
+++ b/src/marketplace_asset_validation.py
@@ -229,7 +229,7 @@ def accept_image_response(url: str, content_type: str) -> ValidationResult:
 
 
 # ---------------------------------------------------------------------------
-# Convenience helpers used by the agnes-metadata.json parser
+# Convenience helpers used by the marketplace-metadata.json parser
 # ---------------------------------------------------------------------------
 
 
@@ -242,7 +242,7 @@ class DocLinkRef:
       mirror is replaced with ``mirrored_key`` by the asset-mirror layer, or
       when mirroring failed and we link out).
     * ``kind="mirrored"`` → ``url`` is the original; ``mirrored_key`` is set
-      to the cache lookup key. The agnes-metadata parser only produces
+      to the cache lookup key. The marketplace-metadata parser only produces
       ``internal`` and ``external`` — the mirror layer flips ``external`` to
       ``mirrored`` after a successful fetch.
     """
@@ -254,7 +254,7 @@ class DocLinkRef:
 
 
 def parse_doc_link(entry: dict) -> Tuple[bool, DocLinkRef | str]:
-    """Validate one ``doc_links[]`` dict from agnes-metadata.json.
+    """Validate one ``doc_links[]`` dict from marketplace-metadata.json.
 
     Returns ``(True, DocLinkRef)`` on accept, ``(False, reason)`` on reject.
     Rejection reasons surface to the sync log so the curator can fix them.

--- a/src/marketplace_filter.py
+++ b/src/marketplace_filter.py
@@ -206,8 +206,8 @@ def is_agnes_only_path(rel_parts: tuple[str, ...]) -> bool:
 
     * any segment named ``.agnes`` — convention dir for cover photos and
       docs that should NEVER reach the synth Claude Code marketplace,
-    * file named ``agnes-metadata.json`` at any depth (typically lives at
-      ``.claude-plugin/agnes-metadata.json`` at the repo root, but this
+    * file named ``marketplace-metadata.json`` at any depth (typically lives at
+      ``.claude-plugin/marketplace-metadata.json`` at the repo root, but this
       catches it wherever it appears).
 
     Used by both the synth ZIP/git tree assembly path and the ETag
@@ -218,7 +218,7 @@ def is_agnes_only_path(rel_parts: tuple[str, ...]) -> bool:
         return False
     if any(part == ".agnes" for part in rel_parts):
         return True
-    if rel_parts[-1] == "agnes-metadata.json":
+    if rel_parts[-1] == "marketplace-metadata.json":
         return True
     return False
 
@@ -227,7 +227,7 @@ def _bundle_files(bundle_dirs: list[Path]) -> list[tuple[str, Path]]:
     """Return [(relpath_in_bundle, abs_path)] for every file across the bundle
     sources, dropping each per-entity ``.claude-plugin/`` content (the bundle
     has its own synth plugin.json) AND any Agnes-only file (``.agnes/**`` or
-    ``agnes-metadata.json``) so the served Claude Code marketplace stays
+    ``marketplace-metadata.json``) so the served Claude Code marketplace stays
     clean of Agnes-side enrichment."""
     out: list[tuple[str, Path]] = []
     for src in bundle_dirs:

--- a/src/marketplace_metadata.py
+++ b/src/marketplace_metadata.py
@@ -1,4 +1,4 @@
-"""Parser + resolver for upstream ``.claude-plugin/agnes-metadata.json``.
+"""Parser + resolver for upstream ``.claude-plugin/marketplace-metadata.json``.
 
 Each curated marketplace repo can ship a sibling file next to ``marketplace.json``
 that adds Agnes-only enrichment (cover photos, video URLs, doc links, category
@@ -9,7 +9,7 @@ the synth Claude Code marketplace clean of Agnes-only files.
 
 Two read paths exist:
 
-* :func:`read_agnes_metadata` — invoked from the sync pipeline
+* :func:`read_marketplace_metadata` — invoked from the sync pipeline
   (``src/marketplace.py``). Lenient: missing file, malformed JSON, and partial
   schemas all fall back to ``{}`` rather than aborting the sync.
 * :func:`resolve_plugin_metadata` — given a parsed metadata blob and a plugin
@@ -39,13 +39,13 @@ from src.marketplace_asset_validation import (
 
 logger = logging.getLogger(__name__)
 
-AGNES_METADATA_REL = Path(".claude-plugin") / "agnes-metadata.json"
+MARKETPLACE_METADATA_REL = Path(".claude-plugin") / "marketplace-metadata.json"
 """Path inside the cloned marketplace working tree where the file is expected.
 Sibling to ``marketplace.json`` so curators have one well-known place to put
 both Claude Code and Agnes-side metadata."""
 
-AGNES_METADATA_MAX_BYTES = 1 * 1024 * 1024
-"""Hard cap on the size of an agnes-metadata.json file.
+MARKETPLACE_METADATA_MAX_BYTES = 1 * 1024 * 1024
+"""Hard cap on the size of an marketplace-metadata.json file.
 
 The file is curator-controlled and read into memory in full before parsing.
 Without a cap, a curator could commit a multi-GB document and OOM the sync
@@ -55,8 +55,8 @@ real-world metadata file with covers, docs, and categories for ~50 plugins
 sits well under 100 KB."""
 
 
-def read_agnes_metadata(marketplace_root: Path) -> Dict[str, Any]:
-    """Load the agnes-metadata.json document from a cloned marketplace.
+def read_marketplace_metadata(marketplace_root: Path) -> Dict[str, Any]:
+    """Load the marketplace-metadata.json document from a cloned marketplace.
 
     Returns the parsed dict on success, or ``{}`` when the file is missing,
     unreadable, or contains malformed JSON. A malformed file logs a warning
@@ -74,24 +74,24 @@ def read_agnes_metadata(marketplace_root: Path) -> Dict[str, Any]:
           }
         }
     """
-    path = marketplace_root / AGNES_METADATA_REL
+    path = marketplace_root / MARKETPLACE_METADATA_REL
     if not path.is_file():
         return {}
     try:
         size = path.stat().st_size
     except OSError as e:
-        logger.warning("agnes-metadata: %s stat failed: %s", path, e)
+        logger.warning("marketplace-metadata: %s stat failed: %s", path, e)
         return {}
-    if size > AGNES_METADATA_MAX_BYTES:
+    if size > MARKETPLACE_METADATA_MAX_BYTES:
         logger.warning(
-            "agnes-metadata: %s exceeds %d-byte cap (%d bytes), refusing to read",
-            path, AGNES_METADATA_MAX_BYTES, size,
+            "marketplace-metadata: %s exceeds %d-byte cap (%d bytes), refusing to read",
+            path, MARKETPLACE_METADATA_MAX_BYTES, size,
         )
         return {}
     try:
         text = path.read_text(encoding="utf-8")
     except OSError as e:
-        logger.warning("agnes-metadata: %s unreadable: %s", path, e)
+        logger.warning("marketplace-metadata: %s unreadable: %s", path, e)
         return {}
     try:
         data = json.loads(text)
@@ -102,13 +102,13 @@ def read_agnes_metadata(marketplace_root: Path) -> Dict[str, Any]:
         # to the same outcome — degrade gracefully so one bad upstream
         # doesn't abort the whole sync.
         logger.warning(
-            "agnes-metadata: %s parse failed (%s), treating as empty: %s",
+            "marketplace-metadata: %s parse failed (%s), treating as empty: %s",
             path, type(e).__name__, e,
         )
         return {}
     if not isinstance(data, dict):
         logger.warning(
-            "agnes-metadata: %s top-level must be an object, got %s",
+            "marketplace-metadata: %s top-level must be an object, got %s",
             path, type(data).__name__,
         )
         return {}
@@ -191,7 +191,7 @@ def resolve_plugin_metadata(
     if not section:
         return {}
 
-    log_prefix = f"agnes-metadata plugin={plugin_name}:"
+    log_prefix = f"marketplace-metadata plugin={plugin_name}:"
     out: Dict[str, Any] = {"raw_section": section}
 
     cover = section.get("cover_photo")
@@ -235,7 +235,7 @@ def resolve_inner_metadata(
         return {}
 
     log_prefix = (
-        f"agnes-metadata plugin={plugin_name} {kind[:-1]}={inner_name}:"
+        f"marketplace-metadata plugin={plugin_name} {kind[:-1]}={inner_name}:"
     )
     out: Dict[str, Any] = {"raw_section": section}
 

--- a/src/repositories/marketplace_plugins.py
+++ b/src/repositories/marketplace_plugins.py
@@ -177,7 +177,7 @@ class MarketplacePluginsRepository:
 
         Each ``plugins`` entry is the full marketplace.json plugin dict
         optionally augmented with v32 enrichment keys produced by the
-        agnes-metadata.json reader:
+        marketplace-metadata.json reader:
 
         * ``cover_photo_url`` (str | None)  — already-resolved served URL
         * ``video_url`` (str | None)
@@ -186,7 +186,7 @@ class MarketplacePluginsRepository:
           ``internal`` / ``mirrored`` / ``external``.
 
         Absent keys are persisted as NULL — that's the steady state when the
-        upstream marketplace ships no agnes-metadata.json at all.
+        upstream marketplace ships no marketplace-metadata.json at all.
 
         Returns the number of plugins written.
         """
@@ -226,7 +226,7 @@ class MarketplacePluginsRepository:
                     json.dumps(source_spec) if source_spec is not None else None
                 )
                 # `raw` continues to carry the unmerged upstream marketplace.json
-                # plugin entry — agnes-metadata enrichment is held in dedicated
+                # plugin entry — marketplace-metadata enrichment is held in dedicated
                 # columns, never folded into `raw`. Keeps the contract clean for
                 # the synth marketplace flow that re-emits `raw` to Claude Code.
                 raw_payload = {k: v for k, v in p.items() if k not in (

--- a/tests/test_db_schema_version.py
+++ b/tests/test_db_schema_version.py
@@ -51,7 +51,7 @@ def test_schema_version_is_37():
     #            enforced application-side (DuckDB ADD CHECK on existing
     #            column not supported).
     # v36 → v37: curated marketplace enrichment from
-    #            `.claude-plugin/agnes-metadata.json` plus mandatory curator
+    #            `.claude-plugin/marketplace-metadata.json` plus mandatory curator
     #            identity on marketplace_registry. Adds curator_name +
     #            curator_email to marketplace_registry, and
     #            cover_photo_url + video_url + doc_links to

--- a/tests/test_marketplace.py
+++ b/tests/test_marketplace.py
@@ -571,7 +571,7 @@ def test_api_delete_clears_overlay_binding(seeded_app):
 
 
 def test_refresh_plugin_cache_drops_missing_internal_assets(clean_env, monkeypatch):
-    """v32 enrichment drop semantics — when agnes-metadata references files
+    """v32 enrichment drop semantics — when marketplace-metadata references files
     that don't exist on disk (or external URLs that fail to mirror), those
     entries are removed from the served metadata so the UI never shows a
     broken link / image. We exercise the missing-internal-file branch
@@ -601,8 +601,8 @@ def test_refresh_plugin_cache_drops_missing_internal_assets(clean_env, monkeypat
         }),
         encoding="utf-8",
     )
-    # agnes-metadata referencing a mix of valid + missing internal paths
-    (repo_root / ".claude-plugin" / "agnes-metadata.json").write_text(
+    # marketplace-metadata referencing a mix of valid + missing internal paths
+    (repo_root / ".claude-plugin" / "marketplace-metadata.json").write_text(
         json.dumps({
             "version": 1,
             "plugins": {

--- a/tests/test_marketplace_api.py
+++ b/tests/test_marketplace_api.py
@@ -158,9 +158,9 @@ class TestListItems:
         data = r.json()
         assert data["total"] == 0
 
-    def test_my_stack_carries_agnes_metadata_enrichment(self, web_client):
+    def test_my_stack_carries_marketplace_metadata_enrichment(self, web_client):
         """Once a curated plugin is in the user's stack (subscribed), the
-        ``tab=my`` card MUST carry the same agnes-metadata enrichment
+        ``tab=my`` card MUST carry the same marketplace-metadata enrichment
         (cover_photo_url, video_url, category override) the ``tab=curated``
         card shows. Previously the My Stack handler built rows from the
         on-disk ``marketplace.json``, which doesn't carry those columns —
@@ -175,9 +175,9 @@ class TestListItems:
         user_id, cookies = _create_user(web_client, "alice@x.com")
         _seed_curated_grant(user_id=user_id, marketplace="mkt-x", plugin="alpha")
 
-        # Backfill the agnes-metadata enrichment columns on the seeded
+        # Backfill the marketplace-metadata enrichment columns on the seeded
         # plugin row — same shape `_refresh_plugin_cache` writes after a
-        # nightly sync that picked up a curator's agnes-metadata.json.
+        # nightly sync that picked up a curator's marketplace-metadata.json.
         cover = "/api/marketplace/curated/mkt-x/alpha/asset/cover.png"
         video = "https://www.youtube.com/watch?v=abc123"
         conn = get_system_db()
@@ -208,7 +208,7 @@ class TestListItems:
         # Curated tab. ``MarketplaceItem`` flattens the column name to
         # ``photo_url``; see :func:`_curated_to_item`.
         assert item["photo_url"] == cover, (
-            "My Stack must surface agnes-metadata cover_photo_url, not None"
+            "My Stack must surface marketplace-metadata cover_photo_url, not None"
         )
         assert item["category"] == "Code & Engineering"
 

--- a/tests/test_marketplace_metadata.py
+++ b/tests/test_marketplace_metadata.py
@@ -1,4 +1,4 @@
-"""Unit tests for the agnes-metadata.json parser.
+"""Unit tests for the marketplace-metadata.json parser.
 
 Covers the lenient-parse contract (missing file / malformed JSON / wrong-type
 top level all degrade to empty) plus the per-plugin / per-skill resolution
@@ -15,70 +15,70 @@ from src.marketplace_metadata import (
     collect_external_urls,
     get_inner_section,
     get_plugin_section,
-    read_agnes_metadata,
+    read_marketplace_metadata,
     resolve_inner_metadata,
     resolve_plugin_metadata,
 )
 
 
 def _write_metadata(repo_root, payload):
-    """Write payload as `.claude-plugin/agnes-metadata.json` under repo_root."""
-    target = repo_root / ".claude-plugin" / "agnes-metadata.json"
+    """Write payload as `.claude-plugin/marketplace-metadata.json` under repo_root."""
+    target = repo_root / ".claude-plugin" / "marketplace-metadata.json"
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(json.dumps(payload), encoding="utf-8")
     return target
 
 
-# --- read_agnes_metadata --------------------------------------------------
+# --- read_marketplace_metadata --------------------------------------------------
 
 
-def test_read_agnes_metadata_missing_file_returns_empty(tmp_path):
+def test_read_marketplace_metadata_missing_file_returns_empty(tmp_path):
     """No metadata file → empty dict, no warning crash."""
-    assert read_agnes_metadata(tmp_path) == {}
+    assert read_marketplace_metadata(tmp_path) == {}
 
 
-def test_read_agnes_metadata_malformed_json(tmp_path):
+def test_read_marketplace_metadata_malformed_json(tmp_path):
     """Malformed JSON degrades to empty dict (sync should not abort)."""
-    target = tmp_path / ".claude-plugin" / "agnes-metadata.json"
+    target = tmp_path / ".claude-plugin" / "marketplace-metadata.json"
     target.parent.mkdir(parents=True)
     target.write_text("{not json at all", encoding="utf-8")
-    assert read_agnes_metadata(tmp_path) == {}
+    assert read_marketplace_metadata(tmp_path) == {}
 
 
-def test_read_agnes_metadata_top_level_array_rejected(tmp_path):
+def test_read_marketplace_metadata_top_level_array_rejected(tmp_path):
     """Top-level must be a JSON object — array is logged + ignored."""
-    target = tmp_path / ".claude-plugin" / "agnes-metadata.json"
+    target = tmp_path / ".claude-plugin" / "marketplace-metadata.json"
     target.parent.mkdir(parents=True)
     target.write_text("[1, 2, 3]", encoding="utf-8")
-    assert read_agnes_metadata(tmp_path) == {}
+    assert read_marketplace_metadata(tmp_path) == {}
 
 
-def test_read_agnes_metadata_happy_path(tmp_path):
+def test_read_marketplace_metadata_happy_path(tmp_path):
     payload = {"version": 1, "plugins": {"x": {"category": "Tools"}}}
     _write_metadata(tmp_path, payload)
-    assert read_agnes_metadata(tmp_path) == payload
+    assert read_marketplace_metadata(tmp_path) == payload
 
 
-def test_read_agnes_metadata_oversized_file_returns_empty(tmp_path):
+def test_read_marketplace_metadata_oversized_file_returns_empty(tmp_path):
     """Curator-controlled file > 1 MB cap is refused without reading the body.
 
     Defends against a misbehaving (or hostile) curator committing a multi-GB
     JSON that would OOM the sync worker (PR #234 review #9).
     """
-    from src.marketplace_metadata import AGNES_METADATA_MAX_BYTES
+    from src.marketplace_metadata import MARKETPLACE_METADATA_MAX_BYTES
 
-    target = tmp_path / ".claude-plugin" / "agnes-metadata.json"
+    target = tmp_path / ".claude-plugin" / "marketplace-metadata.json"
     target.parent.mkdir(parents=True)
     # Write valid JSON padded with whitespace to exceed the cap. The test
-    # doesn't have to allocate a real GB — anything > AGNES_METADATA_MAX_BYTES
+    # doesn't have to allocate a real GB — anything > MARKETPLACE_METADATA_MAX_BYTES
     # demonstrates the size gate fires before json.loads.
-    padding = " " * (AGNES_METADATA_MAX_BYTES + 1024)
+    padding = " " * (MARKETPLACE_METADATA_MAX_BYTES + 1024)
     target.write_text("{" + padding + "}", encoding="utf-8")
 
-    assert read_agnes_metadata(tmp_path) == {}
+    assert read_marketplace_metadata(tmp_path) == {}
 
 
-def test_read_agnes_metadata_deeply_nested_does_not_crash(tmp_path):
+def test_read_marketplace_metadata_deeply_nested_does_not_crash(tmp_path):
     """A deeply-nested JSON that fits under the size cap must not crash sync.
 
     Even if json.loads raises ``RecursionError`` instead of ``ValueError``
@@ -87,7 +87,7 @@ def test_read_agnes_metadata_deeply_nested_does_not_crash(tmp_path):
     metadata. The previous code only caught ``ValueError`` so this would
     have aborted the whole sync.
     """
-    target = tmp_path / ".claude-plugin" / "agnes-metadata.json"
+    target = tmp_path / ".claude-plugin" / "marketplace-metadata.json"
     target.parent.mkdir(parents=True)
     # 5000 nested arrays — comfortably past cpython's default recursion
     # limit (~1000) but far below the 1 MB size cap (~10 KB).
@@ -96,7 +96,7 @@ def test_read_agnes_metadata_deeply_nested_does_not_crash(tmp_path):
 
     # Function MUST return cleanly — either {} (parser blew up and we
     # caught it) or whatever the parser produced. Either way, no crash.
-    result = read_agnes_metadata(tmp_path)
+    result = read_marketplace_metadata(tmp_path)
     assert isinstance(result, dict)
 
 

--- a/tests/test_marketplace_synth_strip.py
+++ b/tests/test_marketplace_synth_strip.py
@@ -7,7 +7,7 @@ Two surfaces are covered:
 
 Both must strip:
 
-* ``.claude-plugin/agnes-metadata.json`` (anywhere in the plugin tree),
+* ``.claude-plugin/marketplace-metadata.json`` (anywhere in the plugin tree),
 * anything under ``.agnes/`` (anywhere in the plugin tree).
 
 Test fixtures stand up a fake plugin dir on disk + a fake `plugins` list
@@ -41,7 +41,7 @@ def _build_plugin_dir(tmp_path: Path) -> Path:
     )
 
     # Agnes-only files that MUST be stripped
-    (plugin / ".claude-plugin" / "agnes-metadata.json").write_text(
+    (plugin / ".claude-plugin" / "marketplace-metadata.json").write_text(
         '{"version":1}', encoding="utf-8",
     )
     (plugin / ".agnes").mkdir()
@@ -82,9 +82,9 @@ def test_is_agnes_only_path_strips_dot_agnes_anywhere():
     assert is_agnes_only_path(("plugins", "foo", ".agnes", "x.png"))
 
 
-def test_is_agnes_only_path_strips_agnes_metadata_json():
-    assert is_agnes_only_path((".claude-plugin", "agnes-metadata.json"))
-    assert is_agnes_only_path(("nested", "agnes-metadata.json"))
+def test_is_agnes_only_path_strips_marketplace_metadata_json():
+    assert is_agnes_only_path((".claude-plugin", "marketplace-metadata.json"))
+    assert is_agnes_only_path(("nested", "marketplace-metadata.json"))
 
 
 def test_is_agnes_only_path_keeps_normal_files():
@@ -100,7 +100,7 @@ def test_is_agnes_only_path_does_not_match_lookalikes():
     """Naming collisions: a directory named ``.agneswriter`` (single segment
     starting with `.agnes` but not equal) is NOT stripped."""
     assert not is_agnes_only_path((".agneswriter", "x.md"))
-    assert not is_agnes_only_path(("not-agnes-metadata.json",))
+    assert not is_agnes_only_path(("not-marketplace-metadata.json",))
 
 
 # --- ZIP path -------------------------------------------------------------
@@ -121,7 +121,7 @@ def test_zip_strips_agnes_only_files(tmp_path, monkeypatch):
     assert any(a.endswith("skills/foo/SKILL.md") for a in arcnames)
     assert any(a.endswith(".claude-plugin/marketplace.json") for a in arcnames)
     # Agnes-only files DID NOT
-    assert not any("agnes-metadata.json" in a for a in arcnames), arcnames
+    assert not any("marketplace-metadata.json" in a for a in arcnames), arcnames
     assert not any(".agnes/" in a for a in arcnames), arcnames
 
 
@@ -137,7 +137,7 @@ def test_zip_etag_independent_of_agnes_files(tmp_path):
     # Drop the `.agnes/` content and re-compute. ETag must match.
     import shutil
     shutil.rmtree(plugin_dir / ".agnes")
-    (plugin_dir / ".claude-plugin" / "agnes-metadata.json").unlink()
+    (plugin_dir / ".claude-plugin" / "marketplace-metadata.json").unlink()
     etag_without_agnes = marketplace_filter.compute_etag(plugins)
     assert etag_with_agnes == etag_without_agnes
 
@@ -163,5 +163,5 @@ def test_git_tree_strips_agnes_only_files(tmp_path):
 
     assert any(p.endswith("/SKILL.md") for p in files)
     assert any(p.endswith("/.claude-plugin/plugin.json") for p in files)
-    assert not any("agnes-metadata.json" in p for p in files)
+    assert not any("marketplace-metadata.json" in p for p in files)
     assert not any(".agnes/" in p for p in files)


### PR DESCRIPTION
## Summary

- Curated marketplace enrichment file `.claude-plugin/agnes-metadata.json` is renamed to `.claude-plugin/marketplace-metadata.json`. The `agnes-` prefix was project-specific brand; `marketplace-metadata.json` describes the file's actual role and sits naturally next to `marketplace.json`.
- Clean cut, no fallback — curators of upstream marketplace repos must rename the file in their repos.
- Python API renames mirror the file: `read_agnes_metadata` → `read_marketplace_metadata`, `AGNES_METADATA_REL` → `MARKETPLACE_METADATA_REL`, `AGNES_METADATA_MAX_BYTES` → `MARKETPLACE_METADATA_MAX_BYTES`.
- Synth Claude Code marketplace strip rule (`.agnes/**` + the metadata file) follows the new filename; log prefixes, comments, tests, docs, example file all updated.
- `CHANGELOG.md` history is untouched; new **BREAKING** entry under `[Unreleased]`.

## Test plan

- [x] `pytest tests/test_marketplace_metadata.py tests/test_marketplace.py tests/test_marketplace_synth_strip.py tests/test_marketplace_api.py tests/test_db_schema_version.py` → 79 passed, 2 skipped
- [ ] After merge: verify a curator's upstream repo with the new filename produces enrichment on the next nightly sync
- [ ] Confirm `marketplace-metadata.json` is stripped from the served `/marketplace.zip` / `/marketplace.git/` for downstream Claude Code instances