### PR TITLE
fix(web): move keboola {% endif %} so edit-modal JS is always available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.54.27] — 2026-05-18
+
+### Fixed
+- `/admin/tables` edit modal no longer throws `ReferenceError` on
+  non-Keboola instances (BigQuery, CSV). Two JS helpers
+  (`_getEditKbSyncMode`, `onEditKbSyncModeChange`) were wrapped in
+  the `{% if data_source_type == 'keboola' %}` template guard but
+  called unconditionally from sync-mode radio buttons rendered for
+  all instance types. The guard now scopes only the discover /
+  prefill helpers that actually talk to the Keboola Storage API;
+  the shared sync-mode helpers ship to every instance.
+
 ## [0.54.26] — 2026-05-18
 
 ### Changed

--- a/app/web/templates/admin_tables.html
+++ b/app/web/templates/admin_tables.html
@@ -2234,8 +2234,10 @@
                 showToast('' + err.message, 'error');
             });
     }
+    {% endif %}{# data_source_type == 'keboola' — discover helpers #}
 
-    // ── Keboola tab edit modal (Phase F2) ──────────────────────────
+    // ── Keboola edit-modal sync-mode helpers (always needed — radio buttons
+    //    are rendered for all instance types) ───────────────────────────────
 
     function _getEditKbSyncMode() {
         var el = document.querySelector('input[name="editKbSyncMode"]:checked');
@@ -2256,6 +2258,7 @@
         if (mode === 'direct') onEditKbStrategyChange();
     }
 
+    {% if data_source_type == 'keboola' %}{# Phase F2 edit modal + prefill — keboola-only #}
     function _getEditKbStrategy() {
         var el = document.getElementById('editKbStrategy');
         return el ? el.value : 'full_refresh';
@@ -2483,7 +2486,7 @@
         }
         ta.value = 'SELECT *\nFROM kbc."' + bucket + '"."' + sourceTable + '"\nWHERE -- your filter here';
     }
-    {% endif %}{# data_source_type == 'keboola' — discover/prefill JS #}
+    {% endif %}{# data_source_type == 'keboola' — Phase F2 edit modal + prefill #}
 
     // C3: removed dead helper _buildKeboolaLegacyPayload — the Phase F
     // _buildKeboolaPayload (above) replaced it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.54.26"
+version = "0.54.27"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"


### PR DESCRIPTION
## Root cause

Edit-modal functions were wrapped inside `{% if data_source_type == 'keboola' %}` in `admin_tables.html`. Two of them — `_getEditKbSyncMode` and `onEditKbSyncModeChange` — are called from sync-mode radio buttons that are rendered for **all** instance types (not inside any Jinja2 conditional). On a BigQuery or CSV instance the JS functions were absent from the page, causing `ReferenceError` when the edit modal was opened.

## Fix

Split the conditional into two regions:

1. **Discover helpers** (`loadKeboolaBuckets`, `loadKeboolaTables`) — remain inside `{% if keboola %}`, they call the Keboola Storage API
2. **`_getEditKbSyncMode` + `onEditKbSyncModeChange`** — moved outside the guard, because the sync-mode radio buttons are rendered for all instance types
3. **Phase F2 edit modal + `prefillFromKeboolaTable`** — remain inside `{% if keboola %}`, called only from Keboola-conditional HTML

## Test plan

- [ ] Open `/admin/tables` on a non-Keboola instance (BigQuery or CSV) — edit modal opens without `ReferenceError` in the console
- [ ] On a Keboola instance — bucket/table discovery and SQL prefill still work correctly
- [ ] `test_keboola_discover_buttons_hidden_on_bigquery_instance` passes — `prefillFromKeboolaTable` not present in BigQuery-rendered HTML