### PR TITLE
fix(web): scrub personal name + Asana-specific texture from setup prompt example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -249,6 +249,12 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   applies on the redesigned pages.
 
 ### Internal
+- First-run setup prompt — confirm-step bullet's illustrative
+  ✅/❌ example trimmed to the marker shape only
+  (`✅ Asana ready — ...` / `❌ Atlassian setup failed: ...`).
+  Drops a hardcoded personal name (OSS vendor-agnostic rule) and
+  an Asana-specific workspace-count tail that would otherwise
+  imply every connector's verify line shares that shape.
 - New `app/web/static/css/design-tokens.css` declares the `--ds-*`
   design-system token set (green/navy palette, system font stack,
   callout vocabularies, navy-tinted elevation shadows) globally on

--- a/app/web/setup_instructions.py
+++ b/app/web/setup_instructions.py
@@ -578,9 +578,9 @@ def _finale_lines(*, confirm_step_num: str, has_ca: bool) -> list[str]:
         "(the marketplace clone) and that any granted plugins installed",
         "   - For each connector (Asana, Google Workspace, Atlassian): "
         "the verbatim ✅ or ❌ line that the connector's verify step "
-        "emitted earlier in this session (e.g. `✅ Asana ready — connected "
-        "as Vojtech Rysanek. 2 workspace(s) visible.` or `❌ Atlassian setup "
-        "failed: ...`). If the user declined a connector, say declined.",
+        "emitted earlier in this session (e.g. `✅ Asana ready — ...` "
+        "or `❌ Atlassian setup failed: ...`). If the user declined "
+        "a connector, say declined.",
     ]
     if has_ca:
         bullets.append(


### PR DESCRIPTION
## Summary

- Drop hardcoded `Vojtech Rysanek` (OSS vendor-agnostic rule) and the Asana-only `2 workspace(s) visible` texture from the confirm-step bullet's inline example in the first-run setup prompt.
- Trim the example to the marker shape the assistant actually greps for: `✅ Asana ready — ...` / `❌ Atlassian setup failed: ...`. Avoids implying every connector's verify line carries a workspace count (Atlassian/Google don't).
- Producer side already substitutes the live `$display` name at runtime — no functional change to what real verify lines emit.

## Test plan

- [x] `grep -rn "Vojtech\|Rysanek" .` returns nothing.
- [x] `.venv/bin/pytest tests/test_setup_instructions.py --tb=short -q` → 43 passed.