### PR TITLE
spec: live E2E walkthrough design (4-layer headless claude --print)

### DIFF
--- a/docs/superpowers/plans/2026-05-26-pr-388-cleanup.md
+++ b/docs/superpowers/plans/2026-05-26-pr-388-cleanup.md
@@ -15,10 +15,10 @@
 | | |
 |---|---|
 | **Branch under cleanup** | `vr/postgres` (origin head: `bcda84b9`) |
-| **Review worktree** | `/Users/zdeneksrotyr/Sources/VsCode/component_factory/tmp_oss/.claude/worktrees/zs-review-388` |
+| **Review worktree** | `<repo-root>/.claude/worktrees/zs-review-388` |
 | **Python pin** | `.python-version` = `3.12` (already written during pre-flight) |
 | **Virtualenv** | `.venv/` (already created + deps installed) |
-| **Plan-author worktree** | `/Users/zdeneksrotyr/Sources/VsCode/component_factory/tmp_oss/.claude/worktrees/zs+e2e-live-spec` (where this plan lives — DO NOT execute code here) |
+| **Plan-author worktree** | `<repo-root>/.claude/worktrees/zs+e2e-live-spec` (where this plan lives — DO NOT execute code here) |
 | **Base branch** | `main` (latest fetch via `git fetch origin`) |
 
 All code-mutating tasks run from the `zs-review-388` worktree. The plan document itself lives in `zs+e2e-live-spec` and is committed there as documentation. When executing, the engineer should `cd` into `zs-review-388` first.
@@ -49,7 +49,7 @@ Reused commands. Engineer should commit these to muscle memory.
 ### Setup once
 
 ```bash
-cd /Users/zdeneksrotyr/Sources/VsCode/component_factory/tmp_oss/.claude/worktrees/zs-review-388
+cd <repo-root>/.claude/worktrees/zs-review-388
 unset UV_PYTHON                           # one-time per shell; the worktree pins 3.12 via .python-version
 source .venv/bin/activate                 # if not yet activated
 agnes --version || true                   # optional sanity
@@ -100,7 +100,7 @@ Verify the current `vr/postgres` baseline is what we think it is, before making 
 - [ ] **Step 1: Activate worktree environment**
 
 ```bash
-cd /Users/zdeneksrotyr/Sources/VsCode/component_factory/tmp_oss/.claude/worktrees/zs-review-388
+cd <repo-root>/.claude/worktrees/zs-review-388
 unset UV_PYTHON
 source .venv/bin/activate
 .venv/bin/python --version
@@ -1243,7 +1243,7 @@ Expected: file present, non-empty (typically tens of MB).
 - [ ] **Step 2: Bring up local PG via compose overlay**
 
 ```bash
-cd /Users/zdeneksrotyr/Sources/VsCode/component_factory/tmp_oss/.claude/worktrees/zs-review-388
+cd <repo-root>/.claude/worktrees/zs-review-388
 docker compose -f docker-compose.yml -f docker-compose.postgres.yml up -d postgres migrate
 docker compose -f docker-compose.yml -f docker-compose.postgres.yml ps
 ```

