### PR TITLE
fix(infra): pre-create /data/uploads in customer-instance startup script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Fixed
+- **Customer-instance Terraform module pre-creates `/data/uploads`**
+  (`infra/modules/customer-instance/startup-script.sh.tpl`). v50/0.55.0
+  added a marketplace cover-image upload directory mounted under
+  `${DATA_DIR}/uploads`; `app/main.py` eagerly mkdirs it at boot for
+  the `StaticFiles` mount. On host-bind deploys where `/data` root
+  is root-owned, the container's non-root `agnes` user (UID 999)
+  can't create the directory and the app crashloops with
+  `PermissionError: '/data/uploads'`. The startup script now
+  pre-creates `uploads` alongside `state/analytics/extracts` under
+  the existing `chown -R 999:999`. Fresh VMs provisioned at
+  `infra-v1.9.0`+ get the dir at first boot; for existing instances
+  bump the module pin + `terraform apply` (which rewrites the
+  instance startup-script metadata) and reboot the VM so the
+  refreshed mkdir/chown block replays. As a one-off without
+  rebooting, run `sudo mkdir -p /data/uploads && sudo chown 999:999
+  /data/uploads` on the host.
+
 ## [0.55.1] — 2026-05-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.55.2] — 2026-05-19
+
 ### Fixed
 - **Customer-instance Terraform module pre-creates `/data/uploads`**
   (`infra/modules/customer-instance/startup-script.sh.tpl`). v50/0.55.0

--- a/infra/modules/customer-instance/startup-script.sh.tpl
+++ b/infra/modules/customer-instance/startup-script.sh.tpl
@@ -39,12 +39,19 @@ if [ -b "$DATA_DEV" ]; then
     mkdir -p "$DATA_MNT"
     mountpoint -q "$DATA_MNT" || mount -o discard,defaults "$DATA_DEV" "$DATA_MNT"
     grep -qF "$DATA_DEV" /etc/fstab || echo "$DATA_DEV $DATA_MNT ext4 discard,defaults,nofail 0 2" >> /etc/fstab
-    mkdir -p "$DATA_MNT/state" "$DATA_MNT/analytics" "$DATA_MNT/extracts"
+    mkdir -p "$DATA_MNT/state" "$DATA_MNT/analytics" "$DATA_MNT/extracts" "$DATA_MNT/uploads"
     # Match Dockerfile USER agnes (uid:gid 999:999). A freshly-attached PD is
     # root-owned by default; without this chown the non-root container cannot
     # write to /data/state/system.duckdb and every authed request 500s after
     # the first upgrade that flips USER from root to agnes (regression hit
     # agnes-development on 2026-04-29). Idempotent — safe on reboot.
+    #
+    # /data/uploads holds admin-uploaded marketplace cover images
+    # (v50/0.55.0+). app/main.py eagerly mkdirs it at boot for the
+    # StaticFiles mount; on host-bind setups where /data root is
+    # root-owned, that mkdir 403s and the container crashloops — so
+    # pre-create the dir here under the SAME chown -R that already
+    # covers state/analytics/extracts. Cheap insurance.
     chown -R 999:999 "$DATA_MNT"
 fi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.55.1"
+version = "0.55.2"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"


### PR DESCRIPTION
## Summary

Closes the host-bind regression introduced in v50/0.55.0: `app/main.py` eagerly mkdirs `\${DATA_DIR}/uploads` at boot for the `StaticFiles` mount, but on host-bind deploys where `/data` root is root-owned, the container's non-root `agnes` user (UID 999) can't create the directory and the app crashloops with `PermissionError: '/data/uploads'`.

The Terraform `customer-instance` module already pre-creates and chowns `state/analytics/extracts` under `\$DATA_MNT` at provision time — this PR adds `uploads` to the same list. Same idempotency guarantees (block runs inside the `[ -b \$DATA_DEV ]` guard; safe on reboot, no-op when disk missing).

## What's in the box

- **`infra/modules/customer-instance/startup-script.sh.tpl`**: append \`"\$DATA_MNT/uploads"\` to the \`mkdir -p\` line (now: \`{state,analytics,extracts,uploads}\`), update the comment to explain the host-bind crashloop path the addition prevents.
- **CHANGELOG \`### Fixed\`** bullet explaining the symptom + the existing-instance recovery path (terraform apply + reboot, OR one-off \`mkdir + chown\`).
- **Release-cut to 0.55.2** as the last commit (this PR lands the only \`[Unreleased]\` content).

## Out of scope

- App-side defensive harden of \`app/main.py:690\` (wrap mkdir in \`try/except PermissionError\` so a misconfigured host doesn't hard-crash the container). Worth doing separately, but the infra fix is the right surface for the actual deploy contract — the eager mkdir is correct *if* the operator pre-created the dir, which is what the module now guarantees.
- Manual recovery for already-provisioned instances. Documented in the CHANGELOG bullet.

## Test plan

- [x] \`bash -n infra/modules/customer-instance/startup-script.sh.tpl\` — syntax clean.
- [x] Full pytest suite: \`5204 passed, 35 skipped\` on this diff (\`.venv/bin/pytest tests/ --tb=short -n auto -q\` from the worktree).
- [x] Empirically verified the crashloop + workaround on the dev VM that hit this (mkdir + chown on host → container starts healthy on the unchanged 0.55.0 image), confirming the diagnosis.
- [ ] Post-merge: cut a new \`infra-vX.Y.Z\` tag on the merge commit so consumers can bump their module pin (infra tags are tracked separately from app semver per CLAUDE.local.md).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->