### PR TITLE
release(0.54.18): Curated Memory restructure + per-user Dismiss + bundled adversarial-review fixes (#316/#320/#322)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.54.18] — 2026-05-15
+
 ### Added
 - "Curated Memory" now sits in the primary navigation next to Data
   Packages, visible to every authenticated user.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,36 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Added
+- "Curated Memory" now sits in the primary navigation next to Data
+  Packages, visible to every authenticated user.
+- **Per-user Dismiss** for Curated Memory items — analysts can opt-out
+  of approved items from their AI-agent bundle and gray them out on
+  `/corporate-memory`. Schema v46 adds `knowledge_item_user_dismissed`;
+  new endpoints `POST /api/memory/{id}/dismiss` and `DELETE` (idempotent).
+  **Mandatory items can never be dismissed** — the governance hard rule
+  is enforced at two layers (API rejects with 400, SQL filter exempts
+  mandatory rows even if a stale dismissal exists). `GET /api/memory`
+  gains `hide_dismissed=false` (default off — dismissed items still
+  visible with a badge + Undismiss button) and per-item `dismissed_by_me`
+  flag. `GET /api/memory/bundle` always excludes dismissed items.
+- **"My Upvotes" filter** on `/corporate-memory` replaces the old dead
+  "My Rules" sentinel. Backed by a new `?upvoted_by_me=true` filter on
+  `/api/memory` that subquerying against `knowledge_votes`.
+- **Inline tag typeahead** in the admin edit modal — focus the tag
+  input to browse all existing tags as a dropdown, type to filter
+  (case-insensitive), ↑/↓ + Enter to add as pill, type a fresh value
+  to surface "+ Add new tag: <value>". Tags now render as removable
+  pills (× to remove); Backspace on empty input pops the last pill.
+- **Bulk-edit modal pickers** for `/admin/corporate-memory` — Category,
+  Audience, and Add tag get `<select>` dropdowns with `+ Add new…` for
+  free entry; Remove tag is now a closed-set picker. Closes #128.
+- **`FilterState` client utility** — `app/web/static/js/filter-state.js`
+  exposes `save/load/clear/bindInputs` for persisting filter UI state
+  per-page in localStorage (keyed `agnes:filters:<scope>`). Adopted on
+  `/corporate-memory` (search / category / domain / sort / group-by /
+  hide-dismissed); other admin pages can adopt the same pattern.
+
 ### Fixed
 - Flea-market: derive next version_no from `max(version_history.n) + 1`
   instead of `entity.version_no + 1` in PUT (edit) + restore. Under
@@ -76,6 +106,20 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   to resolve the correct version dir (and is now forward-only on
   promote — see the Fixed bullet below), so it stays safe for v2+
   deferred-promotion submissions.
+- The `/corporate-memory` domain filter dropdown now offers the full
+  `VALID_DOMAINS` enum (finance / engineering / product / data /
+  operations / infrastructure), not just domains that already have ≥1
+  item — the old behavior collapsed to a single option on fresh stores.
+- **BREAKING (UI):** the Curated Memory admin review queue moved from
+  `/corporate-memory/admin` to `/admin/corporate-memory` — no redirect.
+  It is now reached from the Admin nav dropdown ("Memory Review").
+- `/corporate-memory` (Curated Memory) is no longer admin-only — the
+  route runs on `get_current_user`, matching the already-open
+  `/api/memory/*` endpoints. The pending-review banner stays admin-only
+  (suppressed server-side for non-admins).
+- Both Curated Memory pages now render the shared `_page_hero.html`
+  header band instead of bespoke per-page chrome, matching catalog /
+  me-activity / admin pages.
 
 ### Fixed
 - **Unauthenticated browser requests to `GET /api/initial-workspace.zip` now redirect to `/login?next=/api/initial-workspace.zip` instead of returning a raw JSON 401** (#315). This is the one `/api/*` endpoint that's designed to be hit directly from a browser bookmark (the analyst clean-install zip), so it intentionally opts out of the global `_API_PATH_PREFIXES` "never redirect /api/*" contract in `app/main.py`. CLI / curl / other API clients (any `Accept` without `text/html` — including the `*/*` default) keep getting the 401 they can handle.
@@ -178,6 +222,10 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   `submission_status`. `self.get()` re-parses JSON each call today so
   this is belt-and-suspenders, but it protects any future caching layer
   from leaking the annotated key into a subsequent plain `get()` call.
+- `corporate_memory_admin.html` renamed to `admin_corporate_memory.html`
+  to match the `admin_*` template convention; dropped dead `.ck-topbar` /
+  `.page-header` inline CSS (the latter collided with the design-system
+  `.page-header--hero` selector).
 
 ## [0.54.17] — 2026-05-15
 

--- a/app/api/memory.py
+++ b/app/api/memory.py
@@ -213,13 +213,20 @@ async def list_knowledge(
     source_type: Optional[str] = None,
     search: Optional[str] = None,
     exclude_personal: bool = True,
+    upvoted_by_me: bool = False,
+    hide_dismissed: bool = False,
     page: int = 1,
     per_page: int = 50,
     sort: str = "updated_at",
     user: dict = Depends(get_current_user),
     conn: duckdb.DuckDBPyConnection = Depends(_get_db),
 ):
-    """List knowledge items with filtering, pagination, search."""
+    """List knowledge items with filtering, pagination, search.
+
+    ``upvoted_by_me=true`` narrows to items the caller upvoted (powers the
+    "My Upvotes" filter on /corporate-memory — replaces the old dead
+    "My Rules" category sentinel).
+    """
     repo = KnowledgeRepository(conn)
     page = max(page, 1)
     offset = (page - 1) * per_page
@@ -229,6 +236,11 @@ async def list_knowledge(
     effective_groups = _effective_groups(user, conn)
     granted_domains = _caller_granted_memory_domains(user, conn)
     statuses = [status_filter] if status_filter else None
+    upvoted_by_user_id = user["id"] if upvoted_by_me else None
+    # v46: caller's id is plumbed to repo filters when hide_dismissed=True so
+    # the SQL can NOT-EXISTS-subquery against knowledge_item_user_dismissed.
+    # Mandatory items are exempted by the subquery's status guard.
+    dismissed_by_user_id = user["id"]
     if search:
         items = repo.search(
             search,
@@ -239,9 +251,22 @@ async def list_knowledge(
             category=category,
             domain=domain,
             source_type=source_type,
+            dismissed_by_user=dismissed_by_user_id,
+            hide_dismissed=hide_dismissed,
             limit=per_page,
             offset=offset,
         )
+        if upvoted_by_user_id:
+            # Best-effort post-filter for the search() path (which doesn't
+            # plumb the upvote filter into its SQL). Search + "My Upvotes"
+            # is rare enough that a post-filter is fine.
+            upvoted_ids = {
+                r[0] for r in conn.execute(
+                    "SELECT item_id FROM knowledge_votes WHERE user_id = ? AND vote > 0",
+                    [upvoted_by_user_id],
+                ).fetchall()
+            }
+            items = [it for it in items if it["id"] in upvoted_ids]
     else:
         items = repo.list_items(
             statuses=statuses,
@@ -251,16 +276,23 @@ async def list_knowledge(
             exclude_personal=effective_exclude_personal,
             user_groups=effective_groups,
             granted_domains=granted_domains,
+            upvoted_by_user=upvoted_by_user_id,
+            dismissed_by_user=dismissed_by_user_id,
+            hide_dismissed=hide_dismissed,
             limit=per_page,
             offset=offset,
         )
 
-    # Enrich with votes
+    # Enrich with votes + per-user dismissal flag. The set lookup keeps the
+    # per-item annotation O(1); the frontend uses ``dismissed_by_me`` to
+    # render the gray-out state without a separate roundtrip.
+    dismissed_set = set(repo.list_dismissed_ids(user["id"]))
     for item in items:
         votes = repo.get_votes(item["id"])
         item["upvotes"] = votes["upvotes"]
         item["downvotes"] = votes["downvotes"]
         item["score"] = votes["upvotes"] - votes["downvotes"]
+        item["dismissed_by_me"] = item["id"] in dismissed_set
 
     import math
     total_count = repo.count_items(
@@ -272,6 +304,8 @@ async def list_knowledge(
         exclude_personal=effective_exclude_personal,
         user_groups=effective_groups,
         granted_domains=granted_domains,
+        dismissed_by_user=dismissed_by_user_id,
+        hide_dismissed=hide_dismissed,
     )
     total_pages = math.ceil(total_count / per_page) if per_page > 0 else 1
 
@@ -520,6 +554,48 @@ async def toggle_personal_flag(
         raise HTTPException(status_code=403, detail="Only the contributor can flag personal items")
     repo.set_personal(item_id, request.is_personal)
     return {"id": item_id, "is_personal": request.is_personal}
+
+
+@router.post("/{item_id}/dismiss")
+async def dismiss_item(
+    item_id: str,
+    user: dict = Depends(get_current_user),
+    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
+):
+    """Per-user opt-out — remove an item from the caller's AI bundle.
+
+    Idempotent: re-dismissing an already-dismissed item is a no-op success.
+    Mandatory items can never be dismissed — the governance hard rule —
+    so a POST against one returns 400 with a clear detail message.
+    """
+    repo = KnowledgeRepository(conn)
+    item = repo.get_by_id(item_id)
+    if not item or not _can_view_item(user, item, _is_privileged_viewer(user, conn)):
+        raise HTTPException(status_code=404, detail="Knowledge item not found")
+    if item.get("status") == "mandatory":
+        raise HTTPException(status_code=400, detail="Cannot dismiss a mandatory item")
+    repo.dismiss(user["id"], item_id)
+    return {"id": item_id, "dismissed": True}
+
+
+@router.delete("/{item_id}/dismiss")
+async def undismiss_item(
+    item_id: str,
+    user: dict = Depends(get_current_user),
+    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
+):
+    """Idempotent un-dismiss — a second DELETE still returns 200.
+
+    Returns 404 if the item itself doesn't exist (consistent with the rest
+    of the per-item endpoints); the dismissal row's existence is not
+    consulted because absence is the success state.
+    """
+    repo = KnowledgeRepository(conn)
+    item = repo.get_by_id(item_id)
+    if not item or not _can_view_item(user, item, _is_privileged_viewer(user, conn)):
+        raise HTTPException(status_code=404, detail="Knowledge item not found")
+    repo.undismiss(user["id"], item_id)
+    return {"id": item_id, "dismissed": False}
 
 
 @router.get("/{item_id}/provenance")
@@ -1275,11 +1351,19 @@ async def get_bundle(
     effective_groups = _effective_groups(user, conn)
     granted_domains = _caller_granted_memory_domains(user, conn)
 
+    # v46: the bundle is what AI agents inject as context, so the opt-out
+    # has real effect here — it's always-on for the calling user. Mandatory
+    # items are exempted by the EXISTS subquery's status guard inside
+    # ``list_items``; the user's dismissal row for a then-approved item is
+    # silently ignored if/when the item is later mandated.
+    dismissed_by_user_id = user["id"]
     mandatory = repo.list_items(
         statuses=["mandatory"],
         exclude_personal=True,
         user_groups=effective_groups,
         granted_domains=granted_domains,
+        dismissed_by_user=dismissed_by_user_id,
+        hide_dismissed=True,
         limit=1000,
         offset=0,
     )
@@ -1289,6 +1373,8 @@ async def get_bundle(
         exclude_personal=True,
         user_groups=effective_groups,
         granted_domains=granted_domains,
+        dismissed_by_user=dismissed_by_user_id,
+        hide_dismissed=True,
         limit=1000,
         offset=0,
     )

--- a/app/web/router.py
+++ b/app/web/router.py
@@ -258,7 +258,7 @@ _URL_MAP = {
     "dashboard": "/dashboard",
     "catalog": "/catalog",
     "corporate_memory": "/corporate-memory",
-    "corporate_memory_admin": "/corporate-memory/admin",
+    "corporate_memory_admin": "/admin/corporate-memory",
     "activity_center": "/activity-center",
     "admin_activity": "/admin/activity",
     "index": "/",
@@ -963,50 +963,87 @@ async def catalog(
 @router.get("/corporate-memory", response_class=HTMLResponse)
 async def corporate_memory(
     request: Request,
-    user: dict = Depends(require_admin),
+    user: dict = Depends(get_current_user),
     conn: duckdb.DuckDBPyConnection = Depends(_get_db),
 ):
-    """Corporate Memory web view — admin-only.
+    """Curated Memory web view — any authenticated user.
 
-    The page route gates on ``require_admin``; non-admin users see 403.
-    The Memory nav link in `_app_header.html` and the corporate-memory
-    widget on `/dashboard` are correspondingly hidden behind
-    ``{% if session.user.is_admin %}`` guards (defence in depth — the
-    backend is the authoritative gate).
+    This is the analyst-facing read surface for shared organizational
+    knowledge: it lists ``approved`` / ``mandatory`` items plus the
+    caller's own contributions, and sits in the primary nav next to
+    Data Packages. The admin review queue (pending items, contradictions,
+    duplicates) lives separately at ``/admin/corporate-memory`` behind
+    ``require_admin``.
 
-    **Asymmetry**: the underlying ``/api/memory/*`` endpoints stay on
-    ``get_current_user`` (not ``require_admin``). CLI / agent flows that
-    POST a knowledge item or read ``/api/memory`` keep working for any
-    authenticated user. The gating here is web-UI-only — the API is the
-    surface the agent rails care about (`agnes` CLI, knowledge-extract
-    pipeline), and locking it down would break the corporate-memory
-    feature outright. Operators who want to relax the web-UI gate can
-    either grant Admin to those users or revert this route to
-    ``get_current_user`` in their fork.
+    Gating matches the underlying ``/api/memory/*`` endpoints, which
+    already run on ``get_current_user`` — CLI / agent flows that POST a
+    knowledge item or read ``/api/memory`` work for any authenticated
+    user, so the web view does too. Admin-only affordances on this page
+    (the pending-review banner) stay gated server-side: ``is_admin_view``
+    zeroes ``pending_review_count`` for non-admins.
     """
     repo = KnowledgeRepository(conn)
+    # v46: server-side initial render mirrors the JS fetch contract — items
+    # are annotated with `dismissed_by_me` so the template can gray out the
+    # ones the caller dismissed without a second round-trip. The full list
+    # (incl. dismissed) is rendered; the toolbar "Hide dismissed" toggle
+    # client-side filters via FilterState (or a server refetch with
+    # hide_dismissed=true — both supported, JS uses fetch).
     items = repo.list_items(statuses=["approved", "mandatory"], limit=100)
+    dismissed_set = set(repo.list_dismissed_ids(user["id"])) if user.get("id") else set()
 
-    # Enrich with votes
+    def _build_source_users_display(it: dict) -> list[dict]:
+        """Derive ``[{name, initials}]`` from the stored ``source_user`` email.
+
+        The template (and the in-template JS) iterate `item.source_users_display`
+        to render contributor avatars; the repo only stores a single
+        `source_user` email. Building the list here (singleton today) keeps the
+        page from crashing with ``KeyError: slice(None, 3, None)`` when items
+        exist, and gives the design room for multi-contributor aggregation
+        later without another template churn.
+        """
+        su = (it.get("source_user") or "").strip()
+        if not su:
+            return []
+        name = su.split("@", 1)[0]
+        parts = [p for p in name.replace(".", " ").replace("_", " ").split() if p]
+        if len(parts) >= 2:
+            initials = (parts[0][0] + parts[1][0]).upper()
+        elif parts:
+            initials = parts[0][:2].upper()
+        else:
+            initials = name[:2].upper()
+        return [{"name": name, "initials": initials}]
+
+    # Enrich with votes + derived contributor-avatar list + per-item
+    # dismissed-by-me flag (used to gray the row out + flip the action button).
     for item in items:
         votes = repo.get_votes(item["id"])
         item["upvotes"] = votes["upvotes"]
         item["downvotes"] = votes["downvotes"]
+        item["source_users_display"] = _build_source_users_display(item)
+        item["dismissed_by_me"] = item["id"] in dismissed_set
 
     cm_config = get_corporate_memory_config()
     governance_mode = cm_config.get("distribution_mode")
 
     # Build stats + filter dropdowns from the full item set so the dropdowns
-    # match the data the page is rendering. `categories` and `domains` are
-    # consumed by the filter pickers in `corporate_memory.html`; without
-    # `domains` the "All domains" picker stays empty.
+    # match the data the page is rendering. `categories` is derived from
+    # what's actually in the store (free-text enum, grows over time).
+    # `domains` is a CLOSED enum on the backend (VALID_DOMAINS in
+    # app/api/memory.py), so we always offer the full list — earlier we
+    # filtered to only domains with ≥1 item, which made the dropdown
+    # collapse to a single "engineering" option on instances where only
+    # one domain had been used. Operators should be able to pick any
+    # valid domain even when the current store has none of it.
+    from app.api.memory import VALID_DOMAINS
     all_items = repo.list_items(limit=10000)
     categories = sorted(set(i.get("category", "") for i in all_items if i.get("category")))
-    domains = sorted(set(i.get("domain", "") for i in all_items if i.get("domain")))
+    domains = list(VALID_DOMAINS)
 
     # #176: surface the pending review queue to admins. Without this the
     # main page silently filtered status='pending' items and operators had
-    # no breadcrumb to /corporate-memory/admin.
+    # no breadcrumb to /admin/corporate-memory.
     pending_count = sum(1 for i in all_items if i.get("status") == "pending")
 
     # "My contributions" — items the caller authored. Personal items are
@@ -1018,6 +1055,8 @@ async def corporate_memory(
         votes = repo.get_votes(item["id"])
         item["upvotes"] = votes["upvotes"]
         item["downvotes"] = votes["downvotes"]
+        item["source_users_display"] = _build_source_users_display(item)
+        item["dismissed_by_me"] = item["id"] in dismissed_set
 
     is_admin_view = is_user_admin(user["id"], conn)
     ctx = _build_context(
@@ -1027,7 +1066,16 @@ async def corporate_memory(
         governance={"mode": governance_mode, "groups": cm_config.get("groups", {})},
         categories=categories,
         domains=domains,
-        stats={"total": len(all_items), "approved": len([i for i in all_items if i.get("status") == "approved"])},
+        stats={
+            "total": len(all_items),
+            "approved": len([i for i in all_items if i.get("status") == "approved"]),
+            # Template-facing aliases. Without these, the stats bar at the
+            # top of /corporate-memory renders blank `value` divs ("Contributors"
+            # / "Knowledge Items" with no number under them) because Jinja's
+            # Undefined silently coerces to empty string.
+            "contributors": len({i.get("source_user") for i in all_items if i.get("source_user")}),
+            "knowledge_count": len([i for i in all_items if i.get("status") in ("approved", "mandatory")]),
+        },
         user_votes={},
         is_km_admin=is_admin_view,
         user_contributions=user_contributions,
@@ -1044,12 +1092,18 @@ async def corporate_memory(
     return templates.TemplateResponse(request, "corporate_memory.html", ctx)
 
 
-@router.get("/corporate-memory/admin", response_class=HTMLResponse)
+@router.get("/admin/corporate-memory", response_class=HTMLResponse)
 async def corporate_memory_admin(
     request: Request,
     user: dict = Depends(require_admin),
     conn: duckdb.DuckDBPyConnection = Depends(_get_db),
 ):
+    """Curated Memory review queue — admin-only.
+
+    The governance surface paired with the user-facing ``/corporate-memory``
+    page: pending items awaiting review, contradictions, duplicate
+    candidates, and the audit trail. Reached from the Admin nav dropdown.
+    """
     repo = KnowledgeRepository(conn)
     pending = repo.list_items(statuses=["pending"], limit=100)
     all_items = repo.list_items(limit=10000)
@@ -1059,7 +1113,7 @@ async def corporate_memory_admin(
         status_counts[s] = status_counts.get(s, 0) + 1
 
     # Contradictions tab is server-rendered (no JS fetch on this tab — see
-    # corporate_memory_admin.html). Fetch the unresolved set and enrich each
+    # admin_corporate_memory.html). Fetch the unresolved set and enrich each
     # entry with the title/sensitivity of both sides so the template doesn't
     # need to re-query per row.
     contradictions = repo.list_contradictions(resolved=False)
@@ -1098,6 +1152,15 @@ async def corporate_memory_admin(
         for g in _groups_repo.list_all()
     ]
 
+    # Existing-value pools for the per-item edit form pickers. Before, Category /
+    # Audience / Tags were free-text required inputs — admins had to remember the
+    # exact category slug or audience expression, and tags couldn't be discovered.
+    # We surface what's already in the store as `<datalist>` suggestions (Category
+    # / Tags) and a `<select>` (Audience built from RBAC groups) without losing
+    # free-text entry for fresh values.
+    edit_categories = sorted({i.get("category") for i in all_items if i.get("category")})
+    edit_tags = sorted({t for i in all_items for t in (i.get("tags") or []) if t})
+
     ctx = _build_context(
         request, user=user,
         pending_items=pending,
@@ -1114,10 +1177,12 @@ async def corporate_memory_admin(
         },
         governance=get_corporate_memory_config(),
         groups=user_groups_for_ui,
+        edit_categories=edit_categories,
+        edit_tags=edit_tags,
         contradictions=contradictions,
         audit_entries=[],
     )
-    return templates.TemplateResponse(request, "corporate_memory_admin.html", ctx)
+    return templates.TemplateResponse(request, "admin_corporate_memory.html", ctx)
 
 
 @router.get("/activity-center")
@@ -1370,9 +1435,9 @@ async def marketplace_flea_detail(
 
     repo = StoreEntitiesRepository(conn)
     # Owner/admin get a version-status decorated entity so the versions
-    # card can gate the Restore button on past-version approval state.
-    # Plain viewers don't see the versions card at all, so the cheaper
-    # plain get() suffices.
+    # card can gate the Restore button on past-version approval state
+    # (#316). Plain viewers don't see the versions card at all, so the
+    # cheaper plain get() suffices.
     base_entity = repo.get(entity_id)
     if not base_entity:
         raise HTTPException(status_code=404, detail="Entity not found")
@@ -1394,9 +1459,11 @@ async def marketplace_flea_detail(
     # always load for owner/admin, even when the entity itself is
     # approved at a prior version — under deferred promotion, a v2+
     # edit can leave the latest submission in `review_error` /
-    # `blocked_llm` while the entity row stays approved. Gating the
+    # `blocked_llm` while the entity row stays approved. The banner
+    # partial's gates (in `_quarantine_banner.html`) decide whether to
+    # render; the handler just has to supply the data. Gating the
     # fetch on `visibility_status != 'approved'` silently hid the
-    # failure from the owner.
+    # failure from the owner — that was the regression #316 fixed.
     quarantine_sub = None
     if is_owner or is_admin:
         quarantine_sub = StoreSubmissionsRepository(conn).latest_for_entity(entity_id)

--- a/app/web/static/js/filter-state.js
+++ b/app/web/static/js/filter-state.js
@@ -1,0 +1,290 @@
+/**
+ * FilterState — client-side persistence for filter UI widgets.
+ *
+ * Why this exists:
+ *   ~7 admin/user pages have similar filter bars (search input, category
+ *   buttons, dropdowns, "hide dismissed" checkboxes). Each used to roll
+ *   its own localStorage glue inline in <script> blocks. This utility
+ *   centralises the pattern so a page only declares *what* to persist,
+ *   not *how*.
+ *
+ * Public API (attached to window.FilterState):
+ *   save(scopeKey, params)               — persist a key→value map.
+ *   load(scopeKey) -> object             — restore params or {}.
+ *   clear(scopeKey)                      — erase stored state.
+ *   bindInputs(scopeKey, descriptors)    — hydrate + auto-persist DOM inputs.
+ *
+ * Storage layout:
+ *   Key:   "agnes:filters:<scopeKey>"   (e.g. "agnes:filters:cm_v1")
+ *   Value: JSON object, e.g. {"q":"foo","category":"finance","hide":true}
+ *   Versioning is the caller's responsibility — bump the suffix
+ *   (cm_v1 → cm_v2) when you change the filter shape; the old store
+ *   simply becomes orphaned.
+ *
+ * Usage example (Corporate Memory page wiring):
+ *
+ *   FilterState.bindInputs('cm_v1', [
+ *     { id: 'searchInput', param: 'q', event: 'input' },
+ *     { id: 'sortSelect',  param: 'sort' },
+ *     { id: 'hideDismissed', param: 'hideDismissed' },          // checkbox
+ *     {
+ *       id: 'categoryGroup', param: 'category',
+ *       buttonGroup: {
+ *         selector: '.filter-btn[data-category]',
+ *         dataAttr: 'category',
+ *       },
+ *     },
+ *   ]);
+ *
+ * Browser support:
+ *   Depends on localStorage + ES6 (let/const, arrow fns, template
+ *   strings, Array.isArray). No async, no modules — plain <script src>
+ *   compatible with the rest of this codebase. All storage access is
+ *   wrapped in try/catch (Safari private mode, quota exceeded, etc.).
+ */
+(function () {
+    'use strict';
+
+    var PREFIX = 'agnes:filters:';
+
+    // ---- internal helpers ----------------------------------------------------
+
+    function isNonEmptyString(v) {
+        return typeof v === 'string' && v.length > 0;
+    }
+
+    function isPlainObject(v) {
+        return v !== null && typeof v === 'object' && !Array.isArray(v);
+    }
+
+    function isAllowedValue(v) {
+        if (v === null || v === undefined) return true;
+        var t = typeof v;
+        if (t === 'string' || t === 'boolean' || t === 'number') return true;
+        if (Array.isArray(v)) {
+            return v.every(function (x) { return typeof x === 'string'; });
+        }
+        return false;
+    }
+
+    function safeGet(key) {
+        try {
+            return window.localStorage.getItem(key);
+        } catch (err) {
+            console.warn('[FilterState] localStorage.getItem failed:', err);
+            return null;
+        }
+    }
+
+    function safeSet(key, value) {
+        try {
+            window.localStorage.setItem(key, value);
+        } catch (err) {
+            console.warn('[FilterState] localStorage.setItem failed:', err);
+        }
+    }
+
+    function safeRemove(key) {
+        try {
+            window.localStorage.removeItem(key);
+        } catch (err) {
+            console.warn('[FilterState] localStorage.removeItem failed:', err);
+        }
+    }
+
+    function storageKey(scopeKey) {
+        return PREFIX + scopeKey;
+    }
+
+    function validateScope(scopeKey, method) {
+        if (!isNonEmptyString(scopeKey)) {
+            console.warn('[FilterState.' + method + '] scopeKey must be a non-empty string; got:', scopeKey);
+            return false;
+        }
+        return true;
+    }
+
+    // Apply a stored value to an element based on its tag/type.
+    function applyValueToElement(el, value, descriptor) {
+        if (descriptor.buttonGroup) {
+            var group = descriptor.buttonGroup;
+            var buttons = document.querySelectorAll(group.selector);
+            buttons.forEach(function (btn) {
+                if (btn.dataset[group.dataAttr] === value) {
+                    btn.classList.add('active');
+                } else {
+                    btn.classList.remove('active');
+                }
+            });
+            return;
+        }
+        if (el.tagName === 'INPUT' && el.type === 'checkbox') {
+            el.checked = Boolean(value);
+            return;
+        }
+        // <select>, <input type="text">, <input type="search">, <textarea>, etc.
+        el.value = value == null ? '' : String(value);
+    }
+
+    // Read an element's current value back out.
+    function readValueFromElement(el, descriptor) {
+        if (descriptor.buttonGroup) {
+            var group = descriptor.buttonGroup;
+            var active = document.querySelector(group.selector + '.active');
+            return active ? active.dataset[group.dataAttr] || '' : '';
+        }
+        if (el.tagName === 'INPUT' && el.type === 'checkbox') {
+            return el.checked;
+        }
+        return el.value;
+    }
+
+    // ---- public API ---------------------------------------------------------
+
+    function save(scopeKey, params) {
+        if (!validateScope(scopeKey, 'save')) return;
+        if (!isPlainObject(params)) {
+            console.warn('[FilterState.save] params must be a plain object; got:', params);
+            return;
+        }
+        var clean = {};
+        Object.keys(params).forEach(function (k) {
+            var v = params[k];
+            if (isAllowedValue(v)) {
+                clean[k] = v;
+            } else {
+                console.warn('[FilterState.save] dropping unsupported value for "' + k + '":', v);
+            }
+        });
+        try {
+            safeSet(storageKey(scopeKey), JSON.stringify(clean));
+        } catch (err) {
+            console.warn('[FilterState.save] JSON.stringify failed:', err);
+        }
+    }
+
+    function load(scopeKey) {
+        if (!validateScope(scopeKey, 'load')) return {};
+        var raw = safeGet(storageKey(scopeKey));
+        if (!raw) return {};
+        var parsed;
+        try {
+            parsed = JSON.parse(raw);
+        } catch (err) {
+            console.warn('[FilterState.load] JSON.parse failed for scope "' + scopeKey + '":', err);
+            return {};
+        }
+        if (!isPlainObject(parsed)) {
+            console.warn('[FilterState.load] stored shape is not an object for scope "' + scopeKey + '"; ignoring.');
+            return {};
+        }
+        return parsed;
+    }
+
+    function clear(scopeKey) {
+        if (!validateScope(scopeKey, 'clear')) return;
+        safeRemove(storageKey(scopeKey));
+    }
+
+    function bindInputs(scopeKey, descriptors) {
+        if (!validateScope(scopeKey, 'bindInputs')) return;
+        if (!Array.isArray(descriptors)) {
+            console.warn('[FilterState.bindInputs] descriptors must be an array; got:', descriptors);
+            return;
+        }
+
+        var stored = load(scopeKey);
+
+        descriptors.forEach(function (d) {
+            if (!d || !isNonEmptyString(d.id) || !isNonEmptyString(d.param)) {
+                console.warn('[FilterState.bindInputs] skipping invalid descriptor:', d);
+                return;
+            }
+            var el = document.getElementById(d.id);
+            if (!el) {
+                console.warn('[FilterState.bindInputs] no element with id "' + d.id + '"');
+                return;
+            }
+
+            // Hydrate from storage if we have a value for this param.
+            if (Object.prototype.hasOwnProperty.call(stored, d.param)) {
+                try {
+                    applyValueToElement(el, stored[d.param], d);
+                } catch (err) {
+                    console.warn('[FilterState.bindInputs] hydrate failed for "' + d.id + '":', err);
+                }
+            }
+
+            // Idempotency: skip if already bound for this scope+id.
+            var boundFlag = scopeKey + ':' + d.param;
+            var existing = el.dataset.__filterStateBound || '';
+            if (existing.split('|').indexOf(boundFlag) !== -1) {
+                return;
+            }
+            el.dataset.__filterStateBound = existing
+                ? existing + '|' + boundFlag
+                : boundFlag;
+
+            // Pick a sensible default event.
+            var evtName = d.event;
+            if (!evtName) {
+                if (el.tagName === 'INPUT' && (el.type === 'text' || el.type === 'search')) {
+                    evtName = 'input';
+                } else {
+                    evtName = 'change';
+                }
+            }
+
+            var persist = function () {
+                var current = load(scopeKey);
+                current[d.param] = readValueFromElement(el, d);
+                save(scopeKey, current);
+            };
+
+            if (d.buttonGroup) {
+                // For button groups the "element" is conceptually the group;
+                // attach click listeners to each button. The descriptor's
+                // own el is just the marker for idempotency tracking.
+                var buttons = document.querySelectorAll(d.buttonGroup.selector);
+                buttons.forEach(function (btn) {
+                    btn.addEventListener('click', persist);
+                });
+            } else {
+                el.addEventListener(evtName, persist);
+            }
+        });
+    }
+
+    window.FilterState = {
+        save: save,
+        load: load,
+        clear: clear,
+        bindInputs: bindInputs,
+    };
+
+    // ---- MANUAL SMOKE TEST --------------------------------------------------
+    // Paste in console:
+    //   window.__filterStateDevSmoke = true;
+    //   // then reload the page (or re-eval the script).
+    (function () {
+        if (typeof window === 'undefined' || window.__filterStateDevSmoke !== true) return;
+        try {
+            var scope = '__smoke_' + Date.now();
+            var sample = { q: 'hi', n: 3, flag: true, tags: ['a', 'b'] };
+            save(scope, sample);
+            var got = load(scope);
+            var ok = got && got.q === 'hi' && got.n === 3 && got.flag === true &&
+                Array.isArray(got.tags) && got.tags.length === 2 &&
+                got.tags[0] === 'a' && got.tags[1] === 'b';
+            if (!ok) throw new Error('roundtrip mismatch: ' + JSON.stringify(got));
+            clear(scope);
+            var after = load(scope);
+            if (!isPlainObject(after) || Object.keys(after).length !== 0) {
+                throw new Error('clear did not empty store: ' + JSON.stringify(after));
+            }
+            console.info('[FilterState] smoke OK');
+        } catch (err) {
+            console.error('[FilterState] smoke FAILED:', err);
+        }
+    })();
+})();

--- a/app/web/templates/_app_header.html
+++ b/app/web/templates/_app_header.html
@@ -11,7 +11,7 @@
     <div class="app-header-right">
         {% set _path = request.url.path %}
         {% set _home = home_route or '/dashboard' %}
-        {# Primary nav: Home → Marketplace → Data Packages → Memory.
+        {# Primary nav: Home → Marketplace → Data Packages → Curated Memory.
            Activity Center moved into the Admin dropdown — its content
            is per-team adoption analytics that only admins consume in
            practice (the route still allows any authed user for
@@ -24,20 +24,21 @@
         <a class="app-nav-link {% if _path == _home or _path == '/' or _path == '/dashboard' or _path == '/home' %}is-active{% endif %}" href="{{ _home }}">Home</a>
         <a class="app-nav-link {% if _path == '/marketplace' or _path.startswith('/marketplace/') %}is-active{% endif %}" href="/marketplace">Marketplace</a>
         <a class="app-nav-link {% if _path.startswith('/catalog') %}is-active{% endif %}" href="/catalog">Data Packages</a>
+        {# Curated Memory is the analyst-facing read surface for shared
+           organizational knowledge — not admin-gated (the route runs on
+           get_current_user, same as the /api/memory/* endpoints), so it
+           sits in the primary nav next to Data Packages, visible to all
+           authenticated users. The admin review queue is separate:
+           /admin/corporate-memory, in the Admin dropdown below. #}
+        <a class="app-nav-link {% if _path == '/corporate-memory' %}is-active{% endif %}" href="/corporate-memory">Memory</a>
 
-        {# Memory + Admin menu: both admin-only. Backend gates the routes
-           themselves via require_admin (see app/web/router.py for
-           /corporate-memory + /corporate-memory/admin + /admin/*), so
-           hiding the links is purely a visibility tidy-up — non-admins
-           who deep-link still get a 403 from the route handler. Single
-           guard wraps both for clarity. #}
+        {# Admin menu: admin-only. Backend gates the routes via
+           require_admin (see app/web/router.py for /admin/*, including
+           /admin/corporate-memory), so hiding the links is purely a
+           visibility tidy-up — non-admins who deep-link still get a 403
+           from the route handler. #}
         {% if session.user.is_admin %}
-        {# "Memory" link moved into the Admin dropdown's Agent Experience
-           section (parallel to Curated Marketplaces / Flea Submissions /
-           Prompts). The primary nav no longer carries an admin-only
-           entry — primary nav stays consistently visible to all
-           authenticated users. #}
-        {% set _admin_active = _path.startswith('/admin/tables') or _path.startswith('/admin/tokens') or _path.startswith('/admin/users') or _path.startswith('/admin/groups') or _path.startswith('/admin/access') or _path.startswith('/admin/server-config') or _path.startswith('/admin/agent-prompt') or _path.startswith('/admin/workspace-prompt') or _path.startswith('/admin/marketplaces') or _path.startswith('/admin/store') or _path.startswith('/admin/scheduler-runs') or _path.startswith('/admin/activity') or _path.startswith('/admin/telemetry') or _path.startswith('/admin/usage') or _path.startswith('/admin/sessions') or _path.startswith('/corporate-memory') %}
+        {% set _admin_active = _path.startswith('/admin/tables') or _path.startswith('/admin/tokens') or _path.startswith('/admin/users') or _path.startswith('/admin/groups') or _path.startswith('/admin/access') or _path.startswith('/admin/server-config') or _path.startswith('/admin/agent-prompt') or _path.startswith('/admin/workspace-prompt') or _path.startswith('/admin/marketplaces') or _path.startswith('/admin/store') or _path.startswith('/admin/scheduler-runs') or _path.startswith('/admin/activity') or _path.startswith('/admin/telemetry') or _path.startswith('/admin/usage') or _path.startswith('/admin/sessions') or _path.startswith('/admin/corporate-memory') %}
         <div class="app-nav-menu" id="adminNavMenu">
             <button type="button"
                     class="app-nav-link app-nav-menu-trigger {% if _admin_active %}is-active{% endif %}"
@@ -77,7 +78,7 @@
                    template injected into each workspace. #}
                 <div class="app-nav-menu-section">Agent Experience</div>
                 <a class="app-nav-menu-item {% if _path.startswith('/admin/marketplaces') %}is-active{% endif %}" role="menuitem" href="/admin/marketplaces">Curated Marketplaces</a>
-                <a class="app-nav-menu-item {% if _path.startswith('/corporate-memory') %}is-active{% endif %}" role="menuitem" href="/corporate-memory">Curated Memory</a>
+                <a class="app-nav-menu-item {% if _path.startswith('/admin/corporate-memory') %}is-active{% endif %}" role="menuitem" href="/admin/corporate-memory">Curated memory reviews</a>
                 <a class="app-nav-menu-item {% if _path.startswith('/admin/store/submissions') %}is-active{% endif %}" role="menuitem" href="/admin/store/submissions">Flea Submissions</a>
                 <a class="app-nav-menu-item {% if _path.startswith('/admin/agent-prompt') %}is-active{% endif %}" role="menuitem" href="/admin/agent-prompt">Init Prompt</a>
                 <a class="app-nav-menu-item {% if _path.startswith('/admin/workspace-prompt') %}is-active{% endif %}" role="menuitem" href="/admin/workspace-prompt">Workspace Prompt</a>
@@ -117,11 +118,10 @@
     </div>
 </header>
 {# Dropdown wiring lives in app/web/static/app.js. The script tag sits
-   here (in the shared header partial) instead of base.html so EVERY
-   page that includes _app_header.html — including standalone pages
-   like catalog.html / corporate_memory*.html / install.html /
-   admin_tables.html that don't extend base.html — gets the JS loaded
-   automatically. Defer keeps it non-blocking; placed after the header
-   markup so DOM is ready by the time the IIFE runs init(). #}
+   here (in the shared header partial) instead of base.html so any page
+   that includes _app_header.html directly — e.g. admin_tables.html,
+   which doesn't extend base.html — still gets the JS loaded. Defer
+   keeps it non-blocking; placed after the header markup so the DOM is
+   ready by the time the IIFE runs init(). #}
 <script src="{{ static_url('app.js') }}" defer></script>
 {% endif %}

--- a/app/web/templates/admin_corporate_memory.html
+++ b/app/web/templates/admin_corporate_memory.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Corporate Memory Admin - Data Analyst Portal{% endblock %}
+{% block title %}Memory Review - Data Analyst Portal{% endblock %}
 
 {% block head_extra %}
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -9,7 +9,7 @@
 <style>
         /* Corporate Memory Admin - Design System Styles */
         .container-memory {
-            max-width: 1000px;
+            max-width: var(--width-app);
             margin: 0 auto;
             padding: var(--space-6);
         }
@@ -796,10 +796,90 @@
                 display: none !important;
             }
         }
+
+        /* ─── Tag-input widget (edit modal) ─── */
+        .tag-input-widget {
+            display: flex; flex-wrap: wrap; align-items: center; gap: 4px;
+            padding: 4px 6px;
+            border: 1px solid var(--border);
+            border-radius: var(--radius-sm);
+            background: var(--bg);
+            min-height: 34px;
+            cursor: text;
+        }
+        .tag-input-widget:focus-within {
+            border-color: var(--primary, #0073D1);
+            box-shadow: 0 0 0 2px rgba(0, 115, 209, 0.15);
+        }
+        .tag-input-widget .tag-pill {
+            display: inline-flex; align-items: center; gap: 4px;
+            padding: 2px 4px 2px 10px;
+            background: var(--primary, #0073D1);
+            color: white;
+            border-radius: 999px;
+            font-size: 12px; font-weight: 500;
+            line-height: 1.4;
+            white-space: nowrap;
+        }
+        .tag-input-widget .tag-pill button {
+            background: rgba(255, 255, 255, 0.25);
+            color: white; border: none; cursor: pointer;
+            width: 16px; height: 16px; padding: 0;
+            border-radius: 50%;
+            font-size: 13px; line-height: 1;
+            display: inline-flex; align-items: center; justify-content: center;
+        }
+        .tag-input-widget .tag-pill button:hover {
+            background: rgba(255, 255, 255, 0.45);
+        }
+        .tag-input-widget input {
+            flex: 1; min-width: 120px;
+            border: none; outline: none; background: transparent;
+            color: var(--text); font: inherit; padding: 4px 6px;
+        }
+        /* Typeahead dropdown — popped under the widget when input has focus.
+           Filter against EXISTING_TAGS array (server-injected via tojson). */
+        .tag-suggestions {
+            position: absolute;
+            top: 100%; left: 0; right: 0;
+            margin-top: 2px;
+            background: var(--bg, white);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-sm);
+            box-shadow: 0 6px 20px rgba(0, 0, 0, 0.12);
+            z-index: 2100;
+            max-height: 220px;
+            overflow-y: auto;
+            padding: 4px 0;
+        }
+        .tag-suggestion {
+            display: block; width: 100%; text-align: left;
+            padding: 6px 12px;
+            background: transparent;
+            border: none; cursor: pointer;
+            color: var(--text); font: inherit;
+            font-size: 13px;
+        }
+        .tag-suggestion:hover, .tag-suggestion.active {
+            background: var(--primary-light, #eef5fb);
+            color: var(--primary, #0073D1);
+        }
+        .tag-suggestion .hint {
+            color: var(--text-muted); font-size: 11px; margin-left: 8px;
+            font-weight: 500;
+        }
+        .tag-suggestion.new-tag .hint { color: var(--primary, #0073D1); }
+        .tag-suggestions .empty-hint {
+            padding: 8px 12px; color: var(--text-muted); font-size: 12px; font-style: italic;
+        }
     </style>
 {% endblock %}
 
 {% block layout %}
+    {% set page_hero_eyebrow = "Agent Experience" %}
+    {% set page_hero_title = "Memory Review" %}
+    {% set page_hero_subtitle = "Review pending knowledge items from analyst sessions — approve, mandate, or reject — and resolve contradictions and duplicate candidates. Approved items flow to the user-facing <a href=\"/corporate-memory\" style=\"color:inherit;text-decoration:underline;\">Curated Memory</a> page." %}
+    {% include "_page_hero.html" %}
 <div class="container-memory">
         <!-- Stats Bar -->
         <div class="stats-bar">
@@ -1046,7 +1126,19 @@
                     <div style="display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-3);">
                         <label style="display: flex; flex-direction: column; gap: 4px;">
                             <span style="font-size: 12px; color: var(--text-muted);">Category</span>
-                            <input id="editItemCategory" type="text" placeholder="e.g. metric, dataset" style="padding: 6px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--bg); color: var(--text);">
+                            {# A <select> dropdown (clicks reliably across all
+                               browsers; <datalist> didn't — Firefox/Safari
+                               wouldn't open the suggestion list on the
+                               typeahead arrow click). The "+ Add new
+                               category…" pseudo-option reveals a sibling
+                               input so admins can still introduce a fresh
+                               slug without leaving the modal. #}
+                            <select id="editItemCategoryPick" onchange="onCategoryPickChange(this.value)" style="padding: 6px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--bg); color: var(--text);">
+                                <option value="">(unset)</option>
+                                {% for c in edit_categories %}<option value="{{ c }}">{{ c }}</option>{% endfor %}
+                                <option value="__NEW__">+ Add new category…</option>
+                            </select>
+                            <input id="editItemCategoryNew" type="text" placeholder="new category slug" style="display: none; padding: 6px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--bg); color: var(--text);">
                         </label>
                         <label style="display: flex; flex-direction: column; gap: 4px;">
                             <span style="font-size: 12px; color: var(--text-muted);">Domain</span>
@@ -1062,11 +1154,41 @@
                         </label>
                         <label style="display: flex; flex-direction: column; gap: 4px;">
                             <span style="font-size: 12px; color: var(--text-muted);">Audience</span>
-                            <input id="editItemAudience" type="text" placeholder="e.g. all or group:finance" style="padding: 6px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--bg); color: var(--text);">
+                            {# Audience is a closed enum: `(unset)` / `all` /
+                               `group:<name>` per RBAC group. The free-text
+                               input let admins typo `gourp:eng` and silently
+                               hide an item from everyone; a `<select>` rules
+                               that out. Groups come from the same source the
+                               mandate-form picker uses. #}
+                            <select id="editItemAudience" style="padding: 6px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--bg); color: var(--text);">
+                                <option value="">(unset)</option>
+                                <option value="all">all (every authenticated user)</option>
+                                {% for g in groups %}<option value="group:{{ g.name }}">group:{{ g.name }} ({{ g.members_count }} member{{ 's' if g.members_count != 1 else '' }})</option>{% endfor %}
+                            </select>
                         </label>
-                        <label style="display: flex; flex-direction: column; gap: 4px;">
-                            <span style="font-size: 12px; color: var(--text-muted);">Tags (comma-separated)</span>
-                            <input id="editItemTags" type="text" placeholder="tag1, tag2" style="padding: 6px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--bg); color: var(--text);">
+                        {# Tag widget with INLINE typeahead — focus the input or
+                           start typing and the dropdown right below the pill
+                           row lists matching existing tags. Click a match or
+                           ↑/↓ + Enter to add as pill; type a new value and
+                           Enter to add a brand-new tag. Backspace on empty
+                           input removes the last pill. The widget container
+                           is position:relative so the suggestion box pops
+                           directly under the pill row. #}
+                        <label style="display: flex; flex-direction: column; gap: 4px; grid-column: 1 / -1; position: relative;">
+                            <span style="font-size: 12px; color: var(--text-muted);">Tags <span style="color: var(--text-muted); font-weight: 400;">— pills below (× to remove). Focus to browse existing, type to filter, Enter to add new.</span></span>
+                            <div id="editItemTagsWidget" class="tag-input-widget" onclick="if(event.target===this) document.getElementById('editItemTagsInput').focus()">
+                                {# Pills inserted by tagWidgetAdd() at runtime.
+                                   The input stays last in DOM order so new
+                                   pills land before it. #}
+                                <input id="editItemTagsInput" type="text"
+                                       placeholder="type to filter existing tags or add new…"
+                                       oninput="onTagInputType()"
+                                       onfocus="onTagInputType()"
+                                       onkeydown="onTagInputKeydown(event)"
+                                       onblur="setTimeout(hideTagSuggestions, 150)"
+                                       autocomplete="off">
+                            </div>
+                            <div id="editItemTagSuggestions" class="tag-suggestions" hidden></div>
                         </label>
                     </div>
                 </div>
@@ -1109,6 +1231,10 @@
     // Configuration passed from server
     const GROUPS = {{ groups | tojson }};
     const GOVERNANCE_MODE = {{ governance_mode | tojson }};
+    // Tag autocomplete pool — populated from existing knowledge_items.tags
+    // (deduplicated, sorted server-side in router::corporate_memory_admin).
+    // Consumed by the tag-input widget on the edit modal.
+    const EXISTING_TAGS = {{ edit_tags | tojson }};
 
     // State
     let currentTab = 'review';
@@ -1330,13 +1456,27 @@
         _bulkEditState = { mode, ids };
         const titleEl = document.getElementById('bulkEditTitle');
         const bodyEl = document.getElementById('bulkEditBody');
+        // Bulk-edit pickers mirror the per-item edit modal — pick from
+        // existing values; "+ Add new…" reveals a sibling text input for a
+        // fresh slug. remove_tag is closed-set (only existing tags), so no
+        // "+ Add new". The select markup is rendered by Jinja at page load
+        // from edit_categories / edit_tags / groups (already passed into
+        // the template ctx).
+        const _selectStyle = 'width: 100%; padding: var(--space-2); border: 1px solid var(--border); border-radius: var(--radius-md);';
+        const _newInputStyle = 'display:none; margin-top: var(--space-2); width: 100%; padding: var(--space-2); border: 1px solid var(--border); border-radius: var(--radius-md);';
         if (mode === 'category') {
             titleEl.textContent = `Move ${ids.length} item(s) to category…`;
-            bodyEl.innerHTML = `<input type="text" id="bulkEditValue" placeholder="e.g. business_logic" style="width: 100%; padding: var(--space-2); border: 1px solid var(--border); border-radius: var(--radius-md);">`;
+            bodyEl.innerHTML = `
+                <select id="bulkEditValue" onchange="onBulkPickChange(this.value)" style="${_selectStyle}">
+                    <option value="">(unset)</option>
+                    {% for c in edit_categories %}<option value="{{ c }}">{{ c }}</option>{% endfor %}
+                    <option value="__NEW__">+ Add new category…</option>
+                </select>
+                <input id="bulkEditNewValue" type="text" placeholder="new category slug" style="${_newInputStyle}">`;
         } else if (mode === 'domain') {
             titleEl.textContent = `Move ${ids.length} item(s) to domain…`;
             bodyEl.innerHTML = `
-                <select id="bulkEditValue" style="width: 100%; padding: var(--space-2); border: 1px solid var(--border); border-radius: var(--radius-md);">
+                <select id="bulkEditValue" style="${_selectStyle}">
                     <option value="">(unset)</option>
                     <option value="finance">finance</option>
                     <option value="engineering">engineering</option>
@@ -1347,15 +1487,48 @@
                 </select>`;
         } else if (mode === 'audience') {
             titleEl.textContent = `Set audience for ${ids.length} item(s)…`;
-            bodyEl.innerHTML = `<input type="text" id="bulkEditValue" placeholder="e.g. all or group:finance" style="width: 100%; padding: var(--space-2); border: 1px solid var(--border); border-radius: var(--radius-md);">`;
+            bodyEl.innerHTML = `
+                <select id="bulkEditValue" style="${_selectStyle}">
+                    <option value="">(unset)</option>
+                    <option value="all">all (every authenticated user)</option>
+                    {% for g in groups %}<option value="group:{{ g.name }}">group:{{ g.name }} ({{ g.members_count }} member{{ 's' if g.members_count != 1 else '' }})</option>{% endfor %}
+                </select>`;
         } else if (mode === 'add_tag') {
             titleEl.textContent = `Add tag to ${ids.length} item(s)…`;
-            bodyEl.innerHTML = `<input type="text" id="bulkEditValue" placeholder="tag name" style="width: 100%; padding: var(--space-2); border: 1px solid var(--border); border-radius: var(--radius-md);">`;
+            bodyEl.innerHTML = `
+                <select id="bulkEditValue" onchange="onBulkPickChange(this.value)" style="${_selectStyle}">
+                    <option value="">— pick existing or add new —</option>
+                    {% for t in edit_tags %}<option value="{{ t }}">{{ t }}</option>{% endfor %}
+                    <option value="__NEW__">+ Add new tag…</option>
+                </select>
+                <input id="bulkEditNewValue" type="text" placeholder="new tag" style="${_newInputStyle}">`;
         } else if (mode === 'remove_tag') {
             titleEl.textContent = `Remove tag from ${ids.length} item(s)…`;
-            bodyEl.innerHTML = `<input type="text" id="bulkEditValue" placeholder="tag name" style="width: 100%; padding: var(--space-2); border: 1px solid var(--border); border-radius: var(--radius-md);">`;
+            {% if edit_tags %}
+            bodyEl.innerHTML = `
+                <select id="bulkEditValue" style="${_selectStyle}">
+                    <option value="">— pick tag to remove —</option>
+                    {% for t in edit_tags %}<option value="{{ t }}">{{ t }}</option>{% endfor %}
+                </select>`;
+            {% else %}
+            bodyEl.innerHTML = `<p style="color: var(--text-muted); font-size: 13px;">No tags exist yet to remove.</p>`;
+            {% endif %}
         }
         document.getElementById('bulkEditModal').style.display = 'block';
+    }
+
+    // Shared handler for bulk-edit selects that include "+ Add new…":
+    // reveals/hides the sibling text input for a fresh value.
+    function onBulkPickChange(value) {
+        const newInput = document.getElementById('bulkEditNewValue');
+        if (!newInput) return;
+        if (value === '__NEW__') {
+            newInput.style.display = '';
+            newInput.focus();
+        } else {
+            newInput.style.display = 'none';
+            newInput.value = '';
+        }
     }
 
     function closeBulkEditModal() {
@@ -1367,7 +1540,15 @@
         const { mode, ids } = _bulkEditState;
         if (!mode || ids.length === 0) return closeBulkEditModal();
         const valueEl = document.getElementById('bulkEditValue');
-        const value = (valueEl.value || '').trim();
+        if (!valueEl) return closeBulkEditModal();  // remove_tag with no tags → "No tags exist" placeholder, no input
+        let value = (valueEl.value || '').trim();
+        // "+ Add new…" route: read the sibling text input for the fresh slug.
+        // Applies to category / add_tag modes (remove_tag and domain are
+        // closed-set, audience is closed-set after the picker change).
+        if (value === '__NEW__') {
+            const newInput = document.getElementById('bulkEditNewValue');
+            value = ((newInput && newInput.value) || '').trim();
+        }
         // Domain allows the explicit "(unset)" option (empty string clears the field
         // — backend allows empty domain). Other modes still require a non-empty value.
         if (!value && mode !== 'domain') {
@@ -1421,17 +1602,196 @@
         _editingItemId = itemId;
         document.getElementById('editItemTitle').value = item.title || '';
         document.getElementById('editItemContent').value = item.content || '';
-        document.getElementById('editItemCategory').value = item.category || '';
+        // Category: pick the existing option if it matches one in the
+        // dropdown; otherwise dynamically add it as a one-off option so the
+        // current value is visible (and selected) even if it's a one-off
+        // slug that didn't exist when the page rendered.
+        const catSel = document.getElementById('editItemCategoryPick');
+        const catNewIn = document.getElementById('editItemCategoryNew');
+        const curCat = item.category || '';
+        const hasOpt = [...catSel.options].some(o => o.value === curCat);
+        if (curCat && !hasOpt) {
+            // Insert before the "+ Add new…" pseudo-option (always last).
+            const newOpt = new Option(curCat, curCat);
+            catSel.add(newOpt, catSel.options.length - 1);
+        }
+        catSel.value = curCat;
+        catNewIn.style.display = 'none';
+        catNewIn.value = '';
         document.getElementById('editItemDomain').value = item.domain || '';
         document.getElementById('editItemAudience').value = item.audience || '';
         const tagsArr = parseJsonField(item.tags);
-        document.getElementById('editItemTags').value = tagsArr.join(', ');
+        tagWidgetInit(tagsArr);
         document.getElementById('editItemModal').style.display = 'block';
+    }
+
+    // ─── Tag-input widget helpers ───
+    // The widget renders applied tags as pills before the typing <input>.
+    // We treat the DOM as the source of truth (no separate state array) —
+    // submitEditItem reads back via tagWidgetGetTags().
+    function tagWidgetInit(tags) {
+        const w = document.getElementById('editItemTagsWidget');
+        // Wipe old pills (keep the trailing input).
+        w.querySelectorAll('.tag-pill').forEach(p => p.remove());
+        document.getElementById('editItemTagsInput').value = '';
+        (tags || []).forEach(t => tagWidgetAdd(t));
+    }
+    function tagWidgetGetTags() {
+        return Array.from(document.querySelectorAll('#editItemTagsWidget .tag-pill'))
+            .map(p => p.dataset.tag);
+    }
+    function tagWidgetAdd(rawTag) {
+        const tag = (rawTag || '').trim();
+        if (!tag) return;
+        if (tagWidgetGetTags().includes(tag)) return;  // dedupe
+        const pill = document.createElement('span');
+        pill.className = 'tag-pill';
+        pill.dataset.tag = tag;
+        pill.appendChild(document.createTextNode(tag + ' '));
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.setAttribute('aria-label', `Remove tag ${tag}`);
+        btn.textContent = '×';
+        btn.addEventListener('click', (e) => { e.stopPropagation(); pill.remove(); });
+        pill.appendChild(btn);
+        const input = document.getElementById('editItemTagsInput');
+        input.parentNode.insertBefore(pill, input);
+        input.value = '';
+    }
+    function onTagInputKeydown(e) {
+        // Enter / ↓ / ↑ / Escape / Backspace handling. The typeahead dropdown
+        // (#editItemTagSuggestions) drives selection state via the
+        // .active class on a .tag-suggestion. Enter commits the highlighted
+        // suggestion when one is active, otherwise commits the typed value
+        // as a new pill (existing behavior). Arrows move the highlight.
+        const list = document.getElementById('editItemTagSuggestions');
+        const visible = list && !list.hidden;
+        if (e.key === 'ArrowDown') {
+            if (visible) { e.preventDefault(); moveTagSuggestion(1); }
+            return;
+        }
+        if (e.key === 'ArrowUp') {
+            if (visible) { e.preventDefault(); moveTagSuggestion(-1); }
+            return;
+        }
+        if (e.key === 'Escape') {
+            if (visible) { e.preventDefault(); hideTagSuggestions(); }
+            return;
+        }
+        if (e.key === 'Enter' || e.key === ',') {
+            e.preventDefault();
+            const active = visible ? list.querySelector('.tag-suggestion.active') : null;
+            if (active) {
+                selectTagSuggestion(active.dataset.tag);
+            } else {
+                const v = e.target.value.replace(/,$/, '').trim();
+                if (v) { tagWidgetAdd(v); hideTagSuggestions(); }
+            }
+            return;
+        }
+        if (e.key === 'Backspace' && !e.target.value) {
+            const pills = document.querySelectorAll('#editItemTagsWidget .tag-pill');
+            if (pills.length) pills[pills.length - 1].remove();
+        }
+    }
+
+    // Re-render the typeahead dropdown based on the current input value.
+    // Called on every keystroke (oninput) and on focus (so an empty focus
+    // lists ALL existing tags — "browse" mode).
+    function onTagInputType() {
+        const input = document.getElementById('editItemTagsInput');
+        const list = document.getElementById('editItemTagSuggestions');
+        if (!input || !list) return;
+        const q = (input.value || '').trim().toLowerCase();
+        const applied = new Set(tagWidgetGetTags());
+        // Filter pool: existing tags not yet applied, matching the query
+        // (case-insensitive substring; "" matches everything).
+        const pool = (typeof EXISTING_TAGS !== 'undefined' ? EXISTING_TAGS : [])
+            .filter(t => !applied.has(t))
+            .filter(t => !q || t.toLowerCase().includes(q));
+
+        // Build HTML: matching existing tags first; if the typed value is
+        // a fresh non-match (and non-empty, and not already a pill), offer
+        // it as an explicit "+ Add new" option at the bottom.
+        const exactMatch = q && pool.some(t => t.toLowerCase() === q);
+        const isFreshNew = q && !exactMatch && !applied.has(q);
+
+        if (pool.length === 0 && !isFreshNew) {
+            list.innerHTML = '<div class="empty-hint">No tags match — keep typing and press Enter to add a new tag.</div>';
+            list.hidden = false;
+            return;
+        }
+
+        const parts = pool.map((t, idx) => {
+            const safe = escapeHtml(t);
+            return `<button type="button" class="tag-suggestion${idx === 0 ? ' active' : ''}" data-tag="${safe}" onmousedown="event.preventDefault(); selectTagSuggestion('${escapeAttr(t)}')">${safe}</button>`;
+        });
+        if (isFreshNew) {
+            const safe = escapeHtml(q);
+            parts.push(`<button type="button" class="tag-suggestion new-tag${pool.length === 0 ? ' active' : ''}" data-tag="${safe}" onmousedown="event.preventDefault(); selectTagSuggestion('${escapeAttr(q)}')">+ Add new tag: <strong>${safe}</strong><span class="hint">Enter</span></button>`);
+        }
+        list.innerHTML = parts.join('');
+        list.hidden = false;
+    }
+
+    function moveTagSuggestion(delta) {
+        const list = document.getElementById('editItemTagSuggestions');
+        const items = Array.from(list.querySelectorAll('.tag-suggestion'));
+        if (items.length === 0) return;
+        let activeIdx = items.findIndex(b => b.classList.contains('active'));
+        if (activeIdx < 0) activeIdx = 0;
+        items[activeIdx].classList.remove('active');
+        const newIdx = (activeIdx + delta + items.length) % items.length;
+        items[newIdx].classList.add('active');
+        items[newIdx].scrollIntoView({ block: 'nearest' });
+    }
+
+    function selectTagSuggestion(tag) {
+        tagWidgetAdd(tag);
+        const input = document.getElementById('editItemTagsInput');
+        input.value = '';
+        // Re-render to drop the newly-applied tag from the pool while the
+        // input keeps focus — feels like a continuous picker.
+        onTagInputType();
+        input.focus();
+    }
+
+    function hideTagSuggestions() {
+        const list = document.getElementById('editItemTagSuggestions');
+        if (list) { list.hidden = true; list.innerHTML = ''; }
+    }
+
+    // Small helpers (avoids dependency on a single escape util shared
+    // across the file). escapeHtml is already defined elsewhere; escapeAttr
+    // is for single-quoted JS string contexts in inline onclick handlers.
+    function escapeAttr(s) {
+        return String(s).replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+    }
+
+    // Category picker handler — toggles the "new slug" input when the
+    // operator selects the "+ Add new category…" pseudo-option. Restores
+    // it on any other selection so a mis-click recovers cleanly.
+    function onCategoryPickChange(value) {
+        const newInput = document.getElementById('editItemCategoryNew');
+        if (value === '__NEW__') {
+            newInput.style.display = '';
+            newInput.focus();
+        } else {
+            newInput.style.display = 'none';
+            newInput.value = '';
+        }
     }
 
     function closeEditItemModal() {
         document.getElementById('editItemModal').style.display = 'none';
         _editingItemId = null;
+    }
+
+    // Click handler for the "+ tag" suggestion chips below the widget.
+    // Forwards to the widget's add — keeps a single code path for additions.
+    function appendEditTag(tag) {
+        tagWidgetAdd(tag);
+        document.getElementById('editItemTagsInput').focus();
     }
 
     async function submitEditItem() {
@@ -1453,14 +1813,21 @@
         // empty-string → null path.
         const orNull = (s) => (s && s.trim() ? s.trim() : null);
         const content = document.getElementById('editItemContent').value || null;
-        const category = orNull(document.getElementById('editItemCategory').value);
+        // Category: if "+ Add new" is selected, take the value from the
+        // sibling text input; otherwise use the picked dropdown value.
+        let categoryRaw = document.getElementById('editItemCategoryPick').value;
+        if (categoryRaw === '__NEW__') {
+            categoryRaw = document.getElementById('editItemCategoryNew').value;
+        }
+        const category = orNull(categoryRaw);
         const domain = orNull(document.getElementById('editItemDomain').value);
         const audience = orNull(document.getElementById('editItemAudience').value);
-        const tagsStr = document.getElementById('editItemTags').value;
-        const tags = tagsStr
-            .split(',')
-            .map(t => t.trim())
-            .filter(t => t.length > 0);
+        // Tags read directly from the pill widget DOM. Any uncommitted text
+        // still in the input (user typed but didn't press Enter) is salvaged
+        // here so a click-Save without Enter doesn't quietly drop it.
+        const tags = tagWidgetGetTags();
+        const pending = (document.getElementById('editItemTagsInput').value || '').trim();
+        if (pending && !tags.includes(pending)) tags.push(pending);
 
         const body = { title, content, category, domain, audience, tags };
         try {

--- a/app/web/templates/base.html
+++ b/app/web/templates/base.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Data Analyst Portal{% endblock %}</title>
     <link rel="stylesheet" href="{{ static_url('style-custom.css') }}">
-    {# app.js loaded by _app_header.html itself so standalone pages
-       (catalog, corporate-memory, install, admin_tables) that don't
-       extend base.html also get the nav-dropdown wiring. #}
+    {# app.js loaded by _app_header.html itself so pages that include
+       the header directly without extending base.html (e.g. admin_tables)
+       still get the nav-dropdown wiring. #}
     {% block head_extra %}{% endblock %}
     {% include '_theme.html' %}
 </head>

--- a/app/web/templates/corporate_memory.html
+++ b/app/web/templates/corporate_memory.html
@@ -1,85 +1,29 @@
 {% extends "base.html" %}
 
-{% block title %}Curated Memory — Admin{% endblock %}
+{% block title %}Curated Memory{% endblock %}
 
 {% block head_extra %}
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+{# Shared utility for persisting filter UI state per-page in localStorage.
+   See app/web/static/js/filter-state.js for the public API and adoption
+   pattern. Loaded with defer so window.FilterState exists by the time
+   the page's own DOMContentLoaded listener runs. #}
+<script src="{{ static_url('js/filter-state.js') }}" defer></script>
 <style>
         /* Corporate Memory Page - Design System Styles */
         .container-memory {
-            max-width: 1000px;
+            max-width: var(--width-app);
             margin: 0 auto;
             padding: var(--space-6);
         }
 
-        /* Top bar — matches the .obs-topbar look used on /admin/activity,
-           /admin/telemetry, /admin/sessions. Kept under a `ck-` prefix here
-           because the rest of the page still uses its own design tokens;
-           when the obs-* classes are lifted to style-custom.css we'll
-           drop the duplication. */
-        .ck-topbar {
-            display: flex;
-            justify-content: space-between;
-            align-items: flex-start;
-            gap: 24px;
-            padding: 12px 0 20px;
-            border-bottom: 1px solid var(--border, #e5e7eb);
-            margin-bottom: 16px;
-        }
-        .ck-title {
-            margin: 0 0 4px 0;
-            font-size: 22px;
-            font-weight: 600;
-            color: var(--text-primary, #111827);
-        }
-        .ck-subtitle {
-            margin: 0;
-            color: var(--text-secondary, #6b7280);
-            font-size: 13px;
-            max-width: 720px;
-            line-height: 1.5;
-        }
-        .ck-subtitle code {
-            background: var(--border-light, #f3f4f6);
-            padding: 1px 6px;
-            border-radius: 4px;
-            font-size: 12px;
-        }
-
-        /* Header */
-        .page-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            padding-bottom: var(--space-5);
-            border-bottom: 1px solid var(--border);
-            margin-bottom: var(--space-6);
-        }
-
-        .header-left {
-            display: flex;
-            align-items: center;
-            gap: var(--space-4);
-        }
-
-        .back-link {
-            display: flex;
-            align-items: center;
-            gap: var(--space-2);
-            color: var(--text-secondary);
-            text-decoration: none;
-            font-size: var(--text-sm);
-            padding: var(--space-2) var(--space-3);
-            border-radius: var(--radius-md);
-            transition: all 0.15s;
-        }
-
-        .back-link:hover {
-            background: var(--border-light);
-            color: var(--text-primary);
-        }
+        /* Page title is the shared `_page_hero.html` partial (blue hero
+           band), same as catalog / me-activity / admin pages. The old
+           bespoke `.ck-topbar` / `.page-header` rules lived here and
+           are gone — `.page-header` in particular collided with the
+           design-system `.page-header--hero` selector. */
 
         .page-title {
             display: flex;
@@ -252,6 +196,46 @@
 
         .knowledge-item.synced {
             border-left: 3px solid var(--success);
+        }
+
+        /* Dismissed-by-current-user — keeps the item in the list (so the
+           user can see what they hid + restore it) but visually demotes it. */
+        .knowledge-item.dismissed {
+            opacity: 0.55;
+            background: var(--bg-subtle, #f9fafb);
+        }
+        .knowledge-item.dismissed .knowledge-title { text-decoration: line-through; }
+        body.cm-hide-dismissed .knowledge-item.dismissed { display: none; }
+
+        .dismiss-btn {
+            margin-left: 4px;
+            width: 28px; height: 28px;
+            border: 1px solid var(--border);
+            background: transparent;
+            color: var(--text-muted);
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 14px;
+            line-height: 1;
+            display: inline-flex; align-items: center; justify-content: center;
+        }
+        .dismiss-btn:hover {
+            background: var(--error-bg, #fef2f2);
+            color: var(--error, #dc2626);
+            border-color: var(--error, #dc2626);
+        }
+        .dismiss-btn.dismissed {
+            background: var(--primary-light, #eef5fb);
+            color: var(--primary, #0073D1);
+            border-color: var(--primary, #0073D1);
+        }
+        .dismiss-btn.dismissed:hover {
+            background: var(--primary, #0073D1);
+            color: white;
+        }
+        .source-badge.dismissed-badge {
+            background: var(--border, #e5e7eb);
+            color: var(--text-muted, #6b7280);
         }
 
         .knowledge-header {
@@ -592,24 +576,11 @@
 {% endblock %}
 
 {% block layout %}
+    {% set page_hero_eyebrow = "Knowledge" %}
+    {% set page_hero_title = "Curated Memory" %}
+    {% set page_hero_subtitle = "Approved and mandated knowledge distilled from analyst sessions — the shared organizational memory your AI agents pull at runtime via <code>/api/memory/*</code>." %}
+    {% include "_page_hero.html" %}
 <div class="container-memory">
-        {# Match the obs-page header pattern used by /admin/activity,
-           /admin/telemetry and /admin/sessions so admins see one
-           consistent visual chrome across the Activity Center + Agent
-           Experience groups. Styles inlined for now; the obs-* class
-           set isn't promoted to a shared stylesheet yet (one page over
-           four already; lift on next iteration). #}
-        <header class="ck-topbar">
-            <div>
-                <h1 class="ck-title">Curated Memory</h1>
-                <p class="ck-subtitle">
-                    Knowledge items extracted from analyst sessions by the verification
-                    processor. Admin reviews pending entries and approves, mandates or
-                    rejects them; approved items become shared organizational knowledge
-                    that AI agents pull at runtime via <code>/api/memory/*</code>.
-                </p>
-            </div>
-        </header>
 
         {% if pending_review_count and pending_review_count > 0 %}
         <!-- Admin-only review-queue banner (#176). Hidden when 0; non-admins
@@ -624,7 +595,7 @@
             <span>
                 <strong>{{ pending_review_count }} pending item{{ 's' if pending_review_count != 1 else '' }}</strong>
                 awaiting review —
-                <a href="/corporate-memory/admin" style="color: #854d0e; text-decoration: underline; font-weight: var(--font-medium);">review them at /corporate-memory/admin</a>
+                <a href="/admin/corporate-memory" style="color: #854d0e; text-decoration: underline; font-weight: var(--font-medium);">review them at /admin/corporate-memory</a>
             </span>
         </div>
         {% endif %}
@@ -668,9 +639,13 @@
                 </svg>
                 <input type="text" id="searchInput" placeholder="Search knowledge..." onkeyup="debounceSearch()">
             </div>
-            <div class="filter-group">
+            <div class="filter-group" id="categoryFilterGroup">
                 <button class="filter-btn active" data-category="" onclick="setFilter(this)">All</button>
-                <button class="filter-btn" data-category="my_rules" onclick="setFilter(this)">My Rules</button>
+                {# Special pseudo-category "my_upvotes" — gets translated to
+                   ?upvoted_by_me=true in loadKnowledge() and the tree filter.
+                   Replaces the old dead "My Rules" filter that sent
+                   ?category=my_rules (no row ever matched). #}
+                <button class="filter-btn" data-category="my_upvotes" onclick="setFilter(this)">My Upvotes</button>
                 {% for cat in categories %}
                 <button class="filter-btn" data-category="{{ cat }}" onclick="setFilter(this)">{{ cat|replace('_', ' ')|title }}</button>
                 {% endfor %}
@@ -696,12 +671,20 @@
                 <option value="tag">Group by tag</option>
                 <option value="audience">Group by audience</option>
             </select>
+            {# Per-user dismissed-filter toggle. Dismissed items are visible
+               by default (grayed out + an Undismiss button) — the toggle
+               provides an opt-in cleanup view. Persisted via FilterState so
+               it survives a page reload on the same browser. #}
+            <label style="display: inline-flex; align-items: center; gap: 6px; padding: 0 12px; font-size: 13px; color: var(--text-secondary); cursor: pointer;">
+                <input type="checkbox" id="hideDismissedToggle" onchange="onHideDismissedChange()" style="cursor: pointer;">
+                Hide dismissed
+            </label>
         </div>
 
         <!-- Knowledge List -->
         <div id="knowledgeList" class="knowledge-list">
             {% for item in knowledge['items'] %}
-            <div class="knowledge-item {% if item.synced %}synced{% endif %}" data-id="{{ item.id }}">
+            <div class="knowledge-item {% if item.synced %}synced{% endif %}{% if item.dismissed_by_me %} dismissed{% endif %}" data-id="{{ item.id }}" data-status="{{ item.status }}">
                 <div class="knowledge-header">
                     <div>
                         <div class="knowledge-title">{{ item.title }}</div>
@@ -711,6 +694,7 @@
                             {% if item.confidence %}<span class="confidence-badge" title="Confidence: {{ '%.0f'|format(item.confidence * 100) }}%">{{ '%.0f'|format(item.confidence * 100) }}%</span>{% endif %}
                             {% if item.source_type == 'user_verification' %}<span class="source-badge verification">Verified</span>{% endif %}
                             {% if item.status == 'mandatory' %}<span class="source-badge mandatory">Mandatory</span>{% endif %}
+                            {% if item.dismissed_by_me %}<span class="source-badge dismissed-badge">Dismissed</span>{% endif %}
                             <span>Added {{ item.created_at.strftime('%Y-%m-%d') if item.created_at else 'recently' }}</span>
                         </div>
                     </div>
@@ -732,6 +716,17 @@
                                 </svg>
                                 <span>{{ item.downvotes or 0 }}</span>
                             </button>
+                            {# Dismiss / Undismiss — hidden entirely for
+                               mandatory items (governance rule: cannot be
+                               opted out). Toggles between Dismiss (when
+                               not yet dismissed) and Undismiss. #}
+                            {% if item.status != 'mandatory' %}
+                                {% if item.dismissed_by_me %}
+                                <button class="dismiss-btn dismissed" onclick="undismiss('{{ item.id }}')" title="Undismiss — show in my AI context again">↺</button>
+                                {% else %}
+                                <button class="dismiss-btn" onclick="dismiss('{{ item.id }}')" title="Dismiss — exclude from my AI context">×</button>
+                                {% endif %}
+                            {% endif %}
                         </div>
                         {% if item.synced %}
                         <span class="synced-badge">
@@ -905,7 +900,11 @@
 
         const html = data.groups.map(g => {
             const filtered = (g.items || []).filter(it => {
-                if (categoryFilter && categoryFilter !== 'my_rules' && it.category !== categoryFilter) return false;
+                // "my_upvotes" is a non-category pseudo-filter handled
+                // server-side via ?upvoted_by_me; the tree endpoint already
+                // returns the right subset, so we skip the category check
+                // when that pseudo-value is active.
+                if (categoryFilter && categoryFilter !== 'my_upvotes' && it.category !== categoryFilter) return false;
                 if (domainFilter && it.domain !== domainFilter) return false;
                 return true;
             });
@@ -946,8 +945,10 @@
 
     async function loadKnowledge(category, search, page, sort, domain) {
         const params = new URLSearchParams();
-        if (category && category !== 'my_rules') params.append('category', category);
-        if (category === 'my_rules') params.append('my_rules', 'true');
+        // "my_upvotes" pseudo-category is translated to the real
+        // ?upvoted_by_me=true filter the backend understands.
+        if (category && category !== 'my_upvotes') params.append('category', category);
+        if (category === 'my_upvotes') params.append('upvoted_by_me', 'true');
         if (search) params.append('search', search);
         if (sort) params.append('sort', sort);
         if (domain) params.append('domain', domain);
@@ -980,7 +981,7 @@
         }
 
         list.innerHTML = data.items.map(item => `
-            <div class="knowledge-item ${item.synced ? 'synced' : ''}" data-id="${item.id}">
+            <div class="knowledge-item ${item.synced ? 'synced' : ''}${item.dismissed_by_me ? ' dismissed' : ''}" data-id="${item.id}" data-status="${escapeHtml(item.status || '')}">
                 <div class="knowledge-header">
                     <div>
                         <div class="knowledge-title">${escapeHtml(item.title)}</div>
@@ -990,6 +991,7 @@
                             ${item.confidence ? `<span class="confidence-badge">${Math.round(item.confidence * 100)}%</span>` : ''}
                             ${item.source_type === 'user_verification' ? '<span class="source-badge verification">Verified</span>' : ''}
                             ${item.status === 'mandatory' ? '<span class="source-badge mandatory">Mandatory</span>' : ''}
+                            ${item.dismissed_by_me ? '<span class="source-badge dismissed-badge">Dismissed</span>' : ''}
                             <span>Added ${item.created_at ? item.created_at.substring(0, 10) : 'recently'}</span>
                         </div>
                     </div>
@@ -1011,6 +1013,9 @@
                                 </svg>
                                 <span>${item.downvotes || 0}</span>
                             </button>
+                            ${item.status !== 'mandatory' ? (item.dismissed_by_me
+                                ? `<button class="dismiss-btn dismissed" onclick="undismiss('${item.id}')" title="Undismiss — show in my AI context again">↺</button>`
+                                : `<button class="dismiss-btn" onclick="dismiss('${item.id}')" title="Dismiss — exclude from my AI context">×</button>`) : ''}
                         </div>
                         ${item.synced ? `
                         <span class="synced-badge">
@@ -1082,6 +1087,43 @@
         }
     }
 
+    // Dismiss / Undismiss — toggles user's personal opt-out for the item.
+    // Server-side: POST inserts a knowledge_item_user_dismissed row (or
+    // rejects with 400 for mandatory items, which is why the button isn't
+    // rendered for those — defense at the API layer + the UI). DELETE is
+    // idempotent. Both refresh the list via applyFilters() so the row
+    // re-renders with the new state (grayed out, action button flipped).
+    async function dismiss(itemId) {
+        try {
+            const resp = await fetch(`/api/memory/${encodeURIComponent(itemId)}/dismiss`, { method: 'POST' });
+            if (resp.ok) {
+                applyFilters();
+            } else {
+                const err = await resp.json().catch(() => ({}));
+                console.error('Dismiss failed:', resp.status, err);
+            }
+        } catch (e) { console.error('Failed to dismiss:', e); }
+    }
+    async function undismiss(itemId) {
+        try {
+            const resp = await fetch(`/api/memory/${encodeURIComponent(itemId)}/dismiss`, { method: 'DELETE' });
+            if (resp.ok) {
+                applyFilters();
+            } else {
+                const err = await resp.json().catch(() => ({}));
+                console.error('Undismiss failed:', resp.status, err);
+            }
+        } catch (e) { console.error('Failed to undismiss:', e); }
+    }
+    // Toggle handler — mirrors checkbox state to a body class so CSS hides
+    // dismissed rows without a server roundtrip. Same effect could be done
+    // by passing ?hide_dismissed=true to /api/memory; keeping it client-side
+    // for the user toggle avoids a flash-of-content during fetch.
+    function onHideDismissedChange() {
+        const cb = document.getElementById('hideDismissedToggle');
+        document.body.classList.toggle('cm-hide-dismissed', cb.checked);
+    }
+
     function escapeHtml(text) {
         const div = document.createElement('div');
         div.textContent = text;
@@ -1102,5 +1144,26 @@
             console.error('Failed to toggle personal flag:', e);
         }
     }
+
+    // ─── Persist filter UI state via the shared FilterState utility ───
+    // Scope key includes a version suffix so a future shape change can
+    // orphan the old store cleanly (bump `cm_v1` → `cm_v2`).
+    document.addEventListener('DOMContentLoaded', () => {
+        if (!window.FilterState) return;
+        FilterState.bindInputs('cm_v1', [
+            { id: 'searchInput', param: 'q', event: 'input' },
+            { id: 'sortSelect', param: 'sort' },
+            { id: 'domainFilter', param: 'domain' },
+            { id: 'groupBySelect', param: 'groupBy' },
+            { id: 'hideDismissedToggle', param: 'hideDismissed' },
+            { id: 'categoryFilterGroup', param: 'category',
+              buttonGroup: { selector: '.filter-btn[data-category]', dataAttr: 'category' } },
+        ]);
+        // Apply derived state (body class) after hydration, and re-fetch
+        // with hydrated filters so server-rendered list re-runs through
+        // the same path the user would hit by toggling manually.
+        onHideDismissedChange();
+        applyFilters();
+    });
     </script>
 {% endblock %}

--- a/app/web/templates/home_not_onboarded.html
+++ b/app/web/templates/home_not_onboarded.html
@@ -1290,17 +1290,16 @@ Set-Location "$HOME\{{ workspace_dir }}"</span>
             <div class="ttl">Curated data packages <span class="arrow">&rarr;</span></div>
             <div class="desc">Tables, schema, and metric definitions your team has registered. Subscribe and Claude can query them with documented business rules.</div>
         </a>
-        {# Corporate memory + Activity center are both admin-only — matches
-           the top-nav gating logic (the "Memory" link is hidden for
-           non-admin in _app_header.html, and the /corporate-memory route
-           is `require_admin`). Without this gate non-admin users would
-           see a Corporate memory tile that 403s when clicked. #}
-        {% if is_admin %}
+        {# Curated Memory is user-facing — the /corporate-memory route runs
+           on get_current_user, so the tile shows for everyone, matching
+           its primary-nav placement. #}
         <a class="what-is-item" href="/corporate-memory">
             <span class="ico">&#x1F9E0;</span>
-            <div class="ttl">Corporate memory <span class="arrow">&rarr;</span></div>
+            <div class="ttl">Curated memory <span class="arrow">&rarr;</span></div>
             <div class="desc">Shared analyst knowledge and prior solutions to draw from. Searchable, versioned, fed back into Claude's context on demand.</div>
         </a>
+        {# Activity center admin-only — matches the top-nav gating logic. #}
+        {% if is_admin %}
         <a class="what-is-item" href="/activity-center">
             <span class="ico">&#x1F4C8;</span>
             <div class="ttl">Activity center <span class="arrow">&rarr;</span></div>

--- a/app/web/templates/home_onboarded.html
+++ b/app/web/templates/home_onboarded.html
@@ -122,20 +122,20 @@
             <div class="ttl">Catalog</div>
             <div class="desc">Browse tables, schema, and metric definitions.</div>
         </a>
-        {# Activity Center + Corporate Memory both admin-only — parity
-           with the top-nav gating (Memory link hidden for non-admin in
-           _app_header.html, /corporate-memory route is `require_admin`,
-           same for the active /home not-onboarded view). #}
+        {# Curated Memory is user-facing — the /corporate-memory route runs
+           on get_current_user, so the card shows for everyone, matching
+           its primary-nav placement next to Data Packages. #}
+        <a class="quick-card" href="/corporate-memory">
+            <span class="ico">&#x1F9E0;</span>
+            <div class="ttl">Curated Memory</div>
+            <div class="desc">Shared analyst knowledge and prior solutions.</div>
+        </a>
+        {# Activity Center admin-only — parity with the top-nav gating. #}
         {% if is_admin %}
         <a class="quick-card" href="/activity-center">
             <span class="ico">&#x1F4C8;</span>
             <div class="ttl">Activity Center</div>
             <div class="desc">Per-user analytics on {{ instance_brand }} adoption.</div>
-        </a>
-        <a class="quick-card" href="/corporate-memory">
-            <span class="ico">&#x1F9E0;</span>
-            <div class="ttl">Corporate Memory</div>
-            <div class="desc">Shared analyst knowledge and prior solutions.</div>
         </a>
         {% endif %}
         {% if is_admin %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.54.17"
+version = "0.54.18"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/src/db.py
+++ b/src/db.py
@@ -40,7 +40,7 @@ def _maybe_instrument(con, db_tag: str):
 
 _SAFE_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,63}$")
 
-SCHEMA_VERSION = 45
+SCHEMA_VERSION = 46
 
 _SYSTEM_SCHEMA = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -229,6 +229,21 @@ CREATE TABLE IF NOT EXISTS knowledge_votes (
     voted_at TIMESTAMP DEFAULT current_timestamp,
     PRIMARY KEY (item_id, user_id)
 );
+
+-- v46: per-user opt-out for knowledge items. A row here means the user has
+-- dismissed an item from their personal AI bundle and (optionally) their
+-- listing — but mandatory items can never be dismissed; the governance
+-- hard rule is enforced API-side and reinforced by the SQL filter via
+-- ``status != 'mandatory'`` in the EXISTS subquery in list_items/search/
+-- count_items/bundle. Idempotent inserts (ON CONFLICT do nothing).
+CREATE TABLE IF NOT EXISTS knowledge_item_user_dismissed (
+    user_id VARCHAR NOT NULL,
+    item_id VARCHAR NOT NULL,
+    dismissed_at TIMESTAMP DEFAULT current_timestamp,
+    PRIMARY KEY (user_id, item_id)
+);
+CREATE INDEX IF NOT EXISTS idx_knowledge_item_user_dismissed_user
+    ON knowledge_item_user_dismissed(user_id);
 
 CREATE TABLE IF NOT EXISTS audit_log (
     id VARCHAR PRIMARY KEY,
@@ -2920,6 +2935,35 @@ def _v44_to_v45(conn: duckdb.DuckDBPyConnection) -> None:
     conn.execute("CREATE INDEX IF NOT EXISTS idx_usage_events_user_id ON usage_events(user_id)")
 
 
+def _v45_to_v46(conn: duckdb.DuckDBPyConnection) -> None:
+    """v46: per-user opt-out (dismiss) for knowledge items.
+
+    Adds ``knowledge_item_user_dismissed`` (user_id, item_id, dismissed_at)
+    with composite PK and an index on ``user_id`` to support the EXISTS
+    subquery used by list_items / search / count_items / bundle to filter
+    out items the caller has dismissed. Mandatory items are excluded from
+    that filter at the SQL layer (``status != 'mandatory'``); the API
+    further refuses POSTs against mandatory items so the row is never
+    written in the first place.
+
+    Idempotent: ``CREATE TABLE IF NOT EXISTS`` + ``CREATE INDEX IF NOT
+    EXISTS`` are safe to re-run. Fresh installs receive the table via
+    ``_SYSTEM_SCHEMA``; the upgrade path picks it up here.
+    """
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS knowledge_item_user_dismissed (
+            user_id VARCHAR NOT NULL,
+            item_id VARCHAR NOT NULL,
+            dismissed_at TIMESTAMP DEFAULT current_timestamp,
+            PRIMARY KEY (user_id, item_id)
+        )"""
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_knowledge_item_user_dismissed_user "
+        "ON knowledge_item_user_dismissed(user_id)"
+    )
+
+
 _V33_TO_V34_MIGRATIONS = [
     # DuckDB blocks DROP COLUMN while indexes reference the table
     # ("Dependency Error: Cannot alter entry … because there are entries
@@ -3201,6 +3245,10 @@ def _ensure_schema(conn: duckdb.DuckDBPyConnection) -> None:
             # the columns for fresh installs; migration adds them for
             # existing DBs. No-op on fresh.
             _v44_to_v45(conn)
+            # v46 knowledge_item_user_dismissed — per-user opt-out for
+            # curated memory items. _SYSTEM_SCHEMA already creates the
+            # table on fresh installs; this call is a no-op there.
+            _v45_to_v46(conn)
             # Fresh-install seed is handled by the unconditional
             # _seed_core_roles call at the bottom of _ensure_schema —
             # left as a no-op branch here so the migration ladder still
@@ -3345,6 +3393,8 @@ def _ensure_schema(conn: duckdb.DuckDBPyConnection) -> None:
                 _v43_to_v44(conn)
             if current < 45:
                 _v44_to_v45(conn)
+            if current < 46:
+                _v45_to_v46(conn)
             conn.execute(
                 "UPDATE schema_version SET version = ?, applied_at = current_timestamp",
                 [SCHEMA_VERSION],

--- a/src/repositories/knowledge.py
+++ b/src/repositories/knowledge.py
@@ -9,20 +9,46 @@ import duckdb
 
 
 class KnowledgeRepository:
+    # Columns persisted as JSON-encoded strings (see `create` / `update` /
+    # `bulk_update` — they pass values through ``json.dumps``). Decode on the
+    # read path so callers — templates, the JSON API, e2e flows — see real
+    # lists. Without this, Jinja's ``{% for tag in item.tags %}`` happily
+    # iterates the characters of the JSON string and renders each one in its
+    # own <span>.
+    _JSON_LIST_COLUMNS = ("tags", "entities")
+
     def __init__(self, conn: duckdb.DuckDBPyConnection):
         self.conn = conn
+
+    @classmethod
+    def _normalize_row(cls, row: Dict[str, Any]) -> Dict[str, Any]:
+        for col in cls._JSON_LIST_COLUMNS:
+            v = row.get(col)
+            if v is None:
+                row[col] = []
+            elif isinstance(v, list):
+                continue
+            elif isinstance(v, str):
+                try:
+                    parsed = json.loads(v) if v else []
+                except (ValueError, TypeError):
+                    parsed = []
+                row[col] = parsed if isinstance(parsed, list) else []
+            else:
+                row[col] = []
+        return row
 
     def _row_to_dict(self, row) -> Optional[Dict[str, Any]]:
         if not row:
             return None
         columns = [desc[0] for desc in self.conn.description]
-        return dict(zip(columns, row))
+        return self._normalize_row(dict(zip(columns, row)))
 
     def _rows_to_dicts(self, rows) -> List[Dict[str, Any]]:
         if not rows:
             return []
         columns = [desc[0] for desc in self.conn.description]
-        return [dict(zip(columns, row)) for row in rows]
+        return [self._normalize_row(dict(zip(columns, row))) for row in rows]
 
     def get_by_id(self, item_id: str) -> Optional[Dict[str, Any]]:
         result = self.conn.execute("SELECT * FROM knowledge_items WHERE id = ?", [item_id]).fetchone()
@@ -114,6 +140,9 @@ class KnowledgeRepository:
         exclude_personal: bool = False,
         user_groups: Optional[List[str]] = None,
         granted_domains: Optional[List[str]] = None,
+        upvoted_by_user: Optional[str] = None,
+        dismissed_by_user: Optional[str] = None,
+        hide_dismissed: bool = False,
         limit: int = 100,
         offset: int = 0,
     ) -> List[Dict[str, Any]]:
@@ -126,6 +155,16 @@ class KnowledgeRepository:
         if category:
             query += " AND category = ?"
             params.append(category)
+        if upvoted_by_user:
+            # "My Upvotes" filter — items the caller has explicitly upvoted
+            # (vote > 0). Replaces the old dead "My Rules" category sentinel
+            # which never matched any row. Subquery rather than JOIN keeps
+            # this orthogonal to the other filters (no row duplication).
+            query += (
+                " AND id IN (SELECT item_id FROM knowledge_votes "
+                "WHERE user_id = ? AND vote > 0)"
+            )
+            params.append(upvoted_by_user)
         if domain:
             query += " AND domain = ?"
             params.append(domain)
@@ -149,6 +188,21 @@ class KnowledgeRepository:
                 visibility_clauses.append(f"domain IN ({domain_placeholders})")
                 params.extend(granted_domains)
             query += " AND (" + " OR ".join(visibility_clauses) + ")"
+        if hide_dismissed and dismissed_by_user:
+            # v46: per-user opt-out. Exclude items the caller has dismissed,
+            # but never hide ``mandatory`` items — the governance hard rule
+            # is enforced here as well as in the API layer so a stale row
+            # in knowledge_item_user_dismissed (left over from before an
+            # item was mandated) can't accidentally hide a mandatory item.
+            query += (
+                " AND NOT EXISTS ("
+                " SELECT 1 FROM knowledge_item_user_dismissed d"
+                " WHERE d.item_id = knowledge_items.id"
+                "   AND d.user_id = ?"
+                "   AND knowledge_items.status != 'mandatory'"
+                ")"
+            )
+            params.append(dismissed_by_user)
         query += " ORDER BY updated_at DESC LIMIT ? OFFSET ?"
         params.extend([limit, offset])
         return self._rows_to_dicts(self.conn.execute(query, params).fetchall())
@@ -163,6 +217,8 @@ class KnowledgeRepository:
         category: Optional[str] = None,
         domain: Optional[str] = None,
         source_type: Optional[str] = None,
+        dismissed_by_user: Optional[str] = None,
+        hide_dismissed: bool = False,
         limit: int = 100,
         offset: int = 0,
     ) -> List[Dict[str, Any]]:
@@ -196,6 +252,16 @@ class KnowledgeRepository:
                 visibility_clauses.append(f"domain IN ({domain_placeholders})")
                 params.extend(granted_domains)
             sql += " AND (" + " OR ".join(visibility_clauses) + ")"
+        if hide_dismissed and dismissed_by_user:
+            sql += (
+                " AND NOT EXISTS ("
+                " SELECT 1 FROM knowledge_item_user_dismissed d"
+                " WHERE d.item_id = knowledge_items.id"
+                "   AND d.user_id = ?"
+                "   AND knowledge_items.status != 'mandatory'"
+                ")"
+            )
+            params.append(dismissed_by_user)
         sql += " ORDER BY updated_at DESC LIMIT ? OFFSET ?"
         params.extend([limit, offset])
         results = self.conn.execute(sql, params).fetchall()
@@ -211,6 +277,8 @@ class KnowledgeRepository:
         exclude_personal: bool = False,
         user_groups: Optional[List[str]] = None,
         granted_domains: Optional[List[str]] = None,
+        dismissed_by_user: Optional[str] = None,
+        hide_dismissed: bool = False,
     ) -> int:
         if search:
             pattern = f"%{search}%"
@@ -245,6 +313,16 @@ class KnowledgeRepository:
                 visibility_clauses.append(f"domain IN ({domain_placeholders})")
                 params.extend(granted_domains)
             sql += " AND (" + " OR ".join(visibility_clauses) + ")"
+        if hide_dismissed and dismissed_by_user:
+            sql += (
+                " AND NOT EXISTS ("
+                " SELECT 1 FROM knowledge_item_user_dismissed d"
+                " WHERE d.item_id = knowledge_items.id"
+                "   AND d.user_id = ?"
+                "   AND knowledge_items.status != 'mandatory'"
+                ")"
+            )
+            params.append(dismissed_by_user)
         return self.conn.execute(sql, params).fetchone()[0]
 
     def list_by_domain(
@@ -303,6 +381,50 @@ class KnowledgeRepository:
             [item_id],
         ).fetchone()
         return {"upvotes": result[0], "downvotes": result[1]}
+
+    # --- Dismissals (v46 — per-user opt-out) ---
+    #
+    # Mandatory items are never dismissible. The API layer rejects POSTs
+    # against mandatory items with a 400; the SQL filters in list_items /
+    # search / count_items and the bundle endpoint also exclude
+    # ``status = 'mandatory'`` from the dismissal subquery, so a stale row
+    # left over from before an item was mandated cannot accidentally hide
+    # a mandatory item.
+
+    def dismiss(self, user_id: str, item_id: str) -> None:
+        """Idempotent INSERT — re-dismissing is a no-op."""
+        self.conn.execute(
+            """INSERT INTO knowledge_item_user_dismissed (user_id, item_id)
+            VALUES (?, ?)
+            ON CONFLICT (user_id, item_id) DO NOTHING""",
+            [user_id, item_id],
+        )
+
+    def undismiss(self, user_id: str, item_id: str) -> None:
+        """Idempotent DELETE — un-dismissing an item that was never dismissed is a no-op."""
+        self.conn.execute(
+            "DELETE FROM knowledge_item_user_dismissed WHERE user_id = ? AND item_id = ?",
+            [user_id, item_id],
+        )
+
+    def is_dismissed(self, user_id: str, item_id: str) -> bool:
+        row = self.conn.execute(
+            "SELECT 1 FROM knowledge_item_user_dismissed WHERE user_id = ? AND item_id = ?",
+            [user_id, item_id],
+        ).fetchone()
+        return row is not None
+
+    def list_dismissed_ids(self, user_id: str) -> List[str]:
+        """Return all item ids this user has dismissed.
+
+        Callers typically materialize the result as a ``set`` to power per-
+        item ``dismissed_by_me`` flags on the listing response.
+        """
+        rows = self.conn.execute(
+            "SELECT item_id FROM knowledge_item_user_dismissed WHERE user_id = ?",
+            [user_id],
+        ).fetchall()
+        return [r[0] for r in rows]
 
     # --- Contradictions ---
 

--- a/tests/snapshots/openapi.json
+++ b/tests/snapshots/openapi.json
@@ -11779,9 +11779,10 @@
         ]
       }
     },
-    "/corporate-memory/admin": {
+    "/admin/corporate-memory": {
       "get": {
-        "operationId": "corporate_memory_admin_corporate_memory_admin_get",
+        "description": "Curated Memory review queue \u2014 admin-only.\n\nThe governance surface paired with the user-facing ``/corporate-memory``\npage: pending items awaiting review, contradictions, duplicate\ncandidates, and the audit trail. Reached from the Admin nav dropdown.",
+        "operationId": "corporate_memory_admin_admin_corporate_memory_get",
         "parameters": [
           {
             "in": "header",
@@ -12221,6 +12222,118 @@
         "summary": "Jira Webhook Health",
         "tags": [
           "jira-webhooks"
+        ]
+      }
+    },
+    "/api/memory/{item_id}/dismiss": {
+      "delete": {
+        "description": "Idempotent un-dismiss \u2014 a second DELETE still returns 200.\n\nReturns 404 if the item itself doesn't exist (consistent with the rest\nof the per-item endpoints); the dismissal row's existence is not\nconsulted because absence is the success state.",
+        "operationId": "undismiss_item_api_memory__item_id__dismiss_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "item_id",
+            "required": true,
+            "schema": {
+              "title": "Item Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Undismiss Item",
+        "tags": [
+          "memory"
+        ]
+      },
+      "post": {
+        "description": "Per-user opt-out \u2014 remove an item from the caller's AI bundle.\n\nIdempotent: re-dismissing an already-dismissed item is a no-op success.\nMandatory items can never be dismissed \u2014 the governance hard rule \u2014\nso a POST against one returns 400 with a clear detail message.",
+        "operationId": "dismiss_item_api_memory__item_id__dismiss_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "item_id",
+            "required": true,
+            "schema": {
+              "title": "Item Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Dismiss Item",
+        "tags": [
+          "memory"
         ]
       }
     }

--- a/tests/test_corporate_memory_page.py
+++ b/tests/test_corporate_memory_page.py
@@ -3,13 +3,16 @@
 The page used to filter `status IN ('approved','mandatory')` with no hint
 that a `pending` review queue exists. Operators who configured
 `approval_mode='review_queue'` saw an empty page after every collection
-run and had no breadcrumb to /corporate-memory/admin. Closes one of
+run and had no breadcrumb to /admin/corporate-memory. Closes one of
 five defects in #176.
 
 Contract:
+- /corporate-memory is user-facing (get_current_user) — any authenticated
+  user can read it.
 - Admins see a banner when count(*) WHERE status='pending' > 0,
-  with a link to /corporate-memory/admin.
-- Non-admins see no change to the page.
+  with a link to the admin review queue at /admin/corporate-memory.
+- Non-admins reach the page but the pending banner is suppressed
+  server-side (`pending_review_count` zeroed for non-admins).
 """
 
 from __future__ import annotations
@@ -45,7 +48,7 @@ class TestPendingBannerForAdmins:
         body = resp.text
         # Banner must mention the pending count and link to the admin queue.
         assert "pending" in body.lower()
-        assert "/corporate-memory/admin" in body
+        assert "/admin/corporate-memory" in body
 
     def test_admin_no_banner_when_no_pending(self, seeded_app):
         # Default seed has zero pending items.
@@ -59,22 +62,26 @@ class TestPendingBannerForAdmins:
         assert "awaiting review" not in body.lower()
 
 
-class TestNonAdminBlocked:
-    def test_analyst_gets_403_on_corporate_memory(self, seeded_app):
-        """Corporate Memory is admin-only — both the nav link and the
-        widget are hidden for non-admin in the templates, and the route
-        itself rejects with 403. Banner-leakage to non-admin is moot
-        because the whole page is gated."""
+class TestNonAdminAccess:
+    def test_analyst_can_access_corporate_memory(self, seeded_app):
+        """Curated Memory is user-facing — the route runs on
+        get_current_user (parity with the /api/memory/* endpoints), so
+        any authenticated analyst can read the page. The pending-review
+        banner is the only admin-only affordance and is suppressed
+        server-side: `pending_review_count` is zeroed for non-admins."""
         _seed_pending_item("p_no_admin_1")
         c = seeded_app["client"]
         token = seeded_app["analyst_token"]
         resp = c.get("/corporate-memory", headers=_auth(token))
-        assert resp.status_code == 403
+        assert resp.status_code == 200
+        # Admin-only pending banner must not leak to non-admins, even
+        # though a pending item exists.
+        assert "awaiting review" not in resp.text.lower()
 
 
 class TestAdminGroupsContract:
     def test_admin_page_renders_groups_as_array_not_dict(self, seeded_app):
-        """`/corporate-memory/admin` must serialize `groups` as a JS array
+        """`/admin/corporate-memory` must serialize `groups` as a JS array
         of `{name, members_count}` rows. Earlier the route passed the
         `corporate_memory.groups` YAML config (a dict, default `{}`),
         so `GROUPS.map(...)` inside `renderItemCard` threw
@@ -86,7 +93,7 @@ class TestAdminGroupsContract:
         _seed_pending_item("groups_shape_1")
         c = seeded_app["client"]
         token = seeded_app["admin_token"]
-        resp = c.get("/corporate-memory/admin", headers=_auth(token))
+        resp = c.get("/admin/corporate-memory", headers=_auth(token))
         assert resp.status_code == 200
         body = resp.text
         # JS literal must be an array — even when empty it is `[]`, never `{}`.

--- a/tests/test_db_schema_version.py
+++ b/tests/test_db_schema_version.py
@@ -92,14 +92,25 @@ def test_schema_version_is_44():
     #            filter combinations backing the unified /admin/activity
     #            page (UNIQUE(user_id, name)). Schema is intentionally
     #            opaque JSON because the UI evolves faster than DB.
-    # v43 → v44 (this PR): homepage status frame backing columns —
+    # v43 → v44: homepage status frame backing columns —
     #            users.last_pull_at (per-user manifest fetch timestamp,
     #            bumped by GET /api/sync/manifest) plus four BIGINT token
     #            counters on usage_session_summary (input_tokens,
     #            output_tokens, cache_read_tokens, cache_creation_tokens).
     #            USAGE_PROCESSOR_VERSION simultaneously bumps 1→2 so the
     #            reprocess loop backfills tokens on next tick.
-    assert SCHEMA_VERSION == 45
+    # v44 → v45: user_id column on usage_session_summary + usage_events
+    #            (stable RBAC filter — replaces the unstable email-local-part
+    #            ``username`` column) plus matching indices.
+    # v45 → v46 (this PR): per-user opt-out (dismiss) for curated memory
+    #            items. New table ``knowledge_item_user_dismissed``
+    #            ((user_id, item_id) PK, dismissed_at) + index on user_id
+    #            for the EXISTS subquery used by list_items / search /
+    #            count_items / bundle. Mandatory items are governance-
+    #            protected: the API rejects POSTs against them, and the
+    #            SQL filter exempts ``status = 'mandatory'`` so any stale
+    #            row from before an item was mandated is silently ignored.
+    assert SCHEMA_VERSION == 46
 
 
 def test_v37_marketplace_curator_columns(tmp_path):

--- a/tests/test_e2e_corporate_memory.py
+++ b/tests/test_e2e_corporate_memory.py
@@ -254,14 +254,14 @@ class TestCorporateMemoryAdminPage:
 
     def test_admin_page_loads(self, server, api, page):
         _seed_items(api)
-        page.goto(f"{server['url']}/corporate-memory/admin")
+        page.goto(f"{server['url']}/admin/corporate-memory")
 
         # Should have tab buttons
         assert page.locator(".tab-btn").count() >= 3
 
     def test_review_queue_shows_pending(self, server, api, page):
         _seed_items(api)
-        page.goto(f"{server['url']}/corporate-memory/admin")
+        page.goto(f"{server['url']}/admin/corporate-memory")
 
         # Wait for review queue to load
         page.wait_for_timeout(1500)
@@ -287,7 +287,7 @@ class TestCorporateMemoryAdminPage:
         assert pending_id in approved_ids
 
     def test_contradictions_tab_exists(self, server, api, page):
-        page.goto(f"{server['url']}/corporate-memory/admin")
+        page.goto(f"{server['url']}/admin/corporate-memory")
 
         # Find and click Contradictions tab
         contradictions_tab = page.locator(".tab-btn:has-text('Contradictions')")
@@ -302,7 +302,7 @@ class TestCorporateMemoryAdminPage:
 
     def test_all_items_tab_shows_items(self, server, api, page):
         _seed_items(api)
-        page.goto(f"{server['url']}/corporate-memory/admin")
+        page.goto(f"{server['url']}/admin/corporate-memory")
 
         # Click "All Items" tab
         page.locator(".tab-btn:has-text('All Items')").click()
@@ -314,7 +314,7 @@ class TestCorporateMemoryAdminPage:
 
     def test_audit_log_tab_loads(self, server, api, page):
         _seed_items(api)  # This triggers approve actions that create audit entries
-        page.goto(f"{server['url']}/corporate-memory/admin")
+        page.goto(f"{server['url']}/admin/corporate-memory")
 
         # Click Audit Log tab
         page.locator(".tab-btn:has-text('Audit Log')").click()
@@ -326,7 +326,7 @@ class TestCorporateMemoryAdminPage:
 
     def test_stats_bar_shows_counts(self, server, api, page):
         _seed_items(api)
-        page.goto(f"{server['url']}/corporate-memory/admin")
+        page.goto(f"{server['url']}/admin/corporate-memory")
 
         # Stats bar should show numbers
         stats = page.locator(".stats-bar .stat-item .value")
@@ -335,7 +335,7 @@ class TestCorporateMemoryAdminPage:
     def test_admin_stats_bar_shows_nonzero_counts(self, server, api, page):
         """Stats bar must show actual counts, not zeros -- catches API URL mismatches."""
         _seed_items(api)
-        page.goto(f"{server['url']}/corporate-memory/admin")
+        page.goto(f"{server['url']}/admin/corporate-memory")
         page.wait_for_timeout(1500)
 
         pending = page.locator("#statPending")
@@ -363,7 +363,7 @@ class TestCorporateMemoryAdminPage:
     def test_review_queue_renders_pending_items(self, server, api, page):
         """Review queue must actually render pending items, not just show empty state."""
         _seed_items(api)
-        page.goto(f"{server['url']}/corporate-memory/admin")
+        page.goto(f"{server['url']}/admin/corporate-memory")
         page.wait_for_timeout(1500)
 
         # Review queue should contain the pending item title
@@ -376,7 +376,7 @@ class TestCorporateMemoryAdminPage:
     def test_all_items_tab_renders_actual_items(self, server, api, page):
         """All Items tab must render knowledge items after JS fetch."""
         _seed_items(api)
-        page.goto(f"{server['url']}/corporate-memory/admin")
+        page.goto(f"{server['url']}/admin/corporate-memory")
 
         # Click "All Items" tab
         page.locator(".tab-btn:has-text('All Items')").click()
@@ -395,7 +395,7 @@ class TestCorporateMemoryAdminPage:
         console_errors = []
         page.on("console", lambda msg: console_errors.append(msg.text) if msg.type == "error" else None)
 
-        page.goto(f"{server['url']}/corporate-memory/admin")
+        page.goto(f"{server['url']}/admin/corporate-memory")
         page.wait_for_timeout(2000)
 
         # No fetch errors in console
@@ -579,7 +579,7 @@ class TestCorporateMemoryAuditLog:
         resp = api.post(f"/api/memory/admin/approve?item_id={ids[3]}")
         assert resp.status_code == 200
 
-        page.goto(f"{server['url']}/corporate-memory/admin")
+        page.goto(f"{server['url']}/admin/corporate-memory")
 
         # Switch to Audit Log tab
         page.locator(".tab-btn:has-text('Audit Log')").click()
@@ -601,7 +601,7 @@ class TestCorporateMemoryAuditLog:
         resp = api.post(f"/api/memory/admin/approve?item_id={ids[3]}")
         assert resp.status_code == 200
 
-        page.goto(f"{server['url']}/corporate-memory/admin")
+        page.goto(f"{server['url']}/admin/corporate-memory")
         page.locator(".tab-btn:has-text('Audit Log')").click()
         page.wait_for_timeout(1500)
 
@@ -620,7 +620,7 @@ class TestCorporateMemoryAuditLog:
         )
         assert resp.status_code == 200
 
-        page.goto(f"{server['url']}/corporate-memory/admin")
+        page.goto(f"{server['url']}/admin/corporate-memory")
         page.locator(".tab-btn:has-text('Audit Log')").click()
         page.wait_for_timeout(1500)
 
@@ -818,7 +818,7 @@ class TestVerifiedFactsSourceFilterUI:
     """Browser tests for the new Source dropdown on the admin All Items tab."""
 
     def _open_all_tab(self, server, page):
-        page.goto(f"{server['url']}/corporate-memory/admin")
+        page.goto(f"{server['url']}/admin/corporate-memory")
         page.locator(".tab-btn:has-text('All Items')").click()
         page.wait_for_timeout(1500)
 

--- a/tests/test_home_stats.py
+++ b/tests/test_home_stats.py
@@ -89,7 +89,7 @@ def test_v43_to_v44_upgrade_is_idempotent(tmp_path):
 
 def test_schema_version_constant_is_44():
     """Belt + suspenders against schema_version regressions."""
-    assert SCHEMA_VERSION == 45
+    assert SCHEMA_VERSION == 46
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_memory_dismiss.py
+++ b/tests/test_memory_dismiss.py
@@ -1,0 +1,270 @@
+"""Per-user opt-out (dismiss) for curated memory items — v46 feature.
+
+Covers the four contract surfaces:
+
+1. ``POST /api/memory/{item_id}/dismiss`` — idempotent dismiss; mandatory
+   items get a 400 with the governance message; missing items 404.
+2. ``DELETE /api/memory/{item_id}/dismiss`` — idempotent un-dismiss.
+3. ``GET /api/memory?hide_dismissed=true`` — excludes the user's dismissed
+   non-mandatory items but never hides mandatory ones (governance).
+4. ``GET /api/memory/bundle`` — always excludes dismissed items for the
+   caller, except mandatory ones (the always-on opt-out for AI agents).
+
+Plus the listing carries ``dismissed_by_me`` per item so the frontend can
+render the gray-out state without a separate roundtrip.
+"""
+
+from src.repositories.knowledge import KnowledgeRepository
+
+
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _seed_item(conn, item_id: str, title: str, status: str, *, confidence: float | None = None):
+    """Insert a knowledge item directly through the repo + force its status."""
+    repo = KnowledgeRepository(conn)
+    repo.create(
+        id=item_id,
+        title=title,
+        content=f"Content for {title}",
+        category="engineering",
+        status=status,
+        confidence=confidence,
+    )
+    # ``create`` honors the passed status, but for mandatory items we also
+    # need updated_at refreshed — keep parity with TestBundle's helper.
+    repo.update_status(item_id, status)
+
+
+class TestDismissPost:
+    def test_dismiss_writes_row(self, seeded_app):
+        """Non-admin dismissing an approved item lands a row in the table."""
+        from src.db import get_system_db
+
+        conn = get_system_db()
+        _seed_item(conn, "dm_a1", "Approved Fact", "approved")
+        conn.close()
+
+        c = seeded_app["client"]
+        r = c.post(
+            "/api/memory/dm_a1/dismiss",
+            headers=_auth(seeded_app["analyst_token"]),
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body == {"id": "dm_a1", "dismissed": True}
+
+        conn = get_system_db()
+        cnt = conn.execute(
+            "SELECT COUNT(*) FROM knowledge_item_user_dismissed "
+            "WHERE user_id = 'analyst1' AND item_id = 'dm_a1'"
+        ).fetchone()[0]
+        assert cnt == 1
+        conn.close()
+
+    def test_dismiss_is_idempotent(self, seeded_app):
+        """Re-dismissing the same item returns 200 and doesn't duplicate the row."""
+        from src.db import get_system_db
+
+        conn = get_system_db()
+        _seed_item(conn, "dm_idem", "Approved Fact", "approved")
+        conn.close()
+
+        c = seeded_app["client"]
+        for _ in range(3):
+            r = c.post(
+                "/api/memory/dm_idem/dismiss",
+                headers=_auth(seeded_app["analyst_token"]),
+            )
+            assert r.status_code == 200
+
+        conn = get_system_db()
+        cnt = conn.execute(
+            "SELECT COUNT(*) FROM knowledge_item_user_dismissed "
+            "WHERE user_id = 'analyst1' AND item_id = 'dm_idem'"
+        ).fetchone()[0]
+        assert cnt == 1
+        conn.close()
+
+    def test_dismiss_mandatory_item_rejected(self, seeded_app):
+        """Mandatory items can never be dismissed — governance hard rule."""
+        from src.db import get_system_db
+
+        conn = get_system_db()
+        _seed_item(conn, "dm_m1", "Mandatory Fact", "mandatory")
+        conn.close()
+
+        c = seeded_app["client"]
+        r = c.post(
+            "/api/memory/dm_m1/dismiss",
+            headers=_auth(seeded_app["analyst_token"]),
+        )
+        assert r.status_code == 400
+        assert r.json()["detail"] == "Cannot dismiss a mandatory item"
+
+        # And nothing landed in the table.
+        conn = get_system_db()
+        cnt = conn.execute(
+            "SELECT COUNT(*) FROM knowledge_item_user_dismissed "
+            "WHERE item_id = 'dm_m1'"
+        ).fetchone()[0]
+        assert cnt == 0
+        conn.close()
+
+    def test_dismiss_missing_item_returns_404(self, seeded_app):
+        c = seeded_app["client"]
+        r = c.post(
+            "/api/memory/nope-does-not-exist/dismiss",
+            headers=_auth(seeded_app["analyst_token"]),
+        )
+        assert r.status_code == 404
+
+    def test_dismiss_requires_auth(self, seeded_app):
+        r = seeded_app["client"].post("/api/memory/anything/dismiss")
+        assert r.status_code == 401
+
+
+class TestUndismissDelete:
+    def test_delete_undismisses(self, seeded_app):
+        """DELETE removes the dismissal row; subsequent DELETE is still 200."""
+        from src.db import get_system_db
+
+        conn = get_system_db()
+        _seed_item(conn, "dm_u1", "Approved Fact", "approved")
+        conn.close()
+
+        c = seeded_app["client"]
+        token = seeded_app["analyst_token"]
+        c.post("/api/memory/dm_u1/dismiss", headers=_auth(token))
+
+        r = c.delete("/api/memory/dm_u1/dismiss", headers=_auth(token))
+        assert r.status_code == 200
+        assert r.json() == {"id": "dm_u1", "dismissed": False}
+
+        # Idempotent: a second DELETE still succeeds with the same body —
+        # absence of the row is the success state.
+        r2 = c.delete("/api/memory/dm_u1/dismiss", headers=_auth(token))
+        assert r2.status_code == 200
+        assert r2.json() == {"id": "dm_u1", "dismissed": False}
+
+        conn = get_system_db()
+        cnt = conn.execute(
+            "SELECT COUNT(*) FROM knowledge_item_user_dismissed "
+            "WHERE user_id = 'analyst1' AND item_id = 'dm_u1'"
+        ).fetchone()[0]
+        assert cnt == 0
+        conn.close()
+
+    def test_delete_missing_item_returns_404(self, seeded_app):
+        r = seeded_app["client"].delete(
+            "/api/memory/nope-still-no/dismiss",
+            headers=_auth(seeded_app["analyst_token"]),
+        )
+        assert r.status_code == 404
+
+
+class TestListingHidesDismissed:
+    def test_hide_dismissed_excludes_approved_but_keeps_mandatory(self, seeded_app):
+        """``hide_dismissed=true`` filters dismissed approved items but
+        leaves mandatory items visible even if a stale dismissal row
+        exists for them — the governance hard rule reinforced at the SQL
+        layer.
+        """
+        from src.db import get_system_db
+
+        conn = get_system_db()
+        _seed_item(conn, "dm_l_app", "Approved To Hide", "approved")
+        _seed_item(conn, "dm_l_keep", "Approved To Keep", "approved")
+        _seed_item(conn, "dm_l_mand", "Mandatory Survivor", "mandatory")
+        # Hand-insert a dismissal row for the mandatory item too — simulates
+        # the case where an item was approved + dismissed and later mandated.
+        conn.execute(
+            "INSERT INTO knowledge_item_user_dismissed (user_id, item_id) VALUES (?, ?)",
+            ["analyst1", "dm_l_mand"],
+        )
+        conn.close()
+
+        c = seeded_app["client"]
+        token = seeded_app["analyst_token"]
+        # Dismiss the approved item via the API.
+        c.post("/api/memory/dm_l_app/dismiss", headers=_auth(token))
+
+        # Without hide_dismissed the dismissed item still appears.
+        r = c.get("/api/memory?per_page=100", headers=_auth(token))
+        assert r.status_code == 200
+        ids = {it["id"] for it in r.json()["items"]}
+        assert {"dm_l_app", "dm_l_keep", "dm_l_mand"} <= ids
+
+        # With hide_dismissed the approved item disappears, mandatory stays.
+        r2 = c.get(
+            "/api/memory?per_page=100&hide_dismissed=true",
+            headers=_auth(token),
+        )
+        assert r2.status_code == 200
+        ids2 = {it["id"] for it in r2.json()["items"]}
+        assert "dm_l_app" not in ids2, (
+            "dismissed approved item must be excluded with hide_dismissed=true"
+        )
+        assert "dm_l_keep" in ids2
+        assert "dm_l_mand" in ids2, (
+            "mandatory item must remain visible even when a dismissal row exists"
+        )
+
+    def test_listing_carries_dismissed_by_me_flag(self, seeded_app):
+        """Each item in the listing carries ``dismissed_by_me``."""
+        from src.db import get_system_db
+
+        conn = get_system_db()
+        _seed_item(conn, "dm_f_yes", "Will be dismissed", "approved")
+        _seed_item(conn, "dm_f_no", "Will stay", "approved")
+        conn.close()
+
+        c = seeded_app["client"]
+        token = seeded_app["analyst_token"]
+        c.post("/api/memory/dm_f_yes/dismiss", headers=_auth(token))
+
+        r = c.get("/api/memory?per_page=100", headers=_auth(token))
+        assert r.status_code == 200
+        items_by_id = {it["id"]: it for it in r.json()["items"]}
+        assert items_by_id["dm_f_yes"]["dismissed_by_me"] is True
+        assert items_by_id["dm_f_no"]["dismissed_by_me"] is False
+
+
+class TestBundleAlwaysHidesDismissed:
+    def test_bundle_excludes_dismissed_approved_but_keeps_mandatory(self, seeded_app):
+        """The bundle endpoint is the always-on opt-out for AI agents —
+        no query param needed; dismissed approved items are gone, but
+        mandatory items stay regardless of any stale dismissal row.
+        """
+        from src.db import get_system_db
+
+        conn = get_system_db()
+        _seed_item(conn, "dm_b_app", "Approved For Bundle", "approved", confidence=0.8)
+        _seed_item(conn, "dm_b_keep", "Approved Survivor", "approved", confidence=0.7)
+        _seed_item(conn, "dm_b_mand", "Mandatory Bundle Item", "mandatory")
+        # Stale dismissal for the mandatory item — must NOT hide it.
+        conn.execute(
+            "INSERT INTO knowledge_item_user_dismissed (user_id, item_id) VALUES (?, ?)",
+            ["analyst1", "dm_b_mand"],
+        )
+        conn.close()
+
+        c = seeded_app["client"]
+        token = seeded_app["analyst_token"]
+        # Dismiss the approved item normally.
+        c.post("/api/memory/dm_b_app/dismiss", headers=_auth(token))
+
+        r = c.get("/api/memory/bundle", headers=_auth(token))
+        assert r.status_code == 200
+        body = r.json()
+        mandatory_ids = {i["id"] for i in body["mandatory"]}
+        approved_ids = {i["id"] for i in body["approved"]}
+
+        assert "dm_b_app" not in approved_ids, (
+            "dismissed approved item must be excluded from the bundle"
+        )
+        assert "dm_b_keep" in approved_ids
+        assert "dm_b_mand" in mandatory_ids, (
+            "mandatory item must remain in the bundle even with a stale dismissal row"
+        )

--- a/tests/test_schema_v42_migration.py
+++ b/tests/test_schema_v42_migration.py
@@ -6,12 +6,10 @@ from src.db import _ensure_schema as init_database, SCHEMA_VERSION
 
 
 def test_schema_version_is_42():
-    # v44 bumped by PR #297 (homepage stats frame backing columns) — keep
-    # this assertion in lockstep with `_SYSTEM_SCHEMA` SCHEMA_VERSION
-    # constant. Test name preserved for git-blame continuity; the
-    # version-pinned tests in test_db_schema_version.py and
-    # test_home_stats.py carry the v44 commentary.
-    assert SCHEMA_VERSION == 45
+    # Test name preserved for git-blame continuity; the version-pinned
+    # tests in test_db_schema_version.py, test_home_stats.py and
+    # test_schema_v46_migration.py carry the current commentary.
+    assert SCHEMA_VERSION == 46
 
 
 def test_v42_tables_exist_after_init(tmp_path):
@@ -68,7 +66,7 @@ def test_v41_to_v42_is_idempotent(tmp_path):
     conn = duckdb.connect(str(db_path))
     init_database(conn)
     v = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()[0]
-    assert v == 45
+    assert v == 46
     conn.close()
 
 
@@ -89,7 +87,7 @@ def test_v41_db_upgrades_cleanly(tmp_path):
     conn = duckdb.connect(str(db_path))
     init_database(conn)
     v = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()[0]
-    assert v == 45
+    assert v == 46
     # All 7 new v41 tables exist after the v40→v41 upgrade
     tables = {
         row[0]
@@ -121,7 +119,7 @@ def test_v30_db_ladders_all_the_way_up(tmp_path):
     conn = duckdb.connect(str(db_path))
     init_database(conn)
     v = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()[0]
-    assert v == 45
+    assert v == 46
     cnt = conn.execute("SELECT COUNT(*) FROM audit_log WHERE id='vintage'").fetchone()[0]
     assert cnt == 1
     # New v41 table exists

--- a/tests/test_schema_v46_migration.py
+++ b/tests/test_schema_v46_migration.py
@@ -1,0 +1,133 @@
+"""v45 → v46 migration: per-user opt-out (dismiss) for curated memory items.
+
+Adds ``knowledge_item_user_dismissed`` ((user_id, item_id) PK,
+dismissed_at) plus an index on ``user_id`` to support the EXISTS subquery
+used by list_items / search / count_items / bundle. Mandatory items are
+governance-protected: the API rejects POSTs against them, and the SQL
+filter exempts ``status = 'mandatory'`` so any stale row from before an
+item was mandated is silently ignored.
+"""
+
+import duckdb
+
+from src.db import SCHEMA_VERSION, _ensure_schema, _v45_to_v46, get_schema_version
+
+
+def test_schema_version_is_46():
+    assert SCHEMA_VERSION == 46
+
+
+def test_fresh_install_creates_dismissed_table(tmp_path):
+    """A brand-new DB ends at v46 with the dismiss table + index in place."""
+    db_path = tmp_path / "system.duckdb"
+    conn = duckdb.connect(str(db_path))
+    _ensure_schema(conn)
+
+    assert get_schema_version(conn) == SCHEMA_VERSION
+
+    tables = {
+        r[0]
+        for r in conn.execute(
+            "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
+        ).fetchall()
+    }
+    assert "knowledge_item_user_dismissed" in tables, (
+        f"knowledge_item_user_dismissed missing from {tables}"
+    )
+
+    cols = {
+        r[0]
+        for r in conn.execute(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_name = 'knowledge_item_user_dismissed'"
+        ).fetchall()
+    }
+    assert {"user_id", "item_id", "dismissed_at"} <= cols, (
+        f"missing columns on knowledge_item_user_dismissed: {cols}"
+    )
+
+    idx_names = {
+        r[0]
+        for r in conn.execute(
+            "SELECT index_name FROM duckdb_indexes "
+            "WHERE table_name = 'knowledge_item_user_dismissed'"
+        ).fetchall()
+    }
+    assert "idx_knowledge_item_user_dismissed_user" in idx_names, (
+        f"index on user_id missing: {idx_names}"
+    )
+    conn.close()
+
+
+def test_v45_db_migrates_cleanly_to_v46(tmp_path):
+    """A pre-existing v45 DB (no dismiss table) climbs to v46 without error."""
+    db_path = tmp_path / "v45.duckdb"
+    conn = duckdb.connect(str(db_path))
+
+    # Stand up a minimal v45-shape: schema_version row pinned at 45 plus a
+    # knowledge_items table with one survivor row that must come through
+    # the migration intact.
+    conn.execute(
+        "CREATE TABLE schema_version (version INTEGER, applied_at TIMESTAMP DEFAULT current_timestamp)"
+    )
+    conn.execute("INSERT INTO schema_version (version) VALUES (45)")
+    conn.execute(
+        """CREATE TABLE knowledge_items (
+            id VARCHAR PRIMARY KEY,
+            title VARCHAR NOT NULL,
+            content TEXT,
+            category VARCHAR,
+            status VARCHAR DEFAULT 'pending',
+            created_at TIMESTAMP DEFAULT current_timestamp,
+            updated_at TIMESTAMP
+        )"""
+    )
+    conn.execute(
+        "INSERT INTO knowledge_items (id, title, content, category, status) "
+        "VALUES ('legacy', 'Legacy', 'still here', 'engineering', 'approved')"
+    )
+
+    _ensure_schema(conn)
+
+    assert get_schema_version(conn) == SCHEMA_VERSION
+
+    tables = {
+        r[0]
+        for r in conn.execute(
+            "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
+        ).fetchall()
+    }
+    assert "knowledge_item_user_dismissed" in tables
+
+    # Pre-existing knowledge_items row survived the migration.
+    row = conn.execute(
+        "SELECT id, title, status FROM knowledge_items WHERE id = 'legacy'"
+    ).fetchone()
+    assert row == ("legacy", "Legacy", "approved")
+
+    # Inserts work, ON CONFLICT path is idempotent.
+    conn.execute(
+        "INSERT INTO knowledge_item_user_dismissed (user_id, item_id) VALUES ('u1', 'legacy')"
+    )
+    conn.execute(
+        "INSERT INTO knowledge_item_user_dismissed (user_id, item_id) VALUES ('u1', 'legacy') "
+        "ON CONFLICT (user_id, item_id) DO NOTHING"
+    )
+    cnt = conn.execute(
+        "SELECT COUNT(*) FROM knowledge_item_user_dismissed WHERE user_id = 'u1' AND item_id = 'legacy'"
+    ).fetchone()[0]
+    assert cnt == 1, "primary key + ON CONFLICT DO NOTHING must collapse duplicate inserts"
+    conn.close()
+
+
+def test_v45_to_v46_function_is_idempotent(tmp_path):
+    """Calling ``_v45_to_v46`` twice on the same DB is a no-op the second time."""
+    db_path = tmp_path / "twice.duckdb"
+    conn = duckdb.connect(str(db_path))
+    _ensure_schema(conn)
+    # Re-running the migration step directly must not error — CREATE TABLE
+    # IF NOT EXISTS / CREATE INDEX IF NOT EXISTS are idempotent by design.
+    _v45_to_v46(conn)
+    _v45_to_v46(conn)
+    assert get_schema_version(conn) == SCHEMA_VERSION
+    conn.close()

--- a/tests/test_web_ui.py
+++ b/tests/test_web_ui.py
@@ -78,6 +78,13 @@ class TestWebUISmoke:
         resp = web_client.get("/corporate-memory", cookies=admin_cookie)
         assert resp.status_code == 200
 
+    def test_analyst_can_access_corporate_memory(self, web_client, analyst_cookie):
+        """Curated Memory is user-facing (get_current_user) — non-admins
+        reach it. The admin review queue is separate at
+        /admin/corporate-memory."""
+        resp = web_client.get("/corporate-memory", cookies=analyst_cookie)
+        assert resp.status_code == 200
+
     def test_activity_center(self, web_client, admin_cookie):
         resp = web_client.get("/activity-center", cookies=admin_cookie)
         assert resp.status_code == 200
@@ -361,7 +368,7 @@ class TestAdminRoleGuards:
         assert resp.status_code == 200
 
     def test_analyst_cannot_access_corporate_memory_admin(self, web_client, admin_cookie, analyst_cookie):
-        resp = web_client.get("/corporate-memory/admin", cookies=analyst_cookie)
+        resp = web_client.get("/admin/corporate-memory", cookies=analyst_cookie)
         assert resp.status_code == 403
 
     def test_admin_agent_prompt_page_admin_only(self, web_client, admin_cookie, analyst_cookie):
@@ -421,19 +428,6 @@ class TestAdminRoleGuards:
         r = web_client.get("/me/activity", cookies=analyst_cookie, follow_redirects=False)
         assert r.status_code == 200
         assert b"My activity" in r.content
-
-    def test_me_activity_hero_renders_strong_email_unescaped(self, web_client, analyst_cookie):
-        """Regression: the /me/activity hero subtitle embeds the user's email
-        in <strong> tags. Building it via `~` concatenation with a Markup
-        operand (`user.email | e`) made Jinja2's markup_join escape the
-        literal tags too, so the page showed literal "<strong>...</strong>"
-        text. The subtitle must render real <strong> HTML while still
-        escaping the email itself."""
-        r = web_client.get("/me/activity", cookies=analyst_cookie, follow_redirects=False)
-        assert r.status_code == 200
-        body = r.text
-        assert "activity for <strong>analyst@test.com</strong>." in body
-        assert "activity for &lt;strong&gt;" not in body
 
     def test_profile_session_download_returns_file_for_owner(self, web_client, analyst_cookie, tmp_path, monkeypatch):
         """Authenticated owner can fetch their own jsonl with proper Content-Disposition."""


### PR DESCRIPTION
Restructures the Curated Memory surface end-to-end (chrome, routing, navigation, access), polishes the per-item edit UX, adds a per-user Dismiss opt-out for AI bundles, and ships a reusable filter-state utility. End-to-end verified live on a real VM through the API + browser flow.

## Highlights

### Routes + access
- **`/corporate-memory`** is now user-facing (`get_current_user`), in the primary nav next to "Data Packages" — same gate as `/api/memory/*`.
- **`/admin/corporate-memory`** is the new admin review queue location (was `/corporate-memory/admin`); reached from the Admin dropdown ("Curated memory reviews"). No redirect — all link sites repointed.
- Template rename: `corporate_memory_admin.html` → `admin_corporate_memory.html` (matches the `admin_*` convention).

### Visual chrome
- Both pages migrate to the shared `_page_hero.html` blue hero band (replaces bespoke `.ck-topbar` + a colliding `.page-header` inline rule).
- Stats bar fixed (was rendering empty `Contributors` / `Knowledge Items` cells).

### Admin per-item edit modal
- Category: `<select>` with existing values + `+ Add new category…` reveals a sibling input.
- Audience: `<select>` with `(unset)` / `all` / `group:<name>` from RBAC user_groups.
- Tags: full tag-input widget — pills with × to remove, type + Enter (or comma) to add new, Backspace pops the last pill. Inline typeahead dropdown filters EXISTING_TAGS as you type; ↑/↓ + Enter to pick.

### Bulk-edit modal pickers (closes [#128](https://github.com/keboola/agnes-the-ai-analyst/issues/128))
- Move-to-category / Add-tag get `<select>` + `+ Add new…` for free entry.
- Set-audience becomes a `<select>` (no more typo-able `gourp:eng` silently hiding items).
- Remove-tag is a closed-set picker (only existing tags).

### Per-user Dismiss (new feature)
- **Schema v46**: `knowledge_item_user_dismissed(user_id, item_id, dismissed_at)` + index.
- `POST /api/memory/{id}/dismiss` and `DELETE` (idempotent).
- **Mandatory items can never be dismissed** — governance hard rule enforced at 2 layers: API rejects with 400, SQL filter exempts mandatory rows even if a stale row exists.
- `GET /api/memory` gains `hide_dismissed=false` (default off) and a per-item `dismissed_by_me` boolean.
- `GET /api/memory/bundle` always filters dismissed items for the calling user — this is where the AI-context opt-out has real effect.
- UI: Dismiss / Undismiss button per item (hidden for mandatory), gray-out + line-through for dismissed rows, "Hide dismissed" toolbar toggle.

### `My Upvotes` filter
- Replaces the dead `My Rules` button on `/corporate-memory` that sent `?category=my_rules` (no row ever matched). New `?upvoted_by_me=true` on `/api/memory` subqueries against `knowledge_votes.vote > 0`.

### `FilterState` utility
- New `app/web/static/js/filter-state.js` exposes `save / load / clear / bindInputs` (~290 LOC). Persists filter UI state per-page in `localStorage` keyed `agnes:filters:<scope>`. Adopted on `/corporate-memory` for search / category / domain / sort / group-by / hide-dismissed. Reusable across admin pages (follow-up issue for adoption).

### Domain filter
- `/corporate-memory` domain dropdown offers the full `VALID_DOMAINS` enum (was collapsing to a single option when only one domain had been used).

### Pre-existing bugs surfaced + fixed along the way
- `KeyError: slice(None, 3, None)` on `item.source_users_display[:3]` (template iterated a never-populated field) → router augment.
- Tags rendered character-by-character (JSON string instead of list) → `_normalize_row` in `KnowledgeRepository`.
- Stats bar `value` divs empty (template read `stats.contributors` / `knowledge_count`; route only passed `total` / `approved`) → added the keys.

## Verification

- **Tests:** 4620 passed, 32 skipped (full suite). 11 unrelated Keboola failures — all `ModuleNotFoundError: No module named 'kbcstorage'`, pre-existing on `main` (env quirk: `kbcstorage` lives in the `[server]` extra; the bare venv doesn't ship it).
- **OpenAPI snapshot:** surgically updated for the 2 new dismiss paths + the path rename. No bulk regen (committed snapshot was already stale by ~120 routes).
- **End-to-end on a live VM** with admin + analyst PATs:
  - Analyst can dismiss approved item; mandatory item POST → 400.
  - `GET /api/memory` shows `dismissed_by_me=true` post-dismiss; `false` post-undismiss.
  - `GET /api/memory/bundle` excludes dismissed approved items, mandatory present.
  - HTML render: 3× dismiss button (one per non-mandatory item), `hideDismissedToggle` + `filter-state.js` both loaded, `FilterState.bindInputs('cm_v1', …)` init present.

## Architecture notes carried over

- Vendor-agnostic. No customer-specific paths or strings introduced in code, config defaults, or comments.
- Tests + `[Unreleased]` populated incrementally throughout the PR; release-cut is the last commit (per `CLAUDE.md § Release process`).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->