### PR TITLE
fix(api): harden API surface before Swagger (issue #336)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,19 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 - `POST /api/sync/table-subscriptions` now enforces the same RBAC gate as
   `POST /api/sync/settings` — authenticated users can no longer subscribe to
   tables they have no `resource_grants` row for (ADV-001, issue #336).
-- `GET /webhooks/jira/health` is now admin-only; `jira_domain` removed from
-  the response to prevent anonymous information disclosure (ADV-002).
-- `GET /api/version` no longer exposes `commit_sha` or `schema_version` to
-  unauthenticated callers (ADV-003).
-- `/docs`, `/redoc`, and `/openapi.json` now require a valid session — the
-  full admin API surface is no longer visible to unauthenticated requests
-  (ADV-005).
+- **BREAKING:** `GET /webhooks/jira/health` is now admin-only; `jira_domain`
+  removed from the response to prevent anonymous information disclosure
+  (ADV-002). Uptime monitors that polled this endpoint anonymously must now
+  attach an admin PAT or switch to `/api/health` (which remains public).
+- **BREAKING:** `GET /api/version` no longer exposes `commit_sha` or
+  `schema_version` — only `version`, `channel`, `image_tag`, `deployed_at`
+  remain (ADV-003). Deploy scripts / dashboards scraping the removed fields
+  must either authenticate against a (separate, forthcoming) admin endpoint
+  or read them from the GHCR image labels.
+- **BREAKING:** `/docs`, `/redoc`, and `/openapi.json` now require a valid
+  session — the full admin API surface is no longer visible to
+  unauthenticated requests (ADV-005). CLI tools generating client code from
+  the schema must attach a PAT or use an authenticated browser session.
 
 ### Changed
 - `/cli/` and `/webhooks/` prefixes added to `_API_PATH_PREFIXES` so any

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Fixed
+- `POST /api/sync/table-subscriptions` now enforces the same RBAC gate as
+  `POST /api/sync/settings` — authenticated users can no longer subscribe to
+  tables they have no `resource_grants` row for (ADV-001, issue #336).
+- `GET /webhooks/jira/health` is now admin-only; `jira_domain` removed from
+  the response to prevent anonymous information disclosure (ADV-002).
+- `GET /api/version` no longer exposes `commit_sha` or `schema_version` to
+  unauthenticated callers (ADV-003).
+- `/docs`, `/redoc`, and `/openapi.json` now require a valid session — the
+  full admin API surface is no longer visible to unauthenticated requests
+  (ADV-005).
+
+### Changed
+- `/cli/` and `/webhooks/` prefixes added to `_API_PATH_PREFIXES` so any
+  future auth-gated endpoint under those paths returns JSON `401` rather than
+  an HTML redirect (ADV-006).
+- `GET /api/users` and `GET /auth/admin/tokens` accept `limit` (default 1000,
+  max 10 000) and `offset` query parameters; `POST /api/sync/table-subscriptions`
+  now rejects `tables` dicts with more than 500 entries (ADV-008, ADV-009).
+- `GET /api/catalog/tables` now has a typed `response_model` (`CatalogTablesResponse`)
+  so Swagger generates an accurate schema for that endpoint (ADV-007).
+
 ### Internal
 - Added `TestFullLifecycleFromInstaller` integration test class
   (`tests/test_store_entity_versions.py`) covering the full

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.54.25] — 2026-05-18
+
 ### Fixed
 - `POST /api/sync/table-subscriptions` now enforces the same RBAC gate as
   `POST /api/sync/settings` — authenticated users can no longer subscribe to

--- a/app/api/catalog.py
+++ b/app/api/catalog.py
@@ -1,8 +1,10 @@
 """Catalog endpoints — table profiles, metrics."""
 
 import json
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
 import duckdb
 
 from app.auth.dependencies import get_current_user, _get_db
@@ -11,6 +13,20 @@ from src.repositories.profiles import ProfileRepository
 from src.rbac import can_access_table
 
 router = APIRouter(prefix="/api/catalog", tags=["catalog"])
+
+
+class CatalogTableItem(BaseModel):
+    id: str
+    name: str
+    description: Optional[str] = None
+    source_type: Optional[str] = None
+    sync_strategy: Optional[str] = None
+    query_mode: str = "local"
+
+
+class CatalogTablesResponse(BaseModel):
+    tables: List[CatalogTableItem]
+    count: int
 
 
 @router.get("/profile/{table_name}")
@@ -40,7 +56,7 @@ async def get_table_profile(
     return profile
 
 
-@router.get("/tables")
+@router.get("/tables", response_model=CatalogTablesResponse)
 async def list_catalog_tables(
     user: dict = Depends(get_current_user),
     conn: duckdb.DuckDBPyConnection = Depends(_get_db),

--- a/app/api/health.py
+++ b/app/api/health.py
@@ -491,7 +491,5 @@ async def version_info():
         "version": os.environ.get("AGNES_VERSION", "dev"),
         "channel": os.environ.get("RELEASE_CHANNEL", "dev"),
         "image_tag": os.environ.get("AGNES_TAG", "unknown"),
-        "commit_sha": os.environ.get("AGNES_COMMIT_SHA", "unknown"),
-        "schema_version": SCHEMA_VERSION,
         "deployed_at": _DEPLOYED_AT,
     }

--- a/app/api/jira_webhooks.py
+++ b/app/api/jira_webhooks.py
@@ -11,11 +11,12 @@ import json
 import logging
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Request, Response
+from fastapi import APIRouter, Depends, Request, Response
 from fastapi.responses import JSONResponse
 
 import re
 
+from app.auth.access import require_admin as _require_admin
 from connectors.jira.service import Config, get_jira_service
 from connectors.jira.validation import is_valid_issue_key, safe_join_under
 
@@ -182,13 +183,12 @@ async def receive_jira_webhook(request: Request) -> Response:
 
 
 @router.get("/jira/health")
-async def jira_webhook_health() -> dict:
-    """Health check for Jira webhook endpoint."""
+async def jira_webhook_health(user: dict = Depends(_require_admin)) -> dict:
+    """Health check for Jira webhook endpoint. Admin-only: exposes secret presence."""
     jira_service = get_jira_service()
 
     return {
         "status": "ok",
         "configured": jira_service.is_configured(),
         "webhook_secret_set": bool(Config.JIRA_WEBHOOK_SECRET),
-        "jira_domain": Config.JIRA_DOMAIN or "(not set)",
     }

--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any, Optional, List
 
 from fastapi import APIRouter, Body, Depends, HTTPException, BackgroundTasks
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 import duckdb
 
 from app.auth.access import require_admin
@@ -1025,7 +1025,7 @@ async def update_sync_settings(
 
 class TableSubscriptionUpdate(BaseModel):
     table_mode: str = "all"  # "all" or "explicit"
-    tables: dict = {}  # {table_name: bool}
+    tables: dict = Field(default_factory=dict, max_length=500)  # {table_name: bool}
 
 
 @router.get("/table-subscriptions")
@@ -1045,8 +1045,21 @@ async def update_table_subscriptions(
     user: dict = Depends(get_current_user),
     conn: duckdb.DuckDBPyConnection = Depends(_get_db),
 ):
-    """Update per-table subscription preferences."""
+    """Update per-table subscription preferences.
+
+    Mirrors the RBAC gate in POST /settings: a table can only be subscribed
+    to when the user holds a resource_grants row for it (or is Admin). This
+    prevents an authenticated user from subscribing to tables they cannot read.
+    """
+    from app.auth.access import can_access
+    from app.resource_types import ResourceType
+
     repo = SyncSettingsRepository(conn)
+    results = {}
     for table_name, enabled in request.tables.items():
+        if not can_access(user["id"], ResourceType.TABLE.value, table_name, conn):
+            results[table_name] = {"error": "no permission"}
+            continue
         repo.set_dataset_enabled(user["id"], table_name, enabled)
-    return {"table_mode": request.table_mode, "updated": len(request.tables)}
+        results[table_name] = {"enabled": enabled}
+    return {"table_mode": request.table_mode, "updated": results}

--- a/app/api/tokens.py
+++ b/app/api/tokens.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone, timedelta
 from typing import Optional, List
 
 import duckdb
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from app.auth.access import require_admin
@@ -207,10 +207,12 @@ async def revoke_token(
 
 @admin_router.get("", response_model=List[AdminTokenItem])
 async def admin_list_tokens(
+    limit: int = Query(default=1000, ge=1, le=10000),
+    offset: int = Query(default=0, ge=0),
     user: dict = Depends(require_admin),
     conn: duckdb.DuckDBPyConnection = Depends(_get_db),
 ):
-    return [_row_to_admin_item(r) for r in AccessTokenRepository(conn).list_all_with_user()]
+    return [_row_to_admin_item(r) for r in AccessTokenRepository(conn).list_all_with_user(limit=limit, offset=offset)]
 
 
 @admin_router.delete("/{token_id}", status_code=204)

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -233,7 +233,7 @@ async def list_users(
     user: dict = Depends(require_admin),
     conn: duckdb.DuckDBPyConnection = Depends(_get_db),
 ):
-    return [_to_response(u, conn) for u in UserRepository(conn).list_all(limit=limit, offset=offset)]
+    return [_to_response(u, conn) for u in UserRepository(conn).list_paginated(limit=limit, offset=offset)]
 
 
 @router.get("/{user_id}", response_model=UserResponse)

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from typing import Optional, List
 
 import duckdb
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 from argon2 import PasswordHasher
 
@@ -228,10 +228,12 @@ def _set_admin_membership(
 
 @router.get("", response_model=List[UserResponse])
 async def list_users(
+    limit: int = Query(default=1000, ge=1, le=10000),
+    offset: int = Query(default=0, ge=0),
     user: dict = Depends(require_admin),
     conn: duckdb.DuckDBPyConnection = Depends(_get_db),
 ):
-    return [_to_response(u, conn) for u in UserRepository(conn).list_all()]
+    return [_to_response(u, conn) for u in UserRepository(conn).list_all(limit=limit, offset=offset)]
 
 
 @router.get("/{user_id}", response_model=UserResponse)

--- a/app/main.py
+++ b/app/main.py
@@ -36,7 +36,7 @@ setup_logging("app")
 
 from app.version import APP_VERSION, MIN_COMPAT_CLI_VERSION
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
@@ -354,6 +354,12 @@ def create_app() -> FastAPI:
         description="Data distribution platform for AI analytical systems",
         version=APP_VERSION,
         lifespan=lifespan,
+        # Swagger UI / OpenAPI JSON gated behind authentication — custom
+        # routes added below before the web_router catch-all. Setting these
+        # to None disables FastAPI's default unauthenticated endpoints.
+        docs_url=None,
+        redoc_url=None,
+        openapi_url=None,
         # Intentionally NOT debug=DEBUG: FastAPI's debug=True installs
         # Starlette's ServerErrorMiddleware which intercepts unhandled
         # Exceptions and renders a plain-HTML traceback BEFORE our
@@ -691,6 +697,27 @@ def create_app() -> FastAPI:
     from a2wsgi import WSGIMiddleware
     app.mount("/marketplace.git", WSGIMiddleware(make_git_wsgi_app()))
 
+    # Authenticated Swagger / ReDoc / OpenAPI JSON — requires a valid session
+    # so the full admin API surface is not visible to unauthenticated callers.
+    # Must be registered before web_router (catch-all). /openapi.json is also
+    # added to _API_PATH_PREFIXES below so auth failures return JSON 401
+    # rather than an HTML redirect.
+    from fastapi.openapi.docs import get_swagger_ui_html, get_redoc_html
+    from fastapi.responses import HTMLResponse as _HTMLResponse
+    from app.auth.dependencies import get_current_user as _get_current_user
+
+    @app.get("/docs", include_in_schema=False, response_class=_HTMLResponse)
+    async def swagger_ui(user: dict = Depends(_get_current_user)):
+        return get_swagger_ui_html(openapi_url="/openapi.json", title="Agnes API")
+
+    @app.get("/redoc", include_in_schema=False, response_class=_HTMLResponse)
+    async def redoc_ui(user: dict = Depends(_get_current_user)):
+        return get_redoc_html(openapi_url="/openapi.json", title="Agnes API — ReDoc")
+
+    @app.get("/openapi.json", include_in_schema=False)
+    async def openapi_spec(user: dict = Depends(_get_current_user)):
+        return app.openapi()
+
     # Web UI router (must be last — has catch-all routes)
     app.include_router(web_router)
 
@@ -699,6 +726,9 @@ def create_app() -> FastAPI:
     _API_PATH_PREFIXES: tuple[str, ...] = (
         "/api/",
         "/auth/",
+        "/cli/",
+        "/openapi.json",
+        "/webhooks/",
         "/marketplace.zip",
         "/marketplace.git",
         "/marketplace/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.54.24"
+version = "0.54.25"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/src/repositories/access_tokens.py
+++ b/src/repositories/access_tokens.py
@@ -60,7 +60,7 @@ class AccessTokenRepository:
         columns = [desc[0] for desc in self.conn.description]
         return [dict(zip(columns, r)) for r in rows]
 
-    def list_all_with_user(self) -> List[Dict[str, Any]]:
+    def list_all_with_user(self, limit: int = 1000, offset: int = 0) -> List[Dict[str, Any]]:
         """Admin view: all tokens joined with the owning user's email.
 
         Returns dict rows including every column of `personal_access_tokens`
@@ -73,7 +73,9 @@ class AccessTokenRepository:
             FROM personal_access_tokens t
             LEFT JOIN users u ON u.id = t.user_id
             ORDER BY t.created_at DESC
-            """
+            LIMIT ? OFFSET ?
+            """,
+            [limit, offset],
         ).fetchall()
         if not rows:
             return []

--- a/src/repositories/users.py
+++ b/src/repositories/users.py
@@ -24,12 +24,17 @@ class UserRepository:
         result = self.conn.execute("SELECT * FROM users WHERE email = ?", [email]).fetchone()
         return self._row_to_dict(result)
 
-    def list_all(self) -> List[Dict[str, Any]]:
-        results = self.conn.execute("SELECT * FROM users ORDER BY email").fetchall()
+    def list_all(self, limit: int = 1000, offset: int = 0) -> List[Dict[str, Any]]:
+        results = self.conn.execute(
+            "SELECT * FROM users ORDER BY email LIMIT ? OFFSET ?", [limit, offset]
+        ).fetchall()
         if not results:
             return []
         columns = [desc[0] for desc in self.conn.description]
         return [dict(zip(columns, row)) for row in results]
+
+    def count_all(self) -> int:
+        return self.conn.execute("SELECT COUNT(*) FROM users").fetchone()[0]
 
     def create(
         self,

--- a/src/repositories/users.py
+++ b/src/repositories/users.py
@@ -24,7 +24,33 @@ class UserRepository:
         result = self.conn.execute("SELECT * FROM users WHERE email = ?", [email]).fetchone()
         return self._row_to_dict(result)
 
-    def list_all(self, limit: int = 1000, offset: int = 0) -> List[Dict[str, Any]]:
+    def list_all(self) -> List[Dict[str, Any]]:
+        """Return EVERY user row. Used by bootstrap-lock + startup
+        warning paths that need to inspect the whole table (see
+        ``app/auth/router.py::bootstrap`` and ``app/main.py``'s
+        no-password-set warning). Do NOT add a LIMIT here — the
+        bootstrap check ``[u for u in list_all() if u.get('password_hash')]``
+        re-opens the endpoint if any password-holder gets paginated
+        out, which would let an unauthenticated caller claim admin
+        on instances with >LIMIT users. API-surface pagination uses
+        ``list_paginated()`` below.
+        """
+        results = self.conn.execute(
+            "SELECT * FROM users ORDER BY email"
+        ).fetchall()
+        if not results:
+            return []
+        columns = [desc[0] for desc in self.conn.description]
+        return [dict(zip(columns, row)) for row in results]
+
+    def list_paginated(self, limit: int = 1000, offset: int = 0) -> List[Dict[str, Any]]:
+        """Paginated user listing for the admin API surface (#336
+        ADV-009). Safe to bound — callers explicitly opt into the
+        windowed shape and the API enforces ``limit <= 10000`` at
+        the Query()-validation layer. Do not call from bootstrap /
+        startup paths that need exhaustive enumeration; use
+        ``list_all()`` for those.
+        """
         results = self.conn.execute(
             "SELECT * FROM users ORDER BY email LIMIT ? OFFSET ?", [limit, offset]
         ).fetchall()

--- a/tests/snapshots/openapi.json
+++ b/tests/snapshots/openapi.json
@@ -55,6 +55,83 @@
         "title": "AdminActionRequest",
         "type": "object"
       },
+      "AdminInitialWorkspaceResponse": {
+        "description": "Admin-facing view; surfaces sync state + has_token (no secret leak).",
+        "properties": {
+          "branch": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Branch"
+          },
+          "configured": {
+            "default": false,
+            "title": "Configured",
+            "type": "boolean"
+          },
+          "file_count": {
+            "default": 0,
+            "title": "File Count",
+            "type": "integer"
+          },
+          "has_token": {
+            "default": false,
+            "title": "Has Token",
+            "type": "boolean"
+          },
+          "last_commit_sha": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Commit Sha"
+          },
+          "last_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Error"
+          },
+          "last_synced_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Synced At"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url"
+          }
+        },
+        "title": "AdminInitialWorkspaceResponse",
+        "type": "object"
+      },
       "AdminTokenItem": {
         "description": "Admin list row: adds owner identity + last IP for incident response.",
         "properties": {
@@ -147,6 +224,99 @@
         "title": "AdminTokenItem",
         "type": "object"
       },
+      "AnalystInitialWorkspaceResponse": {
+        "description": "PAT-authed analyst view; what ``agnes init`` consumes.",
+        "properties": {
+          "configured": {
+            "default": false,
+            "title": "Configured",
+            "type": "boolean"
+          },
+          "files": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Files",
+            "type": "array"
+          },
+          "synced": {
+            "default": false,
+            "title": "Synced",
+            "type": "boolean"
+          },
+          "synced_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Synced At"
+          },
+          "template_sha": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Template Sha"
+          },
+          "template_source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Template Source"
+          }
+        },
+        "title": "AnalystInitialWorkspaceResponse",
+        "type": "object"
+      },
+      "AppliedRequest": {
+        "description": "CLI audit event after the analyst's workspace has been extracted.",
+        "properties": {
+          "files_created": {
+            "default": 0,
+            "title": "Files Created",
+            "type": "integer"
+          },
+          "files_overwritten": {
+            "default": 0,
+            "title": "Files Overwritten",
+            "type": "integer"
+          },
+          "mode": {
+            "title": "Mode",
+            "type": "string"
+          },
+          "template_sha": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Template Sha"
+          }
+        },
+        "required": [
+          "mode"
+        ],
+        "title": "AppliedRequest",
+        "type": "object"
+      },
       "BannerResponse": {
         "properties": {
           "content": {
@@ -203,6 +373,109 @@
         "title": "BatchActionRequest",
         "type": "object"
       },
+      "Body_create_entity_api_store_entities_post": {
+        "properties": {
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "docs": {
+            "default": [],
+            "items": {
+              "contentMediaType": "application/octet-stream",
+              "type": "string"
+            },
+            "title": "Docs",
+            "type": "array"
+          },
+          "file": {
+            "contentMediaType": "application/octet-stream",
+            "title": "File",
+            "type": "string"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "photo": {
+            "anyOf": [
+              {
+                "contentMediaType": "application/octet-stream",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Photo"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string"
+          },
+          "video_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Video Url"
+          }
+        },
+        "required": [
+          "file",
+          "type"
+        ],
+        "title": "Body_create_entity_api_store_entities_post",
+        "type": "object"
+      },
+      "Body_import_bundle_api_store_import_bundle_post": {
+        "properties": {
+          "file": {
+            "contentMediaType": "application/octet-stream",
+            "title": "File",
+            "type": "string"
+          },
+          "mode": {
+            "default": "merge",
+            "title": "Mode",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "title": "Body_import_bundle_api_store_import_bundle_post",
+        "type": "object"
+      },
       "Body_import_metrics_api_admin_metrics_import_post": {
         "properties": {
           "file": {
@@ -238,6 +511,25 @@
           "email"
         ],
         "title": "Body_password_login_web_auth_password_login_web_post",
+        "type": "object"
+      },
+      "Body_preview_entity_api_store_entities_preview_post": {
+        "properties": {
+          "file": {
+            "contentMediaType": "application/octet-stream",
+            "title": "File",
+            "type": "string"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file",
+          "type"
+        ],
+        "title": "Body_preview_entity_api_store_entities_preview_post",
         "type": "object"
       },
       "Body_reset_confirm_auth_password_reset_confirm_post": {
@@ -323,6 +615,91 @@
         "title": "Body_setup_request_auth_password_setup_request_post",
         "type": "object"
       },
+      "Body_update_entity_api_store_entities__entity_id__put": {
+        "properties": {
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "file": {
+            "anyOf": [
+              {
+                "contentMediaType": "application/octet-stream",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "File"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "photo": {
+            "anyOf": [
+              {
+                "contentMediaType": "application/octet-stream",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Photo"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Type"
+          },
+          "video_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Video Url"
+          }
+        },
+        "title": "Body_update_entity_api_store_entities__entity_id__put",
+        "type": "object"
+      },
       "Body_upload_artifact_api_upload_artifacts_post": {
         "properties": {
           "file": {
@@ -397,6 +774,122 @@
         "title": "BulkUpdateRequest",
         "type": "object"
       },
+      "CatalogTableItem": {
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "query_mode": {
+            "default": "local",
+            "title": "Query Mode",
+            "type": "string"
+          },
+          "source_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Type"
+          },
+          "sync_strategy": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sync Strategy"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "CatalogTableItem",
+        "type": "object"
+      },
+      "CatalogTablesResponse": {
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "tables": {
+            "items": {
+              "$ref": "#/components/schemas/CatalogTableItem"
+            },
+            "title": "Tables",
+            "type": "array"
+          }
+        },
+        "required": [
+          "tables",
+          "count"
+        ],
+        "title": "CatalogTablesResponse",
+        "type": "object"
+      },
+      "CategoriesResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/CategoryEntry"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "CategoriesResponse",
+        "type": "object"
+      },
+      "CategoryEntry": {
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "icon_key": {
+            "title": "Icon Key",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "count",
+          "icon_key"
+        ],
+        "title": "CategoryEntry",
+        "type": "object"
+      },
       "ClaudeMdResponse": {
         "properties": {
           "content": {
@@ -464,6 +957,30 @@
           "columns"
         ],
         "title": "ColumnMetadataSave",
+        "type": "object"
+      },
+      "CommandEntry": {
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "CommandEntry",
         "type": "object"
       },
       "ConfigureRequest": {
@@ -723,6 +1240,28 @@
             ],
             "title": "Branch"
           },
+          "curator_email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Curator Email"
+          },
+          "curator_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Curator Name"
+          },
           "description": {
             "anyOf": [
               {
@@ -783,6 +1322,22 @@
           "name": {
             "title": "Name",
             "type": "string"
+          },
+          "scope": {
+            "default": "general",
+            "title": "Scope",
+            "type": "string"
+          },
+          "ttl_seconds": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ttl Seconds"
           }
         },
         "required": [
@@ -859,6 +1414,66 @@
         "title": "CreateUserRequest",
         "type": "object"
       },
+      "CuratedPlugin": {
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "is_system": {
+            "default": false,
+            "title": "Is System",
+            "type": "boolean"
+          },
+          "manifest_name": {
+            "title": "Manifest Name",
+            "type": "string"
+          },
+          "marketplace_id": {
+            "title": "Marketplace Id",
+            "type": "string"
+          },
+          "marketplace_slug": {
+            "title": "Marketplace Slug",
+            "type": "string"
+          },
+          "plugin_name": {
+            "title": "Plugin Name",
+            "type": "string"
+          },
+          "version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Version"
+          }
+        },
+        "required": [
+          "marketplace_id",
+          "marketplace_slug",
+          "plugin_name",
+          "manifest_name",
+          "enabled"
+        ],
+        "title": "CuratedPlugin",
+        "type": "object"
+      },
       "DatasetSettingRequest": {
         "properties": {
           "dataset": {
@@ -904,6 +1519,25 @@
           "source"
         ],
         "title": "DeployScriptRequest",
+        "type": "object"
+      },
+      "DocEntry": {
+        "description": "One doc file shipped alongside a Store entity. URL points at the\nserving endpoint (``/api/store/entities/<id>/docs/<filename>``).",
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "url": {
+            "title": "Url",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "url"
+        ],
+        "title": "DocEntry",
         "type": "object"
       },
       "EditRequest": {
@@ -980,6 +1614,25 @@
           "items"
         ],
         "title": "EffectiveAccessResponse",
+        "type": "object"
+      },
+      "FileEntry": {
+        "description": "One file in a plugin / skill / agent bundle. Path is relative to the\nbundle root; size is bytes (rendered with ``humanbytes`` on the client).",
+        "properties": {
+          "path": {
+            "title": "Path",
+            "type": "string"
+          },
+          "size": {
+            "title": "Size",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "path",
+          "size"
+        ],
+        "title": "FileEntry",
         "type": "object"
       },
       "GrantResponse": {
@@ -1165,6 +1818,41 @@
         "title": "HTTPValidationError",
         "type": "object"
       },
+      "HookEntry": {
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "event": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Event"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "HookEntry",
+        "type": "object"
+      },
       "HybridQueryRequest": {
         "properties": {
           "register_bq": {
@@ -1184,6 +1872,435 @@
           "sql"
         ],
         "title": "HybridQueryRequest",
+        "type": "object"
+      },
+      "ImportBundleResponse": {
+        "properties": {
+          "errors": {
+            "default": [],
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Errors",
+            "type": "array"
+          },
+          "imported": {
+            "title": "Imported",
+            "type": "integer"
+          },
+          "replaced": {
+            "title": "Replaced",
+            "type": "integer"
+          },
+          "skipped": {
+            "title": "Skipped",
+            "type": "integer"
+          },
+          "stub_users_created": {
+            "title": "Stub Users Created",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "imported",
+          "replaced",
+          "skipped",
+          "stub_users_created"
+        ],
+        "title": "ImportBundleResponse",
+        "type": "object"
+      },
+      "InnerDetailResponse": {
+        "properties": {
+          "body": {
+            "title": "Body",
+            "type": "string"
+          },
+          "bundle_size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bundle Size"
+          },
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category"
+          },
+          "cover_photo_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover Photo Url"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "description_long_html": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description Long Html"
+          },
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          },
+          "docs": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/DocEntry"
+            },
+            "title": "Docs",
+            "type": "array"
+          },
+          "files": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/FileEntry"
+            },
+            "title": "Files",
+            "type": "array"
+          },
+          "invocation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Invocation"
+          },
+          "kind": {
+            "enum": [
+              "skill",
+              "agent"
+            ],
+            "title": "Kind",
+            "type": "string"
+          },
+          "manifest_name": {
+            "default": "",
+            "title": "Manifest Name",
+            "type": "string"
+          },
+          "marketplace_id": {
+            "title": "Marketplace Id",
+            "type": "string"
+          },
+          "marketplace_name": {
+            "default": "",
+            "title": "Marketplace Name",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "parent_author_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Author Name"
+          },
+          "parent_display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Display Name"
+          },
+          "parent_stack_count": {
+            "default": 0,
+            "title": "Parent Stack Count",
+            "type": "integer"
+          },
+          "parent_updated_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Updated At"
+          },
+          "plugin_name": {
+            "title": "Plugin Name",
+            "type": "string"
+          },
+          "relpath": {
+            "title": "Relpath",
+            "type": "string"
+          },
+          "sample_interaction": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SampleInteraction"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tagline": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tagline"
+          },
+          "telemetry": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telemetry"
+          },
+          "use_cases": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/UseCase"
+            },
+            "title": "Use Cases",
+            "type": "array"
+          },
+          "video_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Video Url"
+          },
+          "when_to_use_html": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "When To Use Html"
+          }
+        },
+        "required": [
+          "marketplace_id",
+          "plugin_name",
+          "kind",
+          "name",
+          "body",
+          "relpath"
+        ],
+        "title": "InnerDetailResponse",
+        "type": "object"
+      },
+      "InnerItemSummary": {
+        "properties": {
+          "cover_photo_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover Photo Url"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "detail_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detail Url"
+          },
+          "distinct_users_30d": {
+            "default": 0,
+            "title": "Distinct Users 30D",
+            "type": "integer"
+          },
+          "invocations_30d": {
+            "default": 0,
+            "title": "Invocations 30D",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "parent_stack_count": {
+            "default": 0,
+            "title": "Parent Stack Count",
+            "type": "integer"
+          },
+          "trend_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Trend Pct"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "InnerItemSummary",
+        "type": "object"
+      },
+      "InstallActionResponse": {
+        "properties": {
+          "installed": {
+            "title": "Installed",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "installed"
+        ],
+        "title": "InstallActionResponse",
+        "type": "object"
+      },
+      "InstallResponse": {
+        "properties": {
+          "entity_id": {
+            "title": "Entity Id",
+            "type": "string"
+          },
+          "installed": {
+            "title": "Installed",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "entity_id",
+          "installed"
+        ],
+        "title": "InstallResponse",
+        "type": "object"
+      },
+      "ItemListResponse": {
+        "properties": {
+          "available_sorts": {
+            "default": [
+              "recent",
+              "most_used",
+              "most_adopted"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "title": "Available Sorts",
+            "type": "array"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/MarketplaceItem"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "page": {
+            "title": "Page",
+            "type": "integer"
+          },
+          "page_size": {
+            "title": "Page Size",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "page",
+          "page_size"
+        ],
+        "title": "ItemListResponse",
         "type": "object"
       },
       "LocalMdRequest": {
@@ -1230,6 +2347,220 @@
         "title": "MagicLinkVerify",
         "type": "object"
       },
+      "MarketplaceItem": {
+        "properties": {
+          "added": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Added"
+          },
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "detail_url": {
+            "title": "Detail Url",
+            "type": "string"
+          },
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          },
+          "distinct_users_30d": {
+            "default": 0,
+            "title": "Distinct Users 30D",
+            "type": "integer"
+          },
+          "distinct_users_7d": {
+            "default": 0,
+            "title": "Distinct Users 7D",
+            "type": "integer"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "installed": {
+            "default": false,
+            "title": "Installed",
+            "type": "boolean"
+          },
+          "invocations_30d": {
+            "default": 0,
+            "title": "Invocations 30D",
+            "type": "integer"
+          },
+          "invocations_7d": {
+            "default": 0,
+            "title": "Invocations 7D",
+            "type": "integer"
+          },
+          "is_system": {
+            "default": false,
+            "title": "Is System",
+            "type": "boolean"
+          },
+          "is_viewer_owner": {
+            "default": false,
+            "title": "Is Viewer Owner",
+            "type": "boolean"
+          },
+          "marketplace_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Marketplace Name"
+          },
+          "marketplace_slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Marketplace Slug"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "owner": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Owner"
+          },
+          "photo_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Photo Url"
+          },
+          "source": {
+            "enum": [
+              "curated",
+              "flea"
+            ],
+            "title": "Source",
+            "type": "string"
+          },
+          "stack_count": {
+            "default": 0,
+            "title": "Stack Count",
+            "type": "integer"
+          },
+          "tagline": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tagline"
+          },
+          "trend_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Trend Pct"
+          },
+          "type": {
+            "enum": [
+              "skill",
+              "agent",
+              "plugin"
+            ],
+            "title": "Type",
+            "type": "string"
+          },
+          "version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Version"
+          },
+          "visibility_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Visibility Status"
+          }
+        },
+        "required": [
+          "id",
+          "source",
+          "name",
+          "type",
+          "detail_url"
+        ],
+        "title": "MarketplaceItem",
+        "type": "object"
+      },
       "MarketplaceResponse": {
         "properties": {
           "branch": {
@@ -1242,6 +2573,28 @@
               }
             ],
             "title": "Branch"
+          },
+          "curator_email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Curator Email"
+          },
+          "curator_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Curator Name"
           },
           "description": {
             "anyOf": [
@@ -1338,6 +2691,41 @@
           "url"
         ],
         "title": "MarketplaceResponse",
+        "type": "object"
+      },
+      "McpEntry": {
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Type"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "McpEntry",
         "type": "object"
       },
       "MemberResponse": {
@@ -1598,6 +2986,101 @@
         "title": "MetricCreate",
         "type": "object"
       },
+      "MyStackResponse": {
+        "properties": {
+          "curated": {
+            "items": {
+              "$ref": "#/components/schemas/CuratedPlugin"
+            },
+            "title": "Curated",
+            "type": "array"
+          },
+          "store": {
+            "items": {
+              "$ref": "#/components/schemas/StoreInstallEntry"
+            },
+            "title": "Store",
+            "type": "array"
+          }
+        },
+        "required": [
+          "curated",
+          "store"
+        ],
+        "title": "MyStackResponse",
+        "type": "object"
+      },
+      "NewsBody": {
+        "properties": {
+          "content": {
+            "default": "",
+            "title": "Content",
+            "type": "string"
+          },
+          "intro": {
+            "default": "",
+            "title": "Intro",
+            "type": "string"
+          }
+        },
+        "title": "NewsBody",
+        "type": "object"
+      },
+      "OkResponse": {
+        "properties": {
+          "ok": {
+            "default": true,
+            "title": "Ok",
+            "type": "boolean"
+          }
+        },
+        "title": "OkResponse",
+        "type": "object"
+      },
+      "OnboardedRequest": {
+        "properties": {
+          "onboarded": {
+            "default": true,
+            "title": "Onboarded",
+            "type": "boolean"
+          },
+          "source": {
+            "default": "agnes_init",
+            "enum": [
+              "agnes_init",
+              "self_acknowledged",
+              "self_unmark"
+            ],
+            "title": "Source",
+            "type": "string"
+          }
+        },
+        "title": "OnboardedRequest",
+        "type": "object"
+      },
+      "OwnerOption": {
+        "properties": {
+          "display_name": {
+            "title": "Display Name",
+            "type": "string"
+          },
+          "entity_count": {
+            "title": "Entity Count",
+            "type": "integer"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user_id",
+          "display_name",
+          "entity_count"
+        ],
+        "title": "OwnerOption",
+        "type": "object"
+      },
       "PasswordLoginRequest": {
         "properties": {
           "email": {
@@ -1728,6 +3211,360 @@
         "title": "PersonalFlagRequest",
         "type": "object"
       },
+      "PluginDetailResponse": {
+        "description": "Unified detail response for a plugin (curated *or* flea).\n\nFrontend-side switching is purely cosmetic \u2014 `source` controls the\nCurated/Flea pill, photo URL fallback path, and owner label.",
+        "properties": {
+          "agents": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/InnerItemSummary"
+            },
+            "title": "Agents",
+            "type": "array"
+          },
+          "author_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Author Name"
+          },
+          "bundle_size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bundle Size"
+          },
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category"
+          },
+          "commands": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/CommandEntry"
+            },
+            "title": "Commands",
+            "type": "array"
+          },
+          "cover_photo_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover Photo Url"
+          },
+          "curator_email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Curator Email"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "description_long_html": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description Long Html"
+          },
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          },
+          "docs": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/DocEntry"
+            },
+            "title": "Docs",
+            "type": "array"
+          },
+          "entity_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Entity Id"
+          },
+          "files": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/FileEntry"
+            },
+            "title": "Files",
+            "type": "array"
+          },
+          "homepage": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Homepage"
+          },
+          "hooks": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/HookEntry"
+            },
+            "title": "Hooks",
+            "type": "array"
+          },
+          "install_count": {
+            "default": 0,
+            "title": "Install Count",
+            "type": "integer"
+          },
+          "installed": {
+            "default": false,
+            "title": "Installed",
+            "type": "boolean"
+          },
+          "is_system": {
+            "default": false,
+            "title": "Is System",
+            "type": "boolean"
+          },
+          "manifest_name": {
+            "title": "Manifest Name",
+            "type": "string"
+          },
+          "marketplace_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Marketplace Id"
+          },
+          "marketplace_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Marketplace Name"
+          },
+          "mcps": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/McpEntry"
+            },
+            "title": "Mcps",
+            "type": "array"
+          },
+          "owner_display": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Owner Display"
+          },
+          "plugin_name": {
+            "title": "Plugin Name",
+            "type": "string"
+          },
+          "released_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Released At"
+          },
+          "sample_interaction": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SampleInteraction"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "skills": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/InnerItemSummary"
+            },
+            "title": "Skills",
+            "type": "array"
+          },
+          "source": {
+            "enum": [
+              "curated",
+              "flea"
+            ],
+            "title": "Source",
+            "type": "string"
+          },
+          "stack_count": {
+            "default": 0,
+            "title": "Stack Count",
+            "type": "integer"
+          },
+          "submission_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Submission Status"
+          },
+          "tagline": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tagline"
+          },
+          "telemetry": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telemetry"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          },
+          "use_cases": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/UseCase"
+            },
+            "title": "Use Cases",
+            "type": "array"
+          },
+          "version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Version"
+          },
+          "video_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Video Url"
+          },
+          "visibility_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Visibility Status"
+          }
+        },
+        "required": [
+          "source",
+          "plugin_name",
+          "manifest_name"
+        ],
+        "title": "PluginDetailResponse",
+        "type": "object"
+      },
       "PluginResponse": {
         "properties": {
           "author_name": {
@@ -1774,6 +3611,11 @@
             ],
             "title": "Homepage"
           },
+          "is_system": {
+            "default": false,
+            "title": "Is System",
+            "type": "boolean"
+          },
           "name": {
             "title": "Name",
             "type": "string"
@@ -1814,6 +3656,100 @@
           "name"
         ],
         "title": "PluginResponse",
+        "type": "object"
+      },
+      "PreviewComponent": {
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "file": {
+            "title": "File",
+            "type": "string"
+          },
+          "issues": {
+            "default": [],
+            "items": {},
+            "title": "Issues",
+            "type": "array"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "ok": {
+            "title": "Ok",
+            "type": "boolean"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "file",
+          "ok"
+        ],
+        "title": "PreviewComponent",
+        "type": "object"
+      },
+      "PreviewResponse": {
+        "properties": {
+          "components": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/PreviewComponent"
+            },
+            "title": "Components",
+            "type": "array"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "title": "PreviewResponse",
         "type": "object"
       },
       "QueryRequest": {
@@ -1864,6 +3800,42 @@
         "title": "QueryResponse",
         "type": "object"
       },
+      "RegisterRequest": {
+        "description": "Upsert payload \u2014 fields not provided are left untouched on update.\n\n``token = None`` means \"leave existing PAT alone\".\n``token = \"\"``   means \"clear PAT\".\n``token = \"ghp_...\"`` means \"set/rotate PAT\".",
+        "properties": {
+          "branch": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Branch"
+          },
+          "token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Token"
+          },
+          "url": {
+            "title": "Url",
+            "type": "string"
+          }
+        },
+        "required": [
+          "url"
+        ],
+        "title": "RegisterRequest",
+        "type": "object"
+      },
       "RegisterTableRequest": {
         "properties": {
           "bucket": {
@@ -1899,9 +3871,75 @@
             ],
             "title": "Folder"
           },
+          "incremental_column": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Incremental Column"
+          },
+          "incremental_window_days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Incremental Window Days"
+          },
+          "initial_load_chunk_days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Initial Load Chunk Days"
+          },
+          "max_history_days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max History Days"
+          },
           "name": {
             "title": "Name",
             "type": "string"
+          },
+          "partition_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Partition By"
+          },
+          "partition_granularity": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Partition Granularity"
           },
           "primary_key": {
             "anyOf": [
@@ -1975,10 +4013,24 @@
           },
           "sync_strategy": {
             "default": "full_refresh",
-            "deprecated": true,
-            "description": "DEPRECATED: catalog/profiler metadata only. No extractor reads this field; every sync is a full overwrite regardless of value. profiler.is_partitioned() consumes it for parquet-layout detection. Field stays for back-compat; will be removed in a future major release.",
+            "description": "Per-table extraction strategy. v26+: drives the Keboola extractor's dispatcher in connectors/keboola/extractor.py. Allowed values: 'full_refresh' (default; full table dump on each sync), 'incremental' (Storage API changedSince + primary-key dedup merge), 'partitioned' (per-partition parquet files keyed by partition_by column, per-partition merge for daily updates, chunked initial load). Pre-v26 this field was inert; existing rows default to 'full_refresh' so behavior is unchanged unless an admin opts a table in to incremental/partitioned.",
             "title": "Sync Strategy",
             "type": "string"
+          },
+          "where_filters": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Where Filters"
           }
         },
         "required": [
@@ -2042,6 +4094,30 @@
         "title": "RunScriptRequest",
         "type": "object"
       },
+      "SampleInteraction": {
+        "description": "Example dialog shown in the \"Sample interaction\" section.\n\n``assistant`` is markdown \u2014 the API pre-renders to safe HTML in\n``assistant_html`` so the template can inject without a client-side\nmarkdown lib. ``assistant`` stays as the source for copy-paste / future\nre-rendering needs.",
+        "properties": {
+          "assistant": {
+            "title": "Assistant",
+            "type": "string"
+          },
+          "assistant_html": {
+            "title": "Assistant Html",
+            "type": "string"
+          },
+          "user": {
+            "title": "User",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user",
+          "assistant",
+          "assistant_html"
+        ],
+        "title": "SampleInteraction",
+        "type": "object"
+      },
       "ServerConfigUpdateRequest": {
         "description": "Patch payload for POST /api/admin/server-config.\n\nOnly the sections listed in `_EDITABLE_SECTIONS` are accepted; anything\nelse is rejected with 400. `confirm_danger` must be true if the patch\ntouches any danger-zone section (auth.*, server.*).",
         "properties": {
@@ -2077,6 +4153,289 @@
         "title": "SetPasswordRequest",
         "type": "object"
       },
+      "StoreEntityListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/StoreEntityResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "skip": {
+            "title": "Skip",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "skip",
+          "limit"
+        ],
+        "title": "StoreEntityListResponse",
+        "type": "object"
+      },
+      "StoreEntityResponse": {
+        "properties": {
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "doc_paths": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Doc Paths",
+            "type": "array"
+          },
+          "file_size": {
+            "default": 0,
+            "title": "File Size",
+            "type": "integer"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "install_count": {
+            "default": 0,
+            "title": "Install Count",
+            "type": "integer"
+          },
+          "invocation_name": {
+            "title": "Invocation Name",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "owner_display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Owner Display Name"
+          },
+          "owner_user_id": {
+            "title": "Owner User Id",
+            "type": "string"
+          },
+          "owner_username": {
+            "title": "Owner Username",
+            "type": "string"
+          },
+          "photo_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Photo Url"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          },
+          "version": {
+            "title": "Version",
+            "type": "string"
+          },
+          "video_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Video Url"
+          },
+          "visibility_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Visibility Status"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "name",
+          "version",
+          "owner_user_id",
+          "owner_username",
+          "invocation_name"
+        ],
+        "title": "StoreEntityResponse",
+        "type": "object"
+      },
+      "StoreInstallEntry": {
+        "properties": {
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "entity_id": {
+            "title": "Entity Id",
+            "type": "string"
+          },
+          "install_count": {
+            "title": "Install Count",
+            "type": "integer"
+          },
+          "installed_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Installed At"
+          },
+          "invocation_name": {
+            "title": "Invocation Name",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "owner_user_id": {
+            "title": "Owner User Id",
+            "type": "string"
+          },
+          "owner_username": {
+            "title": "Owner Username",
+            "type": "string"
+          },
+          "photo_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Photo Url"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string"
+          },
+          "version": {
+            "title": "Version",
+            "type": "string"
+          },
+          "visibility_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Visibility Status"
+          }
+        },
+        "required": [
+          "entity_id",
+          "type",
+          "name",
+          "version",
+          "owner_user_id",
+          "owner_username",
+          "invocation_name",
+          "install_count"
+        ],
+        "title": "StoreInstallEntry",
+        "type": "object"
+      },
       "SyncSettingsUpdate": {
         "properties": {
           "datasets": {
@@ -2091,6 +4450,40 @@
         "title": "SyncSettingsUpdate",
         "type": "object"
       },
+      "SystemFlagResponse": {
+        "description": "Return shape of the mark/unmark_system endpoints.",
+        "properties": {
+          "affected_groups": {
+            "default": 0,
+            "title": "Affected Groups",
+            "type": "integer"
+          },
+          "affected_users": {
+            "default": 0,
+            "title": "Affected Users",
+            "type": "integer"
+          },
+          "is_system": {
+            "title": "Is System",
+            "type": "boolean"
+          },
+          "marketplace_id": {
+            "title": "Marketplace Id",
+            "type": "string"
+          },
+          "plugin_name": {
+            "title": "Plugin Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "marketplace_id",
+          "plugin_name",
+          "is_system"
+        ],
+        "title": "SystemFlagResponse",
+        "type": "object"
+      },
       "TableSubscriptionUpdate": {
         "properties": {
           "table_mode": {
@@ -2100,59 +4493,12 @@
           },
           "tables": {
             "additionalProperties": true,
-            "default": {},
+            "maxProperties": 500,
             "title": "Tables",
             "type": "object"
           }
         },
         "title": "TableSubscriptionUpdate",
-        "type": "object"
-      },
-      "TemplateGetResponse": {
-        "properties": {
-          "content": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Content"
-          },
-          "default": {
-            "title": "Default",
-            "type": "string"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          },
-          "updated_by": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated By"
-          }
-        },
-        "required": [
-          "content",
-          "default"
-        ],
-        "title": "TemplateGetResponse",
         "type": "object"
       },
       "TemplatePreviewRequest": {
@@ -2183,6 +4529,19 @@
           "content"
         ],
         "title": "TemplatePutRequest",
+        "type": "object"
+      },
+      "ToggleRequest": {
+        "properties": {
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "enabled"
+        ],
+        "title": "ToggleRequest",
         "type": "object"
       },
       "TokenListItem": {
@@ -2341,6 +4700,28 @@
             ],
             "title": "Branch"
           },
+          "curator_email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Curator Email"
+          },
+          "curator_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Curator Name"
+          },
           "description": {
             "anyOf": [
               {
@@ -2413,6 +4794,50 @@
             ],
             "title": "Description"
           },
+          "incremental_column": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Incremental Column"
+          },
+          "incremental_window_days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Incremental Window Days"
+          },
+          "initial_load_chunk_days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Initial Load Chunk Days"
+          },
+          "max_history_days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max History Days"
+          },
           "name": {
             "anyOf": [
               {
@@ -2423,6 +4848,28 @@
               }
             ],
             "title": "Name"
+          },
+          "partition_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Partition By"
+          },
+          "partition_granularity": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Partition Granularity"
           },
           "primary_key": {
             "anyOf": [
@@ -2515,9 +4962,23 @@
                 "type": "null"
               }
             ],
-            "deprecated": true,
-            "description": "DEPRECATED: catalog/profiler metadata only. See RegisterTableRequest.sync_strategy.",
+            "description": "v26+: drives the Keboola extractor dispatcher. PUT-shape requires a value if sent. See RegisterTableRequest.sync_strategy.",
             "title": "Sync Strategy"
+          },
+          "where_filters": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Where Filters"
           }
         },
         "title": "UpdateTableRequest",
@@ -2549,6 +5010,30 @@
           }
         },
         "title": "UpdateUserRequest",
+        "type": "object"
+      },
+      "UseCase": {
+        "description": "One \"When to use it\" example from marketplace-metadata.json.\nCurator-authored: friendly title + 1-2-sentence description + the\nliteral prompt the user would paste into Claude Code.",
+        "properties": {
+          "description": {
+            "title": "Description",
+            "type": "string"
+          },
+          "prompt": {
+            "title": "Prompt",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "description",
+          "prompt"
+        ],
+        "title": "UseCase",
         "type": "object"
       },
       "UserMembershipResponse": {
@@ -2774,13 +5259,130 @@
         ],
         "title": "VoteRequest",
         "type": "object"
+      },
+      "_OverrideRequest": {
+        "properties": {
+          "reason": {
+            "maxLength": 2000,
+            "minLength": 4,
+            "title": "Reason",
+            "type": "string"
+          }
+        },
+        "required": [
+          "reason"
+        ],
+        "title": "_OverrideRequest",
+        "type": "object"
+      },
+      "app__api__claude_md__TemplateGetResponse": {
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content"
+          },
+          "default": {
+            "title": "Default",
+            "type": "string"
+          },
+          "legacy_strings_detected": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Legacy Strings Detected",
+            "type": "array"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          },
+          "updated_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated By"
+          }
+        },
+        "required": [
+          "content",
+          "default"
+        ],
+        "title": "TemplateGetResponse",
+        "type": "object"
+      },
+      "app__api__welcome__TemplateGetResponse": {
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content"
+          },
+          "default": {
+            "title": "Default",
+            "type": "string"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          },
+          "updated_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated By"
+          }
+        },
+        "required": [
+          "content",
+          "default"
+        ],
+        "title": "TemplateGetResponse",
+        "type": "object"
       }
     }
   },
   "info": {
     "description": "Data distribution platform for AI analytical systems",
     "title": "AI Data Analyst",
-    "version": "2.0.0"
+    "version": "0.54.16"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -2835,48 +5437,19 @@
     },
     "/activity-center": {
       "get": {
-        "operationId": "activity_center_activity_center_get",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "authorization",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Authorization"
-            }
-          }
-        ],
+        "description": "Legacy URL \u2014 redirect to /admin/activity.",
+        "operationId": "activity_center_redirect_activity_center_get",
         "responses": {
           "200": {
             "content": {
-              "text/html": {
-                "schema": {
-                  "type": "string"
-                }
+              "application/json": {
+                "schema": {}
               }
             },
             "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
           }
         },
-        "summary": "Activity Center",
+        "summary": "Activity Center Redirect",
         "tags": [
           "web"
         ]
@@ -2932,6 +5505,56 @@
         ]
       }
     },
+    "/admin/activity": {
+      "get": {
+        "description": "Unified observability page \u2014 KPI cards, faceted filter bar, full\naudit_log table with sort/search/saved-views. All data loads\nclient-side from /api/admin/observability/* + /api/admin/activity.",
+        "operationId": "admin_activity_admin_activity_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Admin Activity",
+        "tags": [
+          "web"
+        ]
+      }
+    },
     "/admin/agent-prompt": {
       "get": {
         "operationId": "admin_agent_prompt_page_admin_agent_prompt_get",
@@ -2976,6 +5599,56 @@
           }
         },
         "summary": "Admin Agent Prompt Page",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/admin/corporate-memory": {
+      "get": {
+        "description": "Curated Memory review queue \u2014 admin-only.\n\nThe governance surface paired with the user-facing ``/corporate-memory``\npage: pending items awaiting review, contradictions, duplicate\ncandidates, and the audit trail. Reached from the Admin nav dropdown.",
+        "operationId": "corporate_memory_admin_admin_corporate_memory_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Corporate Memory Admin",
         "tags": [
           "web"
         ]
@@ -3162,6 +5835,104 @@
         ]
       }
     },
+    "/admin/news": {
+      "get": {
+        "description": "Admin authoring surface \u2014 current published banner, draft editor,\nversions table. JS hits the /api/admin/news/* endpoints for the\nwrite paths.",
+        "operationId": "admin_news_editor_admin_news_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Admin News Editor",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/admin/scheduler-runs": {
+      "get": {
+        "description": "Scheduler runs is now a filter on the unified Activity page, not a\nstandalone view \u2014 see the unification done in the platform-telemetry\nepic. Keep the URL as a 308 so existing bookmarks land on the right\npre-filtered view.",
+        "operationId": "admin_scheduler_runs_redirect_admin_scheduler_runs_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Admin Scheduler Runs Redirect",
+        "tags": [
+          "web"
+        ]
+      }
+    },
     "/admin/server-config": {
       "get": {
         "description": "Server configuration editor \u2014 instance.yaml fields grouped by section.\n\nShell-only page. The form is populated client-side from\nGET /api/admin/server-config (which redacts secrets) and submitted\nsection-by-section to POST /api/admin/server-config. Auth/server\nsections require an explicit confirmation dialog before save (see\n``_DANGER_SECTIONS`` in the API). Saves trigger the \"restart required\"\nbanner \u2014 hot-reload is out of scope for #91.",
@@ -3207,6 +5978,365 @@
           }
         },
         "summary": "Admin Server Config Page",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/admin/sessions": {
+      "get": {
+        "description": "Global Sessions browser \u2014 every collected session JSONL across all\nusers. The list page is a shell; data loads client-side via\n/api/admin/sessions/{list,kpis,facets}.",
+        "operationId": "admin_sessions_page_admin_sessions_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Admin Sessions Page",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/admin/sessions/{username}/{session_file}": {
+      "get": {
+        "description": "Session transcript viewer. Username + session_file are revalidated by\nthe API route (regex + path-escape guard) when /transcript is fetched;\nhere we just render the shell.",
+        "operationId": "admin_session_detail_admin_sessions__username___session_file__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "schema": {
+              "title": "Username",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "session_file",
+            "required": true,
+            "schema": {
+              "title": "Session File",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Admin Session Detail",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/admin/store/submissions": {
+      "get": {
+        "description": "Triage page for flea-market guardrail submissions.\n\nLists every submission row newest-first with the inline-check verdicts,\nLLM findings, and override action buttons. Server-side render keeps the\npage accessible without JS for the read-only inspect path; mutating\nactions (override, retry, delete) hit the JSON admin endpoints under\n``/api/admin/store/submissions``.\n\nFilters AND together; URL is bookmarkable. Pagination via ``skip`` /\n``limit`` (default 50, clamped to [1, 200] for the UI page-size\nselector).",
+        "operationId": "admin_store_submissions_page_admin_store_submissions_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "in": "query",
+            "name": "submitter",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Submitter"
+            }
+          },
+          {
+            "in": "query",
+            "name": "type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Type"
+            }
+          },
+          {
+            "in": "query",
+            "name": "name",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Name"
+            }
+          },
+          {
+            "in": "query",
+            "name": "version",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Version"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Sort"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Order"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "skip",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "title": "Skip",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Admin Store Submissions Page",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/admin/store/submissions/{submission_id}": {
+      "get": {
+        "description": "Per-submission detail with full verdict + override + retry actions.",
+        "operationId": "admin_store_submission_detail_page_admin_store_submissions__submission_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "submission_id",
+            "required": true,
+            "schema": {
+              "title": "Submission Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Admin Store Submission Detail Page",
         "tags": [
           "web"
         ]
@@ -3261,9 +6391,59 @@
         ]
       }
     },
+    "/admin/telemetry": {
+      "get": {
+        "description": "Interactive Telemetry page \u2014 filter / group-by / search on usage_events.\n\nAll data loads client-side from /api/admin/telemetry/* (facets, kpis,\nquery) so the page state lives in the URL and the server doesn't\npreload a fixed window's snapshot.",
+        "operationId": "admin_telemetry_page_admin_telemetry_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Admin Telemetry Page",
+        "tags": [
+          "web"
+        ]
+      }
+    },
     "/admin/tokens": {
       "get": {
-        "description": "Admin \u2014 list of ALL tokens for incident response + offboarding.\n\nAdmin-only. No create form here (admins mint their own PATs via /tokens).\nURL param ?user=<email> pre-fills the owner filter (deep-link from\n/admin/users \"Tokens\" action).",
+        "description": "Admin \u2014 list of ALL tokens for incident response + offboarding.\n\nAdmin-only. No create form here (admins mint their own PATs via /me/profile).\nURL param ?user=<email> pre-fills the owner filter (deep-link from\n/admin/users \"Tokens\" action).",
         "operationId": "admin_tokens_page_admin_tokens_get",
         "parameters": [
           {
@@ -3306,6 +6486,54 @@
           }
         },
         "summary": "Admin Tokens Page",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/admin/usage": {
+      "get": {
+        "description": "Legacy URL \u2014 308 to /admin/telemetry. The page was renamed in the\nplatform-telemetry epic to match what's actually shown (tool/skill\ninvocations from session JSONLs). Old bookmarks land on the right\nplace without breaking.",
+        "operationId": "admin_usage_redirect_admin_usage_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Admin Usage Redirect",
         "tags": [
           "web"
         ]
@@ -3521,6 +6749,488 @@
         ]
       }
     },
+    "/api/admin/activity": {
+      "get": {
+        "operationId": "activity_timeline_api_admin_activity_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "since_minutes",
+            "required": false,
+            "schema": {
+              "default": 1440,
+              "maximum": 43200,
+              "minimum": 1,
+              "title": "Since Minutes",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "user_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "User Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "action_prefix",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Action Prefix"
+            }
+          },
+          {
+            "in": "query",
+            "name": "resource",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Resource"
+            }
+          },
+          {
+            "in": "query",
+            "name": "result_pattern",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Result Pattern"
+            }
+          },
+          {
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Q"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor_ts",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor Ts"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Activity Timeline",
+        "tags": [
+          "activity"
+        ]
+      }
+    },
+    "/api/admin/activity/health": {
+      "get": {
+        "operationId": "activity_health_api_admin_activity_health_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Activity Health",
+        "tags": [
+          "activity"
+        ]
+      }
+    },
+    "/api/admin/activity/sync": {
+      "get": {
+        "operationId": "activity_sync_api_admin_activity_sync_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "since_minutes",
+            "required": false,
+            "schema": {
+              "default": 1440,
+              "maximum": 43200,
+              "minimum": 1,
+              "title": "Since Minutes",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Activity Sync",
+        "tags": [
+          "activity"
+        ]
+      }
+    },
+    "/api/admin/bigquery/test-connection": {
+      "post": {
+        "description": "Run `SELECT 1 AS ok` against BigQuery via the configured BqAccess.\n\nReturns 200 with `{ok, billing_project, data_project, elapsed_ms}` on\nsuccess. Maps known failure modes:\n\n- `BqAccessError(not_configured)` \u2192 400 with the typed detail\n- `BqAccessError` (other kinds) \u2192 502 with the typed detail\n- `concurrent.futures.TimeoutError` \u2192 504 with `kind=\"timeout\"` and\n  best-effort `cancel_job` invoked",
+        "operationId": "test_connection_api_admin_bigquery_test_connection_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Test Connection",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/api/admin/cache-warmup/run": {
+      "post": {
+        "operationId": "warmup_run_api_admin_cache_warmup_run_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Warmup Run"
+      }
+    },
+    "/api/admin/cache-warmup/status": {
+      "get": {
+        "operationId": "warmup_status_api_admin_cache_warmup_status_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Warmup Status"
+      }
+    },
+    "/api/admin/cache-warmup/stream": {
+      "get": {
+        "operationId": "warmup_stream_api_admin_cache_warmup_stream_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Warmup Stream"
+      }
+    },
     "/api/admin/configure": {
       "post": {
         "description": "Configure data source and instance settings via API.\n\nWrites config to instance.yaml and persists secrets to .env_overlay.\nAI agents and the /setup wizard use this instead of manual file editing.",
@@ -3581,9 +7291,19 @@
     },
     "/api/admin/discover-and-register": {
       "post": {
-        "description": "Discover tables from configured source and auto-register them.\n\nCombines discover-tables + register-table into one call.\nSkips already-registered tables. Used by /setup wizard and AI agents.",
+        "description": "Discover tables from configured source and auto-register them.\n\nCombines discover-tables + register-table into one call. Already-\nregistered rows are NEVER overwritten \u2014 admin edits to bucket /\nsource_table win. The response surfaces a ``drift`` array listing\nany rows where discovery would have written different coordinates\nthan what's in the registry, so operators can audit divergence\nafter a Keboola-side bucket rename / table move.\n\nQuery params:\n  - ``dry_run=true`` returns the plan without writing anything.\n    Lists ``would_register``, ``drift``, and ``invalid`` so an\n    operator can decide whether to proceed (or, in the drift case,\n    which side they want to fix).\n\nUsed by /setup wizard and AI agents.",
         "operationId": "discover_and_register_api_admin_discover_and_register_post",
         "parameters": [
+          {
+            "in": "query",
+            "name": "dry_run",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Dry Run",
+              "type": "boolean"
+            }
+          },
           {
             "in": "header",
             "name": "authorization",
@@ -4356,6 +8076,213 @@
         ]
       }
     },
+    "/api/admin/initial-workspace": {
+      "delete": {
+        "description": "Remove the ``initial_workspace:`` config + PAT.\n\nOptional ``?purge=true`` also wipes ``${DATA_DIR}/initial-workspace/``\nfrom disk. Default leaves the working copy in place so an admin can\ninspect / re-register the same URL without re-cloning.",
+        "operationId": "admin_delete_api_admin_initial_workspace_delete",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "purge",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Purge",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Admin Delete",
+        "tags": [
+          "initial_workspace"
+        ]
+      },
+      "get": {
+        "description": "Return the current ``initial_workspace:`` config + sync state.",
+        "operationId": "admin_get_api_admin_initial_workspace_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminInitialWorkspaceResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Admin Get",
+        "tags": [
+          "initial_workspace"
+        ]
+      },
+      "post": {
+        "description": "Register / update the template repo.\n\nOnly ``url``, ``branch``, and ``token_env`` land in the YAML overlay.\nSync state (``last_synced_at`` / ``last_commit_sha`` / ``last_error``)\nis written by ``POST .../sync``, not here \u2014 saving a config change\nshould NOT silently invalidate the existing sync state.",
+        "operationId": "admin_post_api_admin_initial_workspace_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminInitialWorkspaceResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Admin Post",
+        "tags": [
+          "initial_workspace"
+        ]
+      }
+    },
+    "/api/admin/initial-workspace/sync": {
+      "post": {
+        "description": "Manual \"Sync now\" \u2014 clone or fast-forward the template repo, then\npersist ``last_synced_at`` + ``last_commit_sha`` (or ``last_error``)\nback to the YAML overlay.\n\nReturns ``{action, commit_sha, file_count, path}`` on success or\nsurfaces a ``400`` with the validation / git error so the admin sees\nit in the Sync-now modal. The error payload uses the typed-``kind``\nshape the CLI's error renderer already understands.",
+        "operationId": "admin_sync_api_admin_initial_workspace_sync_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Admin Sync",
+        "tags": [
+          "initial_workspace"
+        ]
+      }
+    },
     "/api/admin/metadata/{table_id}": {
       "get": {
         "description": "Return column metadata for a table.",
@@ -4708,6 +8635,755 @@
         ]
       }
     },
+    "/api/admin/news/current": {
+      "get": {
+        "description": "Latest published version (or {published: false} if none).",
+        "operationId": "get_current_api_admin_news_current_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Current",
+        "tags": [
+          "news"
+        ]
+      }
+    },
+    "/api/admin/news/draft": {
+      "get": {
+        "description": "Active draft. 404 if none \u2014 UI shows 'create new draft' button.",
+        "operationId": "get_draft_api_admin_news_draft_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Draft",
+        "tags": [
+          "news"
+        ]
+      },
+      "put": {
+        "description": "Upsert the active draft. Sanitizes both fields BEFORE writing.\n\nOptimistic-lock: when `expected_version` is supplied (query string),\nthe request fails with 409 unless the active draft is at that\nversion. Pass `expected_version=0` when you intend to create the\nfirst draft and want the call to fail if another admin already\nstarted one.",
+        "operationId": "put_draft_api_admin_news_draft_put",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "expected_version",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Expected Version"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewsBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Put Draft",
+        "tags": [
+          "news"
+        ]
+      }
+    },
+    "/api/admin/news/preview": {
+      "post": {
+        "description": "Sanitize candidate intro + content and return \u2014 no DB writes.",
+        "operationId": "post_preview_api_admin_news_preview_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewsBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Post Preview",
+        "tags": [
+          "news"
+        ]
+      }
+    },
+    "/api/admin/news/publish": {
+      "post": {
+        "description": "Publish the active draft.\n\nWhen `expected_version` is supplied (query string), the request\nfails with 409 unless the active draft is at that version. Use\nthis when reviewing a specific draft before flipping it live so\na concurrent admin's edit doesn't slip through under your name.",
+        "operationId": "post_publish_api_admin_news_publish_post",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "expected_version",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Expected Version"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Post Publish",
+        "tags": [
+          "news"
+        ]
+      }
+    },
+    "/api/admin/news/unpublish/{version}": {
+      "post": {
+        "operationId": "post_unpublish_api_admin_news_unpublish__version__post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "title": "Version",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Post Unpublish",
+        "tags": [
+          "news"
+        ]
+      }
+    },
+    "/api/admin/news/versions": {
+      "get": {
+        "operationId": "list_versions_api_admin_news_versions_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Versions",
+        "tags": [
+          "news"
+        ]
+      }
+    },
+    "/api/admin/news/versions/{version}": {
+      "get": {
+        "operationId": "get_version_api_admin_news_versions__version__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "title": "Version",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Version",
+        "tags": [
+          "news"
+        ]
+      }
+    },
+    "/api/admin/observability/facets": {
+      "get": {
+        "description": "Return the distinct facet values present in `audit_log` for the\nselected window, each with a count. The UI uses these to populate the\nfilter dropdowns \u2014 so an admin sees only users/actions that actually\nexist, not a free-text guess.\n\nCounts are capped at 50 per facet (largest first). 50 is comfortable in\na dropdown; tighter windows usually have <20 anyway.",
+        "operationId": "facets_api_admin_observability_facets_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "since_minutes",
+            "required": false,
+            "schema": {
+              "default": 1440,
+              "maximum": 43200,
+              "minimum": 1,
+              "title": "Since Minutes",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Facets",
+        "tags": [
+          "observability"
+        ]
+      }
+    },
+    "/api/admin/observability/kpis": {
+      "get": {
+        "description": "Four KPIs for the top-bar cards: events, active users, error rate, p95.",
+        "operationId": "kpis_api_admin_observability_kpis_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "since_minutes",
+            "required": false,
+            "schema": {
+              "default": 1440,
+              "maximum": 43200,
+              "minimum": 1,
+              "title": "Since Minutes",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Kpis",
+        "tags": [
+          "observability"
+        ]
+      }
+    },
+    "/api/admin/observability/views": {
+      "get": {
+        "operationId": "list_views_api_admin_observability_views_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Views",
+        "tags": [
+          "observability"
+        ]
+      },
+      "post": {
+        "operationId": "save_view_api_admin_observability_views_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Payload",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Save View",
+        "tags": [
+          "observability"
+        ]
+      }
+    },
+    "/api/admin/observability/views/{view_id}": {
+      "delete": {
+        "operationId": "delete_view_api_admin_observability_views__view_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "view_id",
+            "required": true,
+            "schema": {
+              "title": "View Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete View",
+        "tags": [
+          "observability"
+        ]
+      }
+    },
     "/api/admin/register-table": {
       "post": {
         "description": "Register a new table in the system.\n\nBehavior by source_type:\n- **bigquery**: validates BQ-specific shape (dataset / source_table /\n  identifier safety / project_id format), forces query_mode='remote' and\n  profile_after_sync=False, then synchronously rebuilds extract.duckdb +\n  master views with a wall-clock budget. Returns 200 with the view name\n  on success, 202 on budget overrun (rebuild continues in a\n  BackgroundTask), or 500 if the synchronous rebuild ran but reported\n  an error (e.g. auth failure, missing project, unsafe identifier).\n- other source types: insert-only, no post-register hook. Returns 201.\n\nDefined as a plain ``def`` (not ``async def``) so FastAPI runs it in a\nthreadpool \u2014 the synchronous-materialize path waits on\n``threading.Event.wait()``, which would otherwise block the asyncio\nevent loop and stall every other request for up to ``_BQ_SYNC_REGISTER_\nTIMEOUT_S``. ``Depends(...)``, ``BackgroundTasks``, and\n``JSONResponse`` all work the same in sync handlers; the rest of the\nadmin module mixes both styles already.\n\nThe route does NOT carry a default ``status_code`` \u2014 each branch returns\nits own JSONResponse with the right code. A blanket ``status_code=201``\non the decorator would mislead OpenAPI consumers about the BQ branch.\n\nAlways: 409 on view-name collision against the existing registry, audit\nlog entry on success.",
@@ -4886,7 +9562,7 @@
     },
     "/api/admin/registry/{table_id}": {
       "delete": {
-        "description": "Unregister a table from the system.\n\nFor BQ rows, schedules a background rebuild so the dropped row's\nmaster view is removed from analytics.duckdb (rather than hanging\naround until the next scheduled sync).\n\nFor materialized rows, also removes the canonical parquet at\n`${DATA_DIR}/extracts/<source_type>/data/<id>.parquet` and clears\nthe matching `sync_state` row. Without these two cleanups, the\nmanifest endpoint kept advertising the dropped table to `da sync`\n(sync_state-driven) and the orchestrator's next rebuild could\nresurrect a master view from the leftover parquet (E2E sub-agent\nfinding 2026-05-01).",
+        "description": "Unregister a table from the system.\n\nFor BQ rows, schedules a background rebuild so the dropped row's\nmaster view is removed from analytics.duckdb (rather than hanging\naround until the next scheduled sync).\n\nFor materialized rows, also removes the canonical parquet at\n`${DATA_DIR}/extracts/<source_type>/data/<id>.parquet` and clears\nthe matching `sync_state` row. Without these two cleanups, the\nmanifest endpoint kept advertising the dropped table to `agnes pull`\n(sync_state-driven) and the orchestrator's next rebuild could\nresurrect a master view from the leftover parquet (E2E sub-agent\nfinding 2026-05-01).",
         "operationId": "unregister_table_api_admin_registry__table_id__delete",
         "parameters": [
           {
@@ -5056,6 +9732,302 @@
         ]
       }
     },
+    "/api/admin/run-blocked-purge": {
+      "post": {
+        "description": "Trigger the TTL purge of blocked bundle bytes.\n\nWraps :func:`src.store_guardrails.purge.purge_blocked_bundles`. The\nscheduler service hits this endpoint daily (under\n``SCHEDULER_API_TOKEN`` like the corporate-memory + verification\njobs); admins can also run it on demand from the UI.",
+        "operationId": "run_blocked_purge_api_admin_run_blocked_purge_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Run Blocked Purge",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/api/admin/run-bq-metadata-refresh": {
+      "post": {
+        "description": "Refresh metadata for every remote BQ row in the registry.\n\nCalled by the scheduler at ``SCHEDULER_BQ_METADATA_REFRESH_INTERVAL``\n(default 4 h). Single-flight guarded: if a refresh is already\nrunning (e.g. operator clicked \"Re-warm all\" while a scheduler tick\nis in flight, or two scheduler containers raced during an upgrade),\nthe second caller gets ``409 already_running`` with the in-flight\n``run_id`` + ``started_at`` so they can correlate against logs.\nThe scheduler treats 409 as a no-op success.\n\nBounded concurrency within a run (default 4, override via\n``AGNES_BQ_METADATA_REFRESH_CONCURRENCY``) so a deployment with\nmany remote tables doesn't fan out to dozens of parallel BQ jobs.",
+        "operationId": "run_bq_metadata_refresh_api_admin_run_bq_metadata_refresh_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Run Bq Metadata Refresh"
+      }
+    },
+    "/api/admin/run-corporate-memory": {
+      "post": {
+        "description": "Trigger the corporate-memory catalog refresh from the scheduler.\n\nReads all CLAUDE.local.md files, sends them through the LLM with the\nexisting catalog, and writes an updated catalog to knowledge.json.",
+        "operationId": "run_corporate_memory_api_admin_run_corporate_memory_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Run Corporate Memory",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/api/admin/run-reap-stuck-reviews": {
+      "post": {
+        "description": "Trigger the stuck-review reaper.\n\nWraps :func:`src.store_guardrails.reaper.reap_stuck_llm_reviews`.\nThe scheduler hits this every 15 minutes; admins can run it on\ndemand if a worker crash is suspected. Flips any\n``status='pending_llm'`` row older than the configured grace to\n``review_error`` so the queue stops growing indefinitely.",
+        "operationId": "run_reap_stuck_reviews_api_admin_run_reap_stuck_reviews_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Run Reap Stuck Reviews",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/api/admin/run-session-collector": {
+      "post": {
+        "description": "Trigger the session-collector job from the scheduler.\n\nWalks /home/*/user/sessions/*.jsonl and copies new files into\n/data/user_sessions/<user>/. Idempotent \u2014 already-collected files\nare skipped.",
+        "operationId": "run_session_collector_api_admin_run_session_collector_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Run Session Collector",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/api/admin/run-session-processor": {
+      "post": {
+        "description": "Trigger one session-pipeline processor against /data/user_sessions/*.\n\nReplaces the per-processor /run-* endpoints with a single parametrized\nentry. The scheduler invokes this once per registered processor on its\nown cadence; processors are independent (one slow / failing processor\ncan't block any other).\n\nReturns 400 if `processor` is unknown. The verification processor\nrequires an LLM extractor \u2014 if the instance has no ai: config and no\nANTHROPIC_API_KEY / LLM_API_KEY, it won't appear in the registry and\nthe call returns 400 the same as a misspelled name.",
+        "operationId": "run_session_processor_api_admin_run_session_processor_post",
+        "parameters": [
+          {
+            "description": "Processor name (e.g. 'verification', 'usage')",
+            "in": "query",
+            "name": "processor",
+            "required": true,
+            "schema": {
+              "description": "Processor name (e.g. 'verification', 'usage')",
+              "title": "Processor",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Run Session Processor",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
     "/api/admin/server-config": {
       "get": {
         "description": "Return the current instance.yaml with secrets redacted.\n\nUsed by the /admin/server-config UI to prefill its form. The redacted\npayload mirrors the actual file shape, so the UI doesn't need to know\nthe schema \u2014 it iterates over the editable sections and renders the\nfields it finds. Empty sections still show in the response so the form\nknows to render their headers.",
@@ -5155,6 +10127,1840 @@
           }
         },
         "summary": "Update Server Config",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/api/admin/sessions/facets": {
+      "get": {
+        "operationId": "facets_api_admin_sessions_facets_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "since_minutes",
+            "required": false,
+            "schema": {
+              "default": 10080,
+              "maximum": 525600,
+              "minimum": 1,
+              "title": "Since Minutes",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Facets",
+        "tags": [
+          "admin-sessions"
+        ]
+      }
+    },
+    "/api/admin/sessions/kpis": {
+      "get": {
+        "operationId": "kpis_api_admin_sessions_kpis_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "since_minutes",
+            "required": false,
+            "schema": {
+              "default": 10080,
+              "maximum": 525600,
+              "minimum": 1,
+              "title": "Since Minutes",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "username",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Username"
+            }
+          },
+          {
+            "in": "query",
+            "name": "model",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Model"
+            }
+          },
+          {
+            "in": "query",
+            "name": "only_errors",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Only Errors",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Q"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Kpis",
+        "tags": [
+          "admin-sessions"
+        ]
+      }
+    },
+    "/api/admin/sessions/list": {
+      "get": {
+        "operationId": "list_sessions_api_admin_sessions_list_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "since_minutes",
+            "required": false,
+            "schema": {
+              "default": 10080,
+              "maximum": 525600,
+              "minimum": 1,
+              "title": "Since Minutes",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "username",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Username"
+            }
+          },
+          {
+            "in": "query",
+            "name": "model",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Model"
+            }
+          },
+          {
+            "in": "query",
+            "name": "only_errors",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Only Errors",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Q"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "default": "started_at:desc",
+              "title": "Sort",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "maximum": 50000,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Sessions",
+        "tags": [
+          "admin-sessions"
+        ]
+      }
+    },
+    "/api/admin/sessions/{username}/{session_file}/download": {
+      "get": {
+        "description": "Stream a single JSONL straight from disk. Path-safety guarded the\nsame way as ``/transcript``. Audit-logged.",
+        "operationId": "download_api_admin_sessions__username___session_file__download_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "schema": {
+              "title": "Username",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "session_file",
+            "required": true,
+            "schema": {
+              "title": "Session File",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Download",
+        "tags": [
+          "admin-sessions"
+        ]
+      }
+    },
+    "/api/admin/sessions/{username}/{session_file}/transcript": {
+      "get": {
+        "operationId": "transcript_api_admin_sessions__username___session_file__transcript_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "schema": {
+              "title": "Username",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "session_file",
+            "required": true,
+            "schema": {
+              "title": "Session File",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Transcript",
+        "tags": [
+          "admin-sessions"
+        ]
+      }
+    },
+    "/api/admin/store/submissions": {
+      "get": {
+        "description": "List flea-market guardrail submissions newest-first.\n\nAll filters AND together. ``status`` is comma-separated\n(e.g. ``blocked_inline,blocked_llm``). ``submitter`` matches\n``submitter_id`` exactly. ``type`` is one of ``skill`` / ``agent`` /\n``plugin``. ``name`` and ``version`` are case-insensitive substrings.\n``limit`` clamped to [1, 500].",
+        "operationId": "admin_list_store_submissions_api_admin_store_submissions_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "in": "query",
+            "name": "submitter",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Submitter"
+            }
+          },
+          {
+            "in": "query",
+            "name": "type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Type"
+            }
+          },
+          {
+            "in": "query",
+            "name": "name",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Name"
+            }
+          },
+          {
+            "in": "query",
+            "name": "version",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Version"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Sort"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Order"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "skip",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "title": "Skip",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Admin List Store Submissions",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/api/admin/store/submissions/{submission_id}": {
+      "delete": {
+        "description": "Hard-delete a submission record + its linked bundle (if any).\n\nUse this for spam / accidental uploads after override-publish is the\nwrong call. The audit_log row preserves what was deleted in case\ntriage needs the evidence trail later.",
+        "operationId": "admin_delete_store_submission_api_admin_store_submissions__submission_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "submission_id",
+            "required": true,
+            "schema": {
+              "title": "Submission Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Admin Delete Store Submission",
+        "tags": [
+          "admin"
+        ]
+      },
+      "get": {
+        "operationId": "admin_get_store_submission_api_admin_store_submissions__submission_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "submission_id",
+            "required": true,
+            "schema": {
+              "title": "Submission Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Admin Get Store Submission",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/api/admin/store/submissions/{submission_id}/bundle.zip": {
+      "get": {
+        "description": "Stream the on-disk bundle as a fresh ZIP for admin inspection.\n\nRequired by the forensic use case: admin needs to inspect what a\nsubmitter actually tried to upload (not just the verdict). Bundle\nmust still be on disk \u2014 TTL purge nulls ``entity_id`` and removes\nthe directory, in which case this returns 410.",
+        "operationId": "admin_download_store_submission_bundle_api_admin_store_submissions__submission_id__bundle_zip_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "submission_id",
+            "required": true,
+            "schema": {
+              "title": "Submission Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Admin Download Store Submission Bundle",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/api/admin/store/submissions/{submission_id}/override": {
+      "post": {
+        "description": "Force-publish a previously-blocked submission.\n\nFlips the submission to ``status='overridden'`` and the linked\nstore_entities row to ``visibility_status='approved'``. Audit row\ncaptures who, why, and the verdict that was overridden so the next\ntime this submission shows up, the trail is intact.",
+        "operationId": "admin_override_store_submission_api_admin_store_submissions__submission_id__override_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "submission_id",
+            "required": true,
+            "schema": {
+              "title": "Submission Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/_OverrideRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Admin Override Store Submission",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/api/admin/store/submissions/{submission_id}/rescan": {
+      "post": {
+        "description": "Re-run **all** guardrail checks (inline + LLM) against the current\nbundle.\n\nDifferent from ``/retry``: rescan starts from scratch (re-runs the\ndeterministic inline checks too) and is allowed regardless of\ncurrent status. Use when check rules have changed and a previously-\napproved entity might now fail (or vice versa).\n\nEffects:\n  * inline checks run sync; verdict written to ``inline_checks``\n  * on inline fail \u2192 ``status='blocked_inline'``, entity hidden\n  * on inline pass \u2192 ``status='pending_llm'``, LLM call scheduled,\n    entity visibility flipped to ``pending`` until verdict lands\n  * audit_log entry recorded for both outcomes \u2014 admin sees the\n    rescan in the detail-page activity timeline\n  * audit row recorded\n\nRequires the bundle to still be on disk. Inline-blocked submissions\nwhose bundle was rolled back (no ``entity_id``) cannot be rescanned \u2014\nnothing to scan.",
+        "operationId": "admin_rescan_store_submission_api_admin_store_submissions__submission_id__rescan_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "submission_id",
+            "required": true,
+            "schema": {
+              "title": "Submission Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Admin Rescan Store Submission",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/api/admin/store/submissions/{submission_id}/retry": {
+      "post": {
+        "description": "Re-queue the LLM review for a submission.\n\nEligible statuses:\n  * ``review_error`` \u2014 LLM call failed, admin retrying after the\n    underlying issue (rate limit, timeout, transient outage) clears.\n  * ``blocked_llm`` \u2014 admin disagrees with the prior verdict; rerun\n    from a clean slate (review rules may have shifted since).\n  * ``pending_llm`` \u2014 submission was held when the LLM provider had\n    no credentials in env (fail-CLOSED matrix: intent True + not\n    ready). Admin sets the key and re-fires from here.\n\nOnly valid when the original submission's plugin tree is still on\ndisk \u2014 for inline-blocked rows the bundle was deleted at POST time.",
+        "operationId": "admin_retry_store_submission_api_admin_store_submissions__submission_id__retry_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "submission_id",
+            "required": true,
+            "schema": {
+              "title": "Submission Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Admin Retry Store Submission",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/api/admin/telemetry/ask": {
+      "post": {
+        "description": "Translate a natural-language question to SELECT-only SQL via Anthropic + execute.\n\nReturns the generated SQL even when validation rejects it, so the\nadmin sees what the LLM tried.",
+        "operationId": "ask_usage_api_admin_telemetry_ask_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Payload",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Ask Usage",
+        "tags": [
+          "admin-telemetry"
+        ]
+      }
+    },
+    "/api/admin/telemetry/export": {
+      "get": {
+        "description": "Stream usage_events filtered by since/until/user_id/source.\n\nCSV: standard library `csv.writer`, one row per event with all columns.\nJSON: streaming NDJSON (one JSON object per line) \u2014 easier to pipe + tail.\nParquet: DuckDB `COPY (SELECT ...) TO '<tmp>.parquet'` then stream the file.",
+        "operationId": "export_usage_api_admin_telemetry_export_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "default": "csv",
+              "enum": [
+                "csv",
+                "json",
+                "parquet"
+              ],
+              "title": "Format",
+              "type": "string"
+            }
+          },
+          {
+            "description": "ISO date or datetime; events with occurred_at >= since",
+            "in": "query",
+            "name": "since",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "ISO date or datetime; events with occurred_at >= since",
+              "title": "Since"
+            }
+          },
+          {
+            "description": "ISO date or datetime; events with occurred_at < until",
+            "in": "query",
+            "name": "until",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "ISO date or datetime; events with occurred_at < until",
+              "title": "Until"
+            }
+          },
+          {
+            "description": "Filter to a single user_id",
+            "in": "query",
+            "name": "user_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to a single user_id",
+              "title": "User Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "curated",
+                    "flea",
+                    "builtin"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Source"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Export Usage",
+        "tags": [
+          "admin-telemetry"
+        ]
+      }
+    },
+    "/api/admin/telemetry/facets": {
+      "get": {
+        "description": "Distinct values present in usage_events for the selected window so the\nUI dropdowns are closed-set instead of free-text guesses.",
+        "operationId": "usage_facets_api_admin_telemetry_facets_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "since_minutes",
+            "required": false,
+            "schema": {
+              "default": 10080,
+              "maximum": 525600,
+              "minimum": 1,
+              "title": "Since Minutes",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Usage Facets",
+        "tags": [
+          "admin-telemetry"
+        ]
+      }
+    },
+    "/api/admin/telemetry/kpis": {
+      "get": {
+        "description": "Four headline numbers, scoped to the same filters as /query.\n\nThe cards on /admin/usage echo these as clickable quick-filters, so the\nserver applies the same WHERE the table will see \u2014 otherwise the cards\nand the table tell different stories at the same time.",
+        "operationId": "usage_kpis_api_admin_telemetry_kpis_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "since_minutes",
+            "required": false,
+            "schema": {
+              "default": 10080,
+              "maximum": 525600,
+              "minimum": 1,
+              "title": "Since Minutes",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "username",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Username"
+            }
+          },
+          {
+            "in": "query",
+            "name": "tool_name",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Tool Name"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Source"
+            }
+          },
+          {
+            "in": "query",
+            "name": "event_type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Event Type"
+            }
+          },
+          {
+            "in": "query",
+            "name": "only_errors",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Only Errors",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Q"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Usage Kpis",
+        "tags": [
+          "admin-telemetry"
+        ]
+      }
+    },
+    "/api/admin/telemetry/prune": {
+      "post": {
+        "description": "Delete usage_events older than USAGE_EVENTS_RETENTION_DAYS.\n\nDefault retention: env var unset or ``0`` \u2192 no pruning (forever).\nDaily rollup tables untouched \u2014 they're tiny and lossy-by-design.",
+        "operationId": "prune_usage_api_admin_telemetry_prune_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Prune Usage",
+        "tags": [
+          "admin-telemetry"
+        ]
+      }
+    },
+    "/api/admin/telemetry/query": {
+      "get": {
+        "description": "Filtered + optionally grouped read against usage_events.\n\n`group_by` \u2208 {None, 'day', 'username', 'tool_name', 'source', 'ref_id'}.\nWhen grouped, returns one bucket per row with `invocations`,\n`distinct_users`, `distinct_sessions`, `errors`. When ungrouped, returns\nthe raw event rows.\n\n`sort` syntax: `<column>:<asc|desc>`. For grouped queries the valid\ncolumns are `bucket`, `invocations`, `distinct_users`, `distinct_sessions`,\n`errors`. For ungrouped queries: `occurred_at`. Unknown sort keys fall\nback to a safe default rather than 400 \u2014 UIs evolve faster than this\nendpoint.",
+        "operationId": "usage_query_api_admin_telemetry_query_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "since_minutes",
+            "required": false,
+            "schema": {
+              "default": 10080,
+              "maximum": 525600,
+              "minimum": 1,
+              "title": "Since Minutes",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "username",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Username"
+            }
+          },
+          {
+            "in": "query",
+            "name": "tool_name",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Tool Name"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Source"
+            }
+          },
+          {
+            "in": "query",
+            "name": "event_type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Event Type"
+            }
+          },
+          {
+            "in": "query",
+            "name": "only_errors",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Only Errors",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Q"
+            }
+          },
+          {
+            "in": "query",
+            "name": "group_by",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Group By"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "default": "invocations:desc",
+              "title": "Sort",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "maximum": 50000,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Usage Query",
+        "tags": [
+          "admin-telemetry"
+        ]
+      }
+    },
+    "/api/admin/telemetry/reprocess": {
+      "post": {
+        "description": "Force re-extraction of all sessions for the usage processor.\n\nDELETEs:\n  - session_processor_state WHERE processor_name='usage' (so the next\n    scheduler tick re-scans every JSONL) + processor_name='marketplace_rollup_30d'\n    (forces 30d window rebuild on the next tick)\n  - usage_events\n  - usage_session_summary\n  - usage_tool_daily (legacy)\n  - usage_marketplace_item_daily\n  - usage_marketplace_item_window\n\nVerification processor's state untouched (composite PK isolates each processor).\nAudit-logged with deleted-row counts.",
+        "operationId": "reprocess_usage_api_admin_telemetry_reprocess_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Reprocess Usage",
+        "tags": [
+          "admin-telemetry"
+        ]
+      }
+    },
+    "/api/admin/telemetry/summary": {
+      "get": {
+        "description": "Compute six summaries:\n- top_tools: list[{tool_name, invocations, source}]\n- top_users: list[{username, tool_calls}]\n- error_rate: list[{tool_name, invocations, errors, rate}]\n- dau_series: list[{day, active_users}] \u2014 30 entries even when window=7d (sparkline likes 30)\n- dau_avg: float\n- slow_actions: list[{action, p50, p95, p99, max_ms, n}]",
+        "operationId": "usage_summary_api_admin_telemetry_summary_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "window",
+            "required": false,
+            "schema": {
+              "default": "7d",
+              "enum": [
+                "7d",
+                "30d",
+                "all"
+              ],
+              "title": "Window",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Usage Summary",
+        "tags": [
+          "admin-telemetry"
+        ]
+      }
+    },
+    "/api/admin/users/{user_id}/activity": {
+      "get": {
+        "description": "List audit_log rows for a specific user.\n\nResolves user_id to the user record (404 if not found), filters audit_log\non the user_id field, returns paginated rows newest first.",
+        "operationId": "list_user_activity_api_admin_users__user_id__activity_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List User Activity",
         "tags": [
           "admin"
         ]
@@ -5410,6 +12216,209 @@
         ]
       }
     },
+    "/api/admin/users/{user_id}/sessions": {
+      "get": {
+        "description": "Return a paginated session list for *user_id*.\n\nEach row joins ``usage_session_summary`` (preferred, ``processed=true``)\nwith a filesystem scan of ``${SESSION_DATA_DIR}/<username>/*.jsonl`` so\nthe response surfaces sessions even when the UsageProcessor hasn't run yet\n(``processed=false`` for those rows).\n\n``processed=false`` rows carry only: ``session_file``, ``session_id``\n(extracted from the filename when possible), ``started_at`` (file mtime),\nand zeroed-out counters.",
+        "operationId": "list_user_sessions_api_admin_users__user_id__sessions_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List User Sessions",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/api/admin/users/{user_id}/sessions/download-all": {
+      "get": {
+        "description": "Stream a ZIP of every *.jsonl under the user's session directory.\n\nReturns 404 when the directory doesn't exist.\nReturns 200 + empty ZIP when the directory exists but has no JSONL files.",
+        "operationId": "download_all_sessions_api_admin_users__user_id__sessions_download_all_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Download All Sessions",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/api/admin/users/{user_id}/sessions/{session_file}/download": {
+      "get": {
+        "description": "Stream the raw JSONL for a single session.\n\nPath-traversal is guarded by three layers:\n1. ``safe_name = Path(session_file).name``  \u2014 strips any ``../`` etc.\n2. The name must match ``^[A-Za-z0-9._-]+\\.jsonl$``.\n3. ``path.resolve()`` must still be under the session directory.",
+        "operationId": "download_session_api_admin_users__user_id__sessions__session_file__download_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "session_file",
+            "required": true,
+            "schema": {
+              "title": "Session File",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Download Session",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
     "/api/admin/welcome-template": {
       "delete": {
         "operationId": "admin_reset_template_api_admin_welcome_template_delete",
@@ -5476,7 +12485,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TemplateGetResponse"
+                  "$ref": "#/components/schemas/app__api__welcome__TemplateGetResponse"
                 }
               }
             },
@@ -5680,7 +12689,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TemplateGetResponse"
+                  "$ref": "#/components/schemas/app__api__claude_md__TemplateGetResponse"
                 }
               }
             },
@@ -6017,7 +13026,9 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/CatalogTablesResponse"
+                }
               }
             },
             "description": "Successful Response"
@@ -6039,9 +13050,66 @@
         ]
       }
     },
+    "/api/data/{table_id}/check-access": {
+      "get": {
+        "description": "Lightweight RBAC probe used by Caddy's ``forward_auth`` directive\nto gate file_server-served parquet downloads without involving the\napp's request workers in the bulk byte transfer.\n\nReturns HTTP 204 No Content when the caller has read access to\n``table_id``; HTTP 403 (via ``can_access_table`` returning False)\notherwise. Caddy treats 2xx as authorized and forwards the request\nto its own ``file_server`` block; non-2xx is returned to the client\nverbatim.\n\nWhy a separate endpoint and not just ``HEAD /download``: ``HEAD`` on\nthe FileResponse-based ``download`` handler still opens the file and\nruns stat() to populate Content-Length / ETag. ``forward_auth`` calls\nthis endpoint on every request, so the per-call cost matters; a pure\nRBAC check is ~1 ms while a HEAD path involves filesystem walks\n(``rglob`` for the parquet across source subdirs).",
+        "operationId": "check_access_api_data__table_id__check_access_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "table_id",
+            "required": true,
+            "schema": {
+              "title": "Table Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Check Access",
+        "tags": [
+          "data"
+        ]
+      }
+    },
     "/api/data/{table_id}/download": {
       "get": {
-        "description": "Stream a parquet file for download. Supports ETag for caching.",
+        "description": "Stream a parquet file for download. Supports ETag for caching.\n\nOn Caddy-fronted deployments the matching Caddyfile rule intercepts\n``GET /api/data/{table_id}/download``, calls ``check-access`` via\n``forward_auth``, and serves the parquet directly via ``file_server``\n\u2014 bypassing this handler entirely. This handler stays as the\ncanonical fallback for non-Caddy deployments (dev `docker compose\nup`, alternative reverse proxies, direct :8000 access) where the\nbulk transfer goes through uvicorn.",
         "operationId": "download_table_api_data__table_id__download_get",
         "parameters": [
           {
@@ -6096,6 +13164,74 @@
         ]
       }
     },
+    "/api/debug/throw": {
+      "get": {
+        "description": "Deliberate-crash route for verifying observability wiring.\n\nGated by ``DEBUG=1`` \u2014 returns 404 in production. Always raises after\nthe auth dependency resolves, so ``request.state.user`` is populated\nby the time the unhandled-exception handler captures the event. Use\nto confirm that PostHog receives the exception with full user context\n(``distinct_id``, ``user_id``, ``user_email``) and not just\n``request_id``.\n\nOptional query params let you pick the exception type and message:\n    /api/debug/throw?kind=ValueError&msg=hello",
+        "operationId": "debug_throw_api_debug_throw_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "kind",
+            "required": false,
+            "schema": {
+              "default": "RuntimeError",
+              "title": "Kind",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "msg",
+            "required": false,
+            "schema": {
+              "default": "intentional debug throw",
+              "title": "Msg",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Debug Throw",
+        "tags": [
+          "health"
+        ]
+      }
+    },
     "/api/health": {
       "get": {
         "description": "Minimal health check for load balancers / compose healthcheck. No auth required.",
@@ -6121,6 +13257,18 @@
         "description": "Structured health check with deployment metadata. Requires authentication.",
         "operationId": "health_check_detailed_api_health_detailed_get",
         "parameters": [
+          {
+            "description": "Comma-separated list of optional checks to include. Recognised values: `schema` (DB schema version against the expected migration). The default response omits these because they're rarely actionable on a healthy instance and add noise to `agnes diagnose` output (issue #204). Pass `?include=schema` to get the legacy behavior.",
+            "in": "query",
+            "name": "include",
+            "required": false,
+            "schema": {
+              "default": "",
+              "description": "Comma-separated list of optional checks to include. Recognised values: `schema` (DB schema version against the expected migration). The default response omits these because they're rarely actionable on a healthy instance and add noise to `agnes diagnose` output (issue #204). Pass `?include=schema` to get the legacy behavior.",
+              "title": "Include",
+              "type": "string"
+            }
+          },
           {
             "in": "header",
             "name": "authorization",
@@ -6161,6 +13309,1178 @@
         "summary": "Health Check Detailed",
         "tags": [
           "health"
+        ]
+      }
+    },
+    "/api/initial-workspace": {
+      "get": {
+        "description": "Status probe consumed by ``agnes init``. Always 200.\n\nReturns ``configured: false`` when no template is registered (CLI then\nfalls through to the existing default flow). Returns ``configured:\ntrue, synced: false`` when registered but never synced (or last sync\nfailed); CLI shows a typed error pointing at /admin/server-config.\nReturns full metadata + manifest when configured + synced.",
+        "operationId": "analyst_status_api_initial_workspace_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnalystInitialWorkspaceResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Analyst Status",
+        "tags": [
+          "initial_workspace"
+        ]
+      }
+    },
+    "/api/initial-workspace.zip": {
+      "get": {
+        "description": "Return the zip of the cloned template tree (sans ``.git/``).\n\nWrites a server-side ``initial_workspace.fetch_started`` audit row so\nwe have an authoritative event the analyst's PAT-holder cannot spoof\n(the matching ``initial_workspace.applied`` event from\n``POST /applied`` is best-effort).\n\n404 when not configured (the CLI status probe should have caught\nthis; defense in depth). 503 when configured but never synced \u2014 the\nCLI then surfaces a typed error pointing at \"Sync now\".",
+        "operationId": "analyst_zip_api_initial_workspace_zip_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Analyst Zip",
+        "tags": [
+          "initial_workspace"
+        ]
+      }
+    },
+    "/api/initial-workspace/applied": {
+      "post": {
+        "description": "Best-effort audit event from ``agnes init`` confirming the\nanalyst's workspace has been extracted + sentinel written.\n\nThe authoritative anchor is the server-side\n``initial_workspace.fetch_started`` event written by ``GET .../zip`` \u2014\na fetch_started without a matching applied = the analyst downloaded\nbut never confirmed extraction (useful signal for operators).",
+        "operationId": "analyst_applied_api_initial_workspace_applied_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AppliedRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Analyst Applied",
+        "tags": [
+          "initial_workspace"
+        ]
+      }
+    },
+    "/api/marketplace/categories": {
+      "get": {
+        "description": "Per-tab category list with non-zero counts.\n\nSource of categories: union of ``STORE_CATEGORIES`` and any non-empty\n``marketplace_plugins.category`` values in the caller's RBAC scope.\nCategories with zero matching items are omitted (the frontend hides\nthem this way).",
+        "operationId": "list_categories_api_marketplace_categories_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "tab",
+            "required": false,
+            "schema": {
+              "default": "curated",
+              "enum": [
+                "curated",
+                "flea",
+                "my"
+              ],
+              "title": "Tab",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "skill",
+                    "agent",
+                    "plugin"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Type"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CategoriesResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Categories",
+        "tags": [
+          "marketplace"
+        ]
+      }
+    },
+    "/api/marketplace/curated/{marketplace_id}/{plugin_name}": {
+      "get": {
+        "description": "Return the curated plugin detail + inner skill/agent/command/hook/mcp list.\n\nThe 403 guard fires before this body runs (via ``require_resource_access``).\nA second ``get_current_user`` dependency is included so we still have the\ncaller's user dict for the ``installed`` flag.",
+        "operationId": "curated_detail_api_marketplace_curated__marketplace_id___plugin_name__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "marketplace_id",
+            "required": true,
+            "schema": {
+              "title": "Marketplace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "plugin_name",
+            "required": true,
+            "schema": {
+              "title": "Plugin Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PluginDetailResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Curated Detail",
+        "tags": [
+          "marketplace"
+        ]
+      }
+    },
+    "/api/marketplace/curated/{marketplace_id}/{plugin_name}/agent/{agent_name}": {
+      "get": {
+        "operationId": "curated_agent_detail_api_marketplace_curated__marketplace_id___plugin_name__agent__agent_name__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "marketplace_id",
+            "required": true,
+            "schema": {
+              "title": "Marketplace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "plugin_name",
+            "required": true,
+            "schema": {
+              "title": "Plugin Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "agent_name",
+            "required": true,
+            "schema": {
+              "title": "Agent Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InnerDetailResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Curated Agent Detail",
+        "tags": [
+          "marketplace"
+        ]
+      }
+    },
+    "/api/marketplace/curated/{marketplace_id}/{plugin_name}/asset/{path}": {
+      "get": {
+        "description": "Serve an internal image asset from the cloned marketplace working tree.\n\nPaths are repo-root-relative \u2014 ``{path}`` may be e.g.\n``.agnes/cover.png`` or ``plugins/foo/icon.png``.\n\n**Auth model: login-only, no per-plugin RBAC.** Cover photos are\ncurator-designed marketing visuals \u2014 they exist specifically to be seen\nand carry no PII / source / secrets. The previous\n``require_resource_access`` check serialized every image request through\na DuckDB join under ``_system_db_lock``, making the /marketplace grid\n(12-20 cover photos per render) pay N round-trips of auth+RBAC cost in\nsequence. Login (``get_current_user``) still required \u2192 no\nunauthenticated public access. See CHANGELOG entry under \"Security\" for\nthe threat-model rationale.\n\n**Image-only by contract.** The endpoint is the source of cover photos\nreferenced from ``marketplace-metadata.json`` and from inner skill / agent\ncards. A curator who could land an arbitrary file in the cloned repo\n(HTML, JS, SVG with inline ``<script>``) would otherwise have a\nsame-origin XSS via this endpoint, since the response shares the\ncookie scope with ``/admin`` and ``/api/me/*``. Two layered checks:\n\n1. Extension must be in :data:`src.marketplace_asset_validation.IMAGE_EXTENSIONS`\n   (``.png``/``.jpg``/``.jpeg``/``.webp``); anything else \u2192 415.\n2. ``Content-Type`` is pinned from the extension table (not stdlib\n   mimetypes), so the response is never served as ``text/html`` even\n   if mimetypes were misconfigured.\n\nMagic-bytes body validation that previously ran per request was dropped\nafter the perf audit found it re-read the file just to discard the\nbytes (``FileResponse`` reads it again to stream). The repo is fetched\nvia ``git pull`` from a trusted upstream the operator registered in\n``marketplace_registry`` \u2014 accepting curator content at sync time is\nthe layer where adversarial-payload detection belongs, not at every\nGET. Extension + Content-Type pinning + path-traversal guard remain.\n\nSVG is intentionally not in the allowlist \u2014 ``<script>`` inside SVG\nexecutes in the browser. ``X-Content-Type-Options: nosniff`` plus a\nstrict CSP harden the response further.\n\nInline rendering (no ``Content-Disposition``) \u2014 covers display in\n``<img>``, not as a download.",
+        "operationId": "curated_asset_api_marketplace_curated__marketplace_id___plugin_name__asset__path__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "marketplace_id",
+            "required": true,
+            "schema": {
+              "title": "Marketplace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "plugin_name",
+            "required": true,
+            "schema": {
+              "title": "Plugin Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "path",
+            "required": true,
+            "schema": {
+              "title": "Path",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Curated Asset",
+        "tags": [
+          "marketplace"
+        ]
+      }
+    },
+    "/api/marketplace/curated/{marketplace_id}/{plugin_name}/doc/{path}": {
+      "get": {
+        "description": "Serve an internal doc path from the cloned marketplace working tree.\n\nSame path-traversal guard as ``/asset/``. Adds an allowlist check \u2014 the\ndoc endpoint refuses to serve a file whose extension isn't in the\ndocumented PDF / Markdown / plain text set (HTTP 415). Defense-in-depth\neven though the marketplace-metadata parser already rejects out-of-allowlist\nextensions during the doc_link parse \u2014 a curator who edits the working\ntree directly (or whose JSON survived parsing because of a generic\nextension match elsewhere) shouldn't be able to land a .docx through\na re-served doc URL.\n\nForce-download via Content-Disposition: attachment \u2014 clicking a doc\nlink in the UI saves the file to disk rather than opening it in a tab.",
+        "operationId": "curated_doc_api_marketplace_curated__marketplace_id___plugin_name__doc__path__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "marketplace_id",
+            "required": true,
+            "schema": {
+              "title": "Marketplace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "plugin_name",
+            "required": true,
+            "schema": {
+              "title": "Plugin Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "path",
+            "required": true,
+            "schema": {
+              "title": "Path",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Curated Doc",
+        "tags": [
+          "marketplace"
+        ]
+      }
+    },
+    "/api/marketplace/curated/{marketplace_id}/{plugin_name}/install": {
+      "delete": {
+        "operationId": "curated_uninstall_api_marketplace_curated__marketplace_id___plugin_name__install_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "marketplace_id",
+            "required": true,
+            "schema": {
+              "title": "Marketplace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "plugin_name",
+            "required": true,
+            "schema": {
+              "title": "Plugin Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstallActionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Curated Uninstall",
+        "tags": [
+          "marketplace"
+        ]
+      },
+      "post": {
+        "description": "Subscribe the caller to a curated plugin (Model B opt-in).\n\nIdempotent \u2014 repeated calls are no-ops. The plugin must exist in\n``marketplace_plugins``; otherwise 404. The RBAC guard already ensured\nthe caller is allowed to install.",
+        "operationId": "curated_install_api_marketplace_curated__marketplace_id___plugin_name__install_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "marketplace_id",
+            "required": true,
+            "schema": {
+              "title": "Marketplace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "plugin_name",
+            "required": true,
+            "schema": {
+              "title": "Plugin Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstallActionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Curated Install",
+        "tags": [
+          "marketplace"
+        ]
+      }
+    },
+    "/api/marketplace/curated/{marketplace_id}/{plugin_name}/mirrored/{key}": {
+      "get": {
+        "description": "Serve a mirrored external asset from the marketplace cache.\n\n``key`` is the ``local`` relpath stored in the cache manifest minus the\nleading ``<plugin>/`` prefix \u2014 the mirror writes files at\n``${DATA_DIR}/marketplace-cache/<slug>/<plugin>/<rest>``, and this\nendpoint expects ``{plugin}/{rest}`` so the same path-resolution check\ncatches escapes whether the caller provided ``cover.png`` or\n``docs/abc-setup.pdf``.\n\nDoc-shaped paths (key starting with ``docs/``) get the same force-download\ntreatment as the internal /doc/ endpoint. Cover photos under the cache\nroot render inline so the <img> tag works.\n\n**Auth model: login-only for cover photos**, same rationale as\n``curated_asset`` above. The doc branch below is still gated by login\nonly at this point \u2014 RBAC was dropped here too because the mirrored\ncache is just the cover-photo serving complement, not user-facing\ndocument distribution. Tighter doc gating lives on the separate\n``curated_doc`` endpoint which retains ``require_resource_access``.",
+        "operationId": "curated_mirrored_api_marketplace_curated__marketplace_id___plugin_name__mirrored__key__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "marketplace_id",
+            "required": true,
+            "schema": {
+              "title": "Marketplace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "plugin_name",
+            "required": true,
+            "schema": {
+              "title": "Plugin Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "title": "Key",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Curated Mirrored",
+        "tags": [
+          "marketplace"
+        ]
+      }
+    },
+    "/api/marketplace/curated/{marketplace_id}/{plugin_name}/skill/{skill_name}": {
+      "get": {
+        "operationId": "curated_skill_detail_api_marketplace_curated__marketplace_id___plugin_name__skill__skill_name__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "marketplace_id",
+            "required": true,
+            "schema": {
+              "title": "Marketplace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "plugin_name",
+            "required": true,
+            "schema": {
+              "title": "Plugin Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "skill_name",
+            "required": true,
+            "schema": {
+              "title": "Skill Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InnerDetailResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Curated Skill Detail",
+        "tags": [
+          "marketplace"
+        ]
+      }
+    },
+    "/api/marketplace/flea/{entity_id}/agent/{agent_name}": {
+      "get": {
+        "description": "Inner agent detail for an agent nested inside a flea plugin entity.\n\nMirror of ``curated_agent_detail``. Agents are flat single-file .md\nso ``bundle_size`` is the file size and ``files`` is a single entry.",
+        "operationId": "flea_agent_detail_api_marketplace_flea__entity_id__agent__agent_name__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "entity_id",
+            "required": true,
+            "schema": {
+              "title": "Entity Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "agent_name",
+            "required": true,
+            "schema": {
+              "title": "Agent Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InnerDetailResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Flea Agent Detail",
+        "tags": [
+          "marketplace"
+        ]
+      }
+    },
+    "/api/marketplace/flea/{entity_id}/detail": {
+      "get": {
+        "description": "Same shape as curated detail, sourced from a Store entity.\n\nFlea entities live at ``${DATA_DIR}/store/<entity_id>/plugin/`` \u2014\ncanonical Claude Code plugin tree, so the same parsers apply.",
+        "operationId": "flea_detail_api_marketplace_flea__entity_id__detail_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "entity_id",
+            "required": true,
+            "schema": {
+              "title": "Entity Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PluginDetailResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Flea Detail",
+        "tags": [
+          "marketplace"
+        ]
+      }
+    },
+    "/api/marketplace/flea/{entity_id}/skill/{skill_name}": {
+      "get": {
+        "description": "Inner skill detail for a skill nested inside a flea plugin entity.\n\nMirror of ``curated_skill_detail`` for the flea bundle root layout\n(``${DATA_DIR}/store/<entity_id>/plugin/``). Visibility gate matches\nthe standalone flea_detail handler \u2014 owner / admin see quarantined\nentities, everyone else gets 404.",
+        "operationId": "flea_skill_detail_api_marketplace_flea__entity_id__skill__skill_name__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "entity_id",
+            "required": true,
+            "schema": {
+              "title": "Entity Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "skill_name",
+            "required": true,
+            "schema": {
+              "title": "Skill Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InnerDetailResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Flea Skill Detail",
+        "tags": [
+          "marketplace"
+        ]
+      }
+    },
+    "/api/marketplace/items": {
+      "get": {
+        "description": "Paginated, RBAC-scoped item list for the ``/marketplace`` browse page.\n\nPer-tab dispatch:\n\n* ``curated`` \u2192 ``MarketplacePluginsRepository.list_with_filters`` scoped to\n  the caller's ``user_group_members``. Results are tagged with the\n  caller's subscription state.\n* ``flea`` \u2192 ``StoreEntitiesRepository.list`` (community Store).\n* ``my`` \u2192 direct read from ``user_curated_subscriptions`` (filtered\n  against the caller's RBAC-allowed plugins) \u222a ``user_store_installs``\n  (all flea types \u2014 skill / agent / plugin \u2014 surface as individual\n  cards). We deliberately don't reuse ``resolve_user_marketplace``\n  here: that resolver bundles flea skills/agents into a single\n  synthetic ``store-bundle`` entry useful for the served Claude Code\n  marketplace ZIP/git endpoints but wrong for /marketplace browsing,\n  where each item should appear as its own card. Mirrors the\n  ``/api/my-stack`` reading pattern.\n\n``sort`` controls ordering after stats are joined:\n  * ``recent``    \u2014 existing DB order (default, backward-compatible).\n  * ``most_used`` \u2014 DESC by invocations_30d, ties by install_count then name.\n  * ``trending``  \u2014 DESC by trend_pct; items with no trend data are excluded.",
+        "operationId": "list_items_api_marketplace_items_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "tab",
+            "required": false,
+            "schema": {
+              "default": "curated",
+              "enum": [
+                "curated",
+                "flea",
+                "my"
+              ],
+              "title": "Tab",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Q"
+            }
+          },
+          {
+            "in": "query",
+            "name": "category",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Category"
+            }
+          },
+          {
+            "in": "query",
+            "name": "type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "skill",
+                    "agent",
+                    "plugin"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Type"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "default": "recent",
+              "enum": [
+                "recent",
+                "most_used",
+                "most_adopted",
+                "trending"
+              ],
+              "title": "Sort",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "minimum": 1,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "default": 24,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Page Size",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Items",
+        "tags": [
+          "marketplace"
         ]
       }
     },
@@ -6512,6 +14832,140 @@
         ]
       }
     },
+    "/api/marketplaces/{marketplace_id}/plugins/{plugin_name}/system": {
+      "delete": {
+        "description": "Flip ``is_system`` to FALSE. Materialized grants/subscriptions\nsurvive \u2014 admin curates cleanup via the standard /admin/access UI\n(which immediately unlocks the checkboxes for this plugin) and\nusers can unsubscribe normally on /marketplace?tab=my.",
+        "operationId": "unmark_plugin_system_api_marketplaces__marketplace_id__plugins__plugin_name__system_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "marketplace_id",
+            "required": true,
+            "schema": {
+              "title": "Marketplace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "plugin_name",
+            "required": true,
+            "schema": {
+              "title": "Plugin Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SystemFlagResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Unmark Plugin System",
+        "tags": [
+          "marketplaces"
+        ]
+      },
+      "post": {
+        "description": "Mark a plugin as system (mandatory for every user).\n\nIdempotent \u2014 re-running a mark on an already-system plugin still\nruns the fanout (cheap; ON CONFLICT DO NOTHING) so any user/group\nthat slipped past the creation hooks gets caught up.",
+        "operationId": "mark_plugin_system_api_marketplaces__marketplace_id__plugins__plugin_name__system_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "marketplace_id",
+            "required": true,
+            "schema": {
+              "title": "Marketplace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "plugin_name",
+            "required": true,
+            "schema": {
+              "title": "Plugin Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SystemFlagResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Mark Plugin System",
+        "tags": [
+          "marketplaces"
+        ]
+      }
+    },
     "/api/marketplaces/{marketplace_id}/sync": {
       "post": {
         "operationId": "trigger_sync_api_marketplaces__marketplace_id__sync_post",
@@ -6570,7 +15024,7 @@
     },
     "/api/me/effective-access": {
       "get": {
-        "description": "Same payload as /api/admin/users/{id}/effective-access but scoped to\nthe calling user. Drives the /profile page's read-only access summary \u2014\nso non-admin callers can self-audit without elevation. Admins get the\nsame explicit grant breakdown as everyone else (no short-circuit) so\nthe profile page audits the actual grant graph; runtime authorization\nstill gives Admin god-mode regardless of this list.",
+        "description": "Same payload as /api/admin/users/{id}/effective-access but scoped to\nthe calling user. Drives the /me/profile page's read-only access summary \u2014\nso non-admin callers can self-audit without elevation. Admins get the\nsame explicit grant breakdown as everyone else (no short-circuit) so\nthe profile page audits the actual grant graph; runtime authorization\nstill gives Admin god-mode regardless of this list.",
         "operationId": "my_effective_access_api_me_effective_access_get",
         "parameters": [
           {
@@ -6618,9 +15072,460 @@
         ]
       }
     },
+    "/api/me/home-stats": {
+      "get": {
+        "description": "Return the five counters rendered in the /home status frame for\nthe calling user, over a 24-hour or 7-day window.\n\nSingle round-trip: one DuckDB query joins ``users``,\n``usage_session_summary``, and ``usage_events`` so the homepage\nrenders without N+1. Missing rows (new user, no telemetry yet)\nsurface as zeros / null rather than 404 \u2014 the frame still renders\ncleanly for first-day analysts.",
+        "operationId": "get_home_stats_api_me_home_stats_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "window",
+            "required": false,
+            "schema": {
+              "default": "24h",
+              "title": "Window",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Home Stats",
+        "tags": [
+          "me"
+        ]
+      }
+    },
+    "/api/me/onboarded": {
+      "post": {
+        "operationId": "post_onboarded_api_me_onboarded_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OnboardedRequest",
+                "default": {
+                  "onboarded": true,
+                  "source": "agnes_init"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Post Onboarded",
+        "tags": [
+          "me"
+        ]
+      }
+    },
+    "/api/me/stats/queries": {
+      "get": {
+        "description": "Audit-log rows where ``action LIKE 'query.%'`` for the caller.\n\nCovers query.local (DuckDB on parquet), query.hybrid (BQ + local\njoin), query.remote (BQ direct), and query.internal (admin\ninternal queries that get attributed to the actor). Cursor\npagination on (timestamp, id) so streams under concurrent\nwrites don't double-render rows.",
+        "operationId": "list_self_queries_api_me_stats_queries_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor_ts",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor Ts"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Self Queries Api Me Stats Queries Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Self Queries",
+        "tags": [
+          "me"
+        ]
+      }
+    },
+    "/api/me/stats/sessions": {
+      "get": {
+        "description": "Paginated session list for the calling user.\n\nJoins ``usage_session_summary`` (processed=true) with a filesystem\nscan of un-processed JSONL so a session appears immediately even\nbefore the UsageProcessor runs.  Additionally enriches each row\nwith verification-pipeline status (from ``session_processor_state``)\nand a ``download_url`` when the uploaded JSONL exists in\n``${DATA_DIR}/user_sessions/<user_id>/``.",
+        "operationId": "list_self_sessions_api_me_stats_sessions_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Self Sessions Api Me Stats Sessions Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Self Sessions",
+        "tags": [
+          "me"
+        ]
+      }
+    },
+    "/api/me/stats/sync": {
+      "get": {
+        "description": "Audit-log rows where action is ``sync.*`` or ``manifest.*``\nfor the caller, plus ``users.last_pull_at`` for the header card.\n\nTwo action prefixes are merged with a UNION-ish IN filter via\n``AuditRepository.query(action_in=[...])`` \u2014 but the repo helper\ndoesn't take both prefix and IN, so we call twice and merge.\nCheaper alternative is two SELECTs in the repo; for now we fetch\ntwo pages and interleave because cursor merging across two\nindependent streams is fiddly without a unified ORDER. To keep\nthe code obvious, we use ``query_actions(...)`` and accept that\nthe cursor is single-stream (start over to page back; first page\nis what matters for the dashboard).",
+        "operationId": "list_self_sync_activity_api_me_stats_sync_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor_ts",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor Ts"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Self Sync Activity Api Me Stats Sync Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Self Sync Activity",
+        "tags": [
+          "me"
+        ]
+      }
+    },
+    "/api/me/stats/tokens": {
+      "get": {
+        "description": "Token breakdown for the Tokens tab.\n\nReturns a daily series (last *days* days), by-model breakdown\n(lifetime), top-10 biggest sessions (by total tokens, lifetime),\nand the lifetime grand total. Single round-trip via three\nsub-queries \u2014 each scans the same per-user partition of\n``usage_session_summary`` which the\n``idx_usage_session_user`` index supports.",
+        "operationId": "get_tokens_api_me_stats_tokens_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "days",
+            "required": false,
+            "schema": {
+              "default": 30,
+              "maximum": 365,
+              "minimum": 1,
+              "title": "Days",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Tokens Api Me Stats Tokens Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Tokens",
+        "tags": [
+          "me"
+        ]
+      }
+    },
     "/api/memory": {
       "get": {
-        "description": "List knowledge items with filtering, pagination, search.",
+        "description": "List knowledge items with filtering, pagination, search.\n\n``upvoted_by_me=true`` narrows to items the caller upvoted (powers the\n\"My Upvotes\" filter on /corporate-memory \u2014 replaces the old dead\n\"My Rules\" category sentinel).",
         "operationId": "list_knowledge_api_memory_get",
         "parameters": [
           {
@@ -6710,6 +15615,26 @@
             "schema": {
               "default": true,
               "title": "Exclude Personal",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "upvoted_by_me",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Upvoted By Me",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "hide_dismissed",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Hide Dismissed",
               "type": "boolean"
             }
           },
@@ -8223,6 +17148,118 @@
         ]
       }
     },
+    "/api/memory/{item_id}/dismiss": {
+      "delete": {
+        "description": "Idempotent un-dismiss \u2014 a second DELETE still returns 200.\n\nReturns 404 if the item itself doesn't exist (consistent with the rest\nof the per-item endpoints); the dismissal row's existence is not\nconsulted because absence is the success state.",
+        "operationId": "undismiss_item_api_memory__item_id__dismiss_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "item_id",
+            "required": true,
+            "schema": {
+              "title": "Item Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Undismiss Item",
+        "tags": [
+          "memory"
+        ]
+      },
+      "post": {
+        "description": "Per-user opt-out \u2014 remove an item from the caller's AI bundle.\n\nIdempotent: re-dismissing an already-dismissed item is a no-op success.\nMandatory items can never be dismissed \u2014 the governance hard rule \u2014\nso a POST against one returns 400 with a clear detail message.",
+        "operationId": "dismiss_item_api_memory__item_id__dismiss_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "item_id",
+            "required": true,
+            "schema": {
+              "title": "Item Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Dismiss Item",
+        "tags": [
+          "memory"
+        ]
+      }
+    },
     "/api/memory/{item_id}/personal": {
       "post": {
         "description": "Toggle personal/excluded flag on a knowledge item (only by the contributor).",
@@ -8534,9 +17571,137 @@
         ]
       }
     },
+    "/api/my-stack": {
+      "get": {
+        "description": "Combined view of curated plugins the caller can subscribe to\nand Store entities they have installed.",
+        "operationId": "get_my_stack_api_my_stack_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MyStackResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get My Stack",
+        "tags": [
+          "my-stack"
+        ]
+      }
+    },
+    "/api/my-stack/curated/{marketplace_id}/{plugin_name}": {
+      "put": {
+        "description": "Toggle subscribe/unsubscribe for a single curated plugin.\n\nUI thinks in terms of *enabled* (default off in Model B). v28+ the\nrepository stores *subscribed* rows (presence = enabled in served set);\n``enabled=true`` writes a row, ``enabled=false`` removes it.",
+        "operationId": "toggle_curated_api_my_stack_curated__marketplace_id___plugin_name__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "marketplace_id",
+            "required": true,
+            "schema": {
+              "title": "Marketplace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "plugin_name",
+            "required": true,
+            "schema": {
+              "title": "Plugin Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ToggleRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OkResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Toggle Curated",
+        "tags": [
+          "my-stack"
+        ]
+      }
+    },
     "/api/query": {
       "post": {
-        "description": "Execute SQL against the server analytics DuckDB.",
+        "description": "Execute SQL against the server analytics DuckDB.\n\nPlain ``def`` (not ``async def``) so FastAPI auto-offloads the call\nto the anyio thread pool. The body invokes ``analytics.execute(sql)``\nsynchronously, which blocks for the full BQ jobs.query wait when a\nreferenced view resolves through the BQ extension. Under ``async def``\nthat block holds the single uvicorn event loop, freezing every other\nrequest (UI, /api/health, auth) until the query returns. Plain ``def``\nruns each invocation on its own thread, so heavy queries no longer\nstarve unrelated endpoints. See PR #188's CHANGELOG entry for the\nTier 1 event-loop unblocking rollout.",
         "operationId": "execute_query_api_query_post",
         "parameters": [
           {
@@ -9077,9 +18242,1098 @@
         ]
       }
     },
+    "/api/store/bundle.zip": {
+      "get": {
+        "description": "Stream a ZIP of all (filtered) Store entities.\n\nAuth: any authenticated user \u2014 the Store is community-open, the same\nset is already visible via ``GET /api/store/entities``. The bundle is\ndeterministic so two consecutive pulls without state changes produce\nbyte-identical ZIPs (modulo the manifest's ``generated_at`` timestamp).\nFilters mirror the listing endpoint so a backup workflow can scope by\ntype/owner if needed.",
+        "operationId": "export_bundle_api_store_bundle_zip_get",
+        "parameters": [
+          {
+            "description": "skill | agent | plugin",
+            "in": "query",
+            "name": "type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "skill | agent | plugin",
+              "title": "Type"
+            }
+          },
+          {
+            "in": "query",
+            "name": "category",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Category"
+            }
+          },
+          {
+            "in": "query",
+            "name": "search",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Search"
+            }
+          },
+          {
+            "description": "Filter by owner user_id",
+            "in": "query",
+            "name": "owner",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by owner user_id",
+              "title": "Owner"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Export Bundle",
+        "tags": [
+          "store"
+        ]
+      }
+    },
+    "/api/store/categories": {
+      "get": {
+        "description": "Caller's group names \u2014 populates the upload form's category select.",
+        "operationId": "my_categories_api_store_categories_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "title": "Response My Categories Api Store Categories Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "My Categories",
+        "tags": [
+          "store"
+        ]
+      }
+    },
+    "/api/store/entities": {
+      "get": {
+        "operationId": "list_entities_api_store_entities_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "skip",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Skip",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 24,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Type"
+            }
+          },
+          {
+            "in": "query",
+            "name": "category",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Category"
+            }
+          },
+          {
+            "in": "query",
+            "name": "search",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Search"
+            }
+          },
+          {
+            "in": "query",
+            "name": "owner",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Owner"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StoreEntityListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Entities",
+        "tags": [
+          "store"
+        ]
+      },
+      "post": {
+        "operationId": "create_entity_api_store_entities_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_create_entity_api_store_entities_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StoreEntityResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Entity",
+        "tags": [
+          "store"
+        ]
+      }
+    },
+    "/api/store/entities/preview": {
+      "post": {
+        "description": "Wizard step 1 \u2014 validate the uploaded ZIP and parse frontmatter for\npre-fill on step 2. Does **not** persist anything: tmp dir is wiped before\nthe response returns. The browser must hold the same File and re-submit\nit on step 2 (POST /entities) for the actual create.",
+        "operationId": "preview_entity_api_store_entities_preview_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_preview_entity_api_store_entities_preview_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PreviewResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Preview Entity",
+        "tags": [
+          "store"
+        ]
+      }
+    },
+    "/api/store/entities/{entity_id}": {
+      "delete": {
+        "description": "Soft-archive (default) or hard-delete (admin-only).\n\n* **Soft (default)** \u2014 flips `visibility_status='archived'`. Bundle\n  stays on disk; existing user_store_installs continue serving the\n  bundle through marketplace.zip / .git so already-installed users\n  don't lose the plugin. Browse listings hide it; install endpoint\n  refuses new installs. Owner + admin can soft-archive an\n  approved entity.\n* **Hard (`?hard=true`)** \u2014 admin-only. Drops the row, removes the\n  bundle from disk, deletes user_store_installs (existing users\n  lose the plugin). Use for legal / privacy removals where the\n  bytes have to go.\n\nQuarantined (pending / blocked / hidden) entities: only admins can\narchive or hard-delete; owner is refused so they can't erase the\nevidence of a flagged upload before triage.",
+        "operationId": "delete_entity_api_store_entities__entity_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "entity_id",
+            "required": true,
+            "schema": {
+              "title": "Entity Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "hard",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Hard",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OkResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Entity",
+        "tags": [
+          "store"
+        ]
+      },
+      "get": {
+        "operationId": "get_entity_api_store_entities__entity_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "entity_id",
+            "required": true,
+            "schema": {
+              "title": "Entity Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StoreEntityResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Entity",
+        "tags": [
+          "store"
+        ]
+      },
+      "put": {
+        "description": "Edit a flea-market entity. Owner or admin.\n\nv37 edit feature semantics:\n\n* **Type is locked** \u2014 passing ``type`` that differs from the\n  stored row returns 400 ``type_locked``. Replacing one form\n  factor with another is a fresh upload, not an edit.\n* **Display-name change** is allowed. Without a bundle change it\n  flips the live slug immediately (mirrors rename-on-archive).\n  Combined with a bundle change the rename is deferred \u2014 only the\n  staged version dir is renamed; live keeps the prior slug until\n  promotion, so existing installers never see a slug\u2260content pair\n  mid-review.\n* **Bundle change** creates a new version: bake into\n  ``versions/v<N+1>/plugin/``, run guardrails, on approval copy\n  to the live ``plugin/`` dir + bump ``version_no`` + append\n  ``version_history``. The prior version dir stays so rollback\n  can copy it forward.\n* **Block-while-pending**: gates on the latest submission's status\n  directly (``status IN ('pending_inline','pending_llm')``),\n  independent of ``visibility_status``. Under deferred promotion\n  v2+ edits leave the entity ``approved`` through the LLM review\n  window, so a visibility-only check would never fire. Returns 409\n  ``prior_version_pending``; owner waits for the verdict; the\n  detail page auto-refreshes.\n* **Metadata-only edit** (no ``file`` posted) skips the bundle\n  pipeline and the version bump.",
+        "operationId": "update_entity_api_store_entities__entity_id__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "entity_id",
+            "required": true,
+            "schema": {
+              "title": "Entity Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_update_entity_api_store_entities__entity_id__put"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StoreEntityResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Entity",
+        "tags": [
+          "store"
+        ]
+      }
+    },
+    "/api/store/entities/{entity_id}/docs/{filename}": {
+      "get": {
+        "description": "Stream an attached doc \u2014 directory-traversal-guarded.",
+        "operationId": "get_entity_doc_api_store_entities__entity_id__docs__filename__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "entity_id",
+            "required": true,
+            "schema": {
+              "title": "Entity Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "filename",
+            "required": true,
+            "schema": {
+              "title": "Filename",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Entity Doc",
+        "tags": [
+          "store"
+        ]
+      }
+    },
+    "/api/store/entities/{entity_id}/files": {
+      "get": {
+        "operationId": "list_entity_files_api_store_entities__entity_id__files_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "entity_id",
+            "required": true,
+            "schema": {
+              "title": "Entity Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Entity Files",
+        "tags": [
+          "store"
+        ]
+      }
+    },
+    "/api/store/entities/{entity_id}/install": {
+      "delete": {
+        "operationId": "uninstall_entity_api_store_entities__entity_id__install_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "entity_id",
+            "required": true,
+            "schema": {
+              "title": "Entity Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstallResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Uninstall Entity",
+        "tags": [
+          "store"
+        ]
+      },
+      "post": {
+        "operationId": "install_entity_api_store_entities__entity_id__install_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "entity_id",
+            "required": true,
+            "schema": {
+              "title": "Entity Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstallResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Install Entity",
+        "tags": [
+          "store"
+        ]
+      }
+    },
+    "/api/store/entities/{entity_id}/photo": {
+      "get": {
+        "description": "Serve a flea-market entity's cover photo.\n\n**Auth model: login-only, no per-entity visibility check.** Cover\nphotos are uploader-designed showcase images \u2014 they exist to be seen\nand carry no PII / source / secrets. The previous\n``_enforce_visibility`` check serialized every request through a DB\njoin (same ``_system_db_lock`` rationale as\n``app/api/marketplace.py:curated_asset``). Login still required.\n\nCache: bytes change exactly when ``store_entities.version_no`` bumps,\nand listing endpoints append ``?v=<version_no>`` to the photo URL,\nso a 30-day ``immutable`` cache is safe \u2014 a re-upload generates a\nnew URL fingerprint that the browser refetches.",
+        "operationId": "get_entity_photo_api_store_entities__entity_id__photo_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "entity_id",
+            "required": true,
+            "schema": {
+              "title": "Entity Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Entity Photo",
+        "tags": [
+          "store"
+        ]
+      }
+    },
+    "/api/store/entities/{entity_id}/versions/{version_no}/restore": {
+      "post": {
+        "description": "Roll back to a prior version. Owner or admin.\n\nCreates a NEW version (`v<max+1>`) by copying the bundle bytes\nfrom `versions/v<N>/plugin/`, then runs the standard guardrails\npipeline so today's rules apply (rules tighten over time \u2014\npre-approved bundles re-validate at restore time).\n\nThe original `version_no` row in ``version_history`` keeps its\nown verdict; the new copy gets a fresh one. Forward-only history\n\u2014 no deletes from version_history.\n\nRefuses while a prior version is under review (same\n``prior_version_pending`` 409 as PUT).\n\nWrapped in the per-entity write lock so a concurrent PUT and\nrestore on the same entity can't both pass the pending-gate +\nrace on ``versions/v<N+1>/plugin/``.",
+        "operationId": "restore_version_api_store_entities__entity_id__versions__version_no__restore_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "entity_id",
+            "required": true,
+            "schema": {
+              "title": "Entity Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "version_no",
+            "required": true,
+            "schema": {
+              "title": "Version No",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StoreEntityResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Restore Version",
+        "tags": [
+          "store"
+        ]
+      }
+    },
+    "/api/store/import-bundle": {
+      "post": {
+        "description": "Restore a Store bundle ZIP \u2014 admin only.\n\nModes:\n  * ``merge`` (default) \u2014 upsert by ``entity_id``; existing entities\n    are replaced when the bundle's ``version`` differs, otherwise\n    skipped. Safe default for nightly cron round-trips.\n  * ``replace`` \u2014 every entity in the bundle overwrites the existing\n    row + on-disk tree. Bundle-not-in-target rows are NOT deleted.\n  * ``skip`` \u2014 only entities NOT already present are imported.\n\nOwner resolution by ``owner_email``; missing emails get a stub\ndisabled user so the row references an existing ``users.id`` (no\nforeign key, but app code joins).",
+        "operationId": "import_bundle_api_store_import_bundle_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_import_bundle_api_store_import_bundle_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportBundleResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Import Bundle",
+        "tags": [
+          "store"
+        ]
+      }
+    },
+    "/api/store/owners": {
+      "get": {
+        "description": "Owners who have at least one entity in the Store \u2014 populates the\nlisting-page owner filter. Sorted by display name (name fallbacks to\nemail then to username) so the dropdown is alphabetical and stable.\n\nVisibility filter (v32+/v35): non-admin sees owners-of-approved\nonly (a submitter with N quarantined uploads must not surface in\nthe public dropdown until at least one is approved). Admin sees\nevery owner regardless of state.",
+        "operationId": "list_owners_api_store_owners_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/OwnerOption"
+                  },
+                  "title": "Response List Owners Api Store Owners Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Owners",
+        "tags": [
+          "store"
+        ]
+      }
+    },
     "/api/sync/manifest": {
       "get": {
-        "description": "Return hash-based manifest of all synced data, filtered per user.",
+        "description": "Return hash-based manifest of all synced data, filtered per user.\n\nSide-effect: stamps ``users.last_pull_at`` so the /home status frame\ncan show when the analyst last pulled. This GET is the canonical\n\"I am about to sync\" signal \u2014 agnes pull hits it first, then\ndownloads parquets whose hash changed. UI bumps (manifest browsed in\na browser session) also count; cheap and accurate enough for a\nhomepage card.",
         "operationId": "sync_manifest_api_sync_manifest_get",
         "parameters": [
           {
@@ -9229,6 +19483,26 @@
         ]
       }
     },
+    "/api/sync/status": {
+      "get": {
+        "description": "Whether a sync is currently in flight on this app process.\n\nPublic (no auth) \u2014 used by the host-side ``agnes-auto-upgrade.sh``\ncron to decide whether to skip a `docker compose up -d` that would\nkill a running extractor / materialized pass mid-flight. Cheap to\nserve (single Lock.locked() check) and contains no sensitive data.\n\nReturns:\n    ``{\"locked\": bool}`` \u2014 True if `_sync_lock` is currently held by\n    a `_run_sync` invocation, OR a sync was triggered within the\n    last ``_TRIGGER_HOLD_SEC`` seconds (so the FastAPI background\n    task hasn't yet acquired the lock). Without the trigger-hold\n    window, an auto-upgrade probe firing in the gap between the\n    trigger handler's 200 response and the background task's\n    ``_sync_lock.acquire()`` would see ``locked=False`` and proceed\n    with ``up -d`` \u2014 killing the just-spawning extractor.",
+        "operationId": "sync_status_api_sync_status_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Sync Status",
+        "tags": [
+          "sync"
+        ]
+      }
+    },
     "/api/sync/table-subscriptions": {
       "get": {
         "description": "Get user's per-table subscription settings.",
@@ -9277,7 +19551,7 @@
         ]
       },
       "post": {
-        "description": "Update per-table subscription preferences.",
+        "description": "Update per-table subscription preferences.\n\nMirrors the RBAC gate in POST /settings: a table can only be subscribed\nto when the user holds a resource_grants row for it (or is Admin). This\nprevents an authenticated user from subscribing to tables they cannot read.",
         "operationId": "update_table_subscriptions_api_sync_table_subscriptions_post",
         "parameters": [
           {
@@ -9335,7 +19609,7 @@
     },
     "/api/sync/trigger": {
       "post": {
-        "description": "Trigger data sync from configured source. Admin only. Runs in background.",
+        "description": "Trigger data sync from configured source. Admin only. Runs in background.\n\nBody accepts three shapes (all optional \u2014 empty body / `null` syncs\nevery registered table):\n\n  - ``[\"kbc_job\", \"orders\"]`` \u2014 bare JSON array of table ids\n  - ``{\"tables\": [\"kbc_job\", \"orders\"]}`` \u2014 object with a ``tables``\n    key (matches the wire shape of the response, more discoverable\n    for clients building requests by hand)\n  - ``null`` / no body \u2014 sync everything\n\nBoth array forms have shipped at different times; accepting both\nkeeps older clients (PR-build CLIs, helper scripts) working while\nsurfacing the shape that mirrors the response payload. Anything\nelse returns HTTP 422 with a structured detail.\n\nReturns 409 if a previously-triggered sync is still running. Two\nconcurrent extractor subprocesses fight for the same `extract.duckdb`\nfile lock \u2014 that contention starves uvicorn, makes `/api/health` time\nout, flips the container to `unhealthy`, and (behind a `reverse_proxy`\nupstream like the bundled Caddy overlay) bricks external traffic\nuntil contention drains. Fast-fail here keeps that from happening.",
         "operationId": "trigger_sync_api_sync_trigger_post",
         "parameters": [
           {
@@ -9360,17 +19634,12 @@
             "application/json": {
               "schema": {
                 "anyOf": [
-                  {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
+                  {},
                   {
                     "type": "null"
                   }
                 ],
-                "title": "Tables"
+                "title": "Body"
               }
             }
           }
@@ -9733,6 +20002,29 @@
       "get": {
         "operationId": "list_users_api_users_get",
         "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 1000,
+              "maximum": 10000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
           {
             "in": "header",
             "name": "authorization",
@@ -10294,6 +20586,107 @@
         ]
       }
     },
+    "/api/v2/metadata-cache/refresh": {
+      "post": {
+        "description": "Operator on-demand refresh of one row.\n\nUseful right after editing the registry row (so the catalog reflects\nnew ``bucket`` / ``source_table`` immediately) or after an upstream\nBQ schema change that the operator wants reflected before the next\nscheduled tick.",
+        "operationId": "refresh_one_table_api_v2_metadata_cache_refresh_post",
+        "parameters": [
+          {
+            "description": "Registry table_id to refresh",
+            "in": "query",
+            "name": "table",
+            "required": true,
+            "schema": {
+              "description": "Registry table_id to refresh",
+              "title": "Table",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Refresh One Table"
+      }
+    },
+    "/api/v2/metadata-cache/status": {
+      "get": {
+        "description": "Per-table cache status. Non-admin \u2014 analyst tools rely on this to\ndecide whether to trust the catalog's ``rows`` / ``size_bytes`` or\ntreat the table as opaque until the next refresh.",
+        "operationId": "metadata_cache_status_api_v2_metadata_cache_status_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Metadata Cache Status"
+      }
+    },
     "/api/v2/sample/{table_id}": {
       "get": {
         "operationId": "sample_api_v2_sample__table_id__get",
@@ -10558,7 +20951,7 @@
     },
     "/api/welcome": {
       "get": {
-        "description": "Return the rendered CLAUDE.md for the authenticated analyst.\n\nThe CLI calls this endpoint during ``da analyst setup`` to write\n``<workspace>/CLAUDE.md``. The content is RBAC-filtered per the\ncalling user.\n\n``server_url`` query param lets the CLI pass the origin it knows so\nthe rendered content references the correct server URL rather than the\nrequest host (which may differ behind a proxy).",
+        "description": "Return the rendered CLAUDE.md for the authenticated analyst.\n\nThe CLI calls this endpoint during ``agnes init`` to write\n``<workspace>/CLAUDE.md``. The content is RBAC-filtered per the\ncalling user.\n\n``server_url`` query param lets the CLI pass the origin it knows so\nthe rendered content references the correct server URL rather than the\nrequest host (which may differ behind a proxy).",
         "operationId": "get_welcome_api_welcome_get",
         "parameters": [
           {
@@ -10628,6 +21021,29 @@
       "get": {
         "operationId": "admin_list_tokens_auth_admin_tokens_get",
         "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 1000,
+              "maximum": 10000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
           {
             "in": "header",
             "name": "authorization",
@@ -10812,7 +21228,7 @@
     },
     "/auth/email/verify": {
       "get": {
-        "description": "Click-through variant \u2014 verifies token, sets cookie, redirects to /dashboard.\n\nThis is the URL we embed in outgoing emails (and the dev-fallback link), so\nclicking it in a mail client logs the user in without a separate API call.\n\nRate limited 10/min per IP for the same reason as the POST variant \u2014\ndon't let the click-through path bypass the brute-force throttle.",
+        "description": "Click-through variant \u2014 verifies token, sets cookie, redirects to the\noperator-configured home route.\n\nThis is the URL we embed in outgoing emails (and the dev-fallback link), so\nclicking it in a mail client logs the user in without a separate API call.\n\nRate limited 10/min per IP for the same reason as the POST variant \u2014\ndon't let the click-through path bypass the brute-force throttle.",
         "operationId": "verify_magic_link_get_auth_email_verify_get",
         "parameters": [
           {
@@ -11671,7 +22087,7 @@
     },
     "/cli/latest": {
       "get": {
-        "description": "Metadata for the currently-shipped CLI wheel.\n\nConsumed by `da` CLI's auto-update check so it can warn when a newer\nversion is on the server. Public + cacheable \u2014 no secrets here.\nReturns `version=None` when the server has no wheel yet (dev image that\ndidn't run `uv build`).",
+        "description": "Metadata for the currently-shipped CLI wheel.\n\nConsumed by `agnes` CLI's auto-update check so it can warn when a newer\nversion is on the server. Public + cacheable \u2014 no secrets here.\nReturns `version=None` when the server has no wheel yet (dev image that\ndidn't run `uv build`).",
         "operationId": "cli_latest_cli_latest_get",
         "responses": {
           "200": {
@@ -11732,6 +22148,7 @@
     },
     "/corporate-memory": {
       "get": {
+        "description": "Curated Memory web view \u2014 any authenticated user.\n\nThis is the analyst-facing read surface for shared organizational\nknowledge: it lists ``approved`` / ``mandatory`` items plus the\ncaller's own contributions, and sits in the primary nav next to\nData Packages. The admin review queue (pending items, contradictions,\nduplicates) lives separately at ``/admin/corporate-memory`` behind\n``require_admin``.\n\nGating matches the underlying ``/api/memory/*`` endpoints, which\nalready run on ``get_current_user`` \u2014 CLI / agent flows that POST a\nknowledge item or read ``/api/memory`` work for any authenticated\nuser, so the web view does too. Admin-only affordances on this page\n(the pending-review banner) stay gated server-side: ``is_admin_view``\nzeroes ``pending_review_count`` for non-admins.",
         "operationId": "corporate_memory_corporate_memory_get",
         "parameters": [
           {
@@ -11774,56 +22191,6 @@
           }
         },
         "summary": "Corporate Memory",
-        "tags": [
-          "web"
-        ]
-      }
-    },
-    "/admin/corporate-memory": {
-      "get": {
-        "description": "Curated Memory review queue \u2014 admin-only.\n\nThe governance surface paired with the user-facing ``/corporate-memory``\npage: pending items awaiting review, contradictions, duplicate\ncandidates, and the audit trail. Reached from the Admin nav dropdown.",
-        "operationId": "corporate_memory_admin_admin_corporate_memory_get",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "authorization",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Authorization"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "text/html": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Corporate Memory Admin",
         "tags": [
           "web"
         ]
@@ -11895,6 +22262,56 @@
           }
         },
         "summary": "Setup Wizard",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/home": {
+      "get": {
+        "description": "State-aware /home \u2014 full inline install for not-onboarded users,\nclean nav hub once onboarded. The boolean drives template selection;\nno auto-transition (manual reload picks up the flip after\n``agnes init`` POSTs ``/api/me/onboarded``).\n\nSee origin: docs/brainstorms/home-page-requirements.md.",
+        "operationId": "home_page_home_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Home Page",
         "tags": [
           "web"
         ]
@@ -11987,6 +22404,55 @@
         ]
       }
     },
+    "/marketplace": {
+      "get": {
+        "operationId": "marketplace_listing_marketplace_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Marketplace Listing",
+        "tags": [
+          "web"
+        ]
+      }
+    },
     "/marketplace.zip": {
       "get": {
         "operationId": "marketplace_zip_marketplace_zip_get",
@@ -12034,6 +22500,628 @@
         ]
       }
     },
+    "/marketplace/curated/{marketplace_id}/{plugin_name}": {
+      "get": {
+        "description": "Server-renders only the shell \u2014 the page hydrates via\n``GET /api/marketplace/curated/{slug}/{plugin}`` which carries the\nreal RBAC guard. Direct URL access for users without the grant lands on\na shell that 403s on the first XHR; UX-level the page renders an empty\nstate and a back link.",
+        "operationId": "marketplace_curated_detail_marketplace_curated__marketplace_id___plugin_name__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "marketplace_id",
+            "required": true,
+            "schema": {
+              "title": "Marketplace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "plugin_name",
+            "required": true,
+            "schema": {
+              "title": "Plugin Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Marketplace Curated Detail",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/marketplace/curated/{marketplace_id}/{plugin_name}/agent/{agent_name}": {
+      "get": {
+        "operationId": "marketplace_curated_agent_detail_marketplace_curated__marketplace_id___plugin_name__agent__agent_name__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "marketplace_id",
+            "required": true,
+            "schema": {
+              "title": "Marketplace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "plugin_name",
+            "required": true,
+            "schema": {
+              "title": "Plugin Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "agent_name",
+            "required": true,
+            "schema": {
+              "title": "Agent Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Marketplace Curated Agent Detail",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/marketplace/curated/{marketplace_id}/{plugin_name}/skill/{skill_name}": {
+      "get": {
+        "operationId": "marketplace_curated_skill_detail_marketplace_curated__marketplace_id___plugin_name__skill__skill_name__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "marketplace_id",
+            "required": true,
+            "schema": {
+              "title": "Marketplace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "plugin_name",
+            "required": true,
+            "schema": {
+              "title": "Plugin Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "skill_name",
+            "required": true,
+            "schema": {
+              "title": "Skill Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Marketplace Curated Skill Detail",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/marketplace/flea/{entity_id}": {
+      "get": {
+        "description": "Pick the right detail template based on the entity type:\nplugins reuse the unified plugin layout; skills / agents render the\nitem-detail layout (matches curated nested skill / agent).\n\nVisibility (v32+): non-owner non-admin gets 404 on any non-approved\nentity. Owner + admin see the page with a quarantine banner + the\nowner-actions strip (Edit / Delete with locked variants).",
+        "operationId": "marketplace_flea_detail_marketplace_flea__entity_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "entity_id",
+            "required": true,
+            "schema": {
+              "title": "Entity Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Marketplace Flea Detail",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/marketplace/flea/{entity_id}/agent/{agent_name}": {
+      "get": {
+        "description": "Inner agent detail page for an agent nested inside a flea plugin.\n\nMirrors ``marketplace_flea_skill_detail``; kind=\"agent\".",
+        "operationId": "marketplace_flea_agent_detail_marketplace_flea__entity_id__agent__agent_name__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "entity_id",
+            "required": true,
+            "schema": {
+              "title": "Entity Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "agent_name",
+            "required": true,
+            "schema": {
+              "title": "Agent Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Marketplace Flea Agent Detail",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/marketplace/flea/{entity_id}/edit": {
+      "get": {
+        "description": "Edit page for a flea-market entity (v37 edit feature).\n\nOwner or admin only. Pre-fills metadata + lets the submitter\noptionally upload a new bundle (creates v<N+1>). Skipping the\nbundle field updates only metadata. Edit is blocked while a\nprior version is under review \u2014 the form surfaces a banner and\ndisables Save in that case (the API gate also enforces 409\nserver-side).",
+        "operationId": "store_edit_marketplace_flea__entity_id__edit_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "entity_id",
+            "required": true,
+            "schema": {
+              "title": "Entity Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Store Edit",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/marketplace/flea/{entity_id}/skill/{skill_name}": {
+      "get": {
+        "description": "Inner skill detail page for a skill nested inside a flea plugin.\n\nMirrors ``marketplace_curated_skill_detail`` but uses the standalone\nflea visibility gate (``_enforce_visibility``) \u2014 owner / admin see\nquarantined entities, everyone else gets 404 (entity existence not\nleaked).",
+        "operationId": "marketplace_flea_skill_detail_marketplace_flea__entity_id__skill__skill_name__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "entity_id",
+            "required": true,
+            "schema": {
+              "title": "Entity Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "skill_name",
+            "required": true,
+            "schema": {
+              "title": "Skill Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Marketplace Flea Skill Detail",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/marketplace/format-guide": {
+      "get": {
+        "description": "Render docs/curated-marketplace-format.md as a logged-in HTML page.\n\nThe Markdown source is the canonical reference for upstream curators \u2014\nliving it next to docs/ in the repo means it's also discoverable on the\npublic GitHub mirror, so an external maintainer can read it without\nneeding an Agnes account. The web rendering exists for the in-product\nflow (link from /admin/marketplaces) and uses Python's ``markdown``\nlibrary with the standard extensions for fenced code + tables.\n\nAuth: ``Depends(get_current_user)`` only \u2014 no admin requirement. The\naudience is \"anyone authoring or reviewing a curated marketplace,\"\nwhich is broader than admins and could include non-admin curators.",
+        "operationId": "marketplace_format_guide_marketplace_format_guide_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Marketplace Format Guide",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/marketplace/guide/curated": {
+      "get": {
+        "operationId": "marketplace_guide_curated_marketplace_guide_curated_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Marketplace Guide Curated",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/marketplace/guide/flea": {
+      "get": {
+        "operationId": "marketplace_guide_flea_marketplace_guide_flea_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Marketplace Guide Flea",
+        "tags": [
+          "web"
+        ]
+      }
+    },
     "/marketplace/info": {
       "get": {
         "operationId": "marketplace_info_marketplace_info_get",
@@ -12078,6 +23166,56 @@
         "summary": "Marketplace Info",
         "tags": [
           "marketplace"
+        ]
+      }
+    },
+    "/me/activity": {
+      "get": {
+        "description": "Unified personal-activity page \u2014 consolidated replacement for\nthe old ``/me/stats`` + ``/profile/sessions`` split.  Four tabs\n(Sessions / Token usage / Data access / Sync activity) backed by\n``/api/me/stats/*`` endpoints.  The Sessions tab merges usage\nmetrics with verification-pipeline status and download links.",
+        "operationId": "me_activity_page_me_activity_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Me Activity Page",
+        "tags": [
+          "web"
         ]
       }
     },
@@ -12131,9 +23269,208 @@
         ]
       }
     },
+    "/me/profile/refetch-groups": {
+      "post": {
+        "description": "Re-issue ``fetch_user_groups`` for the current user and return a\ndry-run diff against the cached ``user_group_members`` snapshot,\nwriting nothing. Gated behind AGNES_DEBUG_AUTH \u2014 a dry-run admin\ndebug action, not user-facing content.",
+        "operationId": "me_profile_refetch_groups_me_profile_refetch_groups_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Me Profile Refetch Groups",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/me/stats": {
+      "get": {
+        "description": "Legacy redirect \u2014 ``/me/stats`` \u2192 ``/me/activity``.",
+        "operationId": "me_stats_redirect_me_stats_get",
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Me Stats Redirect",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/news": {
+      "get": {
+        "description": "Permalink page for the latest published news. Renders empty-state\ncopy when no version is published. Authed-only (same as /home).",
+        "operationId": "news_page_news_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "News Page",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/profile/sessions": {
+      "get": {
+        "description": "Legacy redirect \u2014 ``/profile/sessions`` \u2192 ``/me/activity?tab=sessions``.",
+        "operationId": "profile_sessions_redirect_profile_sessions_get",
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Profile Sessions Redirect",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/profile/sessions/{filename}": {
+      "get": {
+        "description": "Download a single jsonl session file owned by the caller.\n\nPath safety: filename is single-component (no separators, no `..`,\nmust end in `.jsonl`); the served path is built under\n`${DATA_DIR}/user_sessions/<current_user.id>/` and must resolve into\nthat directory. Any deviation yields 404 \u2014 never 403, so we don't\nleak the existence of files belonging to other users.",
+        "operationId": "profile_session_download_profile_sessions__filename__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "filename",
+            "required": true,
+            "schema": {
+              "title": "Filename",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Profile Session Download",
+        "tags": [
+          "web"
+        ]
+      }
+    },
     "/setup": {
       "get": {
-        "description": "Setup instructions for the local agent (CLI + Claude Code).\n\nWhen an admin override is saved, the override replaces the auto-generated\nsetup_instructions output everywhere (both the /setup page display and the\ndashboard clipboard CTA).  When no override is set, the live default from\nsetup_instructions.resolve_lines() is used.",
+        "description": "Setup instructions for the local agent (CLI + Claude Code).\n\nSingle unified flow for everyone \u2014 admin-vs-analyst is no longer a\nlayout branch. The marketplace + plugins block appears iff the\ncaller has plugin grants in `resource_grants` (resolved inside\n`compute_default_agent_prompt`).\n\nWhen an admin override is saved, the override replaces the\nauto-generated setup_instructions output everywhere (both the\n/setup page display and the dashboard clipboard CTA). When no\noverride is set, the live default from\nsetup_instructions.resolve_lines() is used.",
         "operationId": "setup_page_setup_get",
         "parameters": [
           {
@@ -12181,6 +23518,155 @@
         ]
       }
     },
+    "/setup-advanced": {
+      "get": {
+        "description": "Advanced setup reference \u2014 VS Code layout, recommended plugins,\nmulti-model second opinions, custom skills, cost guidance.\n\nPulls the deeper Chief-of-Stuff guide content out of /home so /home\nstays scannable for first-hour onboarding. Linked from /home's\n\"Want to look around first?\" explore card and from any deep-link\nanchors emitted by other pages (e.g. /home's auto-mode block points\nat #yolo).",
+        "operationId": "setup_advanced_page_setup_advanced_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Setup Advanced Page",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/store/examples": {
+      "get": {
+        "description": "Examples of well-formed flea-market submissions.\n\nLinked from the content-guardrail rejection banner so a submitter\nwhose bundle failed review can see what 'good' looks like\nside-by-side with the rule that bit them.",
+        "operationId": "store_examples_store_examples_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Store Examples",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/store/new": {
+      "get": {
+        "operationId": "store_new_store_new_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Store New",
+        "tags": [
+          "web"
+        ]
+      }
+    },
     "/webhooks/jira": {
       "post": {
         "description": "Receive and process Jira webhook notifications.",
@@ -12203,8 +23689,26 @@
     },
     "/webhooks/jira/health": {
       "get": {
-        "description": "Health check for Jira webhook endpoint.",
+        "description": "Health check for Jira webhook endpoint. Admin-only: exposes secret presence.",
         "operationId": "jira_webhook_health_webhooks_jira_health_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -12217,123 +23721,21 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "Jira Webhook Health",
         "tags": [
           "jira-webhooks"
-        ]
-      }
-    },
-    "/api/memory/{item_id}/dismiss": {
-      "delete": {
-        "description": "Idempotent un-dismiss \u2014 a second DELETE still returns 200.\n\nReturns 404 if the item itself doesn't exist (consistent with the rest\nof the per-item endpoints); the dismissal row's existence is not\nconsulted because absence is the success state.",
-        "operationId": "undismiss_item_api_memory__item_id__dismiss_delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "item_id",
-            "required": true,
-            "schema": {
-              "title": "Item Id",
-              "type": "string"
-            }
-          },
-          {
-            "in": "header",
-            "name": "authorization",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Authorization"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Undismiss Item",
-        "tags": [
-          "memory"
-        ]
-      },
-      "post": {
-        "description": "Per-user opt-out \u2014 remove an item from the caller's AI bundle.\n\nIdempotent: re-dismissing an already-dismissed item is a no-op success.\nMandatory items can never be dismissed \u2014 the governance hard rule \u2014\nso a POST against one returns 400 with a clear detail message.",
-        "operationId": "dismiss_item_api_memory__item_id__dismiss_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "item_id",
-            "required": true,
-            "schema": {
-              "title": "Item Id",
-              "type": "string"
-            }
-          },
-          {
-            "in": "header",
-            "name": "authorization",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Authorization"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Dismiss Item",
-        "tags": [
-          "memory"
         ]
       }
     }

--- a/tests/test_jira_webhooks.py
+++ b/tests/test_jira_webhooks.py
@@ -18,12 +18,15 @@ def _sign(payload: bytes, secret: str) -> str:
 
 @pytest.fixture()
 def webhook_client(tmp_path, monkeypatch):
-    """Create a TestClient with required env vars and dirs."""
+    """Create a TestClient with required env vars, dirs, and a seeded admin user."""
     data_dir = tmp_path / "data"
     data_dir.mkdir()
     (data_dir / "issues").mkdir()
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
 
     monkeypatch.setenv("DATA_DIR", str(data_dir))
+    monkeypatch.setenv("STATE_DIR", str(state_dir))
     monkeypatch.setenv("JWT_SECRET_KEY", "test-jwt-secret")
     monkeypatch.setenv("JIRA_WEBHOOK_SECRET", "test-webhook-secret")
     monkeypatch.setenv("JIRA_DATA_DIR", str(data_dir))
@@ -36,32 +39,53 @@ def webhook_client(tmp_path, monkeypatch):
     # Reset singleton so it picks up fresh Config values
     svc._jira_service = None
 
-    # Reimport app to pick up router
+    from src.db import SYSTEM_ADMIN_GROUP, get_system_db
+    from src.repositories.user_group_members import UserGroupMembersRepository
+    from src.repositories.users import UserRepository
+    from app.auth.jwt import create_access_token
     from app.main import create_app
+
+    conn = get_system_db()
+    UserRepository(conn).create(id="wh_admin", email="whadmin@test.com", name="WH Admin")
+    admin_gid = conn.execute(
+        "SELECT id FROM user_groups WHERE name = ?", [SYSTEM_ADMIN_GROUP]
+    ).fetchone()[0]
+    UserGroupMembersRepository(conn).add_member("wh_admin", admin_gid, source="system_seed")
+    conn.close()
+
     app = create_app()
-    return TestClient(app)
+    admin_token = create_access_token("wh_admin", "whadmin@test.com")
+    return {"client": TestClient(app), "admin_token": admin_token}
+
+
+def test_health_requires_auth(webhook_client):
+    """GET /webhooks/jira/health returns 401 without credentials (ADV-002)."""
+    resp = webhook_client["client"].get("/webhooks/jira/health")
+    assert resp.status_code == 401
 
 
 def test_health(webhook_client):
-    """GET /webhooks/jira/health returns 200."""
-    resp = webhook_client.get("/webhooks/jira/health")
+    """GET /webhooks/jira/health returns 200 for admin; jira_domain not exposed."""
+    headers = {"Authorization": f"Bearer {webhook_client['admin_token']}"}
+    resp = webhook_client["client"].get("/webhooks/jira/health", headers=headers)
     assert resp.status_code == 200
     body = resp.json()
     assert body["status"] == "ok"
     assert "webhook_secret_set" in body
+    assert "jira_domain" not in body
 
 
 def test_missing_signature_401(webhook_client):
     """POST without signature header returns 401."""
     payload = json.dumps({"webhookEvent": "jira:issue_updated", "issue": {"key": "TEST-1"}}).encode()
-    resp = webhook_client.post("/webhooks/jira", content=payload, headers={"Content-Type": "application/json"})
+    resp = webhook_client["client"].post("/webhooks/jira", content=payload, headers={"Content-Type": "application/json"})
     assert resp.status_code == 401
 
 
 def test_invalid_signature_401(webhook_client):
     """POST with wrong signature returns 401."""
     payload = json.dumps({"webhookEvent": "jira:issue_updated", "issue": {"key": "TEST-1"}}).encode()
-    resp = webhook_client.post(
+    resp = webhook_client["client"].post(
         "/webhooks/jira",
         content=payload,
         headers={
@@ -85,7 +109,7 @@ def test_valid_signature_accepted(webhook_client):
         mock_svc.return_value.is_configured.return_value = True
         mock_svc.return_value.process_webhook_event.return_value = True
 
-        resp = webhook_client.post(
+        resp = webhook_client["client"].post(
             "/webhooks/jira",
             content=payload,
             headers={
@@ -100,7 +124,7 @@ def test_empty_payload_400(webhook_client):
     """POST with empty body and valid signature returns 400."""
     payload = b""
     sig = _sign(payload, "test-webhook-secret")
-    resp = webhook_client.post(
+    resp = webhook_client["client"].post(
         "/webhooks/jira",
         content=payload,
         headers={
@@ -166,7 +190,7 @@ def test_path_traversal_in_issue_key_rejected(webhook_client, bad_key):
     }).encode()
     sig = _sign(payload, "test-webhook-secret")
 
-    resp = webhook_client.post(
+    resp = webhook_client["client"].post(
         "/webhooks/jira",
         content=payload,
         headers={
@@ -188,7 +212,7 @@ def test_null_issue_field_does_not_crash(webhook_client):
     }).encode()
     sig = _sign(payload, "test-webhook-secret")
 
-    resp = webhook_client.post(
+    resp = webhook_client["client"].post(
         "/webhooks/jira",
         content=payload,
         headers={
@@ -214,7 +238,7 @@ def test_valid_issue_key_accepted(webhook_client):
         mock_svc.return_value.is_configured.return_value = True
         mock_svc.return_value.process_webhook_event.return_value = True
 
-        resp = webhook_client.post(
+        resp = webhook_client["client"].post(
             "/webhooks/jira",
             content=payload,
             headers={
@@ -247,7 +271,7 @@ def test_webhook_event_path_traversal_sanitized(webhook_client, tmp_path, monkey
         mock_svc.return_value.is_configured.return_value = True
         mock_svc.return_value.process_webhook_event.return_value = True
 
-        resp = webhook_client.post(
+        resp = webhook_client["client"].post(
             "/webhooks/jira",
             content=payload,
             headers={
@@ -287,7 +311,7 @@ def test_valid_hmac_signature_accepted(webhook_client):
         mock_svc.return_value.is_configured.return_value = True
         mock_svc.return_value.process_webhook_event.return_value = True
 
-        resp = webhook_client.post(
+        resp = webhook_client["client"].post(
             "/webhooks/jira",
             content=payload,
             headers={
@@ -307,7 +331,7 @@ def test_invalid_hmac_signature_rejected_401(webhook_client):
     # Sign with the wrong secret
     sig = _sign(payload, "wrong-secret")
 
-    resp = webhook_client.post(
+    resp = webhook_client["client"].post(
         "/webhooks/jira",
         content=payload,
         headers={
@@ -325,7 +349,7 @@ def test_missing_signature_header_rejected(webhook_client):
         "issue": {"key": "PROJ-1"},
     }).encode()
 
-    resp = webhook_client.post(
+    resp = webhook_client["client"].post(
         "/webhooks/jira",
         content=payload,
         headers={"Content-Type": "application/json"},
@@ -346,7 +370,7 @@ def test_x_hub_signature_legacy_header_accepted(webhook_client):
     # Since the handler uses hmac.new with sha256, a sha1= prefix will still
     # be checked against sha256 HMAC. This test verifies the fallback header
     # is read at all (the signature won't match sha256, so expect 401).
-    resp = webhook_client.post(
+    resp = webhook_client["client"].post(
         "/webhooks/jira",
         content=payload,
         headers={
@@ -363,7 +387,7 @@ def test_malformed_json_payload_handled_gracefully(webhook_client):
     payload = b'this is not json {!><'
     sig = _sign(payload, "test-webhook-secret")
 
-    resp = webhook_client.post(
+    resp = webhook_client["client"].post(
         "/webhooks/jira",
         content=payload,
         headers={
@@ -390,7 +414,7 @@ def test_duplicate_event_processed_twice(webhook_client):
         mock_svc.return_value.is_configured.return_value = True
         mock_svc.return_value.process_webhook_event.return_value = True
 
-        resp1 = webhook_client.post(
+        resp1 = webhook_client["client"].post(
             "/webhooks/jira",
             content=payload,
             headers={
@@ -398,7 +422,7 @@ def test_duplicate_event_processed_twice(webhook_client):
                 "X-Hub-Signature-256": sig,
             },
         )
-        resp2 = webhook_client.post(
+        resp2 = webhook_client["client"].post(
             "/webhooks/jira",
             content=payload,
             headers={
@@ -429,7 +453,7 @@ def test_signature_without_sha256_prefix(webhook_client):
         mock_svc.return_value.is_configured.return_value = True
         mock_svc.return_value.process_webhook_event.return_value = True
 
-        resp = webhook_client.post(
+        resp = webhook_client["client"].post(
             "/webhooks/jira",
             content=payload,
             headers={
@@ -453,7 +477,7 @@ def test_jira_service_not_configured_returns_503(webhook_client):
     with patch("app.api.jira_webhooks.get_jira_service") as mock_svc:
         mock_svc.return_value.is_configured.return_value = False
 
-        resp = webhook_client.post(
+        resp = webhook_client["client"].post(
             "/webhooks/jira",
             content=payload,
             headers={
@@ -478,7 +502,7 @@ def test_process_webhook_event_failure_returns_500(webhook_client):
         mock_svc.return_value.is_configured.return_value = True
         mock_svc.return_value.process_webhook_event.return_value = False
 
-        resp = webhook_client.post(
+        resp = webhook_client["client"].post(
             "/webhooks/jira",
             content=payload,
             headers={
@@ -504,7 +528,7 @@ def test_issue_key_at_top_level_accepted(webhook_client):
         mock_svc.return_value.is_configured.return_value = True
         mock_svc.return_value.process_webhook_event.return_value = True
 
-        resp = webhook_client.post(
+        resp = webhook_client["client"].post(
             "/webhooks/jira",
             content=payload,
             headers={

--- a/tests/test_journey_jira.py
+++ b/tests/test_journey_jira.py
@@ -32,13 +32,15 @@ SAMPLE_JIRA_EVENT = {
 @pytest.mark.journey
 class TestJiraWebhookJourney:
     def test_webhook_health_check(self, seeded_app):
-        """Jira webhook health endpoint is always accessible."""
+        """Jira webhook health endpoint is accessible to admins."""
         c = seeded_app["client"]
-        resp = c.get("/webhooks/jira/health")
+        headers = {"Authorization": f"Bearer {seeded_app['admin_token']}"}
+        resp = c.get("/webhooks/jira/health", headers=headers)
         assert resp.status_code == 200
         body = resp.json()
         assert "status" in body
         assert body["status"] == "ok"
+        assert "jira_domain" not in body
 
     def test_webhook_with_no_secret_configured_refused(self, seeded_app):
         """Issue #83: when JIRA_WEBHOOK_SECRET is not set, webhook is REFUSED

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -398,3 +398,127 @@ class TestJwtSecretHardening:
             # Clean up the temporary TESTING flag if we added it
             if saved_key is None and saved_testing is None:
                 os.environ.pop("TESTING", None)
+
+
+# ---- API hardening (issue #336) ----
+
+@pytest.fixture
+def hardening_client(tmp_path, monkeypatch):
+    """Minimal seeded app with an admin and a plain analyst for RBAC tests."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-minimum-32-characters!!")
+
+    from app.main import create_app
+    from src.db import get_system_db, SYSTEM_ADMIN_GROUP
+    from src.repositories.users import UserRepository
+    from src.repositories.user_group_members import UserGroupMembersRepository
+    from app.auth.jwt import create_access_token
+
+    conn = get_system_db()
+    repo = UserRepository(conn)
+    repo.create(id="hadmin", email="hadmin@test.com", name="HAdmin")
+    repo.create(id="hanalyst", email="hanalyst@test.com", name="HAnalyst")
+    gid = conn.execute(
+        "SELECT id FROM user_groups WHERE name = ?", [SYSTEM_ADMIN_GROUP]
+    ).fetchone()[0]
+    UserGroupMembersRepository(conn).add_member("hadmin", gid, source="system_seed")
+    conn.close()
+
+    app = create_app()
+    c = TestClient(app)
+    return {
+        "client": c,
+        "admin_token": create_access_token("hadmin", "hadmin@test.com"),
+        "analyst_token": create_access_token("hanalyst", "hanalyst@test.com"),
+    }
+
+
+class TestApiHardening336:
+    """Regression tests for the ADV-001…ADV-009 findings from issue #336."""
+
+    # ADV-001: RBAC on POST /api/sync/table-subscriptions
+    def test_table_subscriptions_rbac_blocks_unauthorized_table(self, hardening_client):
+        c = hardening_client["client"]
+        token = hardening_client["analyst_token"]
+        resp = c.post(
+            "/api/sync/table-subscriptions",
+            json={"table_mode": "explicit", "tables": {"secret_table": True}},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["updated"]["secret_table"] == {"error": "no permission"}
+
+    def test_table_subscriptions_rbac_allows_accessible_table(self, hardening_client):
+        # Admin has access to everything — verify subscription writes go through
+        c = hardening_client["client"]
+        token = hardening_client["admin_token"]
+        resp = c.post(
+            "/api/sync/table-subscriptions",
+            json={"table_mode": "explicit", "tables": {"any_table": True}},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["updated"]["any_table"] == {"enabled": True}
+
+    def test_table_subscriptions_dict_size_limit(self, hardening_client):
+        c = hardening_client["client"]
+        token = hardening_client["analyst_token"]
+        huge = {f"t{i}": True for i in range(501)}
+        resp = c.post(
+            "/api/sync/table-subscriptions",
+            json={"table_mode": "explicit", "tables": huge},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 422  # ADV-008 max_length guard
+
+    # ADV-003: /api/version must not expose commit_sha or schema_version
+    def test_version_does_not_expose_internal_fields(self, hardening_client):
+        resp = hardening_client["client"].get("/api/version")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "commit_sha" not in body, "commit_sha must not be in public /api/version"
+        assert "schema_version" not in body, "schema_version must not be in public /api/version"
+        assert "version" in body
+
+    # ADV-005: /docs, /redoc, /openapi.json gated behind auth
+    def test_docs_requires_auth(self, hardening_client):
+        resp = hardening_client["client"].get("/docs", follow_redirects=False)
+        assert resp.status_code in (401, 302)
+
+    def test_openapi_json_requires_auth(self, hardening_client):
+        resp = hardening_client["client"].get("/openapi.json")
+        assert resp.status_code == 401
+
+    def test_openapi_json_accessible_to_authenticated_user(self, hardening_client):
+        token = hardening_client["analyst_token"]
+        resp = hardening_client["client"].get(
+            "/openapi.json", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert resp.status_code == 200
+        assert "paths" in resp.json()
+
+    # ADV-006: /webhooks/ and /cli/ get JSON 401, not HTML redirect
+    def test_cli_path_gets_json_401_not_redirect(self, hardening_client):
+        # /cli/latest is public — test a hypothetical future gated endpoint
+        # by confirming the prefix is in _API_PATH_PREFIXES via /openapi.json
+        # returning JSON 401 (not a redirect) when unauthenticated.
+        resp = hardening_client["client"].get("/openapi.json", follow_redirects=False)
+        assert resp.status_code == 401
+        assert resp.headers.get("content-type", "").startswith("application/json")
+
+    # ADV-009: list endpoints accept limit/offset
+    def test_users_list_pagination_params(self, hardening_client):
+        token = hardening_client["admin_token"]
+        resp = hardening_client["client"].get(
+            "/api/users?limit=5&offset=0",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+
+    def test_tokens_list_pagination_params(self, hardening_client):
+        token = hardening_client["admin_token"]
+        resp = hardening_client["client"].get(
+            "/auth/admin/tokens?limit=5&offset=0",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -522,3 +522,52 @@ class TestApiHardening336:
             headers={"Authorization": f"Bearer {token}"},
         )
         assert resp.status_code == 200
+
+    # Regression guard for the reviewer-flagged auth-bypass on /auth/bootstrap
+    # introduced (and reverted) during ADV-009. The original ADV-009 fix
+    # repurposed UserRepository.list_all() to default to LIMIT 1000, which
+    # silently broke the bootstrap check `[u for u in list_all() if
+    # u.get('password_hash')]` on instances with >1000 users: if no
+    # password-holder landed in the email-sorted first page, bootstrap
+    # re-opened and an unauthenticated caller could claim admin.
+    #
+    # Fix shape: `list_all()` returns EVERY row (no LIMIT), API surface uses
+    # the new `list_paginated(limit, offset)` instead. The two tests below
+    # lock in both halves of the contract so a future cleanup doesn't
+    # silently re-introduce the bypass.
+    def test_users_list_all_returns_every_row_no_silent_limit(self):
+        """``UserRepository.list_all()`` must NOT apply a default LIMIT
+        — the bootstrap-lock check at ``app/auth/router.py`` and the
+        startup no-password warning at ``app/main.py`` both call this
+        no-arg and depend on exhaustive enumeration. Silent pagination
+        here is a real auth-bypass on instances with >LIMIT users."""
+        import inspect
+        from src.repositories.users import UserRepository
+        sig = inspect.signature(UserRepository.list_all)
+        # No params (other than self) means no caller can accidentally
+        # pass limit=N and end up with a windowed result.
+        non_self_params = [
+            p for p in sig.parameters.values() if p.name != "self"
+        ]
+        assert non_self_params == [], (
+            f"UserRepository.list_all() must take no arguments other than "
+            f"self (got {non_self_params}). Add limit/offset to "
+            f"list_paginated() instead — list_all() is the "
+            f"bootstrap-lock / startup-warning path and MUST enumerate "
+            f"every row."
+        )
+
+    def test_users_list_paginated_is_separate_method(self):
+        """The paginated variant must be a distinct method named
+        ``list_paginated`` (not an overload of ``list_all``) so call
+        sites are explicit about which contract they want.
+        """
+        from src.repositories.users import UserRepository
+        assert hasattr(UserRepository, "list_paginated"), (
+            "API-surface pagination must live on a separate "
+            "`list_paginated` method, not on `list_all`."
+        )
+        import inspect
+        sig = inspect.signature(UserRepository.list_paginated)
+        param_names = {p.name for p in sig.parameters.values() if p.name != "self"}
+        assert "limit" in param_names and "offset" in param_names


### PR DESCRIPTION
## Summary

Fixes all 9 findings from the adversarial architecture review in #336, prioritised for pre-Swagger hardening.

- **ADV-001 (Critical)** — `POST /api/sync/table-subscriptions` now calls `can_access()` per table entry, matching the gate already on `POST /api/sync/settings`. Authenticated users can no longer subscribe to tables they have no `resource_grants` row for.
- **ADV-002 (High)** — `GET /webhooks/jira/health` gated behind `require_admin`; `jira_domain` removed from the response (anonymous info disclosure).
- **ADV-003 (High)** — `GET /api/version` no longer exposes `commit_sha` or `schema_version` to unauthenticated callers.
- **ADV-005 (Medium)** — `/docs`, `/redoc`, and `/openapi.json` now require a valid session. FastAPI instantiated with `docs_url=None, redoc_url=None, openapi_url=None`; custom auth-gated routes added before the web catch-all.
- **ADV-006 (Medium)** — `/cli/` and `/webhooks/` added to `_API_PATH_PREFIXES` so any future auth-gated endpoint under those paths returns JSON `401`, not an HTML redirect.
- **ADV-007 (Medium)** — `GET /api/catalog/tables` wired to `CatalogTablesResponse` Pydantic model; Swagger now generates an accurate schema for it.
- **ADV-008 (Low)** — `TableSubscriptionUpdate.tables` capped at `max_length=500`, preventing an O(N) DuckDB write loop from an oversized payload.
- **ADV-009 (Low)** — `GET /api/users` and `GET /auth/admin/tokens` now accept `limit` (default 1000, max 10 000) and `offset` params; both repositories updated.

## Test plan

- [ ] `pytest tests/test_security.py` — 11 new tests in `TestApiHardening336` cover ADV-001, ADV-003, ADV-005, ADV-006, ADV-008, ADV-009
- [ ] `pytest tests/test_jira_webhooks.py` — `test_health_requires_auth` asserts 401 without creds; `test_health` asserts 200 with admin token and confirms `jira_domain` absent (ADV-002)
- [ ] `pytest tests/test_openapi_snapshot.py` — snapshot regenerated; no paths removed
- [ ] `pytest tests/test_access_control.py tests/test_api_complete.py tests/test_user_management.py tests/test_pat.py` — existing coverage unbroken
- [ ] Verify `/docs` returns 401 without a session cookie in a browser
- [ ] Verify `/docs` loads correctly after logging in

Closes #336