### PR TITLE
[codex] Add worktree spawn helper docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,37 @@ curl -X POST http://localhost:8000/api/sync/trigger
 docker compose up
 ```
 
+### Parallel Claude Code worktrees
+
+Use `scripts/dev/worktree-spawn.sh` when starting a second Claude Code session for
+parallel work. It creates an isolated Git worktree under `.worktrees/<branch-slug>`
+while symlinking shared local state (`user/`, `.venv/`, `.env`, `data/`) back to
+the main checkout.
+
+```bash
+scripts/dev/worktree-spawn.sh <branch-name> [base-branch]
+
+# Example: create a feature branch from latest main
+scripts/dev/worktree-spawn.sh fix/auth-redirect origin/main
+cd .worktrees/fix-auth-redirect
+```
+
+Keep only one writer active for DuckDB-backed state at a time. Do not run
+`da sync`, migrations, or other DuckDB-writing commands concurrently across
+worktrees. For parallel Docker Compose stacks, set a unique project name first:
+
+```bash
+export COMPOSE_PROJECT_NAME=agnes-<branch-slug>
+```
+
+When the side work is done, remove the worktree and delete the branch after it
+has been merged:
+
+```bash
+git worktree remove .worktrees/<branch-slug>
+git branch -d <branch-name>
+```
+
 ### Local sync & Claude Code hooks
 
 `agnes pull` is the canonical analyst-side distribution path: pulls the RBAC-filtered manifest from the server, downloads parquets whose MD5 changed (skipping `query_mode='remote'` rows), rebuilds local DuckDB views over them. `agnes push` mirrors it for the upload direction (sessions, CLAUDE.local.md).

--- a/scripts/dev/worktree-spawn.sh
+++ b/scripts/dev/worktree-spawn.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Spawn an isolated worktree for a parallel Claude Code session.
+#
+# Usage:
+#   scripts/dev/worktree-spawn.sh <branch-name> [base-branch]
+#
+# Example:
+#   scripts/dev/worktree-spawn.sh fix/auth-redirect main
+#
+# What it does:
+#   1. Creates .worktrees/<slug>/ off <base-branch> (default: current HEAD).
+#   2. Symlinks user/, .venv/, .env, data/  -> main checkout (single-writer state stays put).
+#   3. Prints next steps (cd, COMPOSE_PROJECT_NAME hint).
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <branch-name> [base-branch]" >&2
+  exit 2
+fi
+
+BRANCH="$1"
+BASE="${2:-HEAD}"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+SLUG="${BRANCH//\//-}"
+WT_DIR=".worktrees/$SLUG"
+
+if [[ -e "$WT_DIR" ]]; then
+  echo "error: $WT_DIR already exists" >&2
+  exit 1
+fi
+
+git worktree add "$WT_DIR" -b "$BRANCH" "$BASE"
+
+# Symlink shared, single-writer state. Worktree gets isolated source files
+# but shares the heavy/stateful bits with the main checkout.
+for target in user .venv .env data; do
+  if [[ -e "$REPO_ROOT/$target" ]]; then
+    ln -s "$REPO_ROOT/$target" "$WT_DIR/$target"
+    echo "  linked $target"
+  fi
+done
+
+cat <<EOF
+
+Worktree ready: $WT_DIR
+Branch:         $BRANCH (off $BASE)
+
+Next:
+  cd $WT_DIR
+  # launch claude code from inside the worktree
+
+Caveats for parallel sessions:
+  - DuckDB (user/duckdb/, data/state/system.duckdb) is single-writer.
+    Don't run 'da sync' or migrations from two worktrees at once.
+  - For parallel docker compose stacks, set:
+      export COMPOSE_PROJECT_NAME=agnes-$SLUG
+  - Cleanup when done:
+      git worktree remove $WT_DIR
+      git branch -d $BRANCH    # or -D if not merged
+EOF


### PR DESCRIPTION
## What changed

- Added scripts/dev/worktree-spawn.sh for creating isolated parallel Claude Code worktrees.
- Documented the worktree workflow in CLAUDE.md, including shared state caveats, Docker Compose project naming, and cleanup.

## Why

This gives future agents and developers a repeatable reference for starting parallel work without disturbing the main checkout.

## Validation

- Ran bash -n scripts/dev/worktree-spawn.sh.