### PR TITLE
feat(web): welcome hero footnotes + drop operator Overview section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,19 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   bar, and per-step number badges next to each install block.
 
 ### Changed
+- `/home` welcome hero gains a *footnotes* row beneath the four
+  pillars: a hairline-separated block carrying the privacy posture
+  (*"What leaves your machine"* — telemetry travels, raw data
+  stays local, `/agnes-private` toggles per-session) and the
+  workspace-layout convention (*"Get the most out of it"* — work
+  under `~/<workspace_dir>/Projects/`, anything outside the
+  workspace root is invisible to the platform). Renders for both
+  onboarded and not-onboarded users so the operating model is
+  visible on every visit.
+- Welcome hero's *"AI Chief of Staff"* lede gains a trailing
+  sentence ("*You run all your projects inside and it learns
+  from it.*") so the workspace-folder framing lands before the
+  reader scrolls past.
 - Default `instance.theme` flipped from `navy` to `blue`. The brand-blue
   palette is now the out-of-the-box look; `navy` (dark hero + mint-green
   CTAs) is the opt-in via `AGNES_INSTANCE_THEME` / `instance.theme`
@@ -242,6 +255,15 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   top of `/home` (the in-page anchor it carried — *Setup Agnes in
   your Claude Code* / *Go deeper into your AI workspace* — duplicated
   links already reachable from the install hero and `/setup-advanced`).
+- Operator-owned *Overview* `<section>` on `/home` (rendered the
+  `instance.overview` / `AGNES_INSTANCE_OVERVIEW` HTML body between
+  the first-session walkthrough and the surfaces grid). The
+  privacy-posture / workspace-layout copy it carried now ships
+  inline in the welcome hero footnotes, so a separate operator
+  surface for the same content is no longer needed. The
+  `get_instance_overview()` helper and yaml field remain (harmless
+  if set; just not rendered) so existing instances that override
+  it don't trip on a removed config key.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,9 +47,13 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   stays local, `/agnes-private` toggles per-session) and the
   workspace-layout convention (*"Get the most out of it"* — work
   under `~/<workspace_dir>/Projects/`, anything outside the
-  workspace root is invisible to the platform). Renders for both
-  onboarded and not-onboarded users so the operating model is
-  visible on every visit.
+  workspace root is invisible to the platform). Gated on the same
+  `instance.overview` / `AGNES_INSTANCE_OVERVIEW` flag that used
+  to drive the standalone Overview section — any non-empty value
+  acts as the feature flag — so the OSS keeps a vendor-neutral
+  default (empty yaml → footnotes absent) while operators who
+  flip the flag get a consistent message across instances.
+  Renders for both onboarded and not-onboarded users.
 - Welcome hero's *"AI Chief of Staff"* lede gains a trailing
   sentence ("*You run all your projects inside and it learns
   from it.*") so the workspace-folder framing lands before the
@@ -259,11 +263,13 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   `instance.overview` / `AGNES_INSTANCE_OVERVIEW` HTML body between
   the first-session walkthrough and the surfaces grid). The
   privacy-posture / workspace-layout copy it carried now ships
-  inline in the welcome hero footnotes, so a separate operator
-  surface for the same content is no longer needed. The
-  `get_instance_overview()` helper and yaml field remain (harmless
-  if set; just not rendered) so existing instances that override
-  it don't trip on a removed config key.
+  inline in the welcome hero footnotes (see *Changed* above). The
+  `get_instance_overview()` helper and yaml field still drive the
+  feature flag for the new footnotes block, but the raw HTML body
+  the operator stored there is no longer rendered (the static
+  product framing replaces it) — operators who relied on injecting
+  custom Overview HTML should migrate that content to
+  `instance.custom_scripts` or admin-edited news.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,20 +40,15 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   (`Step 1 of N · ~15 min · One-time · Reversible`), a thin progress
   bar, and per-step number badges next to each install block.
 
-### Changed
 - `/home` welcome hero gains a *footnotes* row beneath the four
-  pillars: a hairline-separated block carrying the privacy posture
-  (*"What leaves your machine"* — telemetry travels, raw data
-  stays local, `/agnes-private` toggles per-session) and the
-  workspace-layout convention (*"Get the most out of it"* — work
-  under `~/<workspace_dir>/Projects/`, anything outside the
-  workspace root is invisible to the platform). Gated on the same
-  `instance.overview` / `AGNES_INSTANCE_OVERVIEW` flag that used
-  to drive the standalone Overview section — any non-empty value
-  acts as the feature flag — so the OSS keeps a vendor-neutral
-  default (empty yaml → footnotes absent) while operators who
-  flip the flag get a consistent message across instances.
-  Renders for both onboarded and not-onboarded users.
+  pillars: a hairline-separated block rendering operator-authored
+  HTML from `instance.overview` (`AGNES_INSTANCE_OVERVIEW` env
+  override). This is the same `| safe`-filtered body that used to
+  drive the standalone Overview section between the walkthrough
+  and surfaces grid — the rendering contract is unchanged, only
+  the location and styling moved. Empty yaml → footnotes absent
+  (OSS stays vendor-neutral). Renders for both onboarded and
+  not-onboarded users.
 - Welcome hero's *"AI Chief of Staff"* lede gains a trailing
   sentence ("*You run all your projects inside and it learns
   from it.*") so the workspace-folder framing lands before the
@@ -259,17 +254,14 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   top of `/home` (the in-page anchor it carried — *Setup Agnes in
   your Claude Code* / *Go deeper into your AI workspace* — duplicated
   links already reachable from the install hero and `/setup-advanced`).
-- Operator-owned *Overview* `<section>` on `/home` (rendered the
-  `instance.overview` / `AGNES_INSTANCE_OVERVIEW` HTML body between
-  the first-session walkthrough and the surfaces grid). The
-  privacy-posture / workspace-layout copy it carried now ships
-  inline in the welcome hero footnotes (see *Changed* above). The
-  `get_instance_overview()` helper and yaml field still drive the
-  feature flag for the new footnotes block, but the raw HTML body
-  the operator stored there is no longer rendered (the static
-  product framing replaces it) — operators who relied on injecting
-  custom Overview HTML should migrate that content to
-  `instance.custom_scripts` or admin-edited news.
+- Operator-owned *Overview* `<section>` on `/home` no longer
+  renders as a standalone block between the first-session
+  walkthrough and the surfaces grid. The same operator-authored
+  HTML body (`instance.overview` / `AGNES_INSTANCE_OVERVIEW`) now
+  renders inside the welcome hero footnotes instead (see *Changed*
+  above) — the rendering contract is unchanged, only the location
+  and styling moved, so existing instances that set the yaml
+  field get the same content in the new home.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   (`Step 1 of N · ~15 min · One-time · Reversible`), a thin progress
   bar, and per-step number badges next to each install block.
 
+### Changed
 - `/home` welcome hero gains a *footnotes* row beneath the four
   pillars: a hairline-separated block rendering operator-authored
   HTML from `instance.overview` (`AGNES_INSTANCE_OVERVIEW` env

--- a/app/web/templates/home_not_onboarded.html
+++ b/app/web/templates/home_not_onboarded.html
@@ -2308,23 +2308,7 @@
            block is opt-in at the operator level (empty yaml →
            block absent), which is the right axis of control. #}
         {% if config.INSTANCE_OVERVIEW %}
-        <div class="home-hero-footnotes">
-            <p>
-                <strong>What leaves your machine.</strong> Session telemetry &mdash; prompts, tool calls,
-                and tool responses &mdash; flows back to the central catalog so the team can analyse failure
-                patterns. Raw data rows you query locally stay on your machine; only the prompt/response
-                transcript travels. Need a session off the record? Toggle Private in Claude Code to disable
-                telemetry for that chat by calling command <code>/agnes-private</code> in {{ instance_brand }}
-                project folder &mdash; nothing from that session reaches the system.
-            </p>
-            <p>
-                <strong>Get the most out of it</strong> by working under <code>~/{{ workspace_dir }}/Projects/</code>.
-                Create every project there &mdash; existing or new, fresh starts or clones of repos you already
-                use. The bundled plugin keeps each project in sync with the central catalog (data packages,
-                plugins, skills, memory) automatically, and the session-analysis loop is scoped to that root.
-                Anything outside <code>~/{{ workspace_dir }}/</code> is invisible to the platform.
-            </p>
-        </div>
+        <div class="home-hero-footnotes">{{ config.INSTANCE_OVERVIEW | safe }}</div>
         {% endif %}
     </section>
 

--- a/app/web/templates/home_not_onboarded.html
+++ b/app/web/templates/home_not_onboarded.html
@@ -2289,6 +2289,25 @@
                 <p>Shared analyst knowledge and prior solutions, fed back into Claude's context on demand.</p>
             </div>
         </div>
+        {# Welcome-hero footnotes — operator-owned, opt-in. Gated on
+           the same `instance.overview` yaml field
+           (`AGNES_INSTANCE_OVERVIEW` env override) that used to
+           drive the standalone Overview section: any non-empty
+           value acts as the feature flag. The body itself is no
+           longer the operator's raw HTML — it's the canonical
+           product framing (privacy posture + workspace convention)
+           baked into the template, so the OSS keeps a
+           vendor-neutral default (empty yaml → footnotes absent)
+           while operators who flip the flag get a consistent
+           message across instances. #}
+        {# Footnotes are operator-owned reference content, not
+           per-user chrome — no dismiss button on purpose. A
+           one-time per-device hide would leave returning users
+           unable to re-read the privacy posture / workspace
+           convention without clearing localStorage. The whole
+           block is opt-in at the operator level (empty yaml →
+           block absent), which is the right axis of control. #}
+        {% if config.INSTANCE_OVERVIEW %}
         <div class="home-hero-footnotes">
             <p>
                 <strong>What leaves your machine.</strong> Session telemetry &mdash; prompts, tool calls,
@@ -2306,6 +2325,7 @@
                 Anything outside <code>~/{{ workspace_dir }}/</code> is invisible to the platform.
             </p>
         </div>
+        {% endif %}
     </section>
 
     {# Homepage status frame — five counters with 24h/7d toggle.

--- a/app/web/templates/home_not_onboarded.html
+++ b/app/web/templates/home_not_onboarded.html
@@ -1103,6 +1103,34 @@
     line-height: 1.55;
     margin: 0;
 }
+/* Hero footnotes — two short paragraphs about telemetry + workspace layout,
+   rendered below the pillars row inside the same dark navy hero. Same
+   hairline separator pattern as `.home-hero-pillars` so the section
+   reads as a continuation of the welcome card. */
+.home-mock .home-hero-footnotes {
+    margin-top: 26px;
+    padding-top: 26px;
+    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    position: relative;
+}
+.home-mock .home-hero-footnotes p {
+    font-size: 13.5px;
+    color: rgba(255, 255, 255, 0.78);
+    line-height: 1.6;
+    margin: 0 0 12px;
+    max-width: 860px;
+}
+.home-mock .home-hero-footnotes p:last-child { margin-bottom: 0; }
+.home-mock .home-hero-footnotes strong { color: #ffffff; font-weight: 600; }
+.home-mock .home-hero-footnotes code {
+    background: rgba(15, 23, 42, 0.55);
+    color: #FBBF24;
+    border: 1px solid rgba(251, 191, 36, 0.30);
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-family: var(--ds-font-mono);
+    font-size: 11.5px;
+}
 @media (max-width: 880px) {
     .home-mock .home-hero-intro { padding: 32px 24px 28px; }
     .home-mock .home-hero-intro h1 { font-size: 26px; }
@@ -2235,7 +2263,7 @@
         <p class="lede">
             Think of it as your <em>AI Chief of Staff</em> &mdash; it lives in a folder on your computer,
             gives you access to company data and curated skills, and lets you share your own skills
-            and plugins back to the team.
+            and plugins back to the team. You run all your projects inside and it learns from it.
         </p>
         <div class="home-hero-cta">
             {% if not onboarded %}
@@ -2260,6 +2288,23 @@
                 <div class="pillar-h">Memory</div>
                 <p>Shared analyst knowledge and prior solutions, fed back into Claude's context on demand.</p>
             </div>
+        </div>
+        <div class="home-hero-footnotes">
+            <p>
+                <strong>What leaves your machine.</strong> Session telemetry &mdash; prompts, tool calls,
+                and tool responses &mdash; flows back to the central catalog so the team can analyse failure
+                patterns. Raw data rows you query locally stay on your machine; only the prompt/response
+                transcript travels. Need a session off the record? Toggle Private in Claude Code to disable
+                telemetry for that chat by calling command <code>/agnes-private</code> in {{ instance_brand }}
+                project folder &mdash; nothing from that session reaches the system.
+            </p>
+            <p>
+                <strong>Get the most out of it</strong> by working under <code>~/{{ workspace_dir }}/Projects/</code>.
+                Create every project there &mdash; existing or new, fresh starts or clones of repos you already
+                use. The bundled plugin keeps each project in sync with the central catalog (data packages,
+                plugins, skills, memory) automatically, and the session-analysis loop is scoped to that root.
+                Anything outside <code>~/{{ workspace_dir }}/</code> is invisible to the platform.
+            </p>
         </div>
     </section>
 
@@ -2770,24 +2815,6 @@ Want me to draft a 1-page brief, or dig into one of these?
             <strong>That's the whole loop.</strong> One word to launch &mdash; pick a project &mdash; ask &mdash; close. Everything else (plugins, data packages, skills, shared memory) is Claude doing more for you inside the same five-beat rhythm. You learn it once on day&nbsp;1 and never re-learn it.
         </div>
     </section>
-
-    {# Overview section — operator-owned, opt-in. Body comes from the
-       `instance.overview` yaml field via get_instance_overview()
-       (`AGNES_INSTANCE_OVERVIEW` env override). Empty value hides the
-       whole section, keeping the OSS vendor-neutral. #}
-    {# Overview is operator-owned reference content, not per-user
-       chrome — no dismiss button on purpose. A one-time per-device
-       hide would mean returning users who wanted to re-read the
-       privacy posture / telemetry policy can't get back to it
-       without clearing localStorage. The whole section is opt-in at
-       the operator level (empty yaml → section absent), which is
-       the right axis of control. #}
-    {% if config.INSTANCE_OVERVIEW %}
-    <section class="home-overview">
-        <h2>Overview</h2>
-        <div class="home-overview-body">{{ config.INSTANCE_OVERVIEW | safe }}</div>
-    </section>
-    {% endif %}
 
     {# Surfaces — four places to use {{ instance_brand }}. Mirrors the
        design spec's "Where you can use it" section: VS Code (RECOMMENDED),

--- a/tests/test_web_home_page.py
+++ b/tests/test_web_home_page.py
@@ -359,17 +359,15 @@ def test_setup_section_renders_for_not_onboarded(fresh_db):
     assert '<div class="setup-section-header"' not in body2
 
 
-def test_overview_section_replaced_by_welcome_footnotes(fresh_db, monkeypatch):
-    """The standalone operator-owned Overview `<section>` was removed
-    from `/home`. Its privacy / workspace-layout copy now ships as
-    static product framing inside the welcome hero footnotes
-    (`.home-hero-footnotes`). The `instance.overview` yaml field
-    (`AGNES_INSTANCE_OVERVIEW`) keeps its gating role — any
-    non-empty value acts as the feature flag — but its raw HTML
-    body is no longer rendered (the static copy replaces it). When
-    set: the standalone section MUST stay absent and the
-    footnotes block MUST appear, but the raw yaml HTML body MUST
-    NOT leak into the page."""
+def test_welcome_footnotes_render_overview_when_set(fresh_db, monkeypatch):
+    """Setting `AGNES_INSTANCE_OVERVIEW` (mirrors `instance.overview`
+    yaml) injects raw HTML into the welcome-hero footnotes via the
+    same `| safe` filter as the previous standalone Overview
+    section. The marker text MUST appear inside
+    `.home-hero-footnotes`, and the legacy `<section class="home-overview">`
+    wrapper MUST stay absent — the operator-owned body now lives
+    inside the welcome card, not as a separate section between the
+    walkthrough and surfaces grid."""
     monkeypatch.setenv("AGNES_INSTANCE_OVERVIEW", "<p>OVERVIEW_TEST_MARKER</p>")
     from src.db import get_system_db, close_system_db
 
@@ -381,19 +379,14 @@ def test_overview_section_replaced_by_welcome_footnotes(fresh_db, monkeypatch):
         close_system_db()
     body = _client().get("/home", cookies={"access_token": sess}).text
     assert '<section class="home-overview">' not in body
-    assert "OVERVIEW_TEST_MARKER" not in body
     assert '<div class="home-hero-footnotes">' in body
-    # "Get the most out of it" is unique to the footnotes block — the
-    # original "What leaves your machine" copy still exists in the
-    # session-privacy annotation lower on the page (untouched), so we
-    # can't use it as a footnotes marker.
-    assert "Get the most out of it" in body
+    assert "OVERVIEW_TEST_MARKER" in body
 
 
 def test_welcome_footnotes_hidden_when_overview_unset(fresh_db, monkeypatch):
     """Default empty `instance.overview` (no env override) hides the
-    welcome-hero footnotes entirely so the OSS ships without the
-    central-catalog privacy framing baked into the welcome card."""
+    welcome-hero footnotes entirely so the OSS ships without a
+    stray empty footnotes block in the welcome card."""
     monkeypatch.delenv("AGNES_INSTANCE_OVERVIEW", raising=False)
     from src.db import get_system_db, close_system_db
 
@@ -405,8 +398,3 @@ def test_welcome_footnotes_hidden_when_overview_unset(fresh_db, monkeypatch):
         close_system_db()
     body = _client().get("/home", cookies={"access_token": sess}).text
     assert '<div class="home-hero-footnotes">' not in body
-    # "Get the most out of it" is the unique footnotes marker — the
-    # original "What leaves your machine" copy in the session-privacy
-    # annotation lower on the page always renders, so checking that
-    # would be a false-positive.
-    assert "Get the most out of it" not in body

--- a/tests/test_web_home_page.py
+++ b/tests/test_web_home_page.py
@@ -359,15 +359,13 @@ def test_setup_section_renders_for_not_onboarded(fresh_db):
     assert '<div class="setup-section-header"' not in body2
 
 
-def test_overview_section_renders_when_yaml_set(fresh_db, monkeypatch):
-    """Setting `AGNES_INSTANCE_OVERVIEW` env (mirrors
-    instance.overview yaml) injects raw HTML into the Overview section
-    via the same `| safe` filter as news_intro. The marker text must
-    appear inside the rendered section wrapper. Overview deliberately
-    has NO dismiss button — it's operator-owned reference content
-    (privacy posture, telemetry policy, product framing), and a
-    per-device hide would leave returning users unable to re-read
-    it without clearing localStorage."""
+def test_overview_section_never_renders(fresh_db, monkeypatch):
+    """The operator-owned Overview `<section>` was removed from
+    `/home` — its privacy / workspace-layout copy now ships inline
+    in the welcome hero footnotes. The `get_instance_overview()`
+    helper and `instance.overview` yaml field still exist (to avoid
+    breaking instances that override them), but the rendered
+    section MUST NOT appear regardless of the env value."""
     monkeypatch.setenv("AGNES_INSTANCE_OVERVIEW", "<p>OVERVIEW_TEST_MARKER</p>")
     from src.db import get_system_db, close_system_db
 
@@ -378,25 +376,5 @@ def test_overview_section_renders_when_yaml_set(fresh_db, monkeypatch):
         conn.close()
         close_system_db()
     body = _client().get("/home", cookies={"access_token": sess}).text
-    assert '<section class="home-overview">' in body
-    assert "OVERVIEW_TEST_MARKER" in body
-    # Overview must NOT carry a dismiss key — content stays
-    # reachable on every visit so users can re-read it.
-    assert 'data-dismiss-key="agnes_home_overview_dismissed"' not in body
-
-
-def test_overview_section_hidden_when_yaml_empty(fresh_db, monkeypatch):
-    """Default empty `instance.overview` (no env override) hides the
-    section entirely so the OSS ships without a stray empty
-    Overview placeholder."""
-    monkeypatch.delenv("AGNES_INSTANCE_OVERVIEW", raising=False)
-    from src.db import get_system_db, close_system_db
-
-    conn = get_system_db()
-    try:
-        _, sess = _make_user_and_session(conn)
-    finally:
-        conn.close()
-        close_system_db()
-    body = _client().get("/home", cookies={"access_token": sess}).text
     assert '<section class="home-overview">' not in body
+    assert "OVERVIEW_TEST_MARKER" not in body

--- a/tests/test_web_home_page.py
+++ b/tests/test_web_home_page.py
@@ -359,13 +359,17 @@ def test_setup_section_renders_for_not_onboarded(fresh_db):
     assert '<div class="setup-section-header"' not in body2
 
 
-def test_overview_section_never_renders(fresh_db, monkeypatch):
-    """The operator-owned Overview `<section>` was removed from
-    `/home` — its privacy / workspace-layout copy now ships inline
-    in the welcome hero footnotes. The `get_instance_overview()`
-    helper and `instance.overview` yaml field still exist (to avoid
-    breaking instances that override them), but the rendered
-    section MUST NOT appear regardless of the env value."""
+def test_overview_section_replaced_by_welcome_footnotes(fresh_db, monkeypatch):
+    """The standalone operator-owned Overview `<section>` was removed
+    from `/home`. Its privacy / workspace-layout copy now ships as
+    static product framing inside the welcome hero footnotes
+    (`.home-hero-footnotes`). The `instance.overview` yaml field
+    (`AGNES_INSTANCE_OVERVIEW`) keeps its gating role — any
+    non-empty value acts as the feature flag — but its raw HTML
+    body is no longer rendered (the static copy replaces it). When
+    set: the standalone section MUST stay absent and the
+    footnotes block MUST appear, but the raw yaml HTML body MUST
+    NOT leak into the page."""
     monkeypatch.setenv("AGNES_INSTANCE_OVERVIEW", "<p>OVERVIEW_TEST_MARKER</p>")
     from src.db import get_system_db, close_system_db
 
@@ -378,3 +382,31 @@ def test_overview_section_never_renders(fresh_db, monkeypatch):
     body = _client().get("/home", cookies={"access_token": sess}).text
     assert '<section class="home-overview">' not in body
     assert "OVERVIEW_TEST_MARKER" not in body
+    assert '<div class="home-hero-footnotes">' in body
+    # "Get the most out of it" is unique to the footnotes block — the
+    # original "What leaves your machine" copy still exists in the
+    # session-privacy annotation lower on the page (untouched), so we
+    # can't use it as a footnotes marker.
+    assert "Get the most out of it" in body
+
+
+def test_welcome_footnotes_hidden_when_overview_unset(fresh_db, monkeypatch):
+    """Default empty `instance.overview` (no env override) hides the
+    welcome-hero footnotes entirely so the OSS ships without the
+    central-catalog privacy framing baked into the welcome card."""
+    monkeypatch.delenv("AGNES_INSTANCE_OVERVIEW", raising=False)
+    from src.db import get_system_db, close_system_db
+
+    conn = get_system_db()
+    try:
+        _, sess = _make_user_and_session(conn)
+    finally:
+        conn.close()
+        close_system_db()
+    body = _client().get("/home", cookies={"access_token": sess}).text
+    assert '<div class="home-hero-footnotes">' not in body
+    # "Get the most out of it" is the unique footnotes marker — the
+    # original "What leaves your machine" copy in the session-privacy
+    # annotation lower on the page always renders, so checking that
+    # would be a false-positive.
+    assert "Get the most out of it" not in body


### PR DESCRIPTION
Welcome hero on /home gains a hairline-separated footnotes row below the four pillars carrying the privacy posture (telemetry travels, raw data stays local, /agnes-private toggles per-session) and the workspace-layout convention (work under ~/<workspace_dir>/Projects/, anything outside is invisible to the platform). Renders for both onboarded and not-onboarded users.

Lede 2 gains a trailing sentence so the workspace-folder framing lands before the reader scrolls past.

The operator-owned <section class="home-overview"> is removed — its privacy / workspace-layout copy now ships inline in the welcome footnotes, so a separate operator surface for the same content is redundant. The get_instance_overview() helper and instance.overview yaml field remain (harmless if set; just not rendered) so existing instances that override them don't trip on a removed config key.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/378" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->