### PR TITLE
ci(e2e-nightly): unblock nightly smoke (touch .env, --wait, dump logs) + release 0.55.8

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -55,15 +55,19 @@ jobs:
       - name: Build + start agnes stack
         if: env.SKIP_MATRIX != '1'
         run: |
-          docker compose up -d --build
-          # Wait for /healthz with a 90s budget — first build pulls + initialises
-          # so the first poll may take a while.
-          for i in $(seq 1 30); do
-            if curl -fsS http://localhost:8000/healthz >/dev/null 2>&1; then
-              echo "agnes is up after ${i}s"; break
-            fi
-            sleep 3
-          done
+          # docker-compose.yml declares `env_file: .env` as required; CI
+          # ships no .env, so create an empty one. Runtime values are
+          # already in the compose `environment:` block.
+          touch .env
+          # --wait + healthcheck (defined in docker-compose.yml, hits
+          # /api/health) is the same pattern as ci.yml; cleaner than
+          # the prior hand-rolled curl loop, which polled the wrong
+          # path (/healthz) and silently passed on timeout.
+          docker compose up -d --build --wait --wait-timeout 120
+
+      - name: Dump docker logs on stack failure
+        if: failure() && env.SKIP_MATRIX != '1'
+        run: docker compose logs app | tail -200
 
       - name: Run smoke ${{ matrix.script }}
         if: env.SKIP_MATRIX != '1'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,37 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.55.9] — 2026-05-25
+
+### Fixed
+- **`/admin/tables` first-run setup prompt example trimmed.** The verbatim sample
+  for connector verify lines previously hardcoded a personal name + an
+  Asana-specific `2 workspace(s) visible.` tail. Now reads
+  `✅ Asana ready — ...` / `❌ Atlassian setup failed: ...` — the marker shape
+  the assistant actually greps for, with no hardcoded identity or connector-
+  specific texture. Producer side already substitutes the live `$display` name
+  at runtime, so no functional change to real verify lines. (#413 — credit
+  @cvrysanek; CHANGELOG bullet recovered after it was lost during the cross-
+  branch cherry-pick that landed the fix.)
+- **`.github/workflows/e2e-nightly.yml` unblocked.** The agent-browser nightly
+  smoke had been failing every night since it landed in #333 (6 duplicate
+  issues filed in 6 days: #362, #368, #376, #385, #386, #387). Two bugs in the
+  *Build + start agnes stack* step:
+  1. `docker-compose.yml` declares `env_file: .env` as required, but CI never
+     created one — `docker compose up -d --build` aborted with exit 1 before
+     the stack ever started. (Same trap `ci.yml` works around with a plain
+     `touch .env`.)
+  2. The hand-rolled curl loop polled `/healthz`, but the real endpoint is
+     `/api/health` (see `app/api/health.py:331`); on timeout the loop fell
+     through silently — so even past bug 1 the smoke step would have run
+     against a half-dead app and the failure would have pointed at the wrong
+     place.
+  Fix: `touch .env` + `docker compose up -d --build --wait --wait-timeout 120`
+  (relies on compose-defined healthcheck which hits `/api/health`, fails step
+  on timeout, same pattern as `ci.yml`) + `docker compose logs app | tail -200`
+  on failure so triage gets real logs instead of a 404 mystery. Closes #387,
+  #386, #385, #376, #368, #362.
+
 ## [0.55.8] — 2026-05-25
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.55.8"
+version = "0.55.9"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"


### PR DESCRIPTION
## Why

The agent-browser smoke workflow (`.github/workflows/e2e-nightly.yml`) has been failing **every night** since it landed in #333 — 6 noise issues filed in 6 days (#362, #368, #376, #385, #386, #387). All are duplicates of the same root cause: the workflow has been broken from day one and never opened green.

## Root cause

Two bugs in the **Build + start agnes stack** step:

1. `docker-compose.yml:18` declares `env_file: .env` as required, but CI never created one — so `docker compose up -d --build` aborted with exit 1 before the stack ever started. (Same trap `ci.yml:118` works around with a plain `touch .env`.)
2. The hand-rolled curl healthcheck loop polled `/healthz`, but the real endpoint is `/api/health` (see `app/api/health.py:331`). And on timeout the loop fell through silently — so even past bug #1 the smoke step would run against a half-dead app and the failure would point at the wrong place.

## Fix

```yaml
- name: Build + start agnes stack
  if: env.SKIP_MATRIX != '1'
  run: |
    touch .env
    docker compose up -d --build --wait --wait-timeout 120

- name: Dump docker logs on stack failure
  if: failure() && env.SKIP_MATRIX != '1'
  run: docker compose logs app | tail -200
```

- `touch .env` — unblocks docker compose (`environment:` block in compose already supplies the runtime values the stack needs).
- `--wait --wait-timeout 120` — relies on the compose-defined healthcheck (which hits the right endpoint, `/api/health`), and **fails the step** on timeout. Same pattern as `ci.yml`.
- `docker compose logs app | tail -200` on failure — gives the next morning's triage actual logs instead of a 404 mystery.

## Verification

- Full test suite green on this branch: **5249 passed, 35 skipped** (`pytest tests/ -n auto -q`, 2m07s).
- Post-merge: I'll `gh workflow run e2e-nightly.yml` to confirm a green run before closing the 6 duplicate issues.

## Release-cut

Patch bump (`0.55.7 → 0.55.8`) in the same PR per the [CLAUDE.md release-cut rule](../CLAUDE.md) — this PR lands the only `[Unreleased]` content. CHANGELOG entry + `pyproject.toml` bump in the last commit.

## Closes

- #387, #386, #385, #376, #368, #362 — all duplicates of the same broken-from-day-one workflow; will close as duplicates once dispatched run goes green.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/389" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->