### PR TITLE
fix(init): chmod +x workspace hooks in OVERRIDE mode too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Fixed
+- `agnes init` now runs `_chmod_workspace_hooks(workspace)` for OVERRIDE
+  mode too (Initial Workspace Template seed-repo flow), not just the
+  DEFAULT path. Override-mode workspaces seeded from an admin's
+  template repo were leaving hooks like
+  `.claude/hooks/skill-nudge/nudge.sh` and
+  `.claude/hooks/prompt-history/log-prompt.sh` non-executable when
+  the seed repo's git checkout didn't preserve the +x bit
+  (`core.filemode=false`, archive extractions, FUSE/NFS mounts), and
+  every SessionStart fired `Permission denied`. The chmod helper
+  already recurses (`rglob`) so subdir-scoped hook layouts were
+  covered — the bug was that the call site sat inside the
+  `if not override_active:` block. Moved out to a common step
+  before the first pull so every init path runs it.
+
 ## [0.55.4] — 2026-05-19
 
 ### Security

--- a/cli/commands/init.py
+++ b/cli/commands/init.py
@@ -493,7 +493,6 @@ def init(
             ), encoding="utf-8")
         install_claude_hooks(workspace)
         install_claude_commands(workspace)
-        _chmod_workspace_hooks(workspace)
 
         # ------------------------------------------------------------------
         # Step 6: CLAUDE.local.md stub — only when absent. `--force` does NOT
@@ -510,6 +509,22 @@ def init(
                 "# My Notes\n\nPersonal notes for this workspace. Uploaded on `agnes push`.\n",
                 encoding="utf-8",
             )
+
+    # ------------------------------------------------------------------
+    # Always chmod +x hook scripts that landed on disk, regardless of
+    # which path seeded the workspace. In DEFAULT mode the hooks come
+    # from `install_claude_hooks` above; in OVERRIDE mode they come
+    # from the admin's initial-workspace-template clone — and `git
+    # checkout` of that template doesn't reliably preserve the +x bit
+    # (filemode=false repos, archive extractions, FUSE/NFS mounts),
+    # so hooks like `.claude/hooks/skill-nudge/nudge.sh` or
+    # `.claude/hooks/prompt-history/log-prompt.sh` could land non-
+    # executable and fire `Permission denied` on the very next
+    # SessionStart. `_chmod_workspace_hooks` recurses (`rglob`) so
+    # subdir-scoped hook layouts are covered. Best-effort, no-op on
+    # Windows NTFS.
+    # ------------------------------------------------------------------
+    _chmod_workspace_hooks(workspace)
 
     # ------------------------------------------------------------------
     # Step 7: first pull. `run_pull` records per-stage failures inside


### PR DESCRIPTION
## Summary

Closes the chmod gap reported after PR #352 merged: hooks installed by `agnes init` in OVERRIDE mode (Initial Workspace Template seed-repo flow) were still landing as `rw-r--r--` and SessionStart fired `Permission denied`.

### Root cause

`_chmod_workspace_hooks(workspace)` was called inside the `if not override_active:` block in `cli/commands/init.py`. The OVERRIDE path — where the admin's seed-repo template gets cloned into the workspace by `_apply_initial_workspace_override` — silently skipped chmod entirely. When the seed repo's `git checkout` didn't preserve the +x bit (`core.filemode=false`, archive extractions, FUSE/NFS mounts), hooks like `.claude/hooks/skill-nudge/nudge.sh` and `.claude/hooks/prompt-history/log-prompt.sh` landed non-executable and every SessionStart fired `Permission denied`.

The chmod helper itself already recurses (`rglob("*.sh")`) so the subdir-scoped hook layouts were covered — the bug was the **call site**.

### Change

Moved `_chmod_workspace_hooks(workspace)` out of the `if not override_active:` block to a common step that runs unconditionally before the first pull. Both DEFAULT and OVERRIDE paths now chmod hooks before the first SessionStart can fire.

## Test plan

- [x] `.venv/bin/pytest tests/test_cli_init.py tests/test_init_ca_cleanup.py -q` — 17/17 pass.
- [ ] Re-run an end-to-end install on an OVERRIDE-mode workspace and confirm `nudge.sh` + `log-prompt.sh` land as `rwxr-xr-x` (or at least with the user-execute bit set), and SessionStart fires without Permission denied.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/359" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->