### PR TITLE
fix(bq-hint): drop literal backslash escapes from syntax-error hint string (follow-up to #274)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ### Fixed
 
-- **`/api/query` `remote_estimate_failed` hint now branches on the BigQuery error class** instead of always claiming a column doesn't exist. The previous hardcoded "Most often this means a column referenced … doesn't exist" misled analysts whenever BigQuery actually rejected on syntax (e.g. `SELECT COUNT(*) AS rows` — `rows` is reserved, BQ returns `Syntax error: Unexpected keyword ROWS at [1:20]`, the previous hint pointed at non-existent columns). Branching: syntax errors get a hint about reserved-keyword aliases (with the `AS \`rows\`` / `AS row_count` workaround); `Unrecognized name` / `not found inside` still points at `agnes schema <id>`; `Table not found` points at `agnes catalog`; the fallback hint enumerates all three causes for the analyst to triage.
+- **`/api/query` `remote_estimate_failed` hint now branches on the BigQuery error class** instead of always claiming a column doesn't exist. The previous hardcoded "Most often this means a column referenced … doesn't exist" misled analysts whenever BigQuery actually rejected on syntax (e.g. `SELECT COUNT(*) AS rows` — `rows` is reserved, BQ returns `Syntax error: Unexpected keyword ROWS at [1:20]`, the previous hint pointed at non-existent columns). Branching: syntax errors get a hint about reserved-keyword aliases with both rename + BQ-style backtick-quote alternatives; `Unrecognized name` / `not found inside` still points at `agnes schema <id>`; `Table not found` points at `agnes catalog`; the fallback hint enumerates all three causes for the analyst to triage.
 
 ## [0.53.4] — 2026-05-12
 

--- a/app/api/query.py
+++ b/app/api/query.py
@@ -88,13 +88,20 @@ def _hint_for_bq_bad_request(message: str) -> str:
     rather than always blaming columns."""
     msg = message.lower()
     if "unexpected keyword" in msg or "syntax error" in msg:
+        # Plain text — this string is surfaced as JSON `hint:` and printed
+        # verbatim by the CLI. No markdown rendering, so avoid backtick
+        # quoting around BQ-style backtick identifiers (`\\\`` escape in
+        # a Python source literal renders the backslashes literally to
+        # the analyst — exactly the misleading shape this hint tries to
+        # fix).
         return (
             "BigQuery rejected this on SQL syntax. Most often this is a "
             "reserved-keyword identifier used unquoted — e.g. "
-            "`SELECT COUNT(*) AS rows` fails because `rows` is reserved. "
-            "Backtick the alias (`AS \\`rows\\``) or rename it "
-            "(`AS row_count`). For other syntax errors, see the "
-            "`underlying` field below — it carries BigQuery's own "
+            "SELECT COUNT(*) AS rows fails because 'rows' is reserved. "
+            "Either rename the alias to a non-reserved word (AS row_count) "
+            "or backtick-quote it BQ-style (AS `rows` with literal "
+            "backticks around the identifier). For other syntax errors, "
+            "see the 'underlying' field below — it carries BigQuery's own "
             "diagnostic with the error position."
         )
     if "unrecognized name" in msg or "not found inside" in msg or "field name" in msg:

--- a/tests/test_api_query_guardrail.py
+++ b/tests/test_api_query_guardrail.py
@@ -855,6 +855,33 @@ class TestHintForBqBadRequest:
         # Must NOT lead with the misleading column-not-found hint
         assert "column referenced" not in hint.lower()
 
+    def test_no_hint_branch_leaks_literal_backslashes(self):
+        # Hints are surfaced as JSON `hint:` and printed verbatim by the
+        # CLI — no markdown rendering. A backslash-backtick in the Python
+        # source literal becomes a literal backslash followed by a
+        # backtick in the output, which is exactly the misleading shape
+        # this dispatcher exists to fix (see #274 follow-up). Pin every
+        # branch against the regression.
+        from app.api.query import _hint_for_bq_bad_request
+
+        cases = [
+            "Syntax error: Unexpected keyword ROWS at [1:20]",
+            "Unrecognized name: authorize_date at [1:88]",
+            "Field 'foo' not found inside record_type",
+            "Table not found: my-project.dataset.tbl",
+            "Some unfamiliar BQ diagnostic",  # fallback
+        ]
+        for msg in cases:
+            hint = _hint_for_bq_bad_request(msg)
+            assert "\\`" not in hint, (
+                f"hint for {msg!r} contains literal backslash-backtick: "
+                f"{hint!r}"
+            )
+            assert "\\\\" not in hint, (
+                f"hint for {msg!r} contains literal double-backslash: "
+                f"{hint!r}"
+            )
+
     def test_unrecognized_name_hint_points_at_agnes_schema(self):
         from app.api.query import _hint_for_bq_bad_request
 


### PR DESCRIPTION
## Summary

Self-review on the just-merged #274 caught a bug I introduced. The new syntax-error branch in `_hint_for_bq_bad_request` had:

\`\`\`python
"Backtick the alias (\`AS \\\`rows\\\`\`) or rename it ..."
\`\`\`

Python doesn't recognize \`\\\\\\\`\` as an escape sequence — the literal backslashes survived into the JSON \`hint:\` field. Analyst reading the CLI error saw:

\`\`\`
Backtick the alias (\`AS \\\`rows\\\`\`) or rename it ...
\`\`\`

with visible backslashes — **exactly the misleading shape this dispatcher exists to clean up**. The hint that was supposed to demystify reserved-keyword aliases instead introduced a new mystification.

## Changes

- **\`app/api/query.py\`** — replaced the problematic substring with plain prose: \`Either rename the alias to a non-reserved word (AS row_count) or backtick-quote it BQ-style (AS \\\`rows\\\` with literal backticks around the identifier).\` No escape gymnastics, renders cleanly to JSON / terminal.
- **\`tests/test_api_query_guardrail.py\`** — new \`test_no_hint_branch_leaks_literal_backslashes\` pins every dispatch branch (5 BQ error shapes) against \`\\\\\\\`\` and \`\\\\\\\\\` substrings. Pytest catches this regression class next time, instead of waiting for an analyst to spot it.
- **\`CHANGELOG.md\`** — same broken backslashes leaked into the \`[Unreleased]\` bullet I added in #274. Rephrased to plain prose.

## Test plan

- [x] Demo run of the syntax-error branch confirms clean output (no literal backslashes):
  > BigQuery rejected this on SQL syntax. Most often this is a reserved-keyword identifier used unquoted — e.g. SELECT COUNT(*) AS rows fails because 'rows' is reserved. Either rename the alias to a non-reserved word (AS row_count) or backtick-quote it BQ-style (AS \`rows\` with literal backticks around the identifier). For other syntax errors, see the 'underlying' field below — it carries BigQuery's own diagnostic with the error position.
- [x] All 26 tests in \`test_api_query_guardrail.py\` green (including the 5 \`TestHintForBqBadRequest\` cases — 4 from #274 + 1 new regression test).
- [x] Full pytest suite green locally: \`4162 passed, 25 skipped\`.

## Why a separate PR

#274 was already auto-merged by the time I did the independent review and spotted this. Same hygiene scope; goes under \`[Unreleased]\` with the rest of the post-v0.53.4 papercut work — no separate release-cut.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->