### PR TITLE
release: 0.55.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
+### Internal
+
+## [0.55.5] — 2026-05-19
+
 ### Fixed
 - `agnes init` now runs `_chmod_workspace_hooks(workspace)` for OVERRIDE
   mode too (Initial Workspace Template seed-repo flow), not just the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.55.4"
+version = "0.55.5"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"


### PR DESCRIPTION
## Release notes — 0.55.5

### Fixed
- `agnes init` now runs `_chmod_workspace_hooks(workspace)` for OVERRIDE mode too (Initial Workspace Template seed-repo flow), not just the DEFAULT path. Override-mode workspaces seeded from an admin's template repo were leaving hooks like `.claude/hooks/skill-nudge/nudge.sh` non-executable when the seed repo's git checkout didn't preserve the +x bit (`core.filemode=false`, archive extractions, FUSE/NFS mounts). (#359)
- Inline `<code>` chips inside the blue install-hero on `/home` now render as amber-on-dark-navy with a subtle amber border instead of the previous `rgba(255,255,255,0.12)` faint-white-on-blue pill. Previous combination was ≈2:1 contrast (fails WCAG AA); new rule lands at ≈9:1 and matches the existing `.install-cmd` copy-button-box palette. (#358)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/360" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->