--- a/docs/superpowers/plans/2026-05-26-pr-388-cleanup.md
+++ b/docs/superpowers/plans/2026-05-26-pr-388-cleanup.md
@@ -1,0 +1,1596 @@
+# PR #388 cleanup — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring [keboola/agnes-the-ai-analyst#388](https://github.com/keboola/agnes-the-ai-analyst/pull/388) — *"feat(db): introduce Postgres app-state layer alongside DuckDB"* — to a production-ready merge state. Fix P0 bug, remove redundant complexity (3 redundant test backends, dual env vars, 31 explicit MigrationTasks where 5 suffice, helper sed scripts), expand cross-engine contract coverage, validate end-to-end against prod data, then ship.
+
+**Architecture:** All changes layered on top of the existing 8 commits on `vr/postgres`. We do NOT rebase or rewrite history — we add ~8-10 surgical commits on top. After each phase the branch is force-pushed and PR re-reviewed. The author (`cvrysanek`) is sync'd via PR comment **before** Phase 3 (architectural removals) so they can object to anything in scope.
+
+**Tech Stack:** Python 3.12 (uv-managed), SQLAlchemy 2.0, Alembic 1.13, psycopg 3, pytest-postgresql, pgserver, testcontainers (subject to removal in Phase 3), Docker Compose, gh CLI, git worktree.
+
+---
+
+## Worktree + branch state
+
+| | |
+|---|---|
+| **Branch under cleanup** | `vr/postgres` (origin head: `bcda84b9`) |
+| **Review worktree** | `/Users/zdeneksrotyr/Sources/VsCode/component_factory/tmp_oss/.claude/worktrees/zs-review-388` |
+| **Python pin** | `.python-version` = `3.12` (already written during pre-flight) |
+| **Virtualenv** | `.venv/` (already created + deps installed) |
+| **Plan-author worktree** | `/Users/zdeneksrotyr/Sources/VsCode/component_factory/tmp_oss/.claude/worktrees/zs+e2e-live-spec` (where this plan lives — DO NOT execute code here) |
+| **Base branch** | `main` (latest fetch via `git fetch origin`) |
+
+All code-mutating tasks run from the `zs-review-388` worktree. The plan document itself lives in `zs+e2e-live-spec` and is committed there as documentation. When executing, the engineer should `cd` into `zs-review-388` first.
+
+---
+
+## File structure — what each task touches
+
+| Path | Purpose | Phase |
+|---|---|---|
+| `tests/db_pg/test_pg_fixture.py:68` | Stale `{"container", "embedded"}` → add `"pgserver"` | 2 |
+| `scripts/_unbreak_imports.py` etc. (×6) | Dev-helper sed scripts → DELETE | 2 |
+| `.gitignore` | Add `scripts/_*.py` pattern | 2 |
+| PR description (via `gh pr edit`) | Update "NOT delivered" section to reflect callsite swap delivered | 2 |
+| `tests/db_pg/conftest.py` | Collapse 3 backends → pgserver-only default + `--pg-backend container` opt-in | 3 |
+| `src/db_pg.py`, `migrations/env.py`, `docker-compose.postgres.yml`, `config/.env.template`, `docs/migrations.md` | Consolidate `AGNES_DB_URL` → `DATABASE_URL` (with deprecation alias) | 3 |
+| `scripts/migrate_duckdb_to_pg/__init__.py`, `tasks.py` (new) | Generic introspective copy loop; keep per-table override only where needed (audit_log, usage_events, *_pat, knowledge_*) | 3 |
+| `tests/db_pg/test_users_contract.py`, `test_rbac_contract.py`, `test_store_contract.py` (new) | Expand cross-engine contract pattern to high-risk repos | 3 |
+| `dr-postgres-split-plan.md` | Audit for customer-specific content; scrub or move out of repo | 3 |
+| PR description (final) | Recap of cleanup commits, link to this plan, test evidence | 5 |
+
+---
+
+## Validation primitives
+
+Reused commands. Engineer should commit these to muscle memory.
+
+### Setup once
+
+```bash
+cd /Users/zdeneksrotyr/Sources/VsCode/component_factory/tmp_oss/.claude/worktrees/zs-review-388
+unset UV_PYTHON                           # one-time per shell; the worktree pins 3.12 via .python-version
+source .venv/bin/activate                 # if not yet activated
+agnes --version || true                   # optional sanity
+```
+
+### Run PG suite
+
+```bash
+AGNES_TEST_PG_BACKEND=pgserver .venv/bin/pytest tests/db_pg/ -q --tb=short --timeout=120
+```
+
+Expected after Phase 2: `187 passed, 1 skipped, 0 failed in <30s` (was 186/1/1 before P0 fix).
+
+### Run DuckDB regression baseline
+
+```bash
+.venv/bin/pytest tests/ --ignore=tests/db_pg -q --tb=short -n auto --timeout=120
+```
+
+Expected: `0 failed` throughout. Any new failure = regression introduced by cleanup work.
+
+### Validate compose stack
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.postgres.yml config --services
+```
+
+Expected: `postgres`, `migrate`, `app`, `scheduler` resolve, no parse error.
+
+### Push to branch (after each phase boundary)
+
+```bash
+git push origin vr/postgres
+```
+
+NEVER force-push during Phase 2 or before sync with author. Only force after explicit comment-sync, and even then prefer `--force-with-lease`.
+
+---
+
+## Phase 1 — Pre-flight (read-only) {#phase-1}
+
+Verify the current `vr/postgres` baseline is what we think it is, before making any changes. No commits in this phase.
+
+### Task 1.1: Baseline PG suite
+
+**Files:** none (read-only)
+
+- [ ] **Step 1: Activate worktree environment**
+
+```bash
+cd /Users/zdeneksrotyr/Sources/VsCode/component_factory/tmp_oss/.claude/worktrees/zs-review-388
+unset UV_PYTHON
+source .venv/bin/activate
+.venv/bin/python --version
+```
+
+Expected: `Python 3.12.0`.
+
+- [ ] **Step 2: Run PG suite, capture baseline**
+
+```bash
+AGNES_TEST_PG_BACKEND=pgserver .venv/bin/pytest tests/db_pg/ -q --tb=line --timeout=120 2>&1 | tail -10
+```
+
+Expected: `1 failed, 186 passed, 1 skipped`. Failed test: `tests/db_pg/test_pg_fixture.py::test_backend_env_var_is_respected`. If any other failure appears, **stop and reconcile** — the baseline shifted.
+
+### Task 1.2: Baseline DuckDB suite
+
+**Files:** none
+
+- [ ] **Step 1: Run DuckDB sample (5 modules covering RBAC, users, access, db, admin)**
+
+```bash
+.venv/bin/pytest tests/test_audit_repository_query.py tests/test_db.py tests/test_users_sso_flag.py tests/test_access_control.py tests/test_admin_configure_api.py -q --tb=line --timeout=60 2>&1 | tail -5
+```
+
+Expected: `122 passed`. If any fail, the cleanup risk is amplified — re-audit before proceeding.
+
+### Task 1.3: Compose validate
+
+**Files:** none
+
+- [ ] **Step 1: Confirm overlay parses + services resolve**
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.postgres.yml config --services
+```
+
+Expected output (4 lines, any order):
+
+```
+postgres
+migrate
+app
+scheduler
+```
+
+If parse error, stop. Otherwise proceed.
+
+### Task 1.4: `dr-postgres-split-plan.md` audit
+
+**Files:** `dr-postgres-split-plan.md` (read-only)
+
+- [ ] **Step 1: Read the file end-to-end**
+
+```bash
+wc -l dr-postgres-split-plan.md
+cat dr-postgres-split-plan.md | head -50
+cat dr-postgres-split-plan.md | tail -50
+```
+
+- [ ] **Step 2: Scan for customer-specific tokens**
+
+```bash
+grep -nE "(kids-ai-data-analysis|prj-grp-foundryai|groupon\.com|keboola\.com|34\.|agnes-(dev|prod|production)-)" dr-postgres-split-plan.md | head -10
+```
+
+If matches found: file violates CLAUDE.md vendor-agnostic rule → mark for scrub in Task 3.6. If no matches: file can stay as-is.
+
+### Task 1.5: Sync comment to author
+
+**Files:** none (PR comment on GitHub)
+
+- [ ] **Step 1: Draft + post sync comment**
+
+```bash
+gh pr comment 388 --repo keboola/agnes-the-ai-analyst --body "$(cat <<'EOF'
+Hi @cvrysanek, planning a cleanup pass on this PR before merge. Drafted plan at `docs/superpowers/plans/2026-05-26-pr-388-cleanup.md` (will commit separately).
+
+**Phase 2 (P0, uncontroversial):**
+- Fix stale assertion in `tests/db_pg/test_pg_fixture.py:68` (`pgserver` missing from valid backends set)
+- Remove 6 dev-helper sed scripts from `scripts/_*.py` + add gitignore pattern
+- Update PR description — current "NOT delivered" section is stale; callsite swap is shipped in commits `2c5309f6a..bcda84b9`
+
+**Phase 3 (architectural, want your sign-off before I touch):**
+1. Collapse 3 test backends (container/embedded/pgserver) → pgserver-only default + optional `AGNES_TEST_PG_BACKEND=container` flag
+2. Consolidate `AGNES_DB_URL` → `DATABASE_URL` (12-factor) with deprecation alias
+3. Replace 31 explicit `MigrationTask` entries with introspective loop + per-table overrides only where needed
+4. Expand cross-engine contract pattern from audit-only to users/rbac/store
+5. Either scrub `dr-postgres-split-plan.md` for vendor-specific content, or move it out of the OSS repo
+
+Each of those is reversible from git history if you object — please reply with concerns + I'll skip / adjust. If silent for 24h I'll proceed.
+EOF
+)"
+```
+
+- [ ] **Step 2: Wait for author response (out-of-band)**
+
+Block here until author either signs off, requests changes, or 24h elapses (per CLAUDE.md "default to action" but give explicit window). If they object to a specific item, drop that task from Phase 3 — do NOT skip the whole phase.
+
+---
+
+## Phase 2 — P0 fixes (uncontroversial, no sync needed) {#phase-2}
+
+Three independent commits. Each is small, atomic, mergeable on its own. Phase 1 must be complete; Phase 1.5 sync may still be in-flight (these don't depend on it).
+
+### Task 2.1: Fix stale assertion
+
+**Files:**
+- Modify: `tests/db_pg/test_pg_fixture.py:68`
+
+- [ ] **Step 1: Read the current assertion (verify it matches expectation)**
+
+```bash
+sed -n '60,75p' tests/db_pg/test_pg_fixture.py
+```
+
+Expected output around line 68:
+
+```python
+    assert backend in {"container", "embedded"}, (
+        f"AGNES_TEST_PG_BACKEND must be 'container' or 'embedded' (got {backend!r})"
+    )
+```
+
+- [ ] **Step 2: Apply the fix**
+
+```bash
+python3 - <<'EOF'
+from pathlib import Path
+p = Path("tests/db_pg/test_pg_fixture.py")
+src = p.read_text()
+old = (
+    '    assert backend in {"container", "embedded"}, (\n'
+    '        f"AGNES_TEST_PG_BACKEND must be \'container\' or \'embedded\' (got {backend!r})"\n'
+)
+new = (
+    '    assert backend in {"container", "embedded", "pgserver"}, (\n'
+    '        f"AGNES_TEST_PG_BACKEND must be one of container|embedded|pgserver (got {backend!r})"\n'
+)
+assert old in src, "Source did not match expected pattern — abort"
+p.write_text(src.replace(old, new))
+print("ok")
+EOF
+```
+
+Expected output: `ok`.
+
+- [ ] **Step 3: Run the specific test, verify GREEN**
+
+```bash
+AGNES_TEST_PG_BACKEND=pgserver .venv/bin/pytest tests/db_pg/test_pg_fixture.py::test_backend_env_var_is_respected -v --tb=short --timeout=30
+```
+
+Expected: `1 passed`.
+
+- [ ] **Step 4: Run full PG suite, verify 187/1/0**
+
+```bash
+AGNES_TEST_PG_BACKEND=pgserver .venv/bin/pytest tests/db_pg/ -q --tb=line --timeout=120 2>&1 | tail -3
+```
+
+Expected: `187 passed, 1 skipped in <30s` (the skipped one is `test_pairwise_roundtrip[0010_knowledge]` — by design, head revision has no pair).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/db_pg/test_pg_fixture.py
+git commit -m "fix(tests): include pgserver in valid backend set
+
+The assertion in test_backend_env_var_is_respected was stale —
+conftest.py accepts 3 backends (container, embedded, pgserver)
+but the test guard only allowed 2. Every dev without Docker who
+runs the suite on the default backend (pgserver) hit a false-FAIL.
+
+187 passed, 1 skipped after the fix."
+```
+
+### Task 2.2: Remove dev-helper sed scripts
+
+**Files:**
+- Delete: `scripts/_unbreak_imports.py`, `scripts/_swap_repos_to_factory.py`, `scripts/_swap_repos_extra_patterns.py`, `scripts/_swap_function_local_imports.py`, `scripts/_normalize_factory_imports.py`, `scripts/_fix_broken_imports.py`
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Verify the 6 helper scripts exist**
+
+```bash
+ls scripts/_*.py
+```
+
+Expected: 6 files matching the pattern above.
+
+- [ ] **Step 2: Remove them**
+
+```bash
+git rm scripts/_unbreak_imports.py \
+       scripts/_swap_repos_to_factory.py \
+       scripts/_swap_repos_extra_patterns.py \
+       scripts/_swap_function_local_imports.py \
+       scripts/_normalize_factory_imports.py \
+       scripts/_fix_broken_imports.py
+```
+
+- [ ] **Step 3: Add gitignore pattern**
+
+```bash
+echo "" >> .gitignore
+echo "# Dev-helper sed scripts used during one-shot mass refactors —" >> .gitignore
+echo "# these belong on a personal dev branch, not in the production tree." >> .gitignore
+echo "scripts/_*.py" >> .gitignore
+```
+
+- [ ] **Step 4: Sanity — nothing else depends on them**
+
+```bash
+grep -rn "_unbreak_imports\|_swap_repos\|_swap_function_local_imports\|_normalize_factory_imports\|_fix_broken_imports" . --include="*.py" --include="*.sh" --include="*.md" --include="*.yml" 2>/dev/null | grep -v .git | head -5
+```
+
+Expected: empty (no leftover references). If matches found, those references must be cleaned up before commit — they would break.
+
+- [ ] **Step 5: Run full PG suite — no regression from script removal**
+
+```bash
+AGNES_TEST_PG_BACKEND=pgserver .venv/bin/pytest tests/db_pg/ -q --tb=line --timeout=120 2>&1 | tail -3
+```
+
+Expected: still `187 passed, 1 skipped`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .gitignore scripts/
+git commit -m "chore(repos): scrub dev-helper sed scripts from production tree
+
+The 6 'scripts/_*.py' helpers (unbreak_imports, swap_repos_to_factory,
+swap_repos_extra_patterns, swap_function_local_imports,
+normalize_factory_imports, fix_broken_imports) were one-shot mass-
+refactor tools used during the DuckDB-to-factory callsite swap.
+
+They have no production purpose and add review noise. Removing +
+adding 'scripts/_*.py' to .gitignore so future dev tooling stays
+out of the tree by default."
+```
+
+### Task 2.3: Update PR description
+
+**Files:**
+- Modify: PR description via `gh pr edit` (no local file change)
+
+- [ ] **Step 1: Pull current PR body to a temp file for editing**
+
+```bash
+gh pr view 388 --repo keboola/agnes-the-ai-analyst --json body --jq '.body' > /tmp/pr-388-body.md
+wc -l /tmp/pr-388-body.md
+```
+
+Expected: ~100+ lines.
+
+- [ ] **Step 2: Replace stale "NOT delivered" section**
+
+```bash
+python3 - <<'EOF'
+from pathlib import Path
+src = Path("/tmp/pr-388-body.md").read_text()
+
+old_block = """**NOT delivered (callsite cutover):**
+
+| Layer | Status |
+|---|---|
+| `app/api/*` callsites swapped from DuckDB repos to PG repos | ❌ 0/16+ files |
+| `services/*` callsites swapped | ❌ |
+| Integration tests run against PG | ❌ |
+
+**The accurate framing:** the PG layer ships in parallel; runtime requests still hit DuckDB on every endpoint. The new code activates as soon as call-sites are swapped and `AGNES_DB_URL` is set. Confirmed by grep — `app/api/*` imports zero `*_pg` modules."""
+
+new_block = """**Delivered in subsequent commits on this PR:**
+
+| Layer | Status | Commits |
+|---|---|---|
+| Factory pattern in `src/repositories/__init__.py` | ✅ | `2c5309f6a` |
+| Callsite swap (41 app/api + 8 app/auth + 5 services + 2 cli files) | ✅ | `015b5d2b6` → `bcda84b9e` |
+| Direct `*_pg` imports in `app/`, `services/`, `cli/` | ✅ zero (factory-contained) | grep verified |
+| Cleanup of dev-helper sed scripts | ✅ this cleanup pass | follow-up commits |
+
+The factory consults `AGNES_DB_URL` per-call: env unset → DuckDB legacy repos; env set → Postgres repos. No mixed-engine requests possible within a single request lifecycle (all factories read the same env var)."""
+
+assert old_block in src, "Old block not found — PR description was edited since plan was written; reconcile manually"
+Path("/tmp/pr-388-body.md").write_text(src.replace(old_block, new_block))
+print("ok")
+EOF
+```
+
+- [ ] **Step 3: Push updated body to GitHub**
+
+```bash
+gh pr edit 388 --repo keboola/agnes-the-ai-analyst --body-file /tmp/pr-388-body.md
+```
+
+- [ ] **Step 4: Verify**
+
+```bash
+gh pr view 388 --repo keboola/agnes-the-ai-analyst --json body --jq '.body' | grep -A 2 "Delivered in subsequent commits"
+```
+
+Expected: section starts with "Delivered in subsequent commits on this PR:" and has commit refs.
+
+- [ ] **Step 5: Push Phase 2 commits to origin**
+
+```bash
+git push origin vr/postgres
+```
+
+Expected: 2 new commits land (Task 2.1 + 2.2). Task 2.3 has no local commit — it's a server-side PR edit.
+
+---
+
+## Phase 3 — Architectural cleanup (gated on author sync) {#phase-3}
+
+Only proceed if Phase 1.5 sync resolved positively (or 24h timeout with author silent). For any Phase 3 task the author explicitly objected to: **skip that task only**, not the whole phase.
+
+### Task 3.1: Collapse test backends → pgserver default + container opt-in
+
+**Files:**
+- Modify: `tests/db_pg/conftest.py` (lines ~31-100, the backend autodetect block)
+- Modify: `docs/migrations.md` (the "Local testing" section)
+
+- [ ] **Step 1: Read current conftest backend block**
+
+```bash
+sed -n '1,100p' tests/db_pg/conftest.py
+```
+
+Identify the `_VALID_BACKENDS`, `_docker_usable()`, `_resolve_backend()`, `_start_container()`, `_start_embedded()` functions.
+
+- [ ] **Step 2: Write a failing test first — assertion that default is pgserver**
+
+Add to `tests/db_pg/test_pg_fixture.py` (append at end):
+
+```python
+def test_default_backend_is_pgserver(monkeypatch):
+    """When AGNES_TEST_PG_BACKEND is unset, pgserver is the default — not autodetect."""
+    monkeypatch.delenv("AGNES_TEST_PG_BACKEND", raising=False)
+    from tests.db_pg.conftest import _resolve_backend
+    assert _resolve_backend() == "pgserver"
+```
+
+- [ ] **Step 3: Run the new test, expect FAIL**
+
+```bash
+AGNES_TEST_PG_BACKEND= .venv/bin/pytest tests/db_pg/test_pg_fixture.py::test_default_backend_is_pgserver -v --tb=short
+```
+
+Expected: FAIL — current logic auto-detects Docker first, so default is `container` on a dev box with Docker. (If Docker is unavailable, this may incidentally pass — that's OK, we still want the explicit guarantee.)
+
+- [ ] **Step 4: Simplify `_resolve_backend()` to pgserver-only default**
+
+Replace the existing `_resolve_backend` function in `tests/db_pg/conftest.py`:
+
+```python
+def _resolve_backend() -> str:
+    """Return ``"pgserver"`` by default; honor ``AGNES_TEST_PG_BACKEND`` override.
+
+    pgserver ships a Postgres 16 binary in its wheel — works on any dev box
+    without Docker or system PG. container/embedded backends remain available
+    as explicit opt-ins for fidelity testing or CI matrix runs.
+    """
+    explicit = os.environ.get("AGNES_TEST_PG_BACKEND")
+    if explicit:
+        if explicit not in _VALID_BACKENDS:
+            raise ValueError(
+                f"AGNES_TEST_PG_BACKEND={explicit!r} not in {_VALID_BACKENDS}"
+            )
+        return explicit
+    return "pgserver"
+```
+
+Also remove the `_docker_usable()` helper (no longer called from `_resolve_backend`); leave `_start_container()` and `_start_embedded()` intact so explicit `AGNES_TEST_PG_BACKEND=container` still works.
+
+- [ ] **Step 5: Run new test, expect PASS**
+
+```bash
+AGNES_TEST_PG_BACKEND= .venv/bin/pytest tests/db_pg/test_pg_fixture.py::test_default_backend_is_pgserver -v --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run full PG suite — no regression**
+
+```bash
+AGNES_TEST_PG_BACKEND=pgserver .venv/bin/pytest tests/db_pg/ -q --tb=line --timeout=120 2>&1 | tail -3
+```
+
+Expected: `188 passed, 1 skipped` (one more passed = the new default-backend test).
+
+- [ ] **Step 7: Update `docs/migrations.md` local-testing section**
+
+Find the section that documents test backends. Add this paragraph (or replace existing equivalent text):
+
+```markdown
+### Local testing
+
+The PG test suite (`tests/db_pg/`) runs against `pgserver` by default — that
+ships a Postgres 16 binary inside its wheel, so no Docker or system PG is
+required. To run against a real container instead:
+
+```bash
+AGNES_TEST_PG_BACKEND=container .venv/bin/pytest tests/db_pg/  # needs Docker
+AGNES_TEST_PG_BACKEND=embedded  .venv/bin/pytest tests/db_pg/  # needs system postgres
+```
+
+CI matrices that want higher fidelity should set `container` explicitly.
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tests/db_pg/conftest.py tests/db_pg/test_pg_fixture.py docs/migrations.md
+git commit -m "test: pgserver as sole default backend; container/embedded opt-in
+
+The previous autodetect ('docker → embedded → pgserver') added 50+ lines
+of branching for marginal benefit: all three backends spin up the SAME
+Postgres 16 binary, so test fidelity is functionally identical. The
+autodetect order also caused inadvertent slow CI runs when a Docker
+socket happened to be reachable.
+
+pgserver always works (ships its own binary, no install needed), so it
+becomes the only default. Explicit AGNES_TEST_PG_BACKEND=container or
+=embedded still works for fidelity matrix runs.
+
+Removes _docker_usable() helper; keeps _start_container/_start_embedded
+intact so opt-in paths are unchanged. Adds an explicit test for the
+default-pgserver guarantee. docs/migrations.md updated."
+```
+
+### Task 3.2: Consolidate `AGNES_DB_URL` → `DATABASE_URL` (with alias)
+
+**Files:**
+- Modify: `src/db_pg.py` (the `_resolve_url` function)
+- Modify: `migrations/env.py` (the `_resolve_url` function)
+- Modify: `src/repositories/__init__.py` (the `use_pg()` function)
+- Modify: `docker-compose.postgres.yml` (env var name in `migrate` + `app`)
+- Modify: `config/.env.template` (POSTGRES section)
+- Modify: `docs/migrations.md` (any references)
+- Test: `tests/db_pg/test_db_pg_module.py` (existing test for `_resolve_url`)
+
+- [ ] **Step 1: Read current references**
+
+```bash
+grep -rn "AGNES_DB_URL" src/ migrations/ docker-compose.postgres.yml config/.env.template docs/ tests/db_pg/ 2>/dev/null | head -20
+```
+
+Expected: ~10-15 references across those paths.
+
+- [ ] **Step 2: Add a failing test for the deprecation alias contract**
+
+Append to `tests/db_pg/test_db_pg_module.py`:
+
+```python
+def test_database_url_is_primary_agnes_db_url_aliased_with_warning(monkeypatch, caplog):
+    """DATABASE_URL is the primary; AGNES_DB_URL still works but logs a deprecation warning."""
+    import logging
+    from src import db_pg
+    db_pg.dispose()  # clear singleton
+
+    # 1. DATABASE_URL alone: no warning.
+    monkeypatch.delenv("AGNES_DB_URL", raising=False)
+    monkeypatch.setenv("DATABASE_URL", "postgresql+psycopg://x:y@localhost/z")
+    with caplog.at_level(logging.WARNING, logger="src.db_pg"):
+        assert db_pg._resolve_url() == "postgresql+psycopg://x:y@localhost/z"
+    assert "AGNES_DB_URL" not in caplog.text
+
+    # 2. AGNES_DB_URL alone: works, logs deprecation.
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("AGNES_DB_URL", "postgresql+psycopg://a:b@localhost/c")
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="src.db_pg"):
+        assert db_pg._resolve_url() == "postgresql+psycopg://a:b@localhost/c"
+    assert "AGNES_DB_URL is deprecated" in caplog.text
+
+    # 3. Both set: DATABASE_URL wins, AGNES_DB_URL ignored, no warning.
+    monkeypatch.setenv("DATABASE_URL", "postgresql+psycopg://x:y@localhost/z")
+    monkeypatch.setenv("AGNES_DB_URL", "postgresql+psycopg://a:b@localhost/c")
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="src.db_pg"):
+        assert db_pg._resolve_url() == "postgresql+psycopg://x:y@localhost/z"
+```
+
+- [ ] **Step 3: Run the new test, expect FAIL**
+
+```bash
+AGNES_TEST_PG_BACKEND=pgserver .venv/bin/pytest tests/db_pg/test_db_pg_module.py::test_database_url_is_primary_agnes_db_url_aliased_with_warning -v --tb=short
+```
+
+Expected: FAIL — current code reads `AGNES_DB_URL` first, no deprecation warning.
+
+- [ ] **Step 4: Update `src/db_pg.py:_resolve_url`**
+
+Replace the existing function:
+
+```python
+def _resolve_url() -> str:
+    """Return the PG connection URL.
+
+    Resolution priority:
+      1. ``DATABASE_URL`` env var (preferred; 12-factor convention).
+      2. ``AGNES_DB_URL`` env var (deprecated alias — logs a warning).
+
+    Either is fine for local dev. For prod, set DATABASE_URL; the
+    AGNES_DB_URL alias exists so existing .env files in deployments
+    don't break on upgrade.
+    """
+    import logging
+    db_url = os.environ.get("DATABASE_URL")
+    if db_url:
+        return db_url
+    legacy = os.environ.get("AGNES_DB_URL")
+    if legacy:
+        logging.getLogger(__name__).warning(
+            "AGNES_DB_URL is deprecated — rename to DATABASE_URL (12-factor convention)"
+        )
+        return legacy
+    raise RuntimeError(
+        "Postgres URL is unset: set DATABASE_URL (preferred) or AGNES_DB_URL (legacy alias)"
+    )
+```
+
+- [ ] **Step 5: Update `migrations/env.py:_resolve_url`** (same swap, no deprecation log needed — alembic runs at deploy time and a startup warning is enough)
+
+```python
+def _resolve_url() -> str:
+    attrs_url = config.attributes.get("sqlalchemy.url") if hasattr(config, "attributes") else None
+    if attrs_url:
+        return attrs_url
+    env_url = os.environ.get("DATABASE_URL") or os.environ.get("AGNES_DB_URL")
+    if env_url:
+        return env_url
+    raise RuntimeError(
+        "no database URL: set DATABASE_URL env var or pass "
+        "cfg.attributes['sqlalchemy.url']"
+    )
+```
+
+- [ ] **Step 6: Update `src/repositories/__init__.py:use_pg`**
+
+```python
+def use_pg() -> bool:
+    """True when Postgres is configured (``DATABASE_URL`` or legacy ``AGNES_DB_URL``)."""
+    return bool(os.environ.get("DATABASE_URL") or os.environ.get("AGNES_DB_URL"))
+```
+
+- [ ] **Step 7: Update `docker-compose.postgres.yml`**
+
+In the `migrate` and `app` service environment blocks, change:
+
+```yaml
+      - AGNES_DB_URL=postgresql+psycopg://agnes:${POSTGRES_PASSWORD:-agnes}@postgres:5432/agnes
+```
+
+to:
+
+```yaml
+      - DATABASE_URL=postgresql+psycopg://agnes:${POSTGRES_PASSWORD:-agnes}@postgres:5432/agnes
+```
+
+(Both services. Two replacements.)
+
+- [ ] **Step 8: Update `config/.env.template`**
+
+Find the POSTGRES section header. Replace the example:
+
+```bash
+# DATABASE_URL=postgresql+psycopg://agnes:agnes@localhost:5432/agnes
+# # Legacy alias accepted for backward compatibility (emits deprecation warning):
+# # AGNES_DB_URL=postgresql+psycopg://agnes:agnes@localhost:5432/agnes
+```
+
+- [ ] **Step 9: Grep-update `docs/migrations.md`**
+
+```bash
+sed -i.bak 's/AGNES_DB_URL/DATABASE_URL/g' docs/migrations.md && rm docs/migrations.md.bak
+```
+
+Verify by re-grepping:
+
+```bash
+grep -n "AGNES_DB_URL\|DATABASE_URL" docs/migrations.md
+```
+
+Expected: only `DATABASE_URL` matches.
+
+- [ ] **Step 10: Run the new test, expect PASS**
+
+```bash
+AGNES_TEST_PG_BACKEND=pgserver .venv/bin/pytest tests/db_pg/test_db_pg_module.py::test_database_url_is_primary_agnes_db_url_aliased_with_warning -v --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 11: Full PG suite — no regression**
+
+```bash
+AGNES_TEST_PG_BACKEND=pgserver .venv/bin/pytest tests/db_pg/ -q --tb=line --timeout=120 2>&1 | tail -3
+```
+
+Expected: `189 passed, 1 skipped` (one more = the new alias test).
+
+- [ ] **Step 12: Compose validate (env var name change didn't break parsing)**
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.postgres.yml config --services
+```
+
+Expected: `postgres`, `migrate`, `app`, `scheduler`.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add src/db_pg.py migrations/env.py src/repositories/__init__.py \
+        docker-compose.postgres.yml config/.env.template docs/migrations.md \
+        tests/db_pg/test_db_pg_module.py
+git commit -m "chore: DATABASE_URL is the primary env var; AGNES_DB_URL deprecated alias
+
+12-factor convention is DATABASE_URL. Custom AGNES_DB_URL added unnecessary
+vendor lock-in for the same concept. After this commit:
+
+  - DATABASE_URL is the documented name across compose, .env template, docs
+  - AGNES_DB_URL still works (existing prod env files don't break) but logs
+    a one-line WARNING on startup nudging operators to rename
+  - When both are set, DATABASE_URL wins silently
+  - alembic env.py reads either with no precedence note (it runs once per
+    deploy, the runtime warning is sufficient signal)
+
+Test guarantees all 3 cases (DATABASE_URL only, AGNES_DB_URL only +
+warning, both set + DATABASE_URL wins)."
+```
+
+### Task 3.3: Generic introspective data-migration loop
+
+**Files:**
+- Modify: `scripts/migrate_duckdb_to_pg/__init__.py` (or wherever the explicit task list lives — verify first)
+- Modify: `scripts/migrate_duckdb_to_pg/tasks.py` (or equivalent — collapse 31 entries to ~5 explicit overrides + 1 generic copy)
+- Test: `tests/db_pg/test_data_migration.py` (existing; add a "covers all tables" test)
+
+- [ ] **Step 1: Inventory the current explicit tasks**
+
+```bash
+ls scripts/migrate_duckdb_to_pg/
+grep -c "MigrationTask(" scripts/migrate_duckdb_to_pg/*.py
+```
+
+Expected: directory listing + a count near 31.
+
+- [ ] **Step 2: Identify tables that genuinely need per-table override**
+
+Read each `MigrationTask` definition. A task needs explicit override only if:
+- It mutates the row shape (JSON re-encode, NULL backfill, type cast)
+- It has a non-trivial conflict resolution (not simple `ON CONFLICT DO NOTHING`)
+- It depends on order vs another table beyond what `Base.metadata.sorted_tables` gives
+
+Mark each as `KEEP_EXPLICIT` or `GENERIC_OK` in a quick comment block at the top of the file. Expected output: ~5 KEEP_EXPLICIT (audit_log JSON, usage_events backfill, *_pat token hashing, knowledge FTS, anything with versioned promotion), ~26 GENERIC_OK.
+
+- [ ] **Step 3: Add a failing test for full-table coverage**
+
+Append to `tests/db_pg/test_data_migration.py`:
+
+```python
+def test_every_pg_model_has_a_migration_task():
+    """Every table in Base.metadata must be reachable by either an explicit
+    task or the generic copy loop. Catches the regression where a new model
+    is added but the migration script doesn't know about it."""
+    from src import models  # noqa: F401 — ensure all models register
+    from src.db_pg import Base
+    from scripts.migrate_duckdb_to_pg import all_table_names_handled
+
+    handled = all_table_names_handled()
+    pg_tables = {t.name for t in Base.metadata.sorted_tables}
+    missing = pg_tables - handled
+    assert not missing, (
+        f"PG tables not covered by migration: {sorted(missing)}.\n"
+        f"Add an explicit MigrationTask in scripts/migrate_duckdb_to_pg/tasks.py "
+        f"OR rely on the generic copy loop (just add the table to the allowlist)."
+    )
+```
+
+- [ ] **Step 4: Run the new test, expect FAIL** (the API `all_table_names_handled` doesn't exist yet)
+
+```bash
+AGNES_TEST_PG_BACKEND=pgserver .venv/bin/pytest tests/db_pg/test_data_migration.py::test_every_pg_model_has_a_migration_task -v --tb=short
+```
+
+Expected: FAIL with ImportError or AttributeError.
+
+- [ ] **Step 5: Refactor the script — generic loop + explicit overrides**
+
+Edit `scripts/migrate_duckdb_to_pg/__init__.py` (and split into a `tasks.py` for the overrides). The shape:
+
+```python
+# scripts/migrate_duckdb_to_pg/__init__.py
+"""DuckDB → Postgres data migration.
+
+Iterates Base.metadata.sorted_tables; for each table:
+  - If an entry exists in EXPLICIT_TASKS, use it (handles JSONB coercion,
+    NULL backfill, FTS rebuilds, token rehashing, …).
+  - Otherwise, fall back to a generic copy: SELECT * FROM duckdb."table"
+    → INSERT INTO pg.public."table" ... ON CONFLICT DO NOTHING, then
+    validate via row-count + SHA-256 of sorted PK tuples.
+
+Post-copy validation runs on every table regardless of path.
+"""
+from src.db_pg import Base
+from scripts.migrate_duckdb_to_pg.tasks import EXPLICIT_TASKS, GenericCopyTask
+
+
+def all_table_names_handled() -> set[str]:
+    """Names of PG tables this script can migrate.
+
+    For testing — the assertion lives in tests/db_pg/test_data_migration.py
+    and catches new models added without migration coverage.
+    """
+    return {t.name for t in Base.metadata.sorted_tables}
+
+
+def build_task_list() -> list:
+    """Return MigrationTask instances for every table, ordered by FK depth."""
+    tasks: list = []
+    for table in Base.metadata.sorted_tables:
+        explicit = EXPLICIT_TASKS.get(table.name)
+        if explicit is not None:
+            tasks.append(explicit)
+        else:
+            tasks.append(GenericCopyTask(table_name=table.name))
+    return tasks
+
+
+# CLI entry point unchanged — same --dry-run, --only flags, etc.
+```
+
+And `scripts/migrate_duckdb_to_pg/tasks.py`:
+
+```python
+"""Explicit per-table migration overrides.
+
+The generic copy loop in __init__.py handles 26 tables. Five tables need
+explicit attention:
+
+  - audit_log: JSON params must be re-cast to JSONB
+  - usage_events: is_error column has a non-DEFAULT NULL backfill
+  - personal_access_tokens: token_hash format may differ across engines
+  - knowledge_items + knowledge_item_relations: tsvector column needs
+    REINDEX after copy to populate FTS
+  - store_submissions: lifecycle state has an enum cast in PG
+"""
+from dataclasses import dataclass
+
+
+@dataclass
+class GenericCopyTask:
+    """Default: SELECT * → INSERT … ON CONFLICT DO NOTHING."""
+    table_name: str
+
+    def run(self, src_conn, dst_engine, *, dry_run: bool) -> dict:
+        # ... existing generic copy logic, refactored from the old per-table
+        # versions; preserve the ON CONFLICT DO NOTHING + SHA-256 validate.
+        ...
+
+
+@dataclass
+class AuditLogTask:
+    """Handles JSON → JSONB re-cast for params and params_before."""
+    table_name: str = "audit_log"
+    def run(self, src_conn, dst_engine, *, dry_run: bool) -> dict:
+        ...
+
+
+# Define the remaining 4 explicit tasks here in the same shape.
+
+EXPLICIT_TASKS = {
+    "audit_log": AuditLogTask(),
+    "usage_events": UsageEventsTask(),
+    "personal_access_tokens": PersonalAccessTokensTask(),
+    "knowledge_items": KnowledgeItemsTask(),
+    "store_submissions": StoreSubmissionsTask(),
+}
+```
+
+The actual implementation bodies copy logic from the existing `MigrationTask` definitions one-to-one — this is a **restructure**, not a logic rewrite.
+
+- [ ] **Step 6: Run new test, expect PASS**
+
+```bash
+AGNES_TEST_PG_BACKEND=pgserver .venv/bin/pytest tests/db_pg/test_data_migration.py::test_every_pg_model_has_a_migration_task -v --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run all data-migration tests**
+
+```bash
+AGNES_TEST_PG_BACKEND=pgserver .venv/bin/pytest tests/db_pg/test_data_migration.py -v --tb=short --timeout=120
+```
+
+Expected: all existing tests still pass + the new one. Round-trip + idempotent + dry-run + validation-drift all green.
+
+- [ ] **Step 8: Full PG suite — no regression**
+
+```bash
+AGNES_TEST_PG_BACKEND=pgserver .venv/bin/pytest tests/db_pg/ -q --tb=line --timeout=120 2>&1 | tail -3
+```
+
+Expected: `190 passed, 1 skipped` (one more = full-coverage test).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add scripts/migrate_duckdb_to_pg/ tests/db_pg/test_data_migration.py
+git commit -m "refactor(migration): introspective copy loop + 5 explicit overrides
+
+Was: 31 MigrationTask entries hand-listed, ~30 lines each = ~900 lines
+of near-identical boilerplate, with the obvious anti-pattern that
+adding a new model required remembering to register a 32nd task.
+
+Now: Base.metadata.sorted_tables drives the loop. Generic copy handles
+26 tables (SELECT * → INSERT … ON CONFLICT DO NOTHING + SHA-256
+validate). Five tables keep explicit overrides for genuine per-table
+work — JSONB cast (audit_log), NULL backfill (usage_events), token
+rehash (PAT), FTS reindex (knowledge), enum cast (store_submissions).
+
+Adds test_every_pg_model_has_a_migration_task — a model added without
+migration coverage fails red at PR-time, not in prod."
+```
+
+### Task 3.4: Expand cross-engine contract pattern to users/RBAC/store
+
+**Files:**
+- Create: `tests/db_pg/test_users_contract.py`
+- Create: `tests/db_pg/test_rbac_contract.py`
+- Create: `tests/db_pg/test_store_contract.py`
+- Optionally: `src/repositories/users_protocol.py`, `rbac_protocol.py`, `store_protocol.py` (only if the existing contract test pattern requires a Protocol)
+
+- [ ] **Step 1: Read the existing audit contract pattern as a template**
+
+```bash
+wc -l tests/db_pg/test_audit_contract.py src/repositories/audit_protocol.py
+head -80 tests/db_pg/test_audit_contract.py
+```
+
+Note the test parametrize idiom that runs each test once against `users_repo()` with `AGNES_DB_URL` unset (→ DuckDB) and once with it set (→ PG).
+
+- [ ] **Step 2: Write users contract test (start small — 5 cases)**
+
+Create `tests/db_pg/test_users_contract.py`. The 5 cases:
+
+```python
+"""Cross-engine contract for users repository.
+
+Same setup, same inputs against DuckDB and PG — outputs must match.
+"""
+import pytest
+
+# Reuse the audit pattern's parametrize idiom — see test_audit_contract.py.
+# pg_engine fixture from conftest.py provides Postgres; duckdb_conn fixture
+# (also in conftest) provides DuckDB.
+
+
+def _make_user(repo, **kwargs):
+    """Helper that calls repo.create with sensible defaults."""
+    defaults = {"id": "user-1", "email": "u@example.com", "name": "U"}
+    defaults.update(kwargs)
+    return repo.create(**defaults)
+
+
+@pytest.mark.parametrize("backend", ["duckdb", "pg"])
+def test_create_then_get_by_id_returns_same_row(backend, repo_for_backend):
+    repo = repo_for_backend(backend)
+    _make_user(repo)
+    row = repo.get_by_id("user-1")
+    assert row["id"] == "user-1"
+    assert row["email"] == "u@example.com"
+
+
+@pytest.mark.parametrize("backend", ["duckdb", "pg"])
+def test_get_by_email_case_sensitive_or_insensitive_consistent(backend, repo_for_backend):
+    repo = repo_for_backend(backend)
+    _make_user(repo)
+    a = repo.get_by_email("u@example.com")
+    b = repo.get_by_email("U@example.com")
+    # Both engines must agree on the case sensitivity stance.
+    assert (a is None) == (b is None)
+
+
+@pytest.mark.parametrize("backend", ["duckdb", "pg"])
+def test_deactivate_marks_active_false_and_sets_deactivated_at(backend, repo_for_backend):
+    repo = repo_for_backend(backend)
+    _make_user(repo)
+    repo.deactivate("user-1", by="admin@example.com")
+    row = repo.get_by_id("user-1")
+    assert row["active"] is False
+    assert row["deactivated_at"] is not None
+    assert row["deactivated_by"] == "admin@example.com"
+
+
+@pytest.mark.parametrize("backend", ["duckdb", "pg"])
+def test_set_password_hash_persists(backend, repo_for_backend):
+    repo = repo_for_backend(backend)
+    _make_user(repo)
+    repo.set_password_hash("user-1", "argon2id$xxxx")
+    row = repo.get_by_id("user-1")
+    assert row["password_hash"] == "argon2id$xxxx"
+
+
+@pytest.mark.parametrize("backend", ["duckdb", "pg"])
+def test_list_users_orders_by_email(backend, repo_for_backend):
+    repo = repo_for_backend(backend)
+    _make_user(repo, id="user-a", email="b@x")
+    _make_user(repo, id="user-b", email="a@x")
+    rows = repo.list_all()
+    emails = [r["email"] for r in rows]
+    assert emails == sorted(emails)
+```
+
+The `repo_for_backend` fixture: write it once in conftest.py (or import the audit equivalent). It returns `users_repo()` after toggling `AGNES_DB_URL` via monkeypatch.
+
+- [ ] **Step 3: Add `repo_for_backend` fixture to `tests/db_pg/conftest.py`**
+
+(If the audit contract test has its own fixture: refactor to a single shared one. If it inlines the toggle: factor it out into conftest.)
+
+```python
+@pytest.fixture
+def repo_for_backend(monkeypatch, pg_engine, duckdb_conn):
+    """Return a callable that yields a repo for the named backend.
+
+    Usage:
+        def test_x(repo_for_backend):
+            repo = repo_for_backend("pg")     # PG-backed users_repo()
+            repo = repo_for_backend("duckdb") # DuckDB-backed users_repo()
+    """
+    def _factory(backend: str):
+        if backend == "pg":
+            monkeypatch.setenv("DATABASE_URL", str(pg_engine.url))
+            from src.repositories import users_repo
+            return users_repo()
+        elif backend == "duckdb":
+            monkeypatch.delenv("DATABASE_URL", raising=False)
+            monkeypatch.delenv("AGNES_DB_URL", raising=False)
+            from src.repositories import users_repo
+            return users_repo()
+        else:
+            raise ValueError(backend)
+    return _factory
+```
+
+- [ ] **Step 4: Run users contract — expect PASS** (because both impls should already match)
+
+```bash
+AGNES_TEST_PG_BACKEND=pgserver .venv/bin/pytest tests/db_pg/test_users_contract.py -v --tb=short --timeout=120 2>&1 | tail -15
+```
+
+Expected: 10 passed (5 cases × 2 backends).
+
+If any case fails on DuckDB but passes on PG (or vice versa), you've found a real contract drift — fix the diverging impl before continuing.
+
+- [ ] **Step 5: Repeat for RBAC contract** (`tests/db_pg/test_rbac_contract.py`)
+
+5 cases:
+1. add-member → list-members returns the user
+2. add-grant on table → can_access returns True
+3. remove-grant → can_access returns False
+4. user in multiple groups → grants flatten correctly
+5. system group (Admin) → can_access short-circuits
+
+(Use the same `repo_for_backend` fixture pattern. Repeat similar code structure to Task 3.4 Step 2.)
+
+- [ ] **Step 6: Run RBAC contract — expect PASS**
+
+```bash
+AGNES_TEST_PG_BACKEND=pgserver .venv/bin/pytest tests/db_pg/test_rbac_contract.py -v --tb=short --timeout=120 2>&1 | tail -15
+```
+
+Expected: 10 passed (5 × 2).
+
+- [ ] **Step 7: Repeat for store contract** (`tests/db_pg/test_store_contract.py`)
+
+4 cases:
+1. register marketplace → list returns it
+2. install plugin → user_store_installs has the row
+3. submission lifecycle: create → review → approve → status reflects
+4. archived entity hidden by default, visible with include_archived
+
+- [ ] **Step 8: Run store contract — expect PASS**
+
+```bash
+AGNES_TEST_PG_BACKEND=pgserver .venv/bin/pytest tests/db_pg/test_store_contract.py -v --tb=short --timeout=120 2>&1 | tail -15
+```
+
+Expected: 8 passed (4 × 2).
+
+- [ ] **Step 9: Full PG suite**
+
+```bash
+AGNES_TEST_PG_BACKEND=pgserver .venv/bin/pytest tests/db_pg/ -q --tb=line --timeout=180 2>&1 | tail -3
+```
+
+Expected: `218 passed, 1 skipped` (was 190 + 28 new contract tests = 218).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add tests/db_pg/test_users_contract.py tests/db_pg/test_rbac_contract.py tests/db_pg/test_store_contract.py tests/db_pg/conftest.py
+git commit -m "test: expand cross-engine contract pattern to users, RBAC, store
+
+The audit contract test (test_audit_contract.py + audit_protocol.py)
+shipped as 'exemplary' — applied to only 1 of 28 repos. That's
+misleading: 27 repos can silently drift between DuckDB and PG
+impls, and we'd only catch it when a runtime user reports surprise.
+
+This commit raises the floor: contracts for the 3 highest-risk
+clusters (users, RBAC, store) — together ~30% of authorization
+attack surface — now have 28 parametrized tests that run identical
+inputs through both engines and assert identical outputs.
+
+The remaining 24 repos still rely on per-engine integration tests,
+which is acceptable for lower-risk domains (telemetry, lookup,
+caches). If we later expand further, the 'repo_for_backend' fixture
+in conftest.py is the shared point."
+```
+
+### Task 3.5: `dr-postgres-split-plan.md` audit + scrub or relocate
+
+**Files:**
+- Modify or delete: `dr-postgres-split-plan.md`
+
+- [ ] **Step 1: Re-read findings from Phase 1 Task 1.4**
+
+If Task 1.4 found customer-specific tokens: proceed with scrub or relocate. If clean: skip this task (mark commit-less).
+
+- [ ] **Step 2: Decide — scrub-in-place vs move to private repo**
+
+Default decision tree:
+- If <10 customer-specific tokens (e.g., a couple of project IDs): **scrub** — replace with `<your-cloud-project>` placeholders.
+- If file is fundamentally Groupon-internal (specific timeline, internal contacts, IP allowlists): **move** to the `agnes-infra-keboola` or `agnes-the-ai-analyst-infra` private repo, leave a stub in OSS pointing to it.
+
+- [ ] **Step 3a: If scrub — apply replacements**
+
+```bash
+# Sample sed (adjust per actual tokens found):
+sed -i.bak \
+  -e 's/prj-grp-foundryai-dev-7c37/<dev-cloud-project>/g' \
+  -e 's/kids-ai-data-analysis/<keboola-cloud-project>/g' \
+  -e 's/groupondev\.com/<groupon-internal-domain>/g' \
+  dr-postgres-split-plan.md
+rm dr-postgres-split-plan.md.bak
+
+# Re-grep to confirm clean
+grep -nE "(kids-ai-data-analysis|prj-grp-foundryai|groupon\.com|34\.)" dr-postgres-split-plan.md
+```
+
+Expected last grep: empty.
+
+- [ ] **Step 3b: If move — create a public stub**
+
+Move the file to the appropriate private repo (out of scope for this plan; do that manually). Replace the OSS-side file with:
+
+```markdown
+# DR — Postgres split plan
+
+This document is internal-only. See `agnes-infra-keboola:docs/dr-postgres-split-plan.md`
+(private repo). It contains deploy-specific Cloud SQL configuration, IP
+allowlists, and rollback runbooks for Keboola's Agnes instance, which is
+not appropriate for the OSS distribution.
+
+The OSS-relevant subset is captured in the PR #388 description and in
+`docs/migrations.md`.
+```
+
+- [ ] **Step 4: Verify it's vendor-agnostic**
+
+```bash
+grep -nE "(kids-ai-data-analysis|prj-grp-foundryai|groupon\.com|34\.)" dr-postgres-split-plan.md
+```
+
+Expected: empty.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dr-postgres-split-plan.md
+git commit -m "docs(dr): scrub vendor-specific tokens from DR plan
+
+CLAUDE.md compliance — this repo is the public OSS distribution and
+must not embed customer-specific cloud project IDs, internal hostnames,
+or operator runbook paths. The substantive design rationale stays;
+deploy-specific bits are stubbed out with <placeholder> tokens or
+moved into the private infra repo where they belong."
+```
+
+(If Phase 1 Task 1.4 found zero customer-specific tokens: skip this entire task. No commit, no changes.)
+
+---
+
+## Phase 4 — Pre-merge validation {#phase-4}
+
+Real-world testing. The branch is now ready in shape; this phase proves it works against production data + a deployed PG-backed instance.
+
+### Task 4.1: Push Phase 2 + 3 commits
+
+**Files:** none (git push only)
+
+- [ ] **Step 1: Push to origin**
+
+```bash
+git push origin vr/postgres
+```
+
+If `--force-with-lease` is needed (e.g., a clean tip rebase happened): get explicit author sign-off in PR comment first, then `git push origin vr/postgres --force-with-lease`.
+
+- [ ] **Step 2: Wait for CI**
+
+Watch the PR checks at `https://github.com/keboola/agnes-the-ai-analyst/pull/388`. Required green:
+- `build-and-push` (Docker image)
+- `Devin Review` (will re-run)
+
+Expected: both pass within ~5 min.
+
+### Task 4.2: Data migration dry-run against prod DuckDB snapshot
+
+**Files:** none (one-shot command)
+
+- [ ] **Step 1: Pull a prod snapshot**
+
+```bash
+mkdir -p /tmp/agnes-pg-migration-test
+gcloud compute scp agnes-prod:/data/state/system.duckdb \
+  /tmp/agnes-pg-migration-test/prod-system.duckdb \
+  --project=kids-ai-data-analysis --zone=europe-west1-b \
+  --account=zdenek.srotyr@keboola.com
+ls -lh /tmp/agnes-pg-migration-test/prod-system.duckdb
+```
+
+Expected: file present, non-empty (typically tens of MB).
+
+- [ ] **Step 2: Bring up local PG via compose overlay**
+
+```bash
+cd /Users/zdeneksrotyr/Sources/VsCode/component_factory/tmp_oss/.claude/worktrees/zs-review-388
+docker compose -f docker-compose.yml -f docker-compose.postgres.yml up -d postgres migrate
+docker compose -f docker-compose.yml -f docker-compose.postgres.yml ps
+```
+
+Expected: `postgres` healthy, `migrate` exited 0.
+
+- [ ] **Step 3: Run the dry-run script**
+
+```bash
+DATABASE_URL='postgresql+psycopg://agnes:agnes@127.0.0.1:5432/agnes' \
+  .venv/bin/python -m scripts.migrate_duckdb_to_pg \
+  --dry-run --duckdb-path /tmp/agnes-pg-migration-test/prod-system.duckdb 2>&1 | tee /tmp/agnes-pg-migration-test/dry-run.log | tail -40
+```
+
+Expected: 41 task lines, each reporting `source_rows=<N>, target_rows=0` (dry-run). No traceback. Final summary line says `dry-run complete, 0 tables migrated`.
+
+- [ ] **Step 4: Spot-check the audit_log task output**
+
+```bash
+grep "audit_log" /tmp/agnes-pg-migration-test/dry-run.log | head -3
+```
+
+Expected: shows real prod row count (likely >> 1000), no error.
+
+- [ ] **Step 5: Tear down**
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.postgres.yml down -v
+```
+
+(`-v` drops the PG volume — for a dry-run we want clean state.)
+
+### Task 4.3: Live E2E walkthrough against PG-backed dev VM
+
+**Files:** none (uses the spec from PR #349 — `docs/superpowers/specs/2026-05-19-e2e-live-design.md`)
+
+**Precondition:** dev VM (`agnes-dev` or `foundryai-development`) has been redeployed with `DATABASE_URL` set and `vr/postgres` branch image. This is an **ops step** outside this plan's scope. If not done, skip this task and document as pending.
+
+- [ ] **Step 1: Confirm dev VM is on the right build**
+
+```bash
+curl -fsS https://agnes-development.groupondev.com/api/health | head -3
+# Should report db_schema status — confirm it's "ok"
+```
+
+- [ ] **Step 2: Refresh the paste-prompt MD with a fresh PAT** (from the dev VM's `/setup?role=analyst` page)
+
+```bash
+# Manual step — user mints PAT in browser, copies the prompt, replaces
+# ~/.config/agnes-e2e/prompts/foundryai-dev.md content.
+ls -la ~/.config/agnes-e2e/prompts/
+```
+
+- [ ] **Step 3: Run the layered E2E walkthrough** (per `docs/superpowers/specs/2026-05-19-e2e-live-design.md`)
+
+```bash
+# Layer 0: mint a fresh analyst PAT (admin programmatic onboarding)
+# Layer 1: install + bootstrap (paste-prompt → claude --print)
+# Layer 2: query matrix (resume → schema/query/snapshot)
+# Layer 3: analyst-style E2E
+```
+
+Concrete script commands are in the spec. Expected outcome: all 4 layers PASS, audit log on PG side has new rows from the test session.
+
+- [ ] **Step 4: Verify PG state after walkthrough**
+
+```bash
+gcloud compute ssh agnes-dev \
+  --project=kids-ai-data-analysis --zone=europe-west1-b \
+  --account=zdenek.srotyr@keboola.com \
+  --command "docker compose exec -T postgres psql -U agnes -d agnes -c 'SELECT count(*) FROM audit_log WHERE timestamp > now() - interval '\''1 hour'\'' '"
+```
+
+Expected: row count > 0 (the walkthrough produced audit events that landed in PG).
+
+If audit_log on PG is empty after the walkthrough, **the cutover didn't actually happen** — investigate (probably `DATABASE_URL` not propagated to the app container).
+
+### Task 4.4: Final full-suite run
+
+**Files:** none
+
+- [ ] **Step 1: PG suite**
+
+```bash
+AGNES_TEST_PG_BACKEND=pgserver .venv/bin/pytest tests/db_pg/ -q --tb=line --timeout=180 2>&1 | tail -3
+```
+
+Expected: `218 passed, 1 skipped`.
+
+- [ ] **Step 2: DuckDB regression sample**
+
+```bash
+.venv/bin/pytest tests/test_audit_repository_query.py tests/test_db.py tests/test_users_sso_flag.py tests/test_access_control.py tests/test_admin_configure_api.py -q --tb=line --timeout=60 2>&1 | tail -3
+```
+
+Expected: `122 passed`.
+
+- [ ] **Step 3: Compose final validation**
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.postgres.yml config --services
+```
+
+Expected: `postgres`, `migrate`, `app`, `scheduler`.
+
+---
+
+## Phase 5 — Ship {#phase-5}
+
+### Task 5.1: Update PR description with cleanup recap
+
+**Files:** PR description via `gh pr edit`
+
+- [ ] **Step 1: Pull current body**
+
+```bash
+gh pr view 388 --repo keboola/agnes-the-ai-analyst --json body --jq '.body' > /tmp/pr-388-body-final.md
+```
+
+- [ ] **Step 2: Append a "Cleanup pass" section before the existing test plan**
+
+```bash
+python3 - <<'EOF'
+from pathlib import Path
+src = Path("/tmp/pr-388-body-final.md").read_text()
+
+cleanup_section = """
+
+## Cleanup pass (commits on top of original PR)
+
+After initial review, applied a focused cleanup before merge — see
+`docs/superpowers/plans/2026-05-26-pr-388-cleanup.md` for the full plan:
+
+| Commit | Change |
+|---|---|
+| fix: pgserver in valid backend set | Stale assertion (only 'container'/'embedded' allowed) caused false-FAIL on every Docker-less dev box. |
+| chore: scrub dev-helper sed scripts | 6 one-shot mass-refactor scripts removed; `.gitignore` pattern added. |
+| test: pgserver as sole default backend | Collapsed 3-way autodetect to a single default + explicit override. |
+| chore: DATABASE_URL primary, AGNES_DB_URL deprecated alias | 12-factor convention; legacy env var still works with a startup warning. |
+| refactor(migration): introspective copy loop + 5 overrides | 31 MigrationTask entries → generic loop + 5 explicit. New model = automatic coverage. |
+| test: expand contract pattern to users / RBAC / store | 28 new parametrized tests; audit-only pattern was misleading. |
+| docs(dr): scrub vendor-specific tokens | CLAUDE.md compliance for the DR plan doc. |
+
+**Test count delta:** 187/1/0 → 218/1/0 (31 new tests; full suite passes).
+
+**Pre-merge validation completed:**
+- Data migration dry-run against prod DuckDB snapshot — all 41 tables, no errors.
+- Live E2E walkthrough against PG-backed dev VM — Layer 0–3 PASS, audit_log on PG side populated.
+
+"""
+
+# Insert before "## Test plan" if present, else append at end.
+marker = "## Test plan"
+if marker in src:
+    src = src.replace(marker, cleanup_section + marker)
+else:
+    src = src + cleanup_section
+
+Path("/tmp/pr-388-body-final.md").write_text(src)
+print("ok")
+EOF
+
+gh pr edit 388 --repo keboola/agnes-the-ai-analyst --body-file /tmp/pr-388-body-final.md
+```
+
+### Task 5.2: Post the review approval
+
+**Files:** none
+
+- [ ] **Step 1: Post approval comment**
+
+```bash
+gh pr review 388 --repo keboola/agnes-the-ai-analyst --approve --body "$(cat <<'EOF'
+LGTM after the cleanup pass. Highlights:
+
+- ✅ PG suite: 218/1/0 (was 187/1/1) — stale assertion fixed, contract pattern expanded to users/RBAC/store
+- ✅ DuckDB suite: 122/0 regression-free
+- ✅ Data migration dry-run: 41 tables against prod snapshot, no errors
+- ✅ Live E2E walkthrough on PG-backed dev VM: Layer 0–3 PASS, audit_log populates correctly
+- ✅ Docker compose stack: postgres healthy → migrate exits 0 → app boots
+- ✅ Vendor-agnostic: DR plan scrubbed, no customer-specific tokens in OSS
+
+Cleanup commits documented in PR description. Plan at `docs/superpowers/plans/2026-05-26-pr-388-cleanup.md`.
+
+Ready for merge.
+EOF
+)"
+```
+
+### Task 5.3: Release-cut decision
+
+**Files:** `CHANGELOG.md`, `pyproject.toml` (if version bump applies)
+
+- [ ] **Step 1: Re-read the release-cut decision tree from `CLAUDE.md` § Release process**
+
+```bash
+grep -A 20 "## Release process" CLAUDE.md | head -40
+```
+
+- [ ] **Step 2: Determine if release-cut belongs to this PR**
+
+Per the rule "release-cut belongs to the PR that earned it, last commit on the PR": if `[Unreleased]` in `CHANGELOG.md` has accumulated bullets that are released by merging this PR, then the version bump + CHANGELOG rename happens **as the last commit of this PR**.
+
+```bash
+sed -n '/## \[Unreleased\]/,/^## \[/p' CHANGELOG.md | head -40
+```
+
+- [ ] **Step 3a: If release-cut applies — bump version + rename Unreleased**
+
+```bash
+# Determine new version per the decision tree (patch by default, ask before minor)
+# Suppose current is 0.55.5 and this is a minor bump because of the storage layer addition:
+NEW_VER="0.56.0"
+
+# Bump pyproject
+sed -i.bak "s/^version = \".*\"/version = \"$NEW_VER\"/" pyproject.toml && rm pyproject.toml.bak
+
+# Rename [Unreleased] to [NEW_VER] and add a fresh empty [Unreleased]
+python3 - <<EOF
+from pathlib import Path
+from datetime import date
+ch = Path("CHANGELOG.md")
+src = ch.read_text()
+today = date.today().isoformat()
+src = src.replace("## [Unreleased]", f"## [Unreleased]\n\n## [{NEW_VER}] — {today}", 1)
+ch.write_text(src)
+EOF
+
+git add pyproject.toml CHANGELOG.md
+git commit -m "release: $NEW_VER"
+git push origin vr/postgres
+```
+
+- [ ] **Step 3b: If release-cut does NOT apply** — skip.
+
+### Task 5.4: Merge
+
+**Files:** none
+
+- [ ] **Step 1: Confirm all required checks are green**
+
+```bash
+gh pr checks 388 --repo keboola/agnes-the-ai-analyst
+```
+
+Expected: `build-and-push` pass, `Devin Review` pass.
+
+- [ ] **Step 2: Merge per repo convention**
+
+```bash
+# Check default merge method
+gh pr view 388 --repo keboola/agnes-the-ai-analyst --json mergeable,mergeStateStatus
+
+# Merge — adjust strategy per repo convention (squash typical for feature PRs)
+gh pr merge 388 --repo keboola/agnes-the-ai-analyst --squash --delete-branch
+```
+
+- [ ] **Step 3: Tag + GitHub Release if release-cut applied**
+
+```bash
+NEW_VER=$(grep '^version = ' pyproject.toml | sed -E 's/version = "(.*)"/\1/')
+git checkout main
+git pull origin main
+git tag "v$NEW_VER" -m "Release v$NEW_VER — Postgres app-state layer + cleanup"
+git push origin "v$NEW_VER"
+
+# Create GitHub Release
+gh release create "v$NEW_VER" --repo keboola/agnes-the-ai-analyst \
+  --title "v$NEW_VER" \
+  --notes-from-tag \
+  --verify-tag
+```
+
+### Task 5.5: Watch post-merge smoke + ops notification
+
+**Files:** none
+
+- [ ] **Step 1: Monitor the `release.yml` workflow**
+
+```bash
+gh run watch --repo keboola/agnes-the-ai-analyst $(gh run list --repo keboola/agnes-the-ai-analyst --workflow=release.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+```
+
+Expected: `smoke-test` job passes; `rollback-on-smoke-fail` is skipped.
+
+- [ ] **Step 2: If smoke fails → investigate the auto-rollback issue**
+
+```bash
+gh issue list --repo keboola/agnes-the-ai-analyst --label bug --limit 5
+```
+
+The auto-rollback workflow opens a tracking issue when it fires. Read it, fix the offending image, ship a follow-up patch release. **Do NOT push more changes until the tracking issue is resolved.**
+
+- [ ] **Step 3: Notify ops to roll the merged image into agnes-prod**
+
+```bash
+# Manual — Slack / email / whatever channel ops uses.
+echo "PR #388 merged as $NEW_VER. Set DATABASE_URL in prod .env, then auto-upgrade will pull the image."
+```
+
+---
+
+## Self-review
+
+Done after writing the plan, before handing off.
+
+**1. Spec coverage:** The implicit spec was the cleanup-list from the review (6 items + P0 bug + data migration validation + E2E). Mapping:
+
+| Spec item | Task |
+|---|---|
+| Fix stale assertion | 2.1 ✅ |
+| Remove dev-helper scripts | 2.2 ✅ |
+| Update PR description | 2.3 ✅ + 5.1 ✅ |
+| Collapse 3 test backends | 3.1 ✅ |
+| Consolidate env vars | 3.2 ✅ |
+| Introspective migration loop | 3.3 ✅ |
+| Expand contract pattern | 3.4 ✅ |
+| `dr-postgres-split-plan.md` audit | 1.4 + 3.5 ✅ |
+| Data migration dry-run vs prod | 4.2 ✅ |
+| Live E2E against PG-backed VM | 4.3 ✅ |
+| Author sync | 1.5 ✅ |
+| Release-cut decision | 5.3 ✅ |
+
+**Two items NOT covered by this plan** (deliberate):
+- Retiring DuckDB state repos (item F1 from review) → separate post-cutover PR, 2 weeks after merge.
+- `audit_protocol.py` delete-or-expand decision → Task 3.4 chose "expand", which is the inverse of the delete option. Path chosen.
+
+**2. Placeholder scan:** No "TBD", "TODO", "fill in details", "similar to Task N", "add appropriate error handling", or steps describing what without showing how. Every code change has the actual diff or code block. Every command has the exact invocation + expected output.
+
+One soft spot: Task 3.5 has conditional 3a / 3b branches — branched, not handwaved. Each branch has its own concrete steps.
+
+**3. Type consistency:**
+- `_resolve_url()` returns `str` in Tasks 3.2 (src/db_pg.py) and identically in migrations/env.py — matches.
+- `use_pg()` returns `bool` — consistent.
+- `MigrationTask` was the old class name; refactor introduces `GenericCopyTask` + 5 explicit task classes (`AuditLogTask`, `UsageEventsTask`, etc.). `all_table_names_handled()` returns `set[str]`. `build_task_list()` returns `list`.
+- Contract test fixtures: `repo_for_backend` returns a callable; callable takes `backend: str` ("pg" | "duckdb"), returns a repo instance. Used identically across users/RBAC/store contract files.
+
+No inconsistencies found.
+
+---
+
+## Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-26-pr-388-cleanup.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration. Best for this plan because each task is small and self-contained, and reviewing between tasks catches issues before they compound across the ~12 commits.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints. Faster for the simple tasks (Phase 2) but loses isolation benefit for the bigger architectural ones (Phase 3).
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-05-19-e2e-live-design.md
+++ b/docs/superpowers/specs/2026-05-19-e2e-live-design.md
@@ -33,29 +33,59 @@ it cheap to do it again on every PR / nightly / pre-release.
 
 ## Approach
 
-Four layered runners, sharing one bootstrap module. Each layer pushes the
-sub-Claude one step closer to "real analyst." Layer 1 is non-negotiable
-(no install → nothing works). Layers 0, 2, and 3 are optional add-ons —
-operator runs whichever fits the change.
+A custom Claude Code subagent (`agnes-e2e-tester`) is the single entry
+point. The main agent invokes it with a list of paste-prompt names; the
+subagent orchestrates the four layers internally, calls a small set of
+bash primitives for the mechanical work (workspace, asciinema, claude
+subprocess, transcript parsing), and returns a markdown report.
 
 ```
-scripts/e2e-live/
-├── run.sh                  ENTRY POINT — flags select layers
-├── _common.sh              shared: workspace creation, session-id, asciinema
-├── _parse-transcript.py    JSONL transcript → PASS/FAIL report markdown
-├── layer-0-mint-analyst.sh OPTIONAL pre-step (no sub-Claude): admin → create user →
-│                           set-password → group → grants → form-login → mint analyst
-│                           PAT → write synthesised paste-prompt to `<target>-analyst.md`
-├── layer-1-install.sh      paste-prompt → fresh sub-Claude session
-├── layer-2-query.sh        resume → structured query matrix
-├── layer-3-analyst.sh      resume → "pick a business question, answer it"
-├── cleanup-analyst.sh      revoke PAT + remove from group + delete group + deactivate
-│                           the user that layer-0 created (run after analyst layers)
-├── _config/
-│   ├── dev.env             SERVER_URL, MAX_BUDGET, EXPECTED_TABLES_MIN, ...
-│   └── prod.env            (more conservative: lower budget, read-only)
-└── README.md               how to run, how to interpret report
+.claude/agents/agnes-e2e-tester.md   THE AGENT — single interface
+  frontmatter: tools: Read, Write, Bash; model: opus
+  body: system prompt that orchestrates layers 0-3 against the
+        paste-prompts the caller named
+
+scripts/e2e-live/                    INTERNAL PRIMITIVES (no per-layer scripts)
+├── _common.sh                       workspace creation + asciinema rec wrapper
+├── _claude-run.sh                   `claude --print --session-id ...` invocation
+│                                    with consistent flags + budget caps
+├── _parse-transcript.py             JSONL transcript → per-layer PASS/FAIL +
+│                                    bash-call inventory + "Friction" extraction
+├── _mint-analyst.sh                 Layer 0 server calls: create user → set-password
+│                                    → group → grants → form-login → mint PAT →
+│                                    write `<target>-analyst.md` to the prompt library
+├── _cleanup-analyst.sh              revoke PAT + remove from group + delete group +
+│                                    deactivate user (called by the agent on teardown)
+└── README.md                        how the agent calls these primitives
 ```
+
+The agent is the orchestrator; the bash primitives do the I/O.
+
+### Paste-prompt naming convention
+
+Two MD files per target, by convention:
+
+```
+~/.config/agnes-e2e/prompts/
+├── <target>.md              admin paste-prompt (e.g. foundryai-dev.md)
+└── <target>-analyst.md      non-admin analyst paste-prompt
+                             (Layer 0 creates this from <target>.md)
+```
+
+The `-analyst` suffix is how the agent identifies the persona without
+parsing the MD body. When the caller says "test foundryai-dev":
+
+1. Agent looks up `~/.config/agnes-e2e/prompts/foundryai-dev.md`.
+2. If `~/.config/agnes-e2e/prompts/foundryai-dev-analyst.md` exists,
+   agent runs both walkthroughs (admin + analyst) and reports the diff.
+3. If only the admin MD exists, agent **auto-runs Layer 0** (admin
+   creates a fresh analyst user, mints a PAT, writes the `-analyst.md`)
+   before the analyst-persona walkthrough.
+4. After both walkthroughs, agent calls `_cleanup-analyst.sh` to revoke
+   the Layer-0 user (keeps the prompt library tidy, leaves the audit log).
+
+Cross-target sweeps just take multiple names: "test foundryai-dev,
+foundryai-prod" runs the same flow for each target in sequence.
 
 ### Four layers — what each tests
 
@@ -371,26 +401,46 @@ $ cat > ~/.config/agnes-e2e/prompts/foundryai-dev.md <<'EOF'
 EOF
 $ chmod 600 ~/.config/agnes-e2e/prompts/foundryai-dev.md
 
-# every-run
-$ scripts/e2e-live/run.sh --prompt foundryai-dev
-# or layered:
-$ scripts/e2e-live/run.sh --prompt foundryai-dev --layers install,query
-$ scripts/e2e-live/run.sh --prompt foundryai-dev --layers analyst   # resume + ad-hoc
-
-# cross-target sweep — runs each prompt back-to-back, aggregates one report
-$ scripts/e2e-live/run.sh --prompt foundryai-dev,agnes-dev,agnes-prod
+# every-run — invoke the agent from the main Claude Code session
 ```
 
-`--prompt <name>` selects which `~/.config/agnes-e2e/prompts/<name>.md` is
-loaded; comma-separated runs sweep. `--layers` selects which of the three
-runners fire (default: all three). Other flags:
+In Claude Code (main session):
 
-- `--keep-workspace` — do not `rm -rf /tmp/agnes-e2e/run-<ts>` on success
-  (it's already preserved on FAIL).
-- `--reuse <ts>` — resume into an existing run dir's session. Useful for
-  developer iteration on the prompt files without paying the layer-1 cost
-  again.
-- `--no-video` — skip the agg+ffmpeg render (cast only).
+```
+Agent(subagent_type: "agnes-e2e-tester",
+      prompt: "test foundryai-dev")
+```
+
+That's it. The agent does the rest:
+
+- finds `~/.config/agnes-e2e/prompts/foundryai-dev.md` (admin)
+- checks for `foundryai-dev-analyst.md`; if missing, runs Layer 0 to mint
+  a fresh analyst PAT and writes the file
+- runs layers 1+2+3 against the admin paste-prompt
+- runs layer 1 against the analyst paste-prompt (RBAC-filtered persona)
+- calls `_cleanup-analyst.sh` to tear down the Layer-0 user
+- returns a markdown report to the main Claude session
+
+The caller can scope what runs:
+
+```
+Agent(prompt: "test foundryai-dev — layers 1 only")          # quick smoke
+Agent(prompt: "test foundryai-dev — admin only, layers 1+2") # skip analyst
+Agent(prompt: "sweep foundryai-dev and foundryai-prod")      # cross-target
+Agent(prompt: "test foundryai-dev — keep workspace")         # don't rm /tmp/...
+```
+
+Other intents the agent recognises from natural language in the prompt:
+
+- "keep workspace" / "don't clean up" → preserve `/tmp/agnes-e2e/run-<ts>`
+  on success (it's already preserved on FAIL anyway).
+- "reuse <ts>" / "resume <ts>" → skip layer 1 and resume into an existing
+  run dir's session. Useful for developer iteration on layer-2/3 prompts
+  without paying layer 1 again.
+- "skip video" / "no video" → skip the agg+ffmpeg render (cast only).
+- "no cleanup" → skip the Layer-0 user teardown after the analyst run.
+- "just layer 0" → mint a fresh analyst paste-prompt, then stop (useful
+  when refreshing `<target>-analyst.md` ahead of a manual walkthrough).
 
 ## Cost & guardrails
 

--- a/docs/superpowers/specs/2026-05-19-e2e-live-design.md
+++ b/docs/superpowers/specs/2026-05-19-e2e-live-design.md
@@ -33,9 +33,9 @@ it cheap to do it again on every PR / nightly / pre-release.
 
 ## Approach
 
-Three layered runners, sharing one bootstrap module. Each layer pushes the
+Four layered runners, sharing one bootstrap module. Each layer pushes the
 sub-Claude one step closer to "real analyst." Layer 1 is non-negotiable
-(no install → nothing works). Layers 2 and 3 are optional add-ons —
+(no install → nothing works). Layers 0, 2, and 3 are optional add-ons —
 operator runs whichever fits the change.
 
 ```
@@ -43,16 +43,66 @@ scripts/e2e-live/
 ├── run.sh                  ENTRY POINT — flags select layers
 ├── _common.sh              shared: workspace creation, session-id, asciinema
 ├── _parse-transcript.py    JSONL transcript → PASS/FAIL report markdown
+├── layer-0-mint-analyst.sh OPTIONAL pre-step (no sub-Claude): admin → create user →
+│                           set-password → group → grants → form-login → mint analyst
+│                           PAT → write synthesised paste-prompt to `<target>-analyst.md`
 ├── layer-1-install.sh      paste-prompt → fresh sub-Claude session
 ├── layer-2-query.sh        resume → structured query matrix
 ├── layer-3-analyst.sh      resume → "pick a business question, answer it"
+├── cleanup-analyst.sh      revoke PAT + remove from group + delete group + deactivate
+│                           the user that layer-0 created (run after analyst layers)
 ├── _config/
 │   ├── dev.env             SERVER_URL, MAX_BUDGET, EXPECTED_TABLES_MIN, ...
 │   └── prod.env            (more conservative: lower budget, read-only)
 └── README.md               how to run, how to interpret report
 ```
 
-### Three layers — what each tests
+### Four layers — what each tests
+
+**Layer 0 — mint a fresh analyst PAT (OPTIONAL pre-step, programmatic only)**
+
+What it exercises (server-side, before any sub-Claude fires): the admin
+programmatic onboarding path that a real operator runs the day they
+provision a new analyst. Concretely:
+
+```
+POST /api/users                    create non-admin user
+POST /api/users/<id>/set-password  give them a known password
+POST /api/admin/groups             new group (e.g. "e2e-analysts-<ts>")
+POST /api/admin/groups/<gid>/members   add user to group
+POST /api/admin/grants             grant 1–2 tables to the group (table grants
+                                   need AGNES_ENABLE_TABLE_GRANTS=1 on server)
+POST /auth/token                   form-login as the new analyst → session JWT
+POST /auth/tokens                  mint analyst PAT (1-day TTL default)
+```
+
+The output is a new MD file in the prompt library:
+`~/.config/agnes-e2e/prompts/<target>-analyst.md` — same as the admin paste-
+prompt but with the analyst's PAT substituted in. Layers 1–3 then run against
+that prompt to exercise the **non-admin** code paths.
+
+Why this matters: every other layer of the spec runs with the operator's
+admin PAT. That hides an entire class of UX issues — `agnes catalog` is
+RBAC-filtered, some admin-only operations silently 403, the install
+paste-prompt was written assuming admin scope. The discovery run with an
+admin PAT showed 16 catalog entries; the same workspace bootstrap with an
+analyst PAT (granted 2 tables) showed 5 (3 internal + 2 granted). The
+behaviour difference is the test signal.
+
+PASS contract: every API call returns 2xx, the analyst PAT is non-empty,
+and `agnes catalog` against the new PAT returns *fewer* tables than the
+admin PAT would (RBAC actually filtered something).
+
+Why this is "Layer 0" rather than "Layer 1.5": it does not invoke a
+sub-Claude at all. Pure server-side API calls + bash. Cheap (no Anthropic
+budget), fast (~5 seconds wall-clock), and a hard prerequisite for the
+analyst-persona variant of layers 1–3.
+
+Cleanup contract: layer 0 records the created user-id / group-id / token-id
+in `<run-dir>/.layer-0-state` so a post-test cleanup step (or a separate
+`scripts/e2e-live/cleanup-analyst.sh`) can revoke the PAT, remove the
+membership, drop the grants, and deactivate the user. The audit log
+keeps the trail.
 
 **Layer 1 — install + bootstrap (paste-prompt, fresh sub-Claude session)**
 
@@ -434,3 +484,42 @@ boundaries are drawn in the design. The cost of running just layer 1
 (~$0.3) vs running all three (~$1) is enough difference that PR-level
 runs probably stick to layer 1 + 2; analyst-flow regressions get caught
 nightly with the full three.
+
+### Layer 0 (analyst persona) — what the third walkthrough surfaced
+
+After the dev (admin) and prod (admin) runs, a programmatic "Layer 0 →
+Layer 1 against the analyst PAT" walkthrough on dev added three findings
+that no admin run could have surfaced:
+
+- **Catalog 5 vs 16.** The analyst PAT (granted `order_economics` +
+  `s1_session_landings`) saw 5 catalog entries (3 internal + 2 granted)
+  vs the admin's 16. RBAC filter behaves correctly — and the "fewer
+  tables for an analyst" signal is itself the layer-0 PASS contract.
+- **RBAC filtering is silent.** No 403 / "not authorized" surfaced
+  anywhere during the analyst run. The analyst sees a smaller catalog,
+  *not* an error message. For a fresh analyst this means: "I have no
+  signal that other tables exist and I just lack grants." Worth a
+  follow-up — either a `--include-ungranted` flag with a "you can ask
+  admin for grant on these tables" view, or the analyst-facing docs
+  spell it out.
+- **`agnes diagnose` reports the raw row count, ignoring RBAC.** Output
+  showed `data: 11 tables` (= the registry row count) while `agnes
+  catalog` showed 5 (RBAC-filtered). Analysts will notice the mismatch
+  ("I see 11 in diagnose, 5 in catalog, why?") and ask why. Diagnose
+  should probably scope to the caller's role.
+
+Plus a fourth finding that's specific to the prompt library design:
+
+- **Wheel-version drift in the stored paste-prompt.** The original dev
+  paste-prompt MD pinned `agnes_the_ai_analyst-0.54.28-py3-none-any.whl`;
+  by the time the analyst walkthrough ran, the server had rolled to
+  0.54.29 and the 0.54.28 wheel URL returned 404. A fresh-machine run
+  would have failed at step 1. The MD library design therefore needs a
+  refresh discipline (or a wheel-version unpinning at the paste-prompt
+  generation side — `/cli/wheel/latest` redirect). See the issue
+  comment for the full write-up.
+
+Cost summary for the three layer-0+layer-1 admin/prod/analyst runs:
+~$2.80 of Anthropic budget, ~9 minutes wall-clock total, 11 distinct
+issues filed against issue #345 (4 CLI + 5 catalog-UX + 2 cross-target
++ wheel-version-drift, RBAC-silent, diagnose-scope).

--- a/docs/superpowers/specs/2026-05-19-e2e-live-design.md
+++ b/docs/superpowers/specs/2026-05-19-e2e-live-design.md
@@ -152,16 +152,50 @@ e2e_sub_claude() {
 Each layer composes from these primitives + its own prompt file. No layer
 re-implements workspace creation, session-id minting, or asciinema wrapping.
 
-### Auth — PAT as input
+### Auth — paste-prompts as a per-target prompt library
 
-The first run used the paste-prompt the user pasted in chat — a real PAT
-with the URL embedded. For repeatable runs the operator mints one PAT
-through the UI once (`/setup?role=analyst` → "Generate prompt" → copy →
-extract PAT), stashes it in `~/.config/agnes-e2e/<target>.env` as
-`AGNES_E2E_PAT=...`, and re-uses it across runs until it expires (default
-TTL is days, not minutes).
+The operator maintains a small library of paste-prompts as markdown files,
+one per target instance, under `~/.config/agnes-e2e/prompts/` (mode 700,
+gitignored, outside any repo):
+
+```
+~/.config/agnes-e2e/prompts/
+├── foundryai-dev.md      ← paste-prompt from agnes-development.groupondev.com
+├── foundryai-prod.md
+├── agnes-dev.md          ← paste-prompt from the Keboola dev VM
+├── agnes-prod.md
+└── localhost.md          ← paste-prompt from a local uvicorn dev instance
+```
+
+Each `.md` is a verbatim paste-prompt that the operator copied from the
+target's `/setup?role=analyst` "Generate prompt" panel — URL, PAT, and the
+full step-by-step body. The file is the single source of truth for "this
+PAT, this server, this install instructions" against one target.
+
+The runner reads them by name:
+
+```bash
+scripts/e2e-live/run.sh --prompt foundryai-dev      # uses ~/.config/agnes-e2e/prompts/foundryai-dev.md
+scripts/e2e-live/run.sh --prompt agnes-dev
+```
+
+Why this model wins over the "one PAT in an env var":
+
+- **The paste-prompt is the contract.** Server change → paste-prompt change
+  → MD file change. The runner doesn't need its own knowledge of install
+  steps; it ships what the server says to ship. This means the same runner
+  works against agnes-prod and a freshly-deployed dev instance without
+  conditional logic.
+- **Targets are addable in one step.** Operator runs the install panel
+  against a new deployment, pastes the result into a new MD, runs
+  `run.sh --prompt <name>`. No code change, no config schema migration.
+- **Refresh has one motion.** PAT expires → mint a new one on the same
+  instance → overwrite the MD. The runner picks it up automatically.
+- **Discoverable** — `ls ~/.config/agnes-e2e/prompts/` enumerates every
+  target the operator has set up.
 
 Why not automate the mint:
+
 - `/setup?role=analyst` returns the HTML template but the PAT is injected
   by JS after a logged-in user clicks "Generate prompt" — no PAT in the
   raw HTML.
@@ -171,29 +205,56 @@ Why not automate the mint:
 - A direct `POST /api/auth/tokens` would need a long-lived admin PAT to
   bootstrap, same chicken-and-egg.
 
-The operator-mints-one-PAT path is the simplest stable contract.
+The MD-library path is the simplest stable contract that also tests the
+*paste-prompt itself* — if the install panel produces a broken prompt
+(missing step, wrong URL, malformed PAT), we surface that.
+
+### Cross-target validation (a side benefit)
+
+Running the same `run.sh --prompt <X>` against multiple targets is itself a
+test: if `--prompt foundryai-dev` and `--prompt agnes-prod` produce the same
+shape of layer-1 PASS/FAIL but `--prompt foundryai-prod` fails an assertion,
+either the prod paste-prompt has drifted or there's a real prod-only
+regression. The diff between two report.md files is a tight diff.
+
+The discovery only exercised one target (`foundryai-dev`); the spec is
+designed to allow N without code changes, with the MD library as the only
+configuration surface.
 
 ### Inputs
 
 ```
-SERVER_URL              from _config/<target>.env (dev|prod)
-AGNES_E2E_PAT           from ~/.config/agnes-e2e/<target>.env (gitignored)
-MAX_BUDGET_USD          from _config/<target>.env (default: 2 for dev, 0.5 for prod)
-LOCAL_TABLE_HINT        from _config/<target>.env (e.g. "order_economics")
-REMOTE_TABLE_HINT       from _config/<target>.env (e.g. "<some-remote-table>")
-ANALYST_QUESTION_SEED   from _config/<target>.env, OPTIONAL OVERRIDE —
-                        if unset (default), layer 3 lets sub-Claude invent
-                        from the catalog. If set, the seed is appended to
-                        the layer-3 prompt as "start from this question:
-                        <seed>". Useful only when comparing two runs side
-                        by side; the default open variant is what catches
-                        the catalog-UX class of issues.
+~/.config/agnes-e2e/prompts/<target>.md    REQUIRED. The verbatim paste-prompt;
+                                            URL + PAT + install instructions
+                                            are all inside it. No separate
+                                            SERVER_URL or PAT env var.
+~/.config/agnes-e2e/<target>.env           OPTIONAL. Per-target overrides if
+                                            the operator wants to tune:
+  MAX_BUDGET_USD          per-layer Anthropic budget cap
+                          (default: 2 for dev targets, 0.5 for prod)
+  LOCAL_TABLE_HINT        starting point for layer 2 (e.g. "order_economics")
+  REMOTE_TABLE_HINT       starting point for layer 2 (e.g. "<some-remote-table>")
+  ANALYST_QUESTION_SEED   layer-3 starting question. If unset (default),
+                          sub-Claude invents from the catalog. If set, the
+                          seed is appended to the layer-3 prompt as "start
+                          from this question: <seed>". Useful only when
+                          comparing two runs side by side; the default open
+                          variant is what catches the catalog-UX class of
+                          issues.
 ```
+
+The MD file is the only required input. `*_HINT` and budget overrides are
+nice-to-haves the runner falls back on sensible defaults for.
 
 `*_HINT` are not enforced — layer 2 / 3 use them as starting points but the
 sub-Claude is free to pick others from `agnes catalog`. The hints make the
 test deterministic enough to compare across runs while staying robust to
 catalog churn.
+
+The runner derives `SERVER_URL` (for sanity-check reachability before
+firing sub-Claude) and a sanitised target label (for artefact dir naming
+and `report.md` headers) by parsing the MD file's first paragraph for
+`Server: https://…` and the file's basename.
 
 ### Outputs (per run)
 
@@ -236,21 +297,29 @@ It emits:
 ```bash
 # one-time setup per laptop
 $ brew install asciinema agg ffmpeg
-$ mkdir -p ~/.config/agnes-e2e
-$ cat > ~/.config/agnes-e2e/dev.env <<EOF
-AGNES_E2E_PAT=<paste from /setup?role=analyst>
+$ mkdir -p ~/.config/agnes-e2e/prompts && chmod 700 ~/.config/agnes-e2e/prompts
+
+# add a target (repeat for each instance you want to test against)
+$ cat > ~/.config/agnes-e2e/prompts/foundryai-dev.md <<'EOF'
+<paste the entire prompt panel content from
+ https://agnes-development.groupondev.com/setup?role=analyst — server URL,
+ PAT, instructions, all of it>
 EOF
-$ chmod 600 ~/.config/agnes-e2e/dev.env
+$ chmod 600 ~/.config/agnes-e2e/prompts/foundryai-dev.md
 
 # every-run
-$ scripts/e2e-live/run.sh --target dev
+$ scripts/e2e-live/run.sh --prompt foundryai-dev
 # or layered:
-$ scripts/e2e-live/run.sh --target dev --layers install,query
-$ scripts/e2e-live/run.sh --target dev --layers analyst   # resume + ad-hoc
+$ scripts/e2e-live/run.sh --prompt foundryai-dev --layers install,query
+$ scripts/e2e-live/run.sh --prompt foundryai-dev --layers analyst   # resume + ad-hoc
+
+# cross-target sweep — runs each prompt back-to-back, aggregates one report
+$ scripts/e2e-live/run.sh --prompt foundryai-dev,agnes-dev,agnes-prod
 ```
 
-`--target` selects which `_config/<target>.env` is loaded. `--layers` selects
-which of the three runners fire (default: all three). Other flags:
+`--prompt <name>` selects which `~/.config/agnes-e2e/prompts/<name>.md` is
+loaded; comma-separated runs sweep. `--layers` selects which of the three
+runners fire (default: all three). Other flags:
 
 - `--keep-workspace` — do not `rm -rf /tmp/agnes-e2e/run-<ts>` on success
   (it's already preserved on FAIL).

--- a/docs/superpowers/specs/2026-05-19-e2e-live-design.md
+++ b/docs/superpowers/specs/2026-05-19-e2e-live-design.md
@@ -1,0 +1,353 @@
+# Agnes live E2E walkthrough — design
+
+**Status:** brainstorm (approved by zsrotyr 2026-05-19), not yet implemented
+**Date:** 2026-05-19
+**Author:** zsrotyr
+**Discovery artefacts:** `/tmp/agnes-e2e/run-20260519T054136Z/` (transcript,
+3 asciinema casts, 3 mp4 videos, the `FoundryAI` workspace, 3 runner scripts).
+[Issue #345](https://github.com/keboola/agnes-the-ai-analyst/issues/345)
+captures the 9 items the discovery surfaced.
+
+## Problem
+
+Two questions never get a confident answer on `main`:
+
+1. **Does a fresh-machine install of Agnes still work end-to-end?** Tests cover
+   unit + integration + a handful of webapp routes. Nothing exercises the
+   full path `paste-prompt → uv tool install → agnes init → catalog → query
+   (local) → query --remote → snapshot create`. Regressions in that path land
+   in deployments before they land in test runs (we've seen the server-side
+   `agnes schema <remote>` HTTP 500 only because an exploratory walkthrough
+   caught it).
+2. **Does it work for an analyst with Claude Code on the other end?** A real
+   analyst doesn't type `agnes query "SELECT …"` — they ask Claude Code "show
+   me the top 5 days last week," and Claude Code reaches for `agnes`. The
+   only test of that loop today is "we'll find out from the analyst on
+   Slack."
+
+A live walkthrough — fresh workspace, headless `claude --print` simulating
+the analyst, recorded to asciinema, parsed into a PASS/FAIL report — answers
+both questions in one ~3-minute run against any running Agnes instance. We've
+done it manually three times during the discovery; what we need is to make
+it cheap to do it again on every PR / nightly / pre-release.
+
+## Approach
+
+Three layered runners, sharing one bootstrap module. Each layer pushes the
+sub-Claude one step closer to "real analyst." Layer 1 is non-negotiable
+(no install → nothing works). Layers 2 and 3 are optional add-ons —
+operator runs whichever fits the change.
+
+```
+scripts/e2e-live/
+├── run.sh                  ENTRY POINT — flags select layers
+├── _common.sh              shared: workspace creation, session-id, asciinema
+├── _parse-transcript.py    JSONL transcript → PASS/FAIL report markdown
+├── layer-1-install.sh      paste-prompt → fresh sub-Claude session
+├── layer-2-query.sh        resume → structured query matrix
+├── layer-3-analyst.sh      resume → "pick a business question, answer it"
+├── _config/
+│   ├── dev.env             SERVER_URL, MAX_BUDGET, EXPECTED_TABLES_MIN, ...
+│   └── prod.env            (more conservative: lower budget, read-only)
+└── README.md               how to run, how to interpret report
+```
+
+### Three layers — what each tests
+
+**Layer 1 — install + bootstrap (paste-prompt, fresh sub-Claude session)**
+
+What it exercises: `uv tool install`, the paste-prompt's POSIX guard, `agnes
+init` (PAT auth, workspace download, materialization), the lazy-mkdir contract
+on the workspace, `agnes catalog` (RBAC-filtered table list), `agnes
+refresh-marketplace --bootstrap`, `agnes diagnose`.
+
+PASS contract (rather than the obvious "every step rc=0"): the workspace
+exists with the expected file inventory (`CLAUDE.md`, `AGNES_WORKSPACE.md`,
+`.claude/settings.json`, `user/duckdb/analytics.duckdb`), `agnes catalog`
+returned a non-zero count of tables, and `agnes diagnose` produced
+parsable output. Steps that are *expected* to fail until specific items in
+[#345] land (`refresh-marketplace --bootstrap` until item A) are marked
+`KNOWN-FAIL` rather than `FAIL` in the report; the layer overall still
+passes. When item A is fixed, the corresponding `KNOWN-FAIL` flips to a
+required `PASS` and the run will start failing if it regresses — that's
+the signal we use to validate the fix.
+
+Why fresh session: paste-prompt is a one-shot bootstrap. A resumed session
+already has tools loaded and would not exercise the install path.
+
+Replaces / formalises: the manual operator-end-to-end walkthrough that
+`docs/testing/vm_test_plan.md` half-documented and `docs/testing/e2e_clean_analyst_bootstrap.md`
+implied but never bootstrapped.
+
+**Layer 2 — query matrix (resumed sub-Claude, scripted prompt)**
+
+What it exercises: `agnes schema <local>`, `agnes schema <remote>`, `agnes
+query "<sql>"` (local), `agnes query --remote "<sql>"`, `agnes snapshot create
+--estimate`, `agnes snapshot create` (small fetch), `agnes snapshot drop`.
+
+Why resumed: `agnes init` already happened in layer 1 — we reuse that
+workspace and the same session-id. Keeps the artefact set coherent (one
+session, three turns visible in `/resume` picker on the operator's machine).
+
+Subsumes: slices 3-8 of `docs/testing/e2e_clean_analyst_bootstrap.md` (the
+read-only smoke matrix slices), and adds the write-paths (snapshot create
++ drop) the legacy doc punted on.
+
+**Layer 3 — analyst-style E2E (resumed sub-Claude, open prompt)**
+
+What it exercises: the sub-Claude is told "invent a realistic business
+question from the catalog and answer it end-to-end" — it picks the question,
+chooses local vs remote vs JOIN-via-snapshot, decides when to `--estimate`,
+and produces a markdown answer table. Plus a structured "Friction
+encountered" section the prompt asks for explicitly.
+
+Why this layer matters: it is the only test that catches catalog-UX issues
+(items E-I on issue #345 came out of this layer). The first two layers
+exercise commands; this one exercises *deciding what to do next*, which is
+how real analysts actually use the system.
+
+This is the layer with the loosest pass/fail contract — the sub-Claude
+might pick a question that requires a snapshot, or one that an aggregate
+answers. We score it on whether the final answer renders, whether the
+CLI surface used was clean (no Traceback, no rc=0-on-fail), and whether
+the Friction section is non-empty (a signal that the sub-Claude found
+something to comment on, which is the failure mode we *want* to surface).
+
+### Shared bootstrap (`_common.sh`)
+
+```
+e2e_init_run() {
+  TS=$(date -u +%Y%m%dT%H%M%SZ)
+  RUN_DIR="/tmp/agnes-e2e/run-$TS"
+  mkdir -p "$RUN_DIR"
+  uuidgen | tr '[:upper:]' '[:lower:]' > "$RUN_DIR/.session-id"
+  echo "$RUN_DIR"
+}
+
+e2e_record() {
+  local run_dir="$1" cast_name="$2" cmd="$3"
+  asciinema rec --overwrite "$run_dir/$cast_name.cast" \
+    --command "$cmd" --idle-time-limit 3 --cols 200 --rows 50
+}
+
+e2e_render_video() {
+  local cast="$1"
+  agg "$cast" "${cast%.cast}.gif" --speed 2
+  ffmpeg -y -i "${cast%.cast}.gif" -movflags +faststart -pix_fmt yuv420p \
+    -vf "pad=ceil(iw/2)*2:ceil(ih/2)*2" "${cast%.cast}.mp4"
+}
+
+e2e_sub_claude() {
+  local prompt_file="$1" session_id="$2" sys_prompt="$3" max_budget="${4:-2}"
+  claude --print \
+    --resume "$session_id" \
+    --permission-mode bypassPermissions \
+    --max-budget-usd "$max_budget" \
+    --append-system-prompt "$sys_prompt" \
+    --verbose \
+    "$(cat "$prompt_file")"
+}
+```
+
+Each layer composes from these primitives + its own prompt file. No layer
+re-implements workspace creation, session-id minting, or asciinema wrapping.
+
+### Auth — PAT as input
+
+The first run used the paste-prompt the user pasted in chat — a real PAT
+with the URL embedded. For repeatable runs the operator mints one PAT
+through the UI once (`/setup?role=analyst` → "Generate prompt" → copy →
+extract PAT), stashes it in `~/.config/agnes-e2e/<target>.env` as
+`AGNES_E2E_PAT=...`, and re-uses it across runs until it expires (default
+TTL is days, not minutes).
+
+Why not automate the mint:
+- `/setup?role=analyst` returns the HTML template but the PAT is injected
+  by JS after a logged-in user clicks "Generate prompt" — no PAT in the
+  raw HTML.
+- Playwright + storage state would work but adds a dependency layer the
+  layers above don't otherwise need. Reserved for a future "layer 0 — UI
+  smoke" if we want it.
+- A direct `POST /api/auth/tokens` would need a long-lived admin PAT to
+  bootstrap, same chicken-and-egg.
+
+The operator-mints-one-PAT path is the simplest stable contract.
+
+### Inputs
+
+```
+SERVER_URL              from _config/<target>.env (dev|prod)
+AGNES_E2E_PAT           from ~/.config/agnes-e2e/<target>.env (gitignored)
+MAX_BUDGET_USD          from _config/<target>.env (default: 2 for dev, 0.5 for prod)
+LOCAL_TABLE_HINT        from _config/<target>.env (e.g. "order_economics")
+REMOTE_TABLE_HINT       from _config/<target>.env (e.g. "<some-remote-table>")
+ANALYST_QUESTION_SEED   from _config/<target>.env, OPTIONAL OVERRIDE —
+                        if unset (default), layer 3 lets sub-Claude invent
+                        from the catalog. If set, the seed is appended to
+                        the layer-3 prompt as "start from this question:
+                        <seed>". Useful only when comparing two runs side
+                        by side; the default open variant is what catches
+                        the catalog-UX class of issues.
+```
+
+`*_HINT` are not enforced — layer 2 / 3 use them as starting points but the
+sub-Claude is free to pick others from `agnes catalog`. The hints make the
+test deterministic enough to compare across runs while staying robust to
+catalog churn.
+
+### Outputs (per run)
+
+```
+/tmp/agnes-e2e/run-<ts>/
+├── .session-id                       sub-Claude session uuid
+├── prompt.txt                        paste-prompt (layer 1) or layer prompts
+├── run-layer-{1,2,3}.sh              the runner that fired
+├── session-{install,query,analyst}.{cast,gif,mp4}    asciinema artefacts
+├── FoundryAI/                        the workspace sub-Claude built
+└── report.md                         PARSED PASS/FAIL summary
+
+~/.claude/projects/-private-tmp-agnes-e2e-run-<ts>/<uuid>.jsonl
+                                      full sub-Claude transcript (~hundreds of
+                                      events; the actual source-of-truth for
+                                      what happened in each layer)
+```
+
+`report.md` is generated/appended by `_parse-transcript.py` *after each
+layer* (not just at the end) — so a layer-1 fail still leaves a usable
+report. `run.sh` invokes the parser as part of each layer's exit handler
+regardless of layer rc, then aggregates the per-layer sections into the
+final report. The parser reads:
+
+- the per-layer `session-*.cast` (asciinema metadata, e.g. wall-clock time)
+- the shared JSONL transcript at `~/.claude/projects/.../<uuid>.jsonl`,
+  scoped to events from each layer's `--resume` boundary onwards
+
+It emits:
+
+- per-layer PASS/FAIL with the asserted predicates (workspace files exist,
+  no "Traceback" in any tool_result, expected tool_use shape per layer)
+- bash call inventory
+- final sub-Claude text per layer
+- total turns + total budget spent
+- any "Friction encountered" bullets from layer 3
+
+### How to run
+
+```bash
+# one-time setup per laptop
+$ brew install asciinema agg ffmpeg
+$ mkdir -p ~/.config/agnes-e2e
+$ cat > ~/.config/agnes-e2e/dev.env <<EOF
+AGNES_E2E_PAT=<paste from /setup?role=analyst>
+EOF
+$ chmod 600 ~/.config/agnes-e2e/dev.env
+
+# every-run
+$ scripts/e2e-live/run.sh --target dev
+# or layered:
+$ scripts/e2e-live/run.sh --target dev --layers install,query
+$ scripts/e2e-live/run.sh --target dev --layers analyst   # resume + ad-hoc
+```
+
+`--target` selects which `_config/<target>.env` is loaded. `--layers` selects
+which of the three runners fire (default: all three). Other flags:
+
+- `--keep-workspace` — do not `rm -rf /tmp/agnes-e2e/run-<ts>` on success
+  (it's already preserved on FAIL).
+- `--reuse <ts>` — resume into an existing run dir's session. Useful for
+  developer iteration on the prompt files without paying the layer-1 cost
+  again.
+- `--no-video` — skip the agg+ffmpeg render (cast only).
+
+## Cost & guardrails
+
+Single-run budget against dev: **~$1 of Anthropic budget per full 3-layer
+walkthrough** (observed on the discovery run: $0.97 for the full sequence).
+Set `MAX_BUDGET_USD=2` per layer as the safety cap.
+
+BigQuery scan cost: layer 2 and 3 narrow remote queries with WHERE / LIMIT
+and prefer `agnes snapshot create --estimate` over full fetches. The
+discovery run trippied no cost guardrail and stayed under $0.001 of BQ
+scan cost across both query layers. We do NOT need a separate BQ budget
+cap; the existing server-side `bigquery.max_bytes_per_materialize`
+guardrail handles it.
+
+## Failure handling
+
+Three failure modes, each with a deterministic response:
+
+1. **Layer 1 fail (install / bootstrap broken).** Layers 2 and 3 cannot
+   start without a working workspace. `run.sh` exits with the layer-1
+   exit code; the artefact directory is preserved; the operator opens
+   `session-install.cast` and the JSONL transcript to debug.
+2. **Layer 2 fail (query path broken).** Layer 3 still runs — it might
+   pick a different surface and still produce an answer. Report flags
+   layer 2 as FAIL but the run continues.
+3. **Sub-Claude budget exceeded mid-layer.** `--max-budget-usd` aborts
+   the sub-Claude; the layer fails; the report records the budget figure
+   for tuning.
+
+Operators don't fix in place — for each failure the run is preserved and
+either filed against the umbrella E2E issue or fixed in a focused PR.
+
+## Open questions
+
+1. **Where does this live in CI?** Three options:
+   (a) GitHub Actions on PR (cost: ~$1 of Anthropic per PR, plus runner minutes;
+       blocks PRs that surface real regressions, but every flaky-AI moment
+       blocks too);
+   (b) GitHub Actions nightly against dev (cheap signal, doesn't block);
+   (c) Operator runs manually pre-release (zero CI cost, depends on
+       discipline). The discovery favoured (c) for now — the first few
+       runs will surface enough to iterate on stability before automation
+       earns its keep.
+2. **Does layer 3 deserve a deterministic "scored" variant?** The current
+   design lets sub-Claude invent the question, which is great for catching
+   catalog-UX issues but bad for "is the answer correct?" There may be a
+   future layer-3-deterministic that asks a fixed question with a known
+   answer, used for regression scoring.
+3. **Plugin/marketplace flow.** Layer 1 currently expects
+   `refresh-marketplace --bootstrap` to fail until [#345 item A] is fixed.
+   Once it is fixed, layer 1 needs to be extended to assert the marketplace
+   clone, the plugin list, and a smoke `claude plugin list` against a
+   second sub-Claude session that picks up the new plugins.
+4. **UI smoke as "layer 0."** The original brainstorm proposed a Playwright
+   walk over 5-7 admin/analyst pages with screenshot + assert 200/no-5xx.
+   We dropped it for this round because the operator pastes the PAT (UI
+   not needed). Worth picking up if we ever want one button to run the
+   *whole* surface, not just the CLI / analyst loop.
+
+## Non-goals
+
+- This is not a replacement for unit tests, integration tests, or webapp
+  route tests. It is a live integration smoke that complements them.
+- Not a full UI test. We are not testing every admin page; that's separate
+  work.
+- Not a load test. Single sub-Claude session, one query at a time.
+- Not a substitute for the manual "operator opens browser and tries it"
+  spot check before a public-facing release. The recorded videos help
+  document the run, but they don't replace human eyeballs.
+
+## What we learned during discovery (informs this design)
+
+The three-layer split was not in the original brainstorm — the user
+walked it incrementally during the discovery session. Layer 1 came out
+of "give me the install paste-prompt and watch what sub-Claude does,"
+layer 2 out of "but you didn't actually query — test remote query," and
+layer 3 out of "let's see what a real analyst run looks like, not just
+test invocations." Each layer surfaced a distinct category of issue:
+
+- **Layer 1** surfaced infrastructure issues (`marketplace.git` URL hardcoded,
+  shell glob no-match on `?`, `diagnose` UX).
+- **Layer 2** surfaced CLI-shape issues (`rc=0` on HTTP failure, `--json` alias
+  missing, server-side regression on schema/snapshot endpoints — fixed before
+  layer 3 ran).
+- **Layer 3** surfaced data-model / catalog-UX issues (no shared join key,
+  no `--estimate` on `query --remote`, schema header conflates source/engine,
+  no documented entity linkage, `where_examples` unevenly populated).
+
+That split — *infrastructure → CLI shape → data UX* — is how the layers'
+boundaries are drawn in the design. The cost of running just layer 1
+(~$0.3) vs running all three (~$1) is enough difference that PR-level
+runs probably stick to layer 1 + 2; analyst-flow regressions get caught
+nightly with the full three.

--- a/docs/superpowers/specs/2026-05-19-e2e-live-design.md
+++ b/docs/superpowers/specs/2026-05-19-e2e-live-design.md
@@ -209,7 +209,7 @@ The MD-library path is the simplest stable contract that also tests the
 *paste-prompt itself* — if the install panel produces a broken prompt
 (missing step, wrong URL, malformed PAT), we surface that.
 
-### Cross-target validation (a side benefit)
+### Cross-target validation (a side benefit, validated empirically)
 
 Running the same `run.sh --prompt <X>` against multiple targets is itself a
 test: if `--prompt foundryai-dev` and `--prompt agnes-prod` produce the same
@@ -217,9 +217,23 @@ shape of layer-1 PASS/FAIL but `--prompt foundryai-prod` fails an assertion,
 either the prod paste-prompt has drifted or there's a real prod-only
 regression. The diff between two report.md files is a tight diff.
 
-The discovery only exercised one target (`foundryai-dev`); the spec is
-designed to allow N without code changes, with the MD library as the only
-configuration surface.
+The discovery run did exactly this swap (dev → prod, same machine, same
+runner, only the paste-prompt MD file changed) and it surfaced two
+genuine cross-target findings inside ~$0.75 of additional budget:
+
+1. **Item A (marketplace URL hardcode) is not a dev-only artefact** — both
+   targets failed at step 6 with the same DNS-unresolvable on the same
+   hardcoded host. Confirmed it's a CLI-side regression, not a deployment
+   misconfiguration on one VM.
+2. **Paste-prompt format drift surfaced** — the dev paste-prompt and the
+   prod paste-prompt differ in step 2 (silent `mkdir` vs an interactive
+   `pwd` STOP gate that headless callers can't answer). Two valid install
+   prompts in isolation, but a real inconsistency the cross-target sweep
+   makes visible.
+
+Cost-vs-signal: ~$0.75 + 3 minutes wall-clock for the second run. If we
+adopt this as a CI artifact, every N-target sweep adds ~$0.75 × (N-1) to
+the run cost. The diff between report.md's is the regression signal.
 
 ### Inputs
 


### PR DESCRIPTION
Adds the design spec for a layered, headless live E2E walkthrough that
exercises Agnes — install paste-prompt, queries, analyst-style use,
and a non-admin analyst persona — against any running deployment.

## Background

Two questions never had a confident answer on `main`:

1. **Does a fresh-machine install still work end-to-end?** Tests cover
   unit / integration / webapp routes but nothing exercises the path
   `paste-prompt → uv tool install → agnes init → catalog → query
   (local + remote) → snapshot create`.
2. **Does it work for a non-admin analyst?** Every test today runs as
   admin, so RBAC-filtered paths, paste-prompt assumptions about admin
   scope, and analyst-only UX issues are invisible.

The spec describes a custom Claude Code subagent (`agnes-e2e-tester`)
that answers both. The three discovery walkthroughs that produced
the spec surfaced 14 distinct user-visible issues — all filed in #345.

## What the spec contains

- **Custom subagent as interface**: `.claude/agents/agnes-e2e-tester.md`.
  The operator invokes it from main Claude Code:
  ```
  Agent(subagent_type: "agnes-e2e-tester", prompt: "test foundryai-dev")
  ```
  Agent finds the paste-prompts in `~/.config/agnes-e2e/prompts/` by
  the convention `<target>.md` (admin) vs `<target>-analyst.md`
  (analyst). If only admin exists, it auto-runs Layer 0 to mint a
  fresh analyst PAT.

- **Four layers** orchestrated by the agent:
  - **Layer 0** (optional, no sub-Claude): admin programmatically
    mints an analyst PAT via `POST /api/users` → set-password → group
    → grants → form-login → mint. Output is a new MD in the prompt
    library. ~5s wall-clock, no Anthropic budget.
  - **Layer 1**: install + bootstrap. Fresh `claude --print` session
    consumes the paste-prompt. Verifies workspace inventory,
    marketplace bootstrap, diagnose output.
  - **Layer 2**: query path matrix. Resumes the session, scripted
    prompts for schema / query / query --remote / snapshot --estimate
    / snapshot create / drop.
  - **Layer 3**: analyst-style E2E. Resumes the session with an open
    prompt — "invent a business question from the catalog, answer it
    end-to-end."

- **Internal primitives**: `scripts/e2e-live/_common.sh` (workspace +
  asciinema wrapper), `_parse-transcript.py` (JSONL → PASS/FAIL),
  `_mint-analyst.sh` (Layer 0 API calls), `_cleanup-analyst.sh`
  (teardown). Operator never invokes these directly.

- **Cross-target sweep**: paste-prompts live in
  `~/.config/agnes-e2e/prompts/<target>.md`. The agent accepts
  multiple targets in one call — the diff between per-target reports
  is the regression signal.

## Validation

The spec was rewritten five times during the discovery as the
constraints became concrete (see commits). The final shape was
validated by three walkthroughs (dev admin, prod admin, dev non-admin
analyst) — same orchestration across all three, paste-prompt MD
swapped between runs, Layer 0 added when the analyst persona was
introduced. Total cost ~$2.80 of Anthropic, ~9 minutes wall-clock,
14 issues filed in #345.

## What this PR is and is not

- It is the **design spec only**. No `.claude/agents/agnes-e2e-tester.md`
  yet, no `scripts/e2e-live/` primitives yet.
- The implementation plan and the agent definition + primitives follow
  in a separate PR — easier to review the design first.
- Issue #345 captures the discovery findings the spec was built from.