### PR TITLE
fix(theme): load design-tokens.css on login pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,10 +79,14 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 ### Fixed
 - Pre-login pages (`/login`, magic-link screens, first-time `/setup`)
   now honour the configured `instance.theme`. `base_login.html` sets
-  `<html data-theme="...">` from `instance_theme`, and the navy
-  variant flips the `.login-features` hero panel from brand-blue
-  `--primary` to the deep-navy gradient — eliminating the jarring
-  blue → navy flip after sign-in on navy-configured instances.
+  `<html data-theme="...">` from `instance_theme`, additionally loads
+  `design-tokens.css` so the `.btn-primary` Google SSO button gets
+  its `--ds-primary` green fill (previously rendered as invisible
+  white text on a white card because the `--ds-*` tokens weren't
+  defined), and the navy variant flips the `.login-features` hero
+  panel from brand-blue `--primary` to the deep-navy gradient —
+  eliminating the jarring blue → navy flip after sign-in on
+  navy-configured instances.
 - Skill / agent detail pages nested inside a Flea Market plugin
   rendered the parent plugin's title on the hero instead of the
   skill/agent name. The frontend fallback chain branched on

--- a/app/web/templates/base_login.html
+++ b/app/web/templates/base_login.html
@@ -5,6 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Data Analyst Portal{% endblock %}</title>
     <link rel="stylesheet" href="{{ static_url('style-custom.css') }}">
+    {# Design-system tokens (`--ds-*`) — required so `.btn-primary`
+       (Google SSO on /login) gets its `--ds-primary` green fill;
+       otherwise the white button text renders invisible on a white
+       card. Same reason base.html loads it globally. #}
+    <link rel="stylesheet" href="{{ static_url('css/design-tokens.css') }}">
     {% include '_theme.html' %}
 </head>
 <body>


### PR DESCRIPTION
base_login.html only loaded style-custom.css, leaving the --ds-* tokens undefined. The Google SSO btn-primary used
background-color: var(--ds-primary) with color: white, rendering invisible (white text on a card with transparent button bg) on both navy and blue themes. Load design-tokens.css the same way base.html does so the button picks up its green fill.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/373" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->