### PR TITLE
ci: fix indentation in cli-wheel-clean-install Python heredoc (follow-up to #272)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,29 +55,38 @@ jobs:
       - name: Build wheel
         run: uv build --wheel --out-dir dist
 
+      - name: Write CLI install assertion script
+        run: |
+          cat > /tmp/smoke.py <<'PY'
+          import sys, urllib3
+          try:
+              import kbcstorage  # noqa: F401
+              sys.exit("REGRESSION: kbcstorage leaked into the CLI wheel — should be in [server] extra only")
+          except ImportError:
+              pass
+          maj, minor = (int(x) for x in urllib3.__version__.split(".")[:2])
+          assert (maj, minor) >= (2, 7), f"urllib3 too old: {urllib3.__version__}"
+          print(f"OK: kbcstorage absent, urllib3 {urllib3.__version__}")
+          PY
+
       - name: Smoke install in fresh python:3.13-slim
         run: |
-          docker run --rm -v "$PWD/dist:/wheels:ro" python:3.13-slim bash -c '
-            set -euo pipefail
-            apt-get update -qq && apt-get install -y -qq --no-install-recommends curl ca-certificates >/dev/null
-            curl -LsSf https://astral.sh/uv/install.sh | sh > /dev/null 2>&1
-            export PATH="$HOME/.local/bin:$PATH"
-            WHEEL=$(ls /wheels/agnes_the_ai_analyst-*-py3-none-any.whl | head -1)
-            uv tool install --force "$WHEEL"
-            agnes --version
-            agnes --help > /dev/null
-            agnes catalog --help > /dev/null
-            python3 -c "
-            try:
-                import kbcstorage
-                raise SystemExit(\"REGRESSION: kbcstorage leaked into the CLI wheel — should be in [server] extra only\")
-            except ImportError:
-                pass
-            import urllib3
-            assert tuple(int(x) for x in urllib3.__version__.split(\".\")[:2]) >= (2, 7), urllib3.__version__
-            print(\"OK: kbcstorage absent, urllib3\", urllib3.__version__)
-            "
-          '
+          docker run --rm \
+            -v "$PWD/dist:/wheels:ro" \
+            -v /tmp/smoke.py:/smoke.py:ro \
+            python:3.13-slim bash -c '
+              set -euo pipefail
+              apt-get update -qq && apt-get install -y -qq --no-install-recommends curl ca-certificates >/dev/null
+              curl -LsSf https://astral.sh/uv/install.sh | sh > /dev/null 2>&1
+              export PATH="$HOME/.local/bin:$PATH"
+              WHEEL=$(ls /wheels/agnes_the_ai_analyst-*-py3-none-any.whl | head -1)
+              uv tool install --force "$WHEEL"
+              agnes --version
+              agnes --help > /dev/null
+              agnes catalog --help > /dev/null
+              # Run the assertion in the same venv uv tool created
+              "$HOME/.local/share/uv/tools/agnes-the-ai-analyst/bin/python" /smoke.py
+            '
 
   docker-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

The new `cli-wheel-clean-install` CI lane introduced in #272 (v0.53.4) fails on its first main run because YAML `run: |` preserves the relative indent of the inline `python3 -c` heredoc, so the Python interpreter saw `try:` starting at column 12 and refused to parse:

```
File "<string>", line 2
    try:
IndentationError: unexpected indent
```

The kbcstorage / urllib3 fix in the parent PR is correct and shipped — only the new lane that catches the regression class has a bug that prevents it from doing its job.

## Fix

- Write the Python assertion to `/tmp/smoke.py` via a `cat <<'PY'` heredoc (content lands left-aligned regardless of YAML indent).
- Mount it into the docker container alongside `dist/`.
- Invoke the tool's venv python directly (`$HOME/.local/share/uv/tools/agnes-the-ai-analyst/bin/python /smoke.py`) instead of the inline `python3 -c` block. Sidesteps `uv tool run --from <name>` doing a PyPI lookup that would fail because we don't publish to PyPI.

## Test plan

- [x] Reproduced original failure via `gh api repos/.../jobs/75622428308/logs` → confirmed `IndentationError: unexpected indent`.
- [x] Locally ran the new CI step verbatim (`docker run --rm -v ./dist:/wheels:ro -v /tmp/smoke.py:/smoke.py:ro python:3.13-slim bash -c '...'`) — prints:
  ```
  agnes 0.53.3
  OK: kbcstorage absent, urllib3 2.7.0
  ```
- [x] No code changes, no behavior changes — only the assertion mechanism for an existing CI lane.

## Why a separate PR

#272's auto-merge fired before this fix-on-fix could land — the `cli-wheel-clean-install` lane wasn't in branch protection's required-checks list (new lane, hasn't been added), so a failure there didn't block the squash. Promoting the lane to required after this PR lands.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->