### PR TITLE
fix(store-upload): Next/Back/Finish buttons missing .btn base class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Fixed
+- Store submit-flow wizard buttons were missing the `.btn` base class —
+  Next / Back / Finish on `/store/new` and Save on `/store/edit/<id>`
+  carried only the `.btn-primary` / `.btn-secondary` color modifier, so
+  they rendered with no padding, border-radius, or proper sizing
+  (~18px-tall color boxes) instead of matching their sibling Cancel
+  links. Added the `.btn` base class on all four.
+
 ## [0.54.15] — 2026-05-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.54.16] — 2026-05-14
+
 ### Fixed
 - Store submit-flow wizard buttons were missing the `.btn` base class —
   Next / Back / Finish on `/store/new` and Save on `/store/edit/<id>`

--- a/app/web/templates/store_edit.html
+++ b/app/web/templates/store_edit.html
@@ -163,7 +163,7 @@
     </div>
 
     <div class="actions">
-      <button type="submit" class="btn-primary" id="save-btn"
+      <button type="submit" class="btn btn-primary" id="save-btn"
               {% if pending_sub %}disabled{% endif %}>Save</button>
       <a href="/marketplace/flea/{{ entity.id }}" class="btn btn-secondary">Cancel</a>
     </div>

--- a/app/web/templates/store_upload.html
+++ b/app/web/templates/store_upload.html
@@ -418,7 +418,7 @@
         </div>
 
         <div class="actions">
-          <button type="button" class="btn-primary" id="next-btn">Next →</button>
+          <button type="button" class="btn btn-primary" id="next-btn">Next →</button>
           <a href="/marketplace?tab=flea" class="btn btn-secondary">Cancel</a>
         </div>
       </div>
@@ -533,8 +533,8 @@
         </div>
 
         <div class="actions">
-          <button type="button" class="btn-primary" id="finish-btn">Finish</button>
-          <button type="button" class="btn-secondary" id="back-btn">← Back</button>
+          <button type="button" class="btn btn-primary" id="finish-btn">Finish</button>
+          <button type="button" class="btn btn-secondary" id="back-btn">← Back</button>
         </div>
       </div>
     </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.54.15"
+version = "0.54.16"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"


### PR DESCRIPTION
## Summary

Three wizard nav buttons on \`/store/new\` (Next, Back, Finish) used \`class="btn-primary"\` / \`"btn-secondary"\` without the base \`.btn\` class. Padding (10px 20px), border-radius (8px), font-size, and inline-flex centering from \`.btn\` never applied → buttons rendered as ~18px-tall colored boxes with no padding, visibly mismatched against the sibling Cancel \`<a>\` link which correctly had \`class="btn btn-secondary"\`.

Three-character fix per button — add the \`.btn\` base.

## Test plan

- [x] Playwright DOM measurements before/after:
  - **Before**: \`#next-btn\` → \`padding: 0px\`, \`borderRadius: 0px\`, \`height: 18px\`
  - **After**: \`#next-btn\` → \`padding: 10px 20px\`, \`borderRadius: 8px\`, \`height: 38px\` (matches sibling Cancel link's render)
- [x] Visual check at \`/store/new\` — Next button now styled identical to Cancel (proper blue pill).

## Why this was missed

The two other places that use these classes on \`/store/new\` (the Cancel link, the +Add file disclosure) already had the right class set. The three wizard nav buttons were the only outliers. Found during a /store/new walkthrough after #308 landed.