### PR TITLE
Marketplace: configurable 'See all curators' URL + flea-inner hero name fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,15 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   standard step-lede size instead of the previous 13px chip.
 
 ### Fixed
+- Skill / agent detail pages nested inside a Flea Market plugin
+  rendered the parent plugin's title on the hero instead of the
+  skill/agent name. The frontend fallback chain branched on
+  `source === 'curated'` and so flea-inner items fell through to
+  `d.plugin_name`, which the inner-detail API populates with the
+  parent entity name. Branch now keys on the presence of an inner
+  segment in the URL so inner items use `d.name || innerName`
+  (the actual skill/agent name) and standalone flea plugins keep
+  their `d.plugin_name`.
 - `/activity-center` audit-log hero rendered as half-width because
   `_page_hero.html` was nested inside `<header class="obs-topbar">`,
   a flex row that pinned the time-range + auto-refresh controls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 ## [Unreleased]
 
 ### Added
+- New `marketplace.curators_url` config item (editable via
+  `/admin/server-config` → **Marketplace** section). Drives the
+  "See all curators →" link on the `/marketplace` curated-tab info
+  block; when empty the link is hidden (matches today's behaviour).
+  SSRF-guarded on save (private-IP allowlist, same posture as
+  `data_source.keboola.stack_url`).
 - `/home` now opens with a value-first intro hero — eyebrow greeting,
   one-line product framing, **Set up in ~15 min** / **Just browse**
   CTAs, and a four-pillar row (Data packages · Plugins · Skills ·

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -167,6 +167,7 @@ def _normalize_primary_key(v):
 # Devin ANALYSIS_0001 on PR #141 5f649a4 review.
 _URL_BEARING_FIELDS: tuple[tuple[str, ...], ...] = (
     ("data_source", "keboola", "stack_url"),
+    ("marketplace", "curators_url"),
 )
 
 
@@ -257,6 +258,7 @@ _EDITABLE_SECTIONS: tuple[str, ...] = (
     "corporate_memory",
     "materialize",
     "guardrails",
+    "marketplace",
 )
 
 # "Danger-zone" sections — flipping these can lock operators out (auth.*) or
@@ -808,6 +810,17 @@ _KNOWN_FIELDS: dict[str, dict[str, dict]] = {
                 "before the reaper flips it to `review_error`. Default "
                 "1800 (30 min) comfortably exceeds Sonnet / Opus p99 "
                 "wall time. 0 disables the reaper."
+            ),
+        },
+    },
+    "marketplace": {
+        "curators_url": {
+            "kind": "string",
+            "hint": (
+                "URL the 'See all curators →' link on /marketplace points to "
+                "(e.g. an internal wiki page listing curators accountable for "
+                "the curated marketplace). Empty → the link is hidden. "
+                "Validated against private-IP allowlist on save (SSRF guard)."
             ),
         },
     },

--- a/app/web/router.py
+++ b/app/web/router.py
@@ -1921,9 +1921,12 @@ async def marketplace_listing(
 ):
     import json as _json
     from src.category_icons import all_paths
+    from app.instance_config import get_value
+    curators_url = (get_value("marketplace", "curators_url") or "").strip()
     ctx = _build_context(
         request, user=user,
         category_icons_json=_json.dumps(all_paths()),
+        curators_url=curators_url,
     )
     return templates.TemplateResponse(request, "marketplace.html", ctx)
 

--- a/app/web/templates/marketplace.html
+++ b/app/web/templates/marketplace.html
@@ -518,7 +518,9 @@
       <div class="title">Each plugin here has a named curator accountable for it.</div>
       <div class="body">Each plugin in this marketplace has a named curator and meets a baseline review bar (security, telemetry hygiene, documentation).</div>
     </div>
-    <a class="link" href="#">See all curators →</a>
+    {% if curators_url %}
+    <a class="link" href="{{ curators_url }}" target="_blank" rel="noopener">See all curators →</a>
+    {% endif %}
   </div>
 
   <!-- Flea Market info block — open-shelf signal, mirror structure of

--- a/app/web/templates/marketplace_item_detail.html
+++ b/app/web/templates/marketplace_item_detail.html
@@ -1015,12 +1015,16 @@
   const d = await res.json();
 
   // ── Title resolution per source ─────────────────────────────────────
-  // Curated: marketplace-metadata.json `display_name` wins, else frontmatter `name`.
-  // Flea standalone skill/agent reuses PluginDetailResponse — `display_name`
-  // populated by the same on-demand parser path, otherwise `plugin_name`
-  // (the entity name; manifest_name is the suffixed `<name>-by-<username>`).
+  // Curated inner + flea inner: prefer marketplace-metadata `display_name`,
+  // then frontmatter `name` (returned as `d.name`), then the URL slug.
+  // Standalone flea (no innerName) falls back to `d.plugin_name` — for
+  // plugin entities that field IS the entity's user-set title. The earlier
+  // shape branched on `source === 'curated'` and so flea inner skills/agents
+  // fell through to `d.plugin_name`, which the flea inner-detail API
+  // populates with the *parent plugin's* entity name — so a skill nested
+  // inside a flea plugin rendered the plugin's title on its hero.
   const heroTitle = d.display_name
-    || (source === 'curated' ? (d.name || innerName) : (d.plugin_name || ''));
+    || (innerName ? (d.name || innerName) : (d.plugin_name || ''));
 
   document.title = `${heroTitle} — Marketplace`;
 


### PR DESCRIPTION
## Summary

Two small, independent marketplace surface changes:

- **feat(marketplace)** — new `marketplace.curators_url` instance config (editable at `/admin/server-config` → **Marketplace** section). Drives the "See all curators →" link in the `/marketplace` curated-tab info block; when empty the link is hidden (parity with today). SSRF-guarded on save via the existing `_validate_url_not_private` allowlist, same posture as `data_source.keboola.stack_url`.
- **fix(web)** — skill / agent detail pages nested inside a Flea Market plugin rendered the *parent plugin's* title on the hero instead of the skill/agent name. The JS fallback chain in `marketplace_item_detail.html` branched on `source === 'curated'`, so flea-inner items fell through to `d.plugin_name` (which the inner-detail API populates with the parent entity name). Branch now keys on the presence of an inner segment in the URL.

## Test plan

- [ ] `/marketplace` curated tab — link absent by default (empty config)
- [ ] `/admin/server-config` shows new **Marketplace** section with `curators_url` field + hint
- [ ] Save `https://example.com/curators` → refresh `/marketplace` → link visible, opens in new tab
- [ ] Clear field → link hidden again
- [ ] Save `http://127.0.0.1/x` → admin API returns 400 (SSRF guard)
- [ ] Open a skill nested inside a Flea Market plugin (`/marketplace/flea/<id>/skill/<name>`) — hero h1 + window-label show the skill name, not the plugin name
- [ ] Same check for agent (`/marketplace/flea/<id>/agent/<name>`)
- [ ] Curated inner skill/agent hero unchanged (regression check)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->