### PR TITLE
feat(theme): switch default instance theme from navy to blue and enha…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,23 +10,13 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
-### Changed
-- Default `instance.theme` flipped from `navy` to `blue`. The brand-blue
-  palette is now the out-of-the-box look; `navy` (dark hero + mint-green
-  CTAs) is the opt-in via `AGNES_INSTANCE_THEME` / `instance.theme`
-  / admin server-config. Existing instances that explicitly set `navy`
-  are unaffected; instances relying on the implicit default will switch
-  to blue.
-
-### Fixed
-- Pre-login pages (`/login`, magic-link screens, first-time `/setup`)
-  now honour the configured `instance.theme`. `base_login.html` sets
-  `<html data-theme="...">` from `instance_theme`, and the navy
-  variant flips the `.login-features` hero panel from brand-blue
-  `--primary` to the deep-navy gradient — eliminating the jarring
-  blue → navy flip after sign-in on navy-configured instances.
-
 ### Added
+- New `marketplace.curators_url` config item (editable via
+  `/admin/server-config` → **Marketplace** section). Drives the
+  "See all curators →" link on the `/marketplace` curated-tab info
+  block; when empty the link is hidden (matches today's behaviour).
+  SSRF-guarded on save (private-IP allowlist, same posture as
+  `data_source.keboola.stack_url`).
 - `/home` now opens with a value-first intro hero — eyebrow greeting,
   one-line product framing, **Set up in ~15 min** / **Just browse**
   CTAs, and a four-pillar row (Data packages · Plugins · Skills ·
@@ -41,6 +31,12 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   bar, and per-step number badges next to each install block.
 
 ### Changed
+- Default `instance.theme` flipped from `navy` to `blue`. The brand-blue
+  palette is now the out-of-the-box look; `navy` (dark hero + mint-green
+  CTAs) is the opt-in via `AGNES_INSTANCE_THEME` / `instance.theme`
+  / admin server-config. Existing instances that explicitly set `navy`
+  are unaffected; instances relying on the implicit default will switch
+  to blue.
 - `/home` palette shifted from blue to green/navy: brand accent is now
   `#2ea877` (mint green) on light surfaces, hero card is navy
   `#0f1b3a`, code panels are near-black `#0c1224` with warm-yellow
@@ -81,6 +77,21 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   standard step-lede size instead of the previous 13px chip.
 
 ### Fixed
+- Pre-login pages (`/login`, magic-link screens, first-time `/setup`)
+  now honour the configured `instance.theme`. `base_login.html` sets
+  `<html data-theme="...">` from `instance_theme`, and the navy
+  variant flips the `.login-features` hero panel from brand-blue
+  `--primary` to the deep-navy gradient — eliminating the jarring
+  blue → navy flip after sign-in on navy-configured instances.
+- Skill / agent detail pages nested inside a Flea Market plugin
+  rendered the parent plugin's title on the hero instead of the
+  skill/agent name. The frontend fallback chain branched on
+  `source === 'curated'` and so flea-inner items fell through to
+  `d.plugin_name`, which the inner-detail API populates with the
+  parent entity name. Branch now keys on the presence of an inner
+  segment in the URL so inner items use `d.name || innerName`
+  (the actual skill/agent name) and standalone flea plugins keep
+  their `d.plugin_name`.
 - `/activity-center` audit-log hero rendered as half-width because
   `_page_hero.html` was nested inside `<header class="obs-topbar">`,
   a flex row that pinned the time-range + auto-refresh controls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,11 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ### Fixed
 - Pre-login pages (`/login`, magic-link screens, first-time `/setup`)
-  now honour the configured `instance.theme` instead of always
-  rendering with the default `:root` palette. Eliminates the
-  jarring blue → navy flip after sign-in on navy-configured
-  instances.
+  now honour the configured `instance.theme`. `base_login.html` sets
+  `<html data-theme="...">` from `instance_theme`, and the navy
+  variant flips the `.login-features` hero panel from brand-blue
+  `--primary` to the deep-navy gradient — eliminating the jarring
+  blue → navy flip after sign-in on navy-configured instances.
 
 ### Added
 - `/home` now opens with a value-first intro hero — eyebrow greeting,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Changed
+- Default `instance.theme` flipped from `navy` to `blue`. The brand-blue
+  palette is now the out-of-the-box look; `navy` (dark hero + mint-green
+  CTAs) is the opt-in via `AGNES_INSTANCE_THEME` / `instance.theme`
+  / admin server-config. Existing instances that explicitly set `navy`
+  are unaffected; instances relying on the implicit default will switch
+  to blue.
+
+### Fixed
+- Pre-login pages (`/login`, magic-link screens, first-time `/setup`)
+  now honour the configured `instance.theme` instead of always
+  rendering with the default `:root` palette. Eliminates the
+  jarring blue → navy flip after sign-in on navy-configured
+  instances.
+
 ### Added
 - New `marketplace.curators_url` config item (editable via
   `/admin/server-config` → **Marketplace** section). Drives the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Changed
+- Default `instance.theme` flipped from `navy` to `blue`. The brand-blue
+  palette is now the out-of-the-box look; `navy` (dark hero + mint-green
+  CTAs) is the opt-in via `AGNES_INSTANCE_THEME` / `instance.theme`
+  / admin server-config. Existing instances that explicitly set `navy`
+  are unaffected; instances relying on the implicit default will switch
+  to blue.
+
+### Fixed
+- Pre-login pages (`/login`, magic-link screens, first-time `/setup`)
+  now honour the configured `instance.theme` instead of always
+  rendering with the default `:root` palette. Eliminates the
+  jarring blue → navy flip after sign-in on navy-configured
+  instances.
+
 ### Added
 - `/home` now opens with a value-first intro hero — eyebrow greeting,
   one-line product framing, **Set up in ~15 min** / **Just browse**

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -298,13 +298,13 @@ _KNOWN_FIELDS: dict[str, dict[str, dict]] = {
         # `app/instance_config.py::get_instance_theme()`.
         "theme": {
             "kind": "select",
-            "options": ["navy", "blue"],
-            "default": "navy",
+            "options": ["blue", "navy"],
+            "default": "blue",
             "hint": (
-                "Page-hero colour scheme. `navy` (default) uses the "
-                "dark navy hero gradient + mint-green CTAs and "
-                "eyebrow accents. `blue` reverts to the pre-redesign "
-                "brand-blue hero + blue CTAs."
+                "Page-hero colour scheme. `blue` (default) uses the "
+                "brand-blue hero + blue CTAs. `navy` opts into the "
+                "darker palette with the dark navy hero gradient + "
+                "mint-green CTAs and eyebrow accents."
             ),
         },
     },

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -296,13 +296,13 @@ _KNOWN_FIELDS: dict[str, dict[str, dict]] = {
         # `app/instance_config.py::get_instance_theme()`.
         "theme": {
             "kind": "select",
-            "options": ["navy", "blue"],
-            "default": "navy",
+            "options": ["blue", "navy"],
+            "default": "blue",
             "hint": (
-                "Page-hero colour scheme. `navy` (default) uses the "
-                "dark navy hero gradient + mint-green CTAs and "
-                "eyebrow accents. `blue` reverts to the pre-redesign "
-                "brand-blue hero + blue CTAs."
+                "Page-hero colour scheme. `blue` (default) uses the "
+                "brand-blue hero + blue CTAs. `navy` opts into the "
+                "darker palette with the dark navy hero gradient + "
+                "mint-green CTAs and eyebrow accents."
             ),
         },
     },

--- a/app/instance_config.py
+++ b/app/instance_config.py
@@ -234,24 +234,25 @@ def get_instance_theme() -> str:
     (`--ds-*`) flips between palettes without touching markup.
 
     Values:
-      - ``navy``   — current default. Dark navy hero gradient,
-                     mint-green CTAs + eyebrow accents.
-      - ``blue``   — pre-redesign palette. Brand-blue hero gradient,
+      - ``blue``   — current default. Brand-blue hero gradient,
                      blue CTAs, translucent-white eyebrow.
+      - ``navy``   — darker palette opted into via server config.
+                     Dark navy hero gradient, mint-green CTAs +
+                     eyebrow accents.
 
     Resolution: ``AGNES_INSTANCE_THEME`` env var
     (Terraform-friendly) > ``instance.theme`` in instance.yaml >
-    default ``"navy"``. Unrecognised values fall back to ``"navy"``
+    default ``"blue"``. Unrecognised values fall back to ``"blue"``
     so a typo doesn't silently break every page.
     """
     raw = os.environ.get("AGNES_INSTANCE_THEME")
     if raw is None:
-        raw = get_value("instance", "theme", default="navy")
+        raw = get_value("instance", "theme", default="blue")
     if not isinstance(raw, str):
-        return "navy"
+        return "blue"
     value = raw.strip().lower()
     if value not in ("navy", "blue"):
-        return "navy"
+        return "blue"
     return value
 
 

--- a/app/web/router.py
+++ b/app/web/router.py
@@ -491,8 +491,8 @@ def _build_context(
         "workspace_dir": get_workspace_dir_name(),
         # Active palette — drives `<html data-theme="...">` in
         # base.html so `--ds-*` tokens flip via CSS without
-        # touching markup. "navy" (default) = current design;
-        # "blue" = pre-redesign brand. Admin toggles via
+        # touching markup. "blue" (default) = brand-blue palette;
+        # "navy" = darker opt-in palette. Admin toggles via
         # /admin/server-config.
         "instance_theme": get_instance_theme(),
         # Whether /home renders the "Step 3 — turn on auto-accept mode"

--- a/app/web/static/style-custom.css
+++ b/app/web/static/style-custom.css
@@ -2788,6 +2788,18 @@ a.slack-badge:hover {
     justify-content: center;
 }
 
+/* Navy theme — when the instance opts in via
+   `AGNES_INSTANCE_THEME=navy` / `instance.theme=navy`, the
+   `<html data-theme="navy">` attribute is set by base_login.html and
+   we flip the login-page hero panel from the legacy brand-blue
+   `--primary` to the deep-navy gradient used by the design-system
+   hero so /login matches the rest of the navy-themed app. Only
+   `.login-features` carries a brand colour on the pre-login screens;
+   the rest of the login chrome is theme-neutral. */
+:root[data-theme="navy"] .login-features {
+    background: linear-gradient(135deg, #0f1b3a 0%, #0a1430 100%);
+}
+
 .features-content {
     max-width: 480px;
 }

--- a/app/web/templates/base.html
+++ b/app/web/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="{{ instance_theme | default('navy') }}">
+<html lang="en" data-theme="{{ instance_theme | default('blue') }}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/app/web/templates/base_login.html
+++ b/app/web/templates/base_login.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="{{ instance_theme | default('blue') }}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/uv.lock
+++ b/uv.lock
@@ -24,7 +24,7 @@ wheels = [
 
 [[package]]
 name = "agnes-the-ai-analyst"
-version = "0.55.5"
+version = "0.55.6"
 source = { editable = "." }
 dependencies = [
     { name = "a2wsgi" },


### PR DESCRIPTION
…nce theme handling

- Updated the default `instance.theme` to `blue`, making it the new out-of-the-box look. The previous default `navy` can still be used by explicitly setting `AGNES_INSTANCE_THEME`.
- Pre-login pages now respect the configured `instance.theme`, eliminating the abrupt color change after sign-in for navy-configured instances.
- Adjusted documentation and code comments to reflect the new theme settings and their implications for existing instances.
- Version bump to 0.55.6 to reflect these changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->