### PR TITLE
fix(cli-install): move kbcstorage to [server] extra so wheel installs cleanly (P0 onboarding hotfix → 0.53.4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,61 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
-        run: uv pip install --system ".[dev]"
+        run: uv pip install --system ".[dev,server]"
 
       - name: Run tests (parallel)
         run: pytest tests/ -v --tb=short -n auto
         env:
           TESTING: "1"
+
+  cli-wheel-clean-install:
+    # Catches the "wheel METADATA conflicts with transitive deps under fresh
+    # resolver" class — exactly what the workspace-only `[tool.uv]
+    # override-dependencies` does NOT protect against. Builds the wheel the
+    # way `release.yml` ships it to analysts (`uv build --wheel`), then
+    # installs it into a fresh `python:3.13-slim` container with `uv tool
+    # install` (the path the `/setup` page advertises) and asserts the
+    # `agnes` binary actually launches. Without this, a regression like
+    # 0.53.3's `kbcstorage>=0.9.0 → urllib3<2.0.0` cap silently caps the
+    # wheel METADATA, every existing test passes (workspace overrides the
+    # cap), and the break only surfaces on the next analyst's first install.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist
+
+      - name: Smoke install in fresh python:3.13-slim
+        run: |
+          docker run --rm -v "$PWD/dist:/wheels:ro" python:3.13-slim bash -c '
+            set -euo pipefail
+            apt-get update -qq && apt-get install -y -qq --no-install-recommends curl ca-certificates >/dev/null
+            curl -LsSf https://astral.sh/uv/install.sh | sh > /dev/null 2>&1
+            export PATH="$HOME/.local/bin:$PATH"
+            WHEEL=$(ls /wheels/agnes_the_ai_analyst-*-py3-none-any.whl | head -1)
+            uv tool install --force "$WHEEL"
+            agnes --version
+            agnes --help > /dev/null
+            agnes catalog --help > /dev/null
+            python3 -c "
+            try:
+                import kbcstorage
+                raise SystemExit(\"REGRESSION: kbcstorage leaked into the CLI wheel — should be in [server] extra only\")
+            except ImportError:
+                pass
+            import urllib3
+            assert tuple(int(x) for x in urllib3.__version__.split(\".\")[:2]) >= (2, 7), urllib3.__version__
+            print(\"OK: kbcstorage absent, urllib3\", urllib3.__version__)
+            "
+          '
 
   docker-build:
     runs-on: ubuntu-latest
@@ -53,7 +102,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
-        run: uv pip install --system ".[dev]"
+        run: uv pip install --system ".[dev,server]"
 
       - name: Start services
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
-        run: uv pip install --system ".[dev]"
+        run: uv pip install --system ".[dev,server]"
 
       - name: Run tests
         run: pytest tests/ -v --tb=short

--- a/.github/workflows/keboola-deploy.yml
+++ b/.github/workflows/keboola-deploy.yml
@@ -40,7 +40,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
-        run: uv pip install --system ".[dev]"
+        run: uv pip install --system ".[dev,server]"
 
       - name: Lint with ruff
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
-        run: uv pip install --system ".[dev]"
+        run: uv pip install --system ".[dev,server]"
 
       - name: Lint with ruff
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.53.4] — 2026-05-12
+
+### Fixed
+
+- **Analyst CLI install (`uv tool install <wheel>`) no longer fails with `urllib3 / kbcstorage` resolver conflict on a clean machine.** From 0.53.3, every fresh `/setup` walkthrough hit `kbcstorage<=0.9.5 → urllib3<2.0.0` vs the wheel METADATA's `urllib3>=2.7.0` security pin and resolved to `unsatisfiable`. The `[tool.uv] override-dependencies = ["urllib3>=2.7.0"]` workaround that masked the conflict in workspace installs (Dockerfile, dev) does NOT propagate to the wheel — wheel METADATA is plain PEP 621 `Requires-Dist`, and a fresh resolver context (`uv tool install <wheel-url>`) never sees the override. Fix: `kbcstorage` moved out of `[project] dependencies` into `[project.optional-dependencies] server`, since it is server-side-only (`connectors/keboola/client.py` callers — admin endpoints, server connectors, integration tests; no CLI import path). Server install picks it up via the Dockerfile's `uv pip install --system --no-cache ".[server]"`; CI installs `.[dev,server]` so the workspace tests still cover the kbcstorage path. Analyst CLI wheel METADATA now lists `kbcstorage>=0.9.0; extra == 'server'` (gated) — `uv tool install` resolves cleanly.
+
+### Internal
+
+- **New CI lane `cli-wheel-clean-install` in `.github/workflows/ci.yml`** builds the wheel via `uv build` and installs it into a fresh `python:3.13-slim` container with `uv tool install`, asserting `agnes --version` works AND that `kbcstorage` is absent from the CLI venv. Catches the "wheel METADATA conflicts with transitive deps under fresh resolver" regression class — exactly what `[tool.uv] override-dependencies` does NOT protect against. Without this lane, the previous regression slipped through every existing test (workspace overrides masked the conflict in pytest) and only surfaced on the next analyst's first install.
+
 ## [0.53.3] — 2026-05-12
 
 Hygiene round closing #244 + #252 + clearing 5 Dependabot urllib3 advisories. (Originally cut as 0.53.2 — bumped to 0.53.3 after #264 / #268 landed as 0.53.2 in parallel.)

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,10 @@ RUN mkdir -p /opt/agnes-host && \
 # Build wheel artifact (served at /cli/download)
 RUN uv build --wheel --out-dir /app/dist
 
-# Install production dependencies from pyproject.toml
-RUN uv pip install --system --no-cache .
+# Install production dependencies from pyproject.toml. The `[server]` extra
+# pulls in connectors-only deps (kbcstorage) that the CLI wheel deliberately
+# omits — see [project.optional-dependencies].server in pyproject.toml.
+RUN uv pip install --system --no-cache ".[server]"
 
 # Run as non-root user for container hardening (C13).
 # uid/gid pinned to 999 so host-side chown in startup-script.sh.tpl can match

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.53.3"
+version = "0.53.4"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"
@@ -78,7 +78,10 @@ dependencies = [
     # module (export-async + signed-URL download) which talks to Storage API
     # directly via `requests` — no SDK dependency on the data-path side. The
     # SDK stays for the metadata reads.
-    "kbcstorage>=0.9.0",
+    #
+    # NOTE: kbcstorage moved to the [server] extra below — see the rationale
+    # in [project.optional-dependencies].server. CLI wheels installed via
+    # `uv tool install` deliberately ship without it.
     "sse-starlette>=2.0",
     # Optional observability — pure-Python, no compilation. Lazily initialized
     # in src/observability/posthog_client.py and only emits events when
@@ -105,13 +108,26 @@ dependencies = [
     # (4 high, 1 medium) flagged on urllib3<2.7.0: cross-origin sensitive
     # header leak on proxied low-level redirects, decompression-bomb bypass
     # + unbounded decompression chain on the streaming API, redirects-when-
-    # retries-disabled. Forced via `[tool.uv] override-dependencies` below
-    # because kbcstorage<=0.9.5 still pins urllib3<2.0.0 even though
-    # botocore/requests/google-cloud-* all support 2.x on Python 3.10+.
+    # retries-disabled. The `[server]` extra below adds kbcstorage which
+    # transitively caps urllib3<2.0.0; `[tool.uv] override-dependencies`
+    # forces 2.7+ in workspace installs (Dockerfile + dev). Wheel consumers
+    # who install only the CLI (`uv tool install <wheel>`) get no kbcstorage
+    # and no conflict.
     "urllib3>=2.7.0",
 ]
 
 [project.optional-dependencies]
+# Server-side connectors. The CLI wheel does NOT need these — analysts who
+# `uv tool install` the wheel never reach a kbcstorage import. Splitting it
+# out keeps the wheel's METADATA `Requires-Dist` set free of the
+# `kbcstorage<=0.9.5 → urllib3<2.0.0` cap that conflicts with our
+# `urllib3>=2.7.0` security pin under any fresh resolver context (where
+# `[tool.uv] override-dependencies` does NOT apply — see comment on
+# [tool.uv] below). Server install pulls it in via Dockerfile's
+# `uv pip install --system --no-cache .[server]`.
+server = [
+    "kbcstorage>=0.9.0",
+]
 observability = [
     # Already in base dependencies — listed here so operators who want to
     # be explicit can `pip install -e ".[observability]"` and signal intent.


### PR DESCRIPTION
## Summary

P0 fix — every new analyst onboarding **right now** hits an unsatisfiable resolver error on the documented \`uv tool install\` path.

The 0.53.3 wheel served at \`/cli/wheel/\` lists \`kbcstorage>=0.9.0\` and \`urllib3>=2.7.0\` in its plain PEP 621 \`Requires-Dist\`. \`kbcstorage<=0.9.5\` (the latest published) caps \`urllib3<2.0.0\`. The \`[tool.uv] override-dependencies = [\"urllib3>=2.7.0\"]\` workaround that masks this in workspace contexts (Dockerfile, dev) does **not** propagate to the wheel — wheel METADATA is workspace-agnostic, and a fresh resolver context (\`uv tool install <wheel-url>\`) never sees the override. Result on a clean Python 3.13 container:

\`\`\`
× No solution found when resolving dependencies:
╰─▶ Because kbcstorage<=0.9.5 depends on urllib3<2.0.0 and
    agnes-the-ai-analyst==0.53.3 depends on kbcstorage>=0.9.0 and urllib3>=2.7.0,
    we can conclude that agnes-the-ai-analyst==0.53.3 cannot be used.
\`\`\`

Reproduced twice: once in a clean \`python:3.13-slim\` Docker container (sub-agent smoke test), once on host Mac with native uv 0.11.13. Identical failure.

## What this PR does

- **Moves \`kbcstorage>=0.9.0\` from \`[project] dependencies\` → \`[project.optional-dependencies].server\`.** The package is server-side-only — \`connectors/keboola/client.py\` is the sole import site, called from admin endpoints, server connectors, and integration tests. CLI install path never reaches it.
- **Updates \`Dockerfile\`** \`uv pip install --system --no-cache .\` → \`.[server]\` so the production image still ships kbcstorage.
- **Updates 4 CI workflows** (\`.github/workflows/{ci,deploy,release,keboola-deploy}.yml\`) \`.[dev]\` → \`.[dev,server]\` so workspace tests keep covering the kbcstorage path.
- **Adds new CI lane \`cli-wheel-clean-install\`** that builds the wheel via \`uv build\` and installs it into a fresh \`python:3.13-slim\` container with \`uv tool install\`, asserting \`agnes --version\` works AND that \`kbcstorage\` is absent from the CLI venv. Catches the "wheel METADATA conflicts with transitive deps under fresh resolver" regression class — exactly what \`[tool.uv] override-dependencies\` does NOT protect against.
- **Bundles release-cut to 0.53.4** (last commit on the PR per CLAUDE.md hard rule).

## Test plan

- [x] Built wheel locally (\`uv build --wheel\`); inspected METADATA — kbcstorage line is now \`kbcstorage>=0.9.0; extra == 'server'\` (gated, was unconditional).
- [x] \`docker run --rm -v ./dist:/wheels:ro python:3.13-slim bash -c '...uv tool install /wheels/agnes_the_ai_analyst-0.53.4-py3-none-any.whl...'\` → installs clean, \`agnes --version\` prints \`agnes 0.53.4\`, \`agnes catalog --help\` renders, \`import kbcstorage\` raises \`ImportError\` (correct — gated extra), \`urllib3.__version__\` = \`2.7.0\` (security pin satisfied).
- [x] Same container with \`uv pip install --system --no-cache ".[server]"\` (Dockerfile path) → kbcstorage present, urllib3 = 2.7.0 (\`[tool.uv]\` override applies in workspace context as before).
- [x] Full pytest suite green locally: \`4157 passed, 25 skipped\` (\`pytest tests/ -p no:xdist -q\`, sequential because xdist install in this venv is broken — independent issue).
- [x] New \`cli-wheel-clean-install\` CI lane will run on every push + every PR; will fail loudly on any future regression of this class.

## Why no test caught the original break

\`pytest tests/\` runs in the dev venv where \`uv pip install ".[dev]"\` already used workspace overrides; kbcstorage 0.9.5 + urllib3 2.7.0 coexist there without issue. Wheel METADATA — what an external \`uv tool install\` actually consumes — is a different resolver context that overrides never see. No CI lane previously installed the built wheel into a clean env, so the regression was undetectable until it hit a real analyst's first install. The new \`cli-wheel-clean-install\` lane closes that gap.

## Migration notes

- No DB migration. No API change. No env-var change.
- **Operators**: production image (Dockerfile) automatically gets the new install path — no compose / image-pin change needed. The image still ships kbcstorage.
- **Analysts**: onboarding via the \`/setup\` page starts working again as soon as the v0.53.4 wheel is published.
- **Downstream consumers installing from source via \`pip install -e .\`** without the \`[server]\` extra will no longer have kbcstorage available; switch to \`pip install -e ".[server]"\` if you exercise the Keboola admin / extractor paths.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->