### PR TITLE
feat(catalog): promote buckets to top-level Data Package cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,15 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   accordion under a single "Core Business Data" wrapper. The page hero
   title ("Data Packages") now describes the actual visual structure, and
   the card grain matches the `bucket` column on `table_registry`. Tables
-  inside each package are flat-listed (no per-bucket accordion). The
-  `Agnes Internal` and `Business Metrics` cards are unchanged; their
-  flat-list pattern is what the bucket cards now follow. The aggregate
-  meta line ("N tables · ~M rows total · Synced X") that lived on the
-  old wrapper is dropped — the Business Metrics card's existing
-  `data-freshness-note` continues to surface the global sync timestamp.
+  inside each package are flat-listed (no per-bucket accordion),
+  mirroring the existing `Agnes Internal` card; the `Agnes Internal` and
+  `Business Metrics` cards themselves are unchanged. Per-table sync info
+  ("Synced …" / "Queried directly from BigQuery") on each row is
+  preserved. The aggregate meta line ("N tables · ~M rows total ·
+  Synced X") on the old wrapper is dropped with no replacement — the
+  global sync timestamp is no longer shown on this page. An instance
+  with zero registered tables now renders no Data Package cards at all,
+  where the old wrapper always rendered (showing "0 tables").
 
 ## [0.54.10] — 2026-05-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.54.11] — 2026-05-14
+
 ### Changed
 - Catalog page: each `catalog_data` bucket now renders as its own
   top-level Data Package card instead of being nested as a collapsible

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Changed
+- Catalog page: each `catalog_data` bucket now renders as its own
+  top-level Data Package card instead of being nested as a collapsible
+  accordion under a single "Core Business Data" wrapper. The page hero
+  title ("Data Packages") now describes the actual visual structure, and
+  the card grain matches the `bucket` column on `table_registry`. Tables
+  inside each package are flat-listed (no per-bucket accordion). The
+  `Agnes Internal` and `Business Metrics` cards are unchanged; their
+  flat-list pattern is what the bucket cards now follow. The aggregate
+  meta line ("N tables · ~M rows total · Synced X") that lived on the
+  old wrapper is dropped — the Business Metrics card's existing
+  `data-freshness-note` continues to surface the global sync timestamp.
+
 ## [0.54.10] — 2026-05-14
 
 ### Changed

--- a/app/web/templates/catalog.html
+++ b/app/web/templates/catalog.html
@@ -1332,7 +1332,13 @@
     <!-- ═══════════════ SOURCE CARDS ═══════════════ -->
     <div class="source-cards">
 
-        <!-- ── Card 1: Core Business Data ── -->
+        {# ── Data Packages: one source-card per bucket ─────────────────────
+           Previously all buckets were nested as accordions under a single
+           "Core Business Data" wrapper card. Each bucket is now its own
+           top-level Data Package card, matching the page hero title and
+           the bucket grain of the table_registry. The Internal and
+           Business Metrics cards below follow the same flat-list pattern. #}
+        {% for category in catalog_data %}
         <div class="source-card">
             <div class="source-card-header">
                 <div class="source-card-left">
@@ -1346,63 +1352,48 @@
                         </svg>
                     </div>
                     <div class="source-card-info">
-                        <div class="source-card-name">Core Business Data</div>
-                        <div class="source-card-desc">Core business data from internal systems</div>
-                        <div class="source-card-meta">
-                            {{ data_stats.total_tables or data_stats.tables }} tables &middot; ~{{ data_stats.rows_display }} rows total
-                            {% if data_stats.last_updated %}
-                            &middot; Synced {{ data_stats.last_updated }}
-                            {% endif %}
-                        </div>
+                        <div class="source-card-name">{{ category.name }}</div>
+                        <div class="source-card-meta">{{ category.count }} table{{ 's' if category.count != 1 else '' }}</div>
                     </div>
                 </div>
             </div>
 
-            {% for category in catalog_data %}
-            <div class="accordion-category">
-                <button class="accordion-trigger" onclick="toggleAccordion(this)">
-                    <svg class="accordion-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <polyline points="9 18 15 12 9 6"/>
-                    </svg>
-                    {{ category.name }}
-                    <span class="accordion-count">{{ category.count }} tables</span>
-                </button>
-                <div class="accordion-content">
-                    {% for table in category.tables %}
-                    <div class="table-row" {% if table.query_mode != 'remote' %}onclick="openProfiler('{{ table.name }}')"{% endif %}>
-                        <div class="table-row-left">
-                            <div class="table-row-name">
-                                {{ table.name }}
-                                {% if table.query_mode == 'remote' %}
-                                <span class="query-mode-badge live">Live</span>
-                                {% else %}
-                                <span class="query-mode-badge local">Local</span>
-                                {% endif %}
-                            </div>
-                            <div class="table-row-desc">{{ table.description }}</div>
-                            <div class="table-sync-info">
-                                {% if table.query_mode == 'remote' %}
-                                <span class="live-dot"></span> Queried directly from BigQuery
-                                {% elif table.last_sync %}
-                                Synced {{ table.last_sync }}
-                                {% endif %}
-                            </div>
+            {# Plain list — tables shown directly; no accordion since the card IS the package. #}
+            <div class="accordion-content expanded" style="display: block;">
+                {% for table in category.tables %}
+                <div class="table-row" {% if table.query_mode != 'remote' %}onclick="openProfiler('{{ table.name }}')"{% endif %}>
+                    <div class="table-row-left">
+                        <div class="table-row-name">
+                            {{ table.name }}
+                            {% if table.query_mode == 'remote' %}
+                            <span class="query-mode-badge live">Live</span>
+                            {% else %}
+                            <span class="query-mode-badge local">Local</span>
+                            {% endif %}
                         </div>
-                        <div class="table-row-right">
-                            <span class="rows-badge{{ ' large' if table.rows_large }}">{{ table.rows_display }}</span>
-                            {% if table.query_mode != 'remote' %}
-                            <span class="profile-link">
-                                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7z"/><circle cx="12" cy="12" r="3"/></svg>
-                                Profile
-                            </span>
+                        <div class="table-row-desc">{{ table.description }}</div>
+                        <div class="table-sync-info">
+                            {% if table.query_mode == 'remote' %}
+                            <span class="live-dot"></span> Queried directly from BigQuery
+                            {% elif table.last_sync %}
+                            Synced {{ table.last_sync }}
                             {% endif %}
                         </div>
                     </div>
-                    {% endfor %}
+                    <div class="table-row-right">
+                        <span class="rows-badge{{ ' large' if table.rows_large }}">{{ table.rows_display }}</span>
+                        {% if table.query_mode != 'remote' %}
+                        <span class="profile-link">
+                            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7z"/><circle cx="12" cy="12" r="3"/></svg>
+                            Profile
+                        </span>
+                        {% endif %}
+                    </div>
                 </div>
+                {% endfor %}
             </div>
-            {% endfor %}
         </div>
+        {% endfor %}
 
         {# ── Card: Agnes Internal ─────────────────────────────────────────
            Renders the three system tables (agnes_sessions / agnes_telemetry /

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.54.10"
+version = "0.54.11"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"


### PR DESCRIPTION
## Summary

Each bucket in `catalog_data` now renders as its own top-level Data Package card on `/catalog`, instead of being nested under a single "Core Business Data" wrapper as collapsible accordions. The page hero is already titled **Data Packages** (set in #284) — this PR makes the visual structure of the page match that title and the `bucket` grain of `table_registry`.

Follow-up to @ZdenekSrotyr's design system unification (#284); reuses the same flat-list pattern that the `Agnes Internal` and `Business Metrics` cards already use.

## Why

- **Removes a level of indirection** — one click to a table instead of two (expand bucket → click table).
- **Visual matches the data model.** `bucket` is already a first-class column on `table_registry` (`POST /api/admin/register-table`, `PUT /api/admin/registry/{id}`). The old UI hid that grain behind one wrapper.
- **Removes the awkward single-table accordion** when a bucket has only 1 table (e.g. Experiments).
- **Visual parity** with the existing `Agnes Internal` card — it already uses the flat-list pattern this PR adopts. (`Business Metrics` is unchanged and keeps its per-category accordions.)
- **Page hero title now describes what's on the page.** Today: "Data Packages" → one wrapper card. After: "Data Packages" → N package cards.

## Before / After

**Before**
```
[ Core Business Data ]                ← single source-card wraps all buckets
   ▸ Deal (2 tables)            collapsed accordions
   ▸ Location (2 tables)
   ▸ Finance (2 tables)
   ▸ Traffic (2 tables)
   ▸ Search (2 tables)
   ▸ Experiments (1 tables)
[ Agnes Internal ]
[ Business Metrics ]
```

**After**
```
[ Deal ]            ← top-level Data Package card, tables visible
  • ds1_session_deal_impressions    [Live]
  • ds2_session_deal_clicks         [Live]
[ Location ]
  • l0_session_location             [Live]
  • l0_session_location_changes     [Live]
[ Finance ]
  • order_economics                 [Local] · Profile
  • unit_economics                  [Live]
[ Traffic ]
  • s1_session_landings             [Live]
  • s2_session_pageviews            [Live]
[ Search ]
  • s4a_search_deal_detail          [Live]
  • s4b_search_context              [Live]
[ Experiments ]
  • xs1_session_experiments         [Live]
[ Agnes Internal ]                  ← unchanged
[ Business Metrics ]                ← unchanged
```

## What's preserved

- **Per-table behaviour is identical**: `Live` / `Local` query-mode badges, profile-link on local tables, `openProfiler()` click for non-remote, `Synced …` and `Queried directly from BigQuery` per-row info lines, `rows-badge` with `large` modifier.
- **Pluralization fix**: meta now reads `1 table` / `2 tables` (was always `N tables` before, even when N=1).
- **Agnes Internal** and **Business Metrics** cards are untouched.

## What's dropped

- The single aggregate header line on the old wrapper: `N tables · ~M rows total · Synced X`. Per-bucket counts replace `N tables`. The "rows total" string was rendering as `~ rows total` when `data_stats.rows_display` was missing — losing it is intentional.
- **Global aggregate sync timestamp.** The `Synced X` part of that header line is dropped with no replacement — the catalog page no longer shows a page-level sync timestamp. (Per-table `Synced …` lines on each row are unaffected. The Business Metrics card's `data-freshness-note` is *not* a replacement: the catalog handler passes `metrics_data=[]` unconditionally, so that card never renders here.)
- **Empty-state behaviour.** With the wrapper gone, an instance with zero registered tables now renders no Data Package cards at all, where the old `Core Business Data` wrapper always rendered (showing `0 tables`). Arguably an improvement, but it is a real behaviour delta.

## Scope of change

- `app/web/templates/catalog.html` — replaces the Core Business Data wrapper card (one `<div class="source-card">` around the bucket-accordion loop) with a per-bucket card loop. Mostly indentation/restructure.
- `CHANGELOG.md` — `### Changed` entry, plus the `0.54.11` release-cut.
- `pyproject.toml` — version bump `0.54.10` → `0.54.11` (release-cut).

No changes to:
- View handler (`app/web/router.py::catalog_data` shape is unchanged — same `category.name`, `category.count`, `category.tables`).
- CSS / design tokens (reuses existing `.source-card`, `.source-card-header`, `.accordion-content.expanded`, `.table-row` etc.).
- Registry / API / DB schema.

## Out of scope (intentional follow-ups)

- Per-bucket descriptions (`category.description`). Today the loop has no field for this; could be added later via a hardcoded map in the view layer, or via a `bucket_description` field on the registry. Suggest discussing separately if you want descriptions.
- Multi-column grid layout. Cards still stack single-column as today. A 2-col grid at wide widths would shorten vertical scroll but is a separate visual change.
- Per-bucket icons. All packages use the same primary "document" icon (matches the old wrapper). Differentiating icons per bucket (search/deal/location/etc.) could be a follow-up.

## Manual verification

Static preview comparing current vs. proposed: <https://github.com/pcernik-grpn/agnes-the-ai-analyst/pull/new/feat/catalog-buckets-as-packages> (local mockup file: `reports/agnes-ui-mockup/catalog-buckets-as-packages.html` on my laptop — happy to share via screenshot or live deploy if useful).

To verify locally:
```bash
docker compose up
# open http://localhost:8000/catalog
```

cc @ZdenekSrotyr — would value your sign-off given this lands on top of #284.
