### PR TITLE
feat(web): consolidate /me/stats + /profile/sessions into /me/activity

### DIFF
--- a/app/api/me_stats.py
+++ b/app/api/me_stats.py
@@ -66,6 +66,14 @@ def _session_data_dir() -> Path:
 # ---------------------------------------------------------------------------
 
 
+def _uploaded_sessions_dir(user_id: str) -> Path:
+    """``${DATA_DIR}/user_sessions/<user_id>`` — where ``agnes push``
+    deposits JSONL files.  Mirrors ``app.web.router.profile_sessions_page``.
+    """
+    data_dir = Path(os.environ.get("DATA_DIR", "/data"))
+    return data_dir / "user_sessions" / user_id
+
+
 @router.get("/sessions")
 def list_self_sessions(
     limit: int = Query(50, ge=1, le=200),
@@ -77,12 +85,13 @@ def list_self_sessions(
 
     Joins ``usage_session_summary`` (processed=true) with a filesystem
     scan of un-processed JSONL so a session appears immediately even
-    before the UsageProcessor runs. Mirrors the admin
-    ``list_user_sessions`` projection plus the v44 token columns —
-    the Stats tab renders one row per session with totals on the
-    right.
+    before the UsageProcessor runs.  Additionally enriches each row
+    with verification-pipeline status (from ``session_processor_state``)
+    and a ``download_url`` when the uploaded JSONL exists in
+    ``${DATA_DIR}/user_sessions/<user_id>/``.
     """
     username = _username_for_stats(user)
+    user_id: str = user["id"]
     user_dir = _session_data_dir() / username
 
     try:
@@ -102,8 +111,6 @@ def list_self_sessions(
             [username],
         ).fetchall()
     except Exception:
-        # usage_session_summary may not exist on a partially-migrated DB.
-        # Fall back to filesystem-only listing rather than 500.
         rows_db = []
 
     cols = [
@@ -159,6 +166,21 @@ def list_self_sessions(
                 "processed": False,
             })
 
+    # --- Enrich with verification-pipeline status ---
+    _enrich_pipeline_status(all_rows, user_id, conn)
+
+    # --- Enrich with download URLs for uploaded JSONL ---
+    uploaded_dir = _uploaded_sessions_dir(user_id)
+    uploaded_names: set[str] = set()
+    if uploaded_dir.is_dir():
+        uploaded_names = {p.name for p in uploaded_dir.glob("*.jsonl")}
+    for row in all_rows:
+        fname = row.get("session_file", "")
+        if fname in uploaded_names:
+            row["download_url"] = f"/profile/sessions/{fname}"
+        else:
+            row["download_url"] = None
+
     all_rows.sort(
         key=lambda r: r.get("started_at") or "",
         reverse=True,
@@ -171,6 +193,48 @@ def list_self_sessions(
         "limit": limit,
         "rows": page,
     }
+
+
+def _enrich_pipeline_status(
+    rows: list[dict],
+    user_id: str,
+    conn: duckdb.DuckDBPyConnection,
+) -> None:
+    """Add ``pipeline_status`` and ``items_extracted`` from
+    ``session_processor_state`` (verification processor) to each row
+    in-place.  Matches are looked up by ``<user_id>/<session_file>``.
+    """
+    if not rows:
+        return
+    keys = [f"{user_id}/{r['session_file']}" for r in rows]
+    state_map: dict[str, dict] = {}
+    try:
+        placeholders = ",".join("?" for _ in keys)
+        db_rows = conn.execute(
+            f"""SELECT session_file, processed_at, items_extracted
+                FROM session_processor_state
+                WHERE processor_name = 'verification'
+                  AND session_file IN ({placeholders})""",
+            keys,
+        ).fetchall()
+        state_cols = [d[0] for d in conn.description]
+        for row in db_rows:
+            d = dict(zip(state_cols, row))
+            state_map[d["session_file"]] = d
+    except Exception:
+        pass
+    for row in rows:
+        key = f"{user_id}/{row['session_file']}"
+        state = state_map.get(key)
+        if state is None:
+            row["pipeline_status"] = "pending"
+            row["items_extracted"] = None
+        else:
+            items = state.get("items_extracted")
+            row["items_extracted"] = items
+            row["pipeline_status"] = (
+                "extracted" if items and items > 0 else "processed"
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/app/web/router.py
+++ b/app/web/router.py
@@ -761,16 +761,17 @@ async def home_page(
     return templates.TemplateResponse(request, "home_not_onboarded.html", ctx)
 
 
-@router.get("/me/stats", response_class=HTMLResponse)
-async def me_stats_page(
+@router.get("/me/activity", response_class=HTMLResponse)
+async def me_activity_page(
     request: Request,
     user: dict = Depends(get_current_user),
     conn: duckdb.DuckDBPyConnection = Depends(_get_db),
 ):
-    """Per-analyst stats dashboard. Four tabs (Sessions / Tokens /
-    Data access / Sync activity) backed by /api/me/stats/* endpoints.
-    Authed-only; each endpoint enforces user_id = caller scoping
-    server-side so this route just renders the shell.
+    """Unified personal-activity page — consolidated replacement for
+    the old ``/me/stats`` + ``/profile/sessions`` split.  Four tabs
+    (Sessions / Token usage / Data access / Sync activity) backed by
+    ``/api/me/stats/*`` endpoints.  The Sessions tab merges usage
+    metrics with verification-pipeline status and download links.
     """
     ctx = _build_context(
         request,
@@ -778,7 +779,13 @@ async def me_stats_page(
         conn=conn,
         is_admin=is_user_admin(user["id"], conn),
     )
-    return templates.TemplateResponse(request, "me_stats.html", ctx)
+    return templates.TemplateResponse(request, "me_activity.html", ctx)
+
+
+@router.get("/me/stats", response_class=HTMLResponse)
+async def me_stats_redirect(request: Request):
+    """Legacy redirect — ``/me/stats`` → ``/me/activity``."""
+    return RedirectResponse(url="/me/activity", status_code=301)
 
 
 @router.get("/news", response_class=HTMLResponse)
@@ -2160,82 +2167,9 @@ async def profile_page(
 
 
 @router.get("/profile/sessions", response_class=HTMLResponse)
-async def profile_sessions_page(
-    request: Request,
-    user: dict = Depends(get_current_user),
-    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
-):
-    """User-self-view of own uploaded sessions and their extraction state.
-
-    Walks `${DATA_DIR}/user_sessions/<user_id>/*.jsonl` for the caller's
-    own user_id, joins each file against the verification processor's
-    rows in `session_processor_state` to surface processed_at + items_extracted,
-    and renders a table. Items_extracted = 0 means the verification processor
-    ran but the LLM found no claims worth tracking — that's the documented
-    "no items" outcome; it does NOT mean the pipeline is broken.
-    """
-    import pathlib
-    user_id = user["id"]
-    data_dir = pathlib.Path(os.environ.get("DATA_DIR", "/data"))
-    user_sessions_dir = data_dir / "user_sessions" / user_id
-
-    files = []
-    if user_sessions_dir.is_dir():
-        # Stat once per file with OSError tolerance, THEN sort. The previous
-        # `sorted(..., key=lambda p: p.stat().st_mtime)` raised on any
-        # transient stat failure (race with delete, permission flicker) and
-        # 500-ed the whole page (Devin Review on #179).
-        statted = []
-        for jsonl in user_sessions_dir.glob("*.jsonl"):
-            try:
-                stat = jsonl.stat()
-            except OSError:
-                continue
-            statted.append((jsonl, stat))
-        statted.sort(key=lambda pair: pair[1].st_mtime, reverse=True)
-        for jsonl, stat in statted:
-            files.append({
-                "name": jsonl.name,
-                "size_bytes": stat.st_size,
-                "mtime": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc),
-            })
-
-    state_map: dict = {}
-    if files:
-        keys = [f"{user_id}/{f['name']}" for f in files]
-        placeholders = ",".join("?" for _ in keys)
-        rows = conn.execute(
-            f"""SELECT session_file, processed_at, items_extracted, file_hash
-                FROM session_processor_state
-                WHERE processor_name = 'verification'
-                  AND session_file IN ({placeholders})""",
-            keys,
-        ).fetchall()
-        cols = [d[0] for d in conn.description]
-        for row in rows:
-            d = dict(zip(cols, row))
-            state_map[d["session_file"]] = d
-
-    rows_view = []
-    for f in files:
-        key = f"{user_id}/{f['name']}"
-        state = state_map.get(key)
-        rows_view.append({
-            "name": f["name"],
-            "size_kb": round(f["size_bytes"] / 1024, 1),
-            "uploaded_at": f["mtime"],
-            "processed_at": state["processed_at"] if state else None,
-            "items_extracted": state["items_extracted"] if state else None,
-            "is_processed": state is not None,
-        })
-
-    ctx = _build_context(
-        request,
-        user=user,
-        sessions=rows_view,
-        user_id=user_id,
-    )
-    return templates.TemplateResponse(request, "profile_sessions.html", ctx)
+async def profile_sessions_redirect(request: Request):
+    """Legacy redirect — ``/profile/sessions`` → ``/me/activity?tab=sessions``."""
+    return RedirectResponse(url="/me/activity?tab=sessions", status_code=301)
 
 
 @router.get("/profile/sessions/{filename}")

--- a/app/web/templates/_app_header.html
+++ b/app/web/templates/_app_header.html
@@ -24,7 +24,7 @@
         <a class="app-nav-link {% if _path == _home or _path == '/' or _path == '/dashboard' or _path == '/home' %}is-active{% endif %}" href="{{ _home }}">Home</a>
         <a class="app-nav-link {% if _path == '/marketplace' or _path.startswith('/marketplace/') %}is-active{% endif %}" href="/marketplace">Marketplace</a>
         <a class="app-nav-link {% if _path.startswith('/catalog') %}is-active{% endif %}" href="/catalog">Data Packages</a>
-        <a class="app-nav-link {% if _path.startswith('/me/stats') %}is-active{% endif %}" href="/me/stats">Stats</a>
+
         {# Memory + Admin menu: both admin-only. Backend gates the routes
            themselves via require_admin (see app/web/router.py for
            /corporate-memory + /corporate-memory/admin + /admin/*), so
@@ -110,7 +110,7 @@
                     {% endif %}
                 </div>
                 <a class="app-user-menu-item {% if _path == '/profile' %}is-active{% endif %}" role="menuitem" href="/profile">Profile</a>
-                <a class="app-user-menu-item {% if _path == '/profile/sessions' %}is-active{% endif %}" role="menuitem" href="/profile/sessions">My sessions</a>
+                <a class="app-user-menu-item {% if _path.startswith('/me/activity') %}is-active{% endif %}" role="menuitem" href="/me/activity">My activity</a>
                 <a class="app-user-menu-item {% if _path == '/tokens' %}is-active{% endif %}" role="menuitem" href="/tokens">My tokens</a>
                 {% if config.DEBUG_AUTH_ENABLED %}
                 <a class="app-user-menu-item {% if _path.startswith('/me/debug') %}is-active{% endif %}" role="menuitem" href="/me/debug">Auth debug</a>

--- a/app/web/templates/me_activity.html
+++ b/app/web/templates/me_activity.html
@@ -1,0 +1,499 @@
+{% extends "base.html" %}
+
+{% block title %}My activity — {{ instance_brand }}{% endblock %}
+
+{% block layout %}
+    {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+    <div class="flash-messages">
+        {% for category, message in messages %}
+        <div class="flash flash-{{ category }}">{{ message }}</div>
+        {% endfor %}
+    </div>
+    {% endif %}
+    {% endwith %}
+    <main class="main">{{ self.content() }}</main>
+{% endblock %}
+
+{% block content %}
+<style>
+.activity-page { max-width: 1280px; margin: 0 auto; padding: 24px 24px 64px; }
+
+.stats-panel { display: none; }
+.stats-panel.is-active { display: block; }
+.stats-loading { color: var(--hp-text-muted, #6b7280); font-style: italic; padding: 24px 0; }
+.stats-error { color: #b91c1c; padding: 24px 0; }
+.stats-empty { color: var(--hp-text-muted, #6b7280); padding: 24px 0; }
+
+table.stats-table {
+    width: 100%; border-collapse: collapse; font-size: 13px;
+    font-variant-numeric: tabular-nums;
+}
+table.stats-table th, table.stats-table td {
+    padding: 8px 10px; border-bottom: 1px solid var(--hp-border-light, rgba(0,0,0,0.07));
+    text-align: left; vertical-align: top;
+}
+table.stats-table th { font-weight: 600; color: var(--hp-text-muted, #6b7280); font-size: 11.5px;
+    text-transform: uppercase; letter-spacing: 0.04em; }
+table.stats-table td.num { text-align: right; }
+table.stats-table tbody tr:hover { background: rgba(0,0,0,0.02); }
+
+.stats-paginate {
+    display: flex; gap: 8px; justify-content: flex-end; padding: 12px 0;
+}
+.stats-paginate button {
+    padding: 6px 12px; font: inherit; font-size: 12px; cursor: pointer;
+    border: 1px solid var(--hp-border-light, rgba(0,0,0,0.12)); border-radius: 6px;
+    background: #fff;
+}
+.stats-paginate button:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.stats-overview {
+    display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-bottom: 16px;
+}
+@media (max-width: 720px) { .stats-overview { grid-template-columns: repeat(2, 1fr); } }
+.stats-overview .card {
+    padding: 12px; border-radius: 8px;
+    background: var(--hp-stat-bg, rgba(0,0,0,0.025));
+}
+.stats-overview .lbl {
+    font-size: 11px; color: var(--hp-text-muted, #6b7280);
+    text-transform: uppercase; letter-spacing: 0.04em; margin-bottom: 4px;
+}
+.stats-overview .val { font-size: 22px; font-weight: 600; font-variant-numeric: tabular-nums; }
+
+.tok-chart { width: 100%; height: 160px; margin: 8px 0 16px; }
+.tok-chart rect { fill: var(--hp-accent, #2563eb); opacity: 0.85; }
+.tok-chart .axis text { font-size: 10px; fill: var(--hp-text-muted, #6b7280); }
+
+.sess-help {
+    color: var(--text-secondary, #6b7280); font-size: 13px;
+    margin-bottom: 16px; line-height: 1.55;
+}
+.sess-help code {
+    background: var(--border-light, #f3f4f6); padding: 1px 6px;
+    border-radius: 4px; font-size: 12px;
+}
+
+.badge {
+    display: inline-block; padding: 2px 8px; border-radius: 999px;
+    font-size: 11px; font-weight: 500;
+}
+.badge-pending   { background: #fef3c7; color: #92400e; }
+.badge-processed { background: #dbeafe; color: #1e40af; }
+.badge-extracted { background: #d1fae5; color: #065f46; }
+
+.dl-link {
+    display: inline-block; padding: 4px 10px;
+    border: 1px solid var(--border, #e5e7eb); border-radius: 6px;
+    color: inherit; text-decoration: none; font-size: 12px; font-weight: 500;
+    background: var(--surface, #fff);
+    transition: background 0.15s, border-color 0.15s;
+}
+.dl-link:hover {
+    background: var(--border-light, #f9fafb);
+    border-color: var(--primary, #6366f1);
+    color: var(--primary, #4338ca);
+}
+</style>
+
+<div class="activity-page">
+    {% set page_hero_eyebrow = "Profile" %}
+    {% set page_hero_title = "My activity" %}
+    {% set page_hero_subtitle = "Sessions, token usage, data access, and sync activity for <strong>" ~ user.email ~ "</strong>." %}
+    {% include "_page_hero.html" %}
+
+    <nav class="tab-strip" role="tablist" aria-label="Activity sections">
+        <button type="button" role="tab" class="tab-strip__item is-active"
+                data-tab="sessions" aria-selected="true">Sessions</button>
+        <button type="button" role="tab" class="tab-strip__item"
+                data-tab="tokens" aria-selected="false">Token usage</button>
+        <button type="button" role="tab" class="tab-strip__item"
+                data-tab="queries" aria-selected="false">Data access</button>
+        <button type="button" role="tab" class="tab-strip__item"
+                data-tab="sync" aria-selected="false">Sync activity</button>
+    </nav>
+
+    <section class="stats-panel is-active" id="panel-sessions" role="tabpanel" aria-labelledby="tab-sessions">
+        <p class="sess-help">
+            Sessions from your Claude Code workspace. <strong>Items extracted = 0</strong>
+            means the verification detector ran successfully but the LLM didn't find
+            anything worth tracking — that's expected for sessions that are mostly tool
+            calls or coding without confident factual claims.
+            <em>Pending</em> means the file is on disk but the scheduler hasn't processed
+            it yet (next tick: every 15 min by default).
+        </p>
+        <div class="stats-loading" data-state="loading">Loading sessions…</div>
+        <div data-state="ready" hidden>
+            <table class="stats-table">
+                <thead><tr>
+                    <th>Started</th><th>Model</th>
+                    <th class="num">Prompts</th><th class="num">Tools</th>
+                    <th class="num">Tokens</th>
+                    <th>Pipeline</th><th class="num">Items</th>
+                    <th></th>
+                </tr></thead>
+                <tbody data-rows></tbody>
+            </table>
+            <div class="stats-paginate">
+                <button type="button" data-action="prev">‹ Prev</button>
+                <button type="button" data-action="next">Next ›</button>
+            </div>
+        </div>
+    </section>
+
+    <section class="stats-panel" id="panel-tokens" role="tabpanel" aria-labelledby="tab-tokens">
+        <div class="stats-loading" data-state="loading">Loading token usage…</div>
+        <div data-state="ready" hidden>
+            <div class="stats-overview">
+                <div class="card"><div class="lbl">Input</div><div class="val" data-tok-total="input">—</div></div>
+                <div class="card"><div class="lbl">Output</div><div class="val" data-tok-total="output">—</div></div>
+                <div class="card"><div class="lbl">Cache read</div><div class="val" data-tok-total="cache_read">—</div></div>
+                <div class="card"><div class="lbl">Cache creation</div><div class="val" data-tok-total="cache_creation">—</div></div>
+            </div>
+            <svg class="tok-chart" data-tok-chart viewBox="0 0 600 160" preserveAspectRatio="none"></svg>
+
+            <h3 style="font-size: 13px; margin: 16px 0 6px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--hp-text-muted, #6b7280);">By model</h3>
+            <table class="stats-table">
+                <thead><tr>
+                    <th>Model</th><th class="num">Sessions</th>
+                    <th class="num">Input</th><th class="num">Output</th>
+                    <th class="num">Cache R/W</th><th class="num">Total</th>
+                </tr></thead>
+                <tbody data-tok-model></tbody>
+            </table>
+
+            <h3 style="font-size: 13px; margin: 16px 0 6px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--hp-text-muted, #6b7280);">Top sessions</h3>
+            <table class="stats-table">
+                <thead><tr>
+                    <th>Started</th><th>Model</th>
+                    <th class="num">Input</th><th class="num">Output</th>
+                    <th class="num">Cache</th><th class="num">Total</th>
+                </tr></thead>
+                <tbody data-tok-top></tbody>
+            </table>
+        </div>
+    </section>
+
+    <section class="stats-panel" id="panel-queries" role="tabpanel" aria-labelledby="tab-queries">
+        <div class="stats-loading" data-state="loading">Loading queries…</div>
+        <div data-state="ready" hidden>
+            <table class="stats-table">
+                <thead><tr>
+                    <th>When</th><th>Action</th><th>Resource</th>
+                    <th>Result</th><th class="num">Duration (ms)</th>
+                </tr></thead>
+                <tbody data-rows></tbody>
+            </table>
+            <div class="stats-paginate">
+                <button type="button" data-action="next">Older ›</button>
+            </div>
+        </div>
+    </section>
+
+    <section class="stats-panel" id="panel-sync" role="tabpanel" aria-labelledby="tab-sync">
+        <div class="stats-loading" data-state="loading">Loading sync activity…</div>
+        <div data-state="ready" hidden>
+            <div class="stats-overview" style="grid-template-columns: 1fr;">
+                <div class="card">
+                    <div class="lbl">Your last <code>agnes pull</code></div>
+                    <div class="val" data-sync-last-pull>—</div>
+                </div>
+            </div>
+            <table class="stats-table">
+                <thead><tr>
+                    <th>When</th><th>Action</th><th>Source</th>
+                    <th>Result</th>
+                </tr></thead>
+                <tbody data-rows></tbody>
+            </table>
+        </div>
+    </section>
+</div>
+
+<script>
+(function () {
+    const root = document.querySelector('.activity-page');
+    if (!root) return;
+
+    function fmtNum(n) {
+        if (n == null) return '—';
+        if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+        if (n >= 10_000)    return (n / 1_000).toFixed(0) + 'k';
+        if (n >= 1_000)     return (n / 1_000).toFixed(1) + 'k';
+        return String(n);
+    }
+
+    function fmtRelative(iso) {
+        if (!iso) return 'never';
+        const then = new Date(iso);
+        const sec = Math.max(0, (Date.now() - then.getTime()) / 1000);
+        if (sec < 60)        return Math.floor(sec) + 's ago';
+        if (sec < 3600)      return Math.floor(sec / 60) + 'm ago';
+        if (sec < 86400)     return Math.floor(sec / 3600) + 'h ago';
+        return Math.floor(sec / 86400) + 'd ago';
+    }
+
+    function fmtTimestamp(iso) {
+        if (!iso) return '';
+        const d = new Date(iso);
+        return d.toLocaleString();
+    }
+
+    function escapeHtml(s) {
+        const d = document.createElement('div');
+        d.textContent = s == null ? '' : String(s);
+        return d.innerHTML;
+    }
+
+    async function fetchJSON(url) {
+        const r = await fetch(url, { credentials: 'same-origin' });
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        return r.json();
+    }
+
+    function setReady(panel) {
+        panel.querySelector('[data-state="loading"]').hidden = true;
+        panel.querySelector('[data-state="ready"]').hidden = false;
+    }
+
+    function setError(panel, msg) {
+        const loading = panel.querySelector('[data-state="loading"]');
+        loading.className = 'stats-error';
+        loading.textContent = msg;
+    }
+
+    // ----- Sessions tab -----
+
+    const sessionsState = { offset: 0, limit: 25, total: 0 };
+
+    function pipelineBadge(status) {
+        if (status === 'extracted') return '<span class="badge badge-extracted">extracted</span>';
+        if (status === 'processed') return '<span class="badge badge-processed">processed</span>';
+        return '<span class="badge badge-pending">pending</span>';
+    }
+
+    async function loadSessions() {
+        const panel = document.getElementById('panel-sessions');
+        try {
+            const data = await fetchJSON(
+                `/api/me/stats/sessions?offset=${sessionsState.offset}&limit=${sessionsState.limit}`
+            );
+            sessionsState.total = data.total;
+            const tbody = panel.querySelector('[data-rows]');
+            tbody.innerHTML = '';
+            if (data.rows.length === 0) {
+                tbody.innerHTML = '<tr><td colspan="8" class="stats-empty">No sessions yet — start Claude Code in a workspace and they\'ll appear here.</td></tr>';
+            }
+            for (const r of data.rows) {
+                const tr = document.createElement('tr');
+                const dlCell = r.download_url
+                    ? `<a class="dl-link" href="${escapeHtml(r.download_url)}" download>Download</a>`
+                    : '';
+                tr.innerHTML = `
+                    <td>${fmtTimestamp(r.started_at)}</td>
+                    <td>${r.primary_model || '<em style="color:#9ca3af;">unprocessed</em>'}</td>
+                    <td class="num">${fmtNum(r.user_messages)}</td>
+                    <td class="num">${fmtNum(r.tool_calls)}</td>
+                    <td class="num">${fmtNum(r.tokens_total)}</td>
+                    <td>${pipelineBadge(r.pipeline_status)}</td>
+                    <td class="num">${r.items_extracted != null ? r.items_extracted : ''}</td>
+                    <td>${dlCell}</td>
+                `;
+                tbody.appendChild(tr);
+            }
+            setReady(panel);
+            const prevBtn = panel.querySelector('[data-action="prev"]');
+            const nextBtn = panel.querySelector('[data-action="next"]');
+            prevBtn.disabled = sessionsState.offset === 0;
+            nextBtn.disabled = sessionsState.offset + sessionsState.limit >= sessionsState.total;
+        } catch (e) {
+            setError(panel, 'Could not load sessions: ' + e.message);
+        }
+    }
+
+    document.querySelector('#panel-sessions [data-action="prev"]').addEventListener('click', () => {
+        sessionsState.offset = Math.max(0, sessionsState.offset - sessionsState.limit);
+        loadSessions();
+    });
+    document.querySelector('#panel-sessions [data-action="next"]').addEventListener('click', () => {
+        sessionsState.offset += sessionsState.limit;
+        loadSessions();
+    });
+
+    // ----- Token usage tab -----
+
+    async function loadTokens() {
+        const panel = document.getElementById('panel-tokens');
+        try {
+            const data = await fetchJSON('/api/me/stats/tokens?days=30');
+            for (const key of ['input', 'output', 'cache_read', 'cache_creation']) {
+                panel.querySelector(`[data-tok-total="${key}"]`).textContent =
+                    fmtNum(data.totals[key]);
+            }
+
+            const chart = panel.querySelector('[data-tok-chart]');
+            chart.innerHTML = '';
+            const days = data.daily;
+            if (days.length > 0) {
+                const max = Math.max(...days.map(d => d.total), 1);
+                const w = 600 / Math.max(days.length, 1);
+                days.forEach((d, i) => {
+                    const h = Math.max(1, (d.total / max) * 140);
+                    const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+                    rect.setAttribute('x', String(i * w + 1));
+                    rect.setAttribute('y', String(160 - h));
+                    rect.setAttribute('width', String(Math.max(1, w - 2)));
+                    rect.setAttribute('height', String(h));
+                    rect.setAttribute('title', `${d.day}: ${d.total}`);
+                    chart.appendChild(rect);
+                });
+            }
+
+            const modelTbody = panel.querySelector('[data-tok-model]');
+            modelTbody.innerHTML = '';
+            if (data.by_model.length === 0) {
+                modelTbody.innerHTML = '<tr><td colspan="6" class="stats-empty">No token data yet.</td></tr>';
+            }
+            for (const m of data.by_model) {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `
+                    <td>${m.model}</td>
+                    <td class="num">${fmtNum(m.sessions)}</td>
+                    <td class="num">${fmtNum(m.input)}</td>
+                    <td class="num">${fmtNum(m.output)}</td>
+                    <td class="num">${fmtNum(m.cache_read + m.cache_creation)}</td>
+                    <td class="num"><strong>${fmtNum(m.total)}</strong></td>
+                `;
+                modelTbody.appendChild(tr);
+            }
+
+            const topTbody = panel.querySelector('[data-tok-top]');
+            topTbody.innerHTML = '';
+            if (data.top_sessions.length === 0) {
+                topTbody.innerHTML = '<tr><td colspan="6" class="stats-empty">No sessions yet.</td></tr>';
+            }
+            for (const s of data.top_sessions) {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `
+                    <td>${fmtTimestamp(s.started_at)}</td>
+                    <td>${s.primary_model || ''}</td>
+                    <td class="num">${fmtNum(s.input)}</td>
+                    <td class="num">${fmtNum(s.output)}</td>
+                    <td class="num">${fmtNum(s.cache_read + s.cache_creation)}</td>
+                    <td class="num"><strong>${fmtNum(s.total)}</strong></td>
+                `;
+                topTbody.appendChild(tr);
+            }
+
+            setReady(panel);
+        } catch (e) {
+            setError(panel, 'Could not load token data: ' + e.message);
+        }
+    }
+
+    // ----- Queries tab -----
+
+    const queriesState = { cursor: null };
+
+    async function loadQueries(append) {
+        const panel = document.getElementById('panel-queries');
+        try {
+            const params = new URLSearchParams({ limit: '50' });
+            if (queriesState.cursor) {
+                params.set('cursor_ts', queriesState.cursor.timestamp);
+                params.set('cursor_id', queriesState.cursor.id);
+            }
+            const data = await fetchJSON(`/api/me/stats/queries?${params}`);
+            const tbody = panel.querySelector('[data-rows]');
+            if (!append) tbody.innerHTML = '';
+            if (data.rows.length === 0 && !append) {
+                tbody.innerHTML = '<tr><td colspan="5" class="stats-empty">No queries logged for your account yet.</td></tr>';
+            }
+            for (const r of data.rows) {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `
+                    <td>${fmtTimestamp(r.timestamp)}</td>
+                    <td><code>${r.action}</code></td>
+                    <td>${r.resource || ''}</td>
+                    <td>${r.result || ''}</td>
+                    <td class="num">${r.duration_ms != null ? r.duration_ms : ''}</td>
+                `;
+                tbody.appendChild(tr);
+            }
+            queriesState.cursor = data.next_cursor;
+            panel.querySelector('[data-action="next"]').disabled = !queriesState.cursor;
+            setReady(panel);
+        } catch (e) {
+            setError(panel, 'Could not load queries: ' + e.message);
+        }
+    }
+
+    document.querySelector('#panel-queries [data-action="next"]').addEventListener('click', () => {
+        loadQueries(true);
+    });
+
+    // ----- Sync tab -----
+
+    async function loadSync() {
+        const panel = document.getElementById('panel-sync');
+        try {
+            const data = await fetchJSON('/api/me/stats/sync?limit=50');
+            panel.querySelector('[data-sync-last-pull]').textContent =
+                fmtRelative(data.last_pull_at);
+            const tbody = panel.querySelector('[data-rows]');
+            tbody.innerHTML = '';
+            if (data.rows.length === 0) {
+                tbody.innerHTML = '<tr><td colspan="4" class="stats-empty">No sync activity yet.</td></tr>';
+            }
+            for (const r of data.rows) {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `
+                    <td>${fmtTimestamp(r.timestamp)}</td>
+                    <td><code>${r.action}</code></td>
+                    <td>${r.client_kind || ''}</td>
+                    <td>${r.result || ''}</td>
+                `;
+                tbody.appendChild(tr);
+            }
+            setReady(panel);
+        } catch (e) {
+            setError(panel, 'Could not load sync activity: ' + e.message);
+        }
+    }
+
+    // ----- Tab switching -----
+
+    const loaded = new Set();
+    const loaders = {
+        sessions: loadSessions,
+        tokens: loadTokens,
+        queries: loadQueries,
+        sync: loadSync,
+    };
+
+    function activate(name) {
+        document.querySelectorAll('.tab-strip__item').forEach((b) => {
+            const on = b.dataset.tab === name;
+            b.classList.toggle('is-active', on);
+            b.setAttribute('aria-selected', on ? 'true' : 'false');
+        });
+        document.querySelectorAll('.stats-panel').forEach((p) => {
+            p.classList.toggle('is-active', p.id === 'panel-' + name);
+        });
+        if (!loaded.has(name)) {
+            loaded.add(name);
+            loaders[name]();
+        }
+    }
+
+    document.querySelectorAll('.tab-strip__item').forEach((b) => {
+        b.addEventListener('click', () => activate(b.dataset.tab));
+    });
+
+    // URL hash support: /me/activity?tab=sessions
+    const urlTab = new URLSearchParams(window.location.search).get('tab');
+    activate(urlTab && loaders[urlTab] ? urlTab : 'sessions');
+})();
+</script>
+{% endblock %}

--- a/tests/test_web_ui.py
+++ b/tests/test_web_ui.py
@@ -356,16 +356,14 @@ class TestAdminRoleGuards:
         assert r.status_code == 308
         assert r.headers["location"] == "/admin/activity?source=scheduler"
 
-    def test_profile_sessions_page_no_admin_required(self, web_client, analyst_cookie, admin_cookie):
-        """The /profile/sessions page is gated by get_current_user, not require_admin —
-        every authenticated user views their own sessions."""
-        r = web_client.get("/profile/sessions", follow_redirects=False)
-        assert r.status_code in (302, 401, 403)
+    def test_profile_sessions_redirects_to_me_activity(self, web_client, analyst_cookie, admin_cookie):
+        """/profile/sessions now 301-redirects to /me/activity?tab=sessions
+        (consolidated in the /me/activity page)."""
         r = web_client.get("/profile/sessions", cookies=analyst_cookie, follow_redirects=False)
-        assert r.status_code == 200
-        assert b"My sessions" in r.content
+        assert r.status_code == 301
+        assert r.headers["location"] == "/me/activity?tab=sessions"
         r = web_client.get("/profile/sessions", cookies=admin_cookie, follow_redirects=False)
-        assert r.status_code == 200
+        assert r.status_code == 301
 
     def test_profile_session_download_path_safety(self, web_client, analyst_cookie):
         """Per-session download endpoint must reject any filename that could
@@ -382,33 +380,11 @@ class TestAdminRoleGuards:
         r = web_client.get("/profile/sessions/anything.jsonl", follow_redirects=False)
         assert r.status_code in (302, 401, 403)
 
-    def test_profile_sessions_page_tolerates_stat_failures(self, web_client, analyst_cookie, tmp_path, monkeypatch):
-        """Devin Review on d878764a: a transient stat() failure on one file
-        must not 500 the whole page. Skip the bad row, render the rest."""
-        import pathlib
-        user_sessions = tmp_path / "user_sessions" / "analyst1"
-        user_sessions.mkdir(parents=True)
-        good = user_sessions / "good.jsonl"
-        good.write_text('{"event": "ok"}\n')
-        bad = user_sessions / "bad.jsonl"
-        bad.write_text('{"event": "stat-explodes"}\n')
-
-        monkeypatch.setenv("DATA_DIR", str(tmp_path))
-
-        # Make `bad.jsonl`.stat() raise; `good.jsonl`.stat() works.
-        real_stat = pathlib.Path.stat
-
-        def selective_stat(self, *args, **kwargs):
-            if self.name == "bad.jsonl":
-                raise PermissionError("simulated stat failure")
-            return real_stat(self, *args, **kwargs)
-
-        monkeypatch.setattr(pathlib.Path, "stat", selective_stat)
-
-        r = web_client.get("/profile/sessions", cookies=analyst_cookie, follow_redirects=False)
+    def test_me_activity_page_renders(self, web_client, analyst_cookie):
+        """/me/activity renders for authenticated users (consolidated view)."""
+        r = web_client.get("/me/activity", cookies=analyst_cookie, follow_redirects=False)
         assert r.status_code == 200
-        assert b"good.jsonl" in r.content
-        assert b"bad.jsonl" not in r.content
+        assert b"My activity" in r.content
 
     def test_profile_session_download_returns_file_for_owner(self, web_client, analyst_cookie, tmp_path, monkeypatch):
         """Authenticated owner can fetch their own jsonl with proper Content-Disposition."""


### PR DESCRIPTION
## Summary

Unifies the split between `/me/stats` (usage analytics: sessions, token consumption, queries, sync) and `/profile/sessions` (pipeline status, download links) into a single `/me/activity` page.

**Problem**: Sessions data lived on two separate pages with different projections — `/me/stats` had usage metrics (model, tokens, prompts) but no download/pipeline info; `/profile/sessions` had pipeline status and downloads but no usage data. "Stats" in the top-nav was a personal page among global links. "Tokens" tab was ambiguous (LLM usage vs PATs).

**Solution**:
- **New `/me/activity`** page with 4 tabs: Sessions, Token usage, Data access, Sync activity
- **Sessions tab merges both views**: usage metrics + pipeline status (pending/processed/extracted) + items extracted count + download link — complete picture in one table
- **API enrichment**: `/api/me/stats/sessions` now includes `pipeline_status`, `items_extracted`, and `download_url` fields (joined from `session_processor_state` + `user_sessions/` filesystem)
- **Nav cleanup**: "Stats" removed from top-nav; user menu: Profile → My activity → My tokens
- **Redirects**: `/me/stats` → 301 → `/me/activity`; `/profile/sessions` → 301 → `/me/activity?tab=sessions`
- **Download endpoint preserved**: `/profile/sessions/{filename}` still works
- **Tab renamed**: "Tokens" → "Token usage" to disambiguate from PAT management at `/tokens`
- **Tests updated**: redirect expectations + new `test_me_activity_page_renders`

`/profile` (identity, groups, RBAC) and `/tokens` (PAT management) are unchanged.

## Review & Testing Checklist for Human

- [ ] Navigate to `/me/activity` — verify all 4 tabs load data correctly
- [ ] Sessions tab: confirm pipeline status badges (pending/processed/extracted), items extracted count, and download links render correctly alongside usage metrics
- [ ] Verify `/me/stats` redirects to `/me/activity` (301)
- [ ] Verify `/profile/sessions` redirects to `/me/activity?tab=sessions` (301)
- [ ] Verify `/profile/sessions/<filename>` download still works
- [ ] Check user menu dropdown: should show "Profile", "My activity", "My tokens" (no "My sessions")
- [ ] Confirm top-nav no longer shows "Stats" link

### Notes

- Old templates `me_stats.html` and `profile_sessions.html` are kept on disk but no longer served (routes redirect). Can be removed in a future cleanup.
- The `?tab=` URL parameter enables deep-linking to specific tabs.
- Design system contract tests: 9/9 pass. Full test suite: 4606 passed.

## Release Notes
**Justification, description**

Consolidates user-facing personal analytics from 3 pages (`/me/stats`, `/profile/sessions`, `/profile`) into 2 pages (`/me/activity` for analytics, `/profile` for identity). Sessions tab now shows the complete picture: usage metrics + pipeline status + download links in one table.

**Plans for Customer Communication**

N/A — internal navigation restructuring. Old URLs redirect automatically.

**Impact Analysis**

Low risk. No data model changes. API backwards-compatible (new fields added, none removed). Old URLs 301-redirect. Download endpoint preserved.

**Deployment Plan**

Standard deploy. No migration needed.

**Rollback Plan**

Revert commit — old routes/templates still exist on disk.

**Post-Release Support Plan**

N/A

Link to Devin session: https://app.devin.ai/sessions/a6c81987778b4c848b3751e46888e476
Requested by: @ZdenekSrotyr