### PR TITLE
ci(e2e-nightly): sign smoke session in via /auth/password/login/web (#417) + release 0.55.10

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -69,6 +69,14 @@ jobs:
         if: failure() && env.SKIP_MATRIX != '1'
         run: docker compose logs app | tail -200
 
+      - name: Seed E2E test user
+        if: env.SKIP_MATRIX != '1'
+        # The seed_e2e_user.py script is idempotent; running it before
+        # the smoke step lets _login.sh inside the smoke scripts sign
+        # the agent-browser session in. See
+        # docs/superpowers/specs/2026-05-25-smoke-login-flow-design.md.
+        run: docker compose exec -T app python scripts/seed_e2e_user.py
+
       - name: Run smoke ${{ matrix.script }}
         if: env.SKIP_MATRIX != '1'
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.55.11] — 2026-05-25
+
+### Fixed
+- **`e2e-nightly` smoke scripts now sign the agent-browser session in before navigating to protected pages.** After #389 unblocked the workflow far enough to reach the smoke step, both `smoke_catalog.sh` and `smoke_admin_activity.sh` were redirected to `/login?next=…` by the global 401 handler in `app/main.py:898-907` and asserted against the login snapshot. Fix introduces `scripts/seed_e2e_user.py` (idempotent — creates `e2e@example.com` in Admin group with a hardcoded dev-only password; refuses to seed without Admin group present; rehashes only when verify fails) and `scripts/e2e/_login.sh` (sourced by both smoke scripts; uses agent-browser to POST against `/auth/password/login/web`, selectors scoped to `form[action='/auth/password/login/web']` to disambiguate the tabbed login UI). `.github/workflows/e2e-nightly.yml` gains one new step (`docker compose exec` running the seed between stack-up and smoke). The hardcoded password is acceptable here because the user only exists inside an ephemeral CI container (`docker compose down -v` per run) with no external exposure — the container is the privilege boundary, not the credential. Closes #417.
+
+### Internal
+- Three new unit tests in `tests/test_seed_e2e_user.py` covering fresh-create, idempotency, and Admin-group-missing refusal paths.
+
 ## [0.55.10] — 2026-05-25
 
 ### Added

--- a/docs/superpowers/plans/2026-05-25-smoke-login-flow.md
+++ b/docs/superpowers/plans/2026-05-25-smoke-login-flow.md
@@ -1,0 +1,680 @@
+# Smoke sign-in flow (#417) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Unblock the agent-browser nightly smoke (#417) by signing the smoke session in via the existing email/password provider before navigating to protected pages.
+
+**Architecture:** Idempotent Python seed script creates a hardcoded `e2e@example.com` Admin user; a sourced bash helper logs the agent-browser session in via the same `/auth/password/login/web` endpoint a human would; nightly workflow runs the seed between "Build + start agnes stack" and "Run smoke". No production code path is touched.
+
+**Tech Stack:** Python 3.12 / DuckDB / argon2-cffi (existing repo deps) for the seed script; bash + agent-browser CLI for the login helper; GitHub Actions YAML for workflow wiring.
+
+**Spec:** `docs/superpowers/specs/2026-05-25-smoke-login-flow-design.md`
+
+---
+
+## File map
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Create | `scripts/seed_e2e_user.py` | Idempotent CLI: create the e2e user with Admin membership; overwrite password hash on re-run; refuse if Admin group missing |
+| Create | `tests/test_seed_e2e_user.py` | Unit coverage for seed: fresh-create, idempotent re-run, Admin-missing refusal |
+| Create | `scripts/e2e/_login.sh` | Sourced helper: open `/login/password`, fill, click submit, wait for navigation |
+| Modify | `scripts/e2e/smoke_catalog.sh` | One added line: `source "$(dirname "$0")/_login.sh"` |
+| Modify | `scripts/e2e/smoke_admin_activity.sh` | Same one line |
+| Modify | `scripts/e2e/README.md` | "Prerequisites" section pointing at the seed command |
+| Modify | `.github/workflows/e2e-nightly.yml` | One added step between "Build + start agnes stack" and "Run smoke" |
+| Modify | `CHANGELOG.md` | `### Internal` bullet under `[Unreleased]`, then promote to `[0.55.10]` at the end |
+| Modify | `pyproject.toml` | `version = "0.55.9"` → `"0.55.10"` (release-cut, final commit) |
+
+---
+
+## Constants used across multiple tasks
+
+```python
+E2E_USER_EMAIL = "e2e@example.com"
+E2E_USER_NAME = "E2E Smoke Test"
+E2E_USER_ID = "e2e-smoke-user"  # stable id so the same row is targeted across runs
+E2E_USER_PASSWORD = "E2eSmokePass!"  # dev-only; documented in spec
+```
+
+```bash
+# scripts/e2e/_login.sh constants
+E2E_USER_EMAIL='e2e@example.com'
+E2E_USER_PASSWORD='E2eSmokePass!'
+LOGIN_FORM='form[action="/auth/password/login/web"]'
+```
+
+---
+
+## Task 1 — Seed script (TDD)
+
+**Files:**
+- Create: `scripts/seed_e2e_user.py`
+- Test: `tests/test_seed_e2e_user.py`
+
+The seed script exposes a `seed()` function (importable for testing) and a `__main__` block (for CLI). `seed()` returns `True` on success, raises `SystemExit(1)` with a clear stderr message if Admin group is absent.
+
+- [ ] **Step 1.1: Write the first failing test — fresh-DB happy path**
+
+Create `tests/test_seed_e2e_user.py`:
+
+```python
+"""Idempotency + safety contract tests for scripts/seed_e2e_user.py."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+# scripts/ is not a Python package; load by path
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SEED_PATH = REPO_ROOT / "scripts" / "seed_e2e_user.py"
+
+
+def _load_seed_module():
+    spec = importlib.util.spec_from_file_location("seed_e2e_user", SEED_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def seed_module():
+    return _load_seed_module()
+
+
+def test_seed_creates_admin_user_on_fresh_db(e2e_env, seed_module):
+    """Fresh DB → user is created with password hash + Admin membership."""
+    from src.db import SYSTEM_ADMIN_GROUP, get_system_db
+    from src.repositories.user_group_members import UserGroupMembersRepository
+    from src.repositories.users import UserRepository
+
+    seed_module.seed()
+
+    conn = get_system_db()
+    user = UserRepository(conn).get_by_email(seed_module.E2E_USER_EMAIL)
+    assert user is not None
+    assert user["password_hash"], "password_hash must be set"
+
+    admin_gid = conn.execute(
+        "SELECT id FROM user_groups WHERE name = ?", [SYSTEM_ADMIN_GROUP]
+    ).fetchone()[0]
+
+    member_ids = [
+        m["user_id"]
+        for m in UserGroupMembersRepository(conn).list_members(admin_gid)
+    ]
+    assert user["id"] in member_ids
+    conn.close()
+```
+
+- [ ] **Step 1.2: Run the test, see it fail with `ModuleNotFoundError` (file doesn't exist)**
+
+```bash
+.venv/bin/pytest tests/test_seed_e2e_user.py::test_seed_creates_admin_user_on_fresh_db -v
+```
+
+Expected: `FileNotFoundError` or `ModuleNotFoundError` from `spec_from_file_location` because `scripts/seed_e2e_user.py` doesn't exist yet.
+
+- [ ] **Step 1.3: Write minimal `scripts/seed_e2e_user.py` to make the test pass**
+
+```python
+#!/usr/bin/env python3
+"""Idempotent seed for the e2e smoke test user.
+
+Creates ``e2e@example.com`` (Admin group member) with a hardcoded
+dev-only password. The user exists ONLY in dev/CI containers — the
+container is the privilege boundary; see
+docs/superpowers/specs/2026-05-25-smoke-login-flow-design.md.
+
+Usage:
+    python scripts/seed_e2e_user.py
+
+Exits 0 on success (whether the user was newly created or already
+existed), 1 if the system Admin group is missing (DB in half-init
+state — refuses to create an orphan user).
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+
+from argon2 import PasswordHasher
+
+E2E_USER_EMAIL = "e2e@example.com"
+E2E_USER_NAME = "E2E Smoke Test"
+E2E_USER_ID = "e2e-smoke-user"
+E2E_USER_PASSWORD = "E2eSmokePass!"
+
+
+def seed() -> bool:
+    """Idempotent. Returns True on success; SystemExit(1) on missing Admin group."""
+    from src.db import SYSTEM_ADMIN_GROUP, get_system_db
+    from src.repositories.user_group_members import UserGroupMembersRepository
+    from src.repositories.users import UserRepository
+
+    conn = get_system_db()
+    try:
+        admin_row = conn.execute(
+            "SELECT id FROM user_groups WHERE name = ?", [SYSTEM_ADMIN_GROUP]
+        ).fetchone()
+        if not admin_row:
+            print(
+                f"error: {SYSTEM_ADMIN_GROUP!r} group not seeded — refusing to "
+                "create orphan e2e user. Run the app once so the bootstrap "
+                "seeds the system groups, then re-run this script.",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+        admin_gid = admin_row[0]
+
+        users = UserRepository(conn)
+        memberships = UserGroupMembersRepository(conn)
+        password_hash = PasswordHasher().hash(E2E_USER_PASSWORD)
+        existing = users.get_by_email(E2E_USER_EMAIL)
+        now = datetime.now(timezone.utc)
+
+        if existing is None:
+            users.create(
+                id=E2E_USER_ID,
+                email=E2E_USER_EMAIL,
+                name=E2E_USER_NAME,
+                password_hash=password_hash,
+            )
+            user_id = E2E_USER_ID
+        else:
+            # Overwrite hash so a stale row with a forgotten password
+            # doesn't leave the smoke broken.
+            conn.execute(
+                "UPDATE users SET password_hash = ?, updated_at = ? WHERE id = ?",
+                [password_hash, now, existing["id"]],
+            )
+            user_id = existing["id"]
+
+        # Re-assert Admin membership (no-op if already present).
+        current_members = {
+            m["user_id"] for m in memberships.list_members(admin_gid)
+        }
+        if user_id not in current_members:
+            memberships.add_member(user_id, admin_gid, source="system_seed")
+
+        print(f"seeded: {E2E_USER_EMAIL} (id={user_id}) in Admin group")
+        return True
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    seed()
+```
+
+- [ ] **Step 1.4: Run the test, see it pass**
+
+```bash
+.venv/bin/pytest tests/test_seed_e2e_user.py::test_seed_creates_admin_user_on_fresh_db -v
+```
+
+Expected: PASS.
+
+If `UserGroupMembersRepository.list_members` is named differently, fix the test + script to use the actual method (grep `def ` in `src/repositories/user_group_members.py`). If the test fails because `get_system_db()` doesn't auto-create the Admin group on first open, mirror the bootstrap path used by `tests/conftest.py::seeded_app` (it calls `get_system_db()` and Admin exists by virtue of `src.db` initialization — verify with `conn.execute("SELECT name FROM user_groups").fetchall()`).
+
+- [ ] **Step 1.5: Add idempotency test**
+
+Append to `tests/test_seed_e2e_user.py`:
+
+```python
+def test_seed_is_idempotent(e2e_env, seed_module):
+    """Running seed twice does not duplicate the user or fail."""
+    from src.db import SYSTEM_ADMIN_GROUP, get_system_db
+    from src.repositories.user_group_members import UserGroupMembersRepository
+    from src.repositories.users import UserRepository
+
+    seed_module.seed()
+    seed_module.seed()  # must not raise, must not duplicate
+
+    conn = get_system_db()
+    matches = conn.execute(
+        "SELECT COUNT(*) FROM users WHERE email = ?",
+        [seed_module.E2E_USER_EMAIL],
+    ).fetchone()[0]
+    assert matches == 1
+
+    admin_gid = conn.execute(
+        "SELECT id FROM user_groups WHERE name = ?", [SYSTEM_ADMIN_GROUP]
+    ).fetchone()[0]
+    members = UserGroupMembersRepository(conn).list_members(admin_gid)
+    e2e_member_rows = [m for m in members if m["user_id"] == seed_module.E2E_USER_ID]
+    assert len(e2e_member_rows) == 1
+    conn.close()
+```
+
+- [ ] **Step 1.6: Run and confirm it passes**
+
+```bash
+.venv/bin/pytest tests/test_seed_e2e_user.py -v
+```
+
+Expected: both tests PASS. The implementation already covers idempotency (the `if existing is None` branch + the `if user_id not in current_members` guard).
+
+- [ ] **Step 1.7: Add Admin-missing safety test**
+
+Append:
+
+```python
+def test_seed_refuses_when_admin_group_missing(e2e_env, seed_module):
+    """If the Admin system group is absent, seed exits 1 — never an orphan user."""
+    from src.db import SYSTEM_ADMIN_GROUP, get_system_db
+    from src.repositories.users import UserRepository
+
+    # Drop the Admin group to simulate half-init DB
+    conn = get_system_db()
+    conn.execute("DELETE FROM user_groups WHERE name = ?", [SYSTEM_ADMIN_GROUP])
+    conn.close()
+
+    with pytest.raises(SystemExit) as excinfo:
+        seed_module.seed()
+    assert excinfo.value.code == 1
+
+    # And no orphan user was created.
+    conn = get_system_db()
+    user = UserRepository(conn).get_by_email(seed_module.E2E_USER_EMAIL)
+    assert user is None
+    conn.close()
+```
+
+- [ ] **Step 1.8: Run all three tests and confirm**
+
+```bash
+.venv/bin/pytest tests/test_seed_e2e_user.py -v
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 1.9: Make the script executable + commit**
+
+```bash
+chmod +x scripts/seed_e2e_user.py
+git add scripts/seed_e2e_user.py tests/test_seed_e2e_user.py
+git commit -m "feat(scripts): seed_e2e_user — idempotent Admin seed for smoke tests"
+```
+
+---
+
+## Task 2 — Login helper
+
+**Files:**
+- Create: `scripts/e2e/_login.sh`
+
+- [ ] **Step 2.1: Write `scripts/e2e/_login.sh`**
+
+```bash
+#!/usr/bin/env bash
+# Sourced by every scripts/e2e/smoke_*.sh after $SESSION is set, before any
+# agent-browser open against a protected URL. Logs the agent-browser session
+# in via the email/password form so the next page load carries the cookie.
+#
+# Counterpart: scripts/seed_e2e_user.py must have been run against the same
+# stack first (workflow handles this; locally see scripts/e2e/README.md).
+
+set -euo pipefail
+
+if [[ -z "${SESSION:-}" ]]; then
+  echo "::error::_login.sh requires \$SESSION to be set by the caller" >&2
+  exit 2
+fi
+if [[ -z "${BASE_URL:-}" ]]; then
+  echo "::error::_login.sh requires \$BASE_URL to be set by the caller" >&2
+  exit 2
+fi
+
+E2E_USER_EMAIL='e2e@example.com'
+E2E_USER_PASSWORD='E2eSmokePass!'
+# Scope every selector by the unique form action — disambiguates Sign In
+# from the sibling Forgot Password and Sign Up forms in login_email.html.
+LOGIN_FORM='form[action="/auth/password/login/web"]'
+
+echo "→ sign in as ${E2E_USER_EMAIL}"
+agent-browser --session "$SESSION" open "${BASE_URL}/login/password"
+agent-browser --session "$SESSION" fill "${LOGIN_FORM} input[name=email]"    "$E2E_USER_EMAIL"
+agent-browser --session "$SESSION" fill "${LOGIN_FORM} input[name=password]" "$E2E_USER_PASSWORD"
+agent-browser --session "$SESSION" click "${LOGIN_FORM} button[type=submit]"
+agent-browser --session "$SESSION" wait --load networkidle
+```
+
+- [ ] **Step 2.2: Make it executable + shellcheck-clean check**
+
+```bash
+chmod +x scripts/e2e/_login.sh
+# If shellcheck is installed locally, run it; otherwise skip — CI will catch.
+command -v shellcheck >/dev/null 2>&1 && shellcheck scripts/e2e/_login.sh || true
+```
+
+- [ ] **Step 2.3: Commit**
+
+```bash
+git add scripts/e2e/_login.sh
+git commit -m "feat(e2e): _login.sh helper — sign in via password form before smoke"
+```
+
+---
+
+## Task 3 — Smoke scripts source the helper
+
+**Files:**
+- Modify: `scripts/e2e/smoke_catalog.sh`
+- Modify: `scripts/e2e/smoke_admin_activity.sh`
+
+The added line goes between the `trap` line and the first `agent-browser open` call (so the trap fires even if `_login.sh` exits early, and the protected URL open happens after the cookie is set).
+
+- [ ] **Step 3.1: Edit `scripts/e2e/smoke_catalog.sh`**
+
+After this block:
+
+```bash
+SESSION="agnes-e2e-$$"
+trap 'agent-browser --session "$SESSION" close >/dev/null 2>&1 || true' EXIT
+```
+
+Insert:
+
+```bash
+# Sign the session in before hitting a protected page — /catalog otherwise
+# 401-redirects to /login.
+source "$(dirname "$0")/_login.sh"
+```
+
+- [ ] **Step 3.2: Edit `scripts/e2e/smoke_admin_activity.sh`**
+
+Same insertion in the same spot.
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add scripts/e2e/smoke_catalog.sh scripts/e2e/smoke_admin_activity.sh
+git commit -m "feat(e2e): smoke scripts source _login.sh before protected nav"
+```
+
+---
+
+## Task 4 — Workflow integration
+
+**Files:**
+- Modify: `.github/workflows/e2e-nightly.yml`
+
+- [ ] **Step 4.1: Add the seed step between "Build + start agnes stack" and "Run smoke"**
+
+Insert this YAML step after the `Dump docker logs on stack failure` step (which was added by #389) and before `Run smoke ${{ matrix.script }}`:
+
+```yaml
+      - name: Seed E2E test user
+        if: env.SKIP_MATRIX != '1'
+        # The seed_e2e_user.py script is idempotent; running it before
+        # the smoke step lets _login.sh inside the smoke scripts sign
+        # the agent-browser session in. See
+        # docs/superpowers/specs/2026-05-25-smoke-login-flow-design.md.
+        run: docker compose exec -T app python scripts/seed_e2e_user.py
+```
+
+- [ ] **Step 4.2: actionlint locally if available**
+
+```bash
+command -v actionlint >/dev/null 2>&1 && actionlint .github/workflows/e2e-nightly.yml || echo "actionlint not installed locally — CI will run it"
+```
+
+- [ ] **Step 4.3: Commit**
+
+```bash
+git add .github/workflows/e2e-nightly.yml
+git commit -m "ci(e2e-nightly): seed e2e user before smoke step"
+```
+
+---
+
+## Task 5 — README "Prerequisites" section
+
+**Files:**
+- Modify: `scripts/e2e/README.md`
+
+- [ ] **Step 5.1: Add a Prerequisites section between "Local development" and the rest**
+
+Insert after the existing "Local development" code-block:
+
+```markdown
+### Prerequisites — sign-in seed
+
+The smoke scripts authenticate against the running stack via
+`/auth/password/login/web` before hitting any protected page. The
+helper expects a fixed `e2e@example.com` Admin user to exist. After
+`docker compose up` (or in any newly-`down -v`-ed environment), seed
+it once:
+
+\`\`\`bash
+docker compose exec -T app python scripts/seed_e2e_user.py
+\`\`\`
+
+Idempotent — re-running is safe. The CI workflow does this automatically.
+```
+
+(Replace the `\`\`\`` escapes with literal triple-backticks in the actual file.)
+
+- [ ] **Step 5.2: Commit**
+
+```bash
+git add scripts/e2e/README.md
+git commit -m "docs(e2e): note the seed prerequisite for local smoke runs"
+```
+
+---
+
+## Task 6 — Local E2E verification
+
+**Files:** none modified.
+
+This is the gate before pushing — confirm the whole chain works locally.
+
+- [ ] **Step 6.1: Run the full pytest suite — all green (per CLAUDE.md)**
+
+```bash
+.venv/bin/pytest tests/ --tb=short -n auto -q
+```
+
+Expected: 5249+ passed (3 new tests added by Task 1). Fix anything that breaks before pushing.
+
+- [ ] **Step 6.2: Start the stack locally**
+
+```bash
+touch .env  # docker-compose env_file is required
+docker compose up -d --build --wait --wait-timeout 120
+```
+
+Expected: stack reports healthy; `curl -fsS http://localhost:8000/api/health` returns 200.
+
+- [ ] **Step 6.3: Seed the e2e user**
+
+```bash
+docker compose exec -T app python scripts/seed_e2e_user.py
+```
+
+Expected stdout: `seeded: e2e@example.com (id=e2e-smoke-user) in Admin group`.
+
+- [ ] **Step 6.4: Run both smoke scripts**
+
+```bash
+bash scripts/e2e/smoke_catalog.sh        http://localhost:8000
+bash scripts/e2e/smoke_admin_activity.sh http://localhost:8000
+```
+
+Expected: both end with `✓ … smoke passed.`. If `agent-browser` is not installed, install per the README (`npm i -g agent-browser && agent-browser install`).
+
+- [ ] **Step 6.5: Re-run the seed — confirm idempotency end-to-end**
+
+```bash
+docker compose exec -T app python scripts/seed_e2e_user.py
+docker compose exec -T app python scripts/seed_e2e_user.py
+```
+
+Expected: both runs print `seeded: …`, no traceback, no duplicate rows. Optional sanity:
+
+```bash
+docker compose exec -T app python -c "from src.db import get_system_db; \
+  print(get_system_db().execute(\"SELECT COUNT(*) FROM users WHERE email='e2e@example.com'\").fetchone())"
+```
+
+Expected: `(1,)`.
+
+- [ ] **Step 6.6: Tear down**
+
+```bash
+docker compose down -v
+```
+
+- [ ] **Step 6.7: Commit nothing — this task is verification only**
+
+If anything in Task 6 failed, go back to the relevant earlier task and fix before continuing.
+
+---
+
+## Task 7 — CHANGELOG + release-cut (LAST commit on the PR)
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `pyproject.toml`
+
+Per CLAUDE.md "Release-cut belongs to the PR": this PR introduces the only `[Unreleased]` content, so the patch bump ships as the last commit.
+
+- [ ] **Step 7.1: Edit `CHANGELOG.md` — add an `### Internal` bullet under `[Unreleased]`, then rename the section to `[0.55.10] — 2026-05-25` and add a new empty `[Unreleased]` above it**
+
+The relevant block becomes:
+
+```markdown
+## [Unreleased]
+
+## [0.55.10] — 2026-05-25
+
+### Internal
+- Nightly agent-browser smoke now signs in before hitting protected pages (#417, follows #389). New `scripts/seed_e2e_user.py` creates an idempotent hardcoded `e2e@example.com` Admin user in dev/CI containers; `scripts/e2e/_login.sh` (sourced by the smoke scripts) signs the agent-browser session in via `/auth/password/login/web`; the nightly workflow runs the seed between stack-up and smoke. The password is committed in the repo — acceptable because the user exists only inside an ephemeral container (`docker compose down -v` at end of every run) that has no external exposure; the container is the privilege boundary, not the credentials.
+
+## [0.55.9] — 2026-05-25
+```
+
+- [ ] **Step 7.2: Edit `pyproject.toml`**
+
+Change line 3 from:
+
+```toml
+version = "0.55.9"
+```
+
+to:
+
+```toml
+version = "0.55.10"
+```
+
+- [ ] **Step 7.3: Run the test suite one more time as a final sanity check**
+
+```bash
+.venv/bin/pytest tests/ --tb=short -n auto -q
+```
+
+Expected: green.
+
+- [ ] **Step 7.4: Commit release-cut**
+
+```bash
+git add CHANGELOG.md pyproject.toml
+git commit -m "release: 0.55.10 — smoke sign-in flow"
+```
+
+---
+
+## Task 8 — Push branch and open the PR
+
+**Files:** none modified.
+
+- [ ] **Step 8.1: Push to a clean branch name (worktree branch has `worktree-` prefix)**
+
+```bash
+git push -u origin worktree-zs+fix-smoke-login-wall:zs/fix-smoke-login-wall
+```
+
+- [ ] **Step 8.2: Open the PR with a concrete body**
+
+```bash
+gh pr create --base main --head zs/fix-smoke-login-wall \
+  --title "ci(e2e-nightly): sign smoke session in via /auth/password/login/web (#417) + release 0.55.10" \
+  --body "Closes #417. Follows #389 (which unblocked the workflow far enough to surface this).
+
+## Why
+
+After #389 the nightly agent-browser smoke gets past \`docker compose up\` but lands on the login wall when it opens \`/catalog\` and \`/admin/activity\` — the global 401 handler in \`app/main.py:898-907\` redirects unauthenticated HTML GETs to \`/login?next=…\`, so both smoke scripts grep against a login snapshot and fail.
+
+## Fix
+
+Sign the smoke session in via the existing email/password provider before navigating to protected pages — no production code path touched.
+
+- New \`scripts/seed_e2e_user.py\` — idempotent: creates \`e2e@example.com\` (Admin group) with a hardcoded dev-only password. Overwrites the hash on re-run; refuses to create an orphan user if the Admin group is missing.
+- New \`scripts/e2e/_login.sh\` — sourced by both \`smoke_*.sh\`; uses agent-browser to fill the form at \`/login/password\` and POSTs against \`/auth/password/login/web\`. Selectors scoped to the form action (\`form[action='/auth/password/login/web']\`) to disambiguate the three nested forms in the tabbed login UI.
+- One new step in \`.github/workflows/e2e-nightly.yml\` — runs the seed via \`docker compose exec\` between stack-up and smoke.
+- Three unit tests in \`tests/test_seed_e2e_user.py\` — fresh-create, idempotency, Admin-missing-refusal.
+
+The hardcoded password is committed in the repo. This is acceptable because the user only exists inside an ephemeral container (\`docker compose down -v\` at end of every run), the container has no external exposure, and committing the password lets a local developer reproduce the smoke setup byte-for-byte. **The container is the privilege boundary, not the credentials.**
+
+## Spec + plan
+
+- Spec: \`docs/superpowers/specs/2026-05-25-smoke-login-flow-design.md\`
+- Plan: \`docs/superpowers/plans/2026-05-25-smoke-login-flow.md\`
+
+## Release-cut
+
+Patch \`0.55.9 → 0.55.10\` in the same PR per the CLAUDE.md release-cut rule.
+
+## Verification
+
+- Full test suite green locally (\`pytest tests/ -n auto -q\`).
+- End-to-end smoke run locally — both \`smoke_catalog.sh\` and \`smoke_admin_activity.sh\` pass against a freshly-seeded \`docker compose\` stack.
+- Re-running the seed twice is a no-op (verified locally)."
+```
+
+- [ ] **Step 8.3: Wait for CI; address the \`gh pr checks\` output (note: the \`release.yml\` cancelled-by-concurrency artefact from #389 will repeat for new branches — rerun the cancelled run if needed)**
+
+```bash
+gh pr view --json url --jq .url
+gh pr checks
+```
+
+- [ ] **Step 8.4: Final post-merge housekeeping (out of plan but part of the routine — do not merge yet, wait for user GO)**
+
+After merge, follow the same post-merge pattern from #389:
+- Tag \`v0.55.10\` on the merge commit + create GH release.
+- Manually \`gh workflow run e2e-nightly.yml\` to confirm a green nightly.
+- Close #417 with a pointer to the merged PR.
+
+---
+
+## Self-review checklist
+
+(Run this checklist mentally before handing off to executing-plans / subagent-driven-development.)
+
+**Spec coverage:**
+- ✅ Seed user (Section 1) → Task 1 (script + tests + commit).
+- ✅ Seed mechanism (Section 2) → Task 1 + Task 4 (workflow exec line).
+- ✅ Login helper (Section 3) → Task 2.
+- ✅ Workflow integration (Section 4) → Task 4.
+- ✅ Smoke script source line (Section 5) → Task 3.
+- ✅ README (Section 6) → Task 5.
+- ✅ CHANGELOG + release-cut (Section 7) → Task 7.
+- ✅ Failure modes (`Admin missing`, selectors changed, cookie issues) — covered by Task 1 unit tests + Task 6 manual verification.
+
+**Placeholder scan:** ✅ no TBDs / TODOs / "implement later" / "similar to Task N".
+
+**Type/name consistency:**
+- ✅ `E2E_USER_EMAIL` / `E2E_USER_PASSWORD` consistent in Python (Task 1) and bash (Task 2).
+- ✅ `LOGIN_FORM` scope identical in bash helper and spec.
+- ✅ `SYSTEM_ADMIN_GROUP` import path matches the precedent in `tests/conftest.py::seeded_app` (line 240).
+- ✅ `UserGroupMembersRepository.list_members` + `add_member` — verified against `tests/conftest.py:255` usage (`add_member(user_id, group_id, source=...)`); if the actual method name differs, Step 1.4's grep-and-fix note covers it.

--- a/docs/superpowers/specs/2026-05-25-smoke-login-flow-design.md
+++ b/docs/superpowers/specs/2026-05-25-smoke-login-flow-design.md
@@ -1,0 +1,142 @@
+# E2E nightly smoke — sign-in flow design
+
+Date: 2026-05-25
+Issue: [#417](https://github.com/keboola/agnes-the-ai-analyst/issues/417)
+Follows: [#389](https://github.com/keboola/agnes-the-ai-analyst/pull/389) (root-cause fix that uncovered this)
+
+## Problem
+
+The agent-browser smoke scripts under `scripts/e2e/` open `/catalog` and
+`/admin/activity` and grep their snapshots for expected UI markers. But the
+app's global 401 handler (`app/main.py:898-907`) redirects unauthenticated HTML
+GETs to `/login?next=…`, so the smoke scripts land on the login page and fail
+their next assertion. This was masked for weeks because the workflow died
+earlier on a missing `.env`; #389 unblocked that and surfaced this.
+
+## Approach
+
+Smoke scripts sign in via the existing email/password provider before
+navigating to protected pages. No production code path is touched. Three
+alternatives were considered (see _Alternatives considered_ at the end);
+sign-in-flow was chosen over an env-gated auth bypass to keep prod code paths
+unchanged and to exercise the real auth surface end-to-end.
+
+## Components
+
+### 1. E2E seed user
+
+- Email: `e2e@example.com`
+- Password: hardcoded dev-only — `E2eSmokePass!`
+- Membership: `Admin` group (god-mode short-circuit per `docs/RBAC.md`, so
+  `/admin/activity` and any future protected page is reachable without
+  per-resource grant maintenance).
+- Lifetime: only ever exists in the ephemeral CI container (`docker compose
+  down -v` between every run wipes it). No external exposure.
+
+Hardcoded credentials are acceptable because the user has zero privileges
+outside the throwaway container, and committing them lets a local developer
+reproduce the smoke setup byte-for-byte. No GitHub secret involved.
+
+### 2. Seed script — `scripts/seed_e2e_user.py`
+
+Idempotent — running twice is a no-op (creates user only if absent, ensures
+Admin membership only if missing). Uses `UserRepository` + `UserGroupsRepository`
+via the same DuckDB connection the app uses. Exits 0 on success, non-zero with
+a clear stderr message on failure.
+
+Invoked from the workflow via:
+
+    docker compose exec -T app python -m scripts.seed_e2e_user
+
+The `-T` disables TTY (no pty in CI). Local developers run the same command
+before invoking a smoke script.
+
+### 3. Login helper — `scripts/e2e/_login.sh`
+
+Sourced by both `smoke_catalog.sh` and `smoke_admin_activity.sh` _after_ the
+`SESSION` variable is exported and _before_ any `agent-browser open` against a
+protected URL.
+
+    agent-browser --session "$SESSION" open "${BASE_URL}/login"
+    agent-browser --session "$SESSION" fill 'input[name=email]' 'e2e@example.com'
+    agent-browser --session "$SESSION" fill 'input[name=password]' 'E2eSmokePass!'
+    agent-browser --session "$SESSION" click 'button[type=submit]'
+    agent-browser --session "$SESSION" wait --load networkidle
+
+The agent-browser session naturally inherits the cookie set by the form POST —
+no manual cookie injection needed. Selectors (`input[name=email]`,
+`input[name=password]`, `button[type=submit]`) are stable because they map to
+`app/web/templates/login_email.html:26-46`, which uses the actual form-field
+names the password provider reads (`name="email"`, `name="password"` —
+verified in source).
+
+If a future redesign of the login form breaks these selectors, that's the
+right time to discover it: login is a critical surface, and a smoke failure
+that points at the login step is far easier to diagnose than a downstream
+assertion against half-rendered content.
+
+### 4. Workflow changes — `.github/workflows/e2e-nightly.yml`
+
+Insert one step between "Build + start agnes stack" and "Run smoke":
+
+    - name: Seed E2E test user
+      if: env.SKIP_MATRIX != '1'
+      run: docker compose exec -T app python -m scripts.seed_e2e_user
+
+No new env vars, no new secrets, no rerun-loop changes.
+
+### 5. Smoke script changes
+
+Each `scripts/e2e/smoke_*.sh` adds a single line after `SESSION=...` /
+`trap ...`:
+
+    source "$(dirname "$0")/_login.sh"
+
+Everything below that line is unchanged.
+
+### 6. Local-dev documentation
+
+`scripts/e2e/README.md` gets a "Prerequisites" section noting the seed
+command must run once after `docker compose up` and before the first
+smoke script.
+
+## Failure modes
+
+| Failure | Symptom | Diagnosis |
+|---|---|---|
+| Seed script fails (DB locked, migration mismatch) | Workflow stops before "Run smoke" | Step log shows the exact Python traceback. |
+| Login form selectors change | `agent-browser fill 'input[name=email]'` exits non-zero | `set -euo pipefail` in smoke script propagates; failure points at the login step, not at a downstream assertion. |
+| Login cookie expires mid-script | A later `agent-browser open` redirects to `/login` | Existing snapshot-assert behavior — clear failure message. |
+| `docker compose exec` finds no `app` service | Workflow stops at seed step | Step log shows compose error. The new `Dump docker logs on stack failure` step from #389 runs (if `failure()` triggers). |
+
+## Non-goals
+
+- Testing the login flow itself (covered by `tests/test_auth_*`).
+- Multi-user smoke scenarios (one Admin user is enough for current smoke
+  coverage).
+- Testing OAuth / Google / magic-link flows.
+- Persistent test data — every nightly run starts from a clean container.
+
+## Alternatives considered
+
+**Env-gated auth bypass** (`AGNES_E2E_BYPASS_AUTH=1` in 401 handler).
+Smaller diff (1 file in `app/`), zero smoke-script changes. Rejected because
+it adds a production code path that bypasses auth — even with hard env-gate
++ boot warning, reviewers (Devin/humans) understandably balk, and a
+misconfigured `.env` in any deployment that picks the env var up would be a
+security incident. The sign-in path tests the real auth surface and has no
+prod code path at all.
+
+**Dev-VM target** (run smoke against a long-running deployed instance with a
+prior auth token). Rejected because (a) couples OSS repo CI to private
+customer infra, violating the "vendor-agnostic OSS" rule in `CLAUDE.md`,
+(b) shared mutable env produces flaky/non-reproducible failures, (c)
+introduces a secret-rotation chore.
+
+## Acceptance
+
+- Nightly workflow on `main`: `gh workflow run e2e-nightly.yml` → both smoke
+  jobs succeed.
+- Run locally after `docker compose up` + seed: both smoke scripts pass.
+- Removing the seed step: both smoke scripts fail at the login step with a
+  clear `Invalid email or password` artifact in the screenshot.

--- a/docs/superpowers/specs/2026-05-25-smoke-login-flow-design.md
+++ b/docs/superpowers/specs/2026-05-25-smoke-login-flow-design.md
@@ -27,29 +27,45 @@ unchanged and to exercise the real auth surface end-to-end.
 
 - Email: `e2e@example.com`
 - Password: hardcoded dev-only — `E2eSmokePass!`
-- Membership: `Admin` group (god-mode short-circuit per `docs/RBAC.md`, so
-  `/admin/activity` and any future protected page is reachable without
-  per-resource grant maintenance).
-- Lifetime: only ever exists in the ephemeral CI container (`docker compose
-  down -v` between every run wipes it). No external exposure.
+- Membership: `Admin` group (god-mode short-circuit per
+  `src/repositories/user_groups.py:4` + `docs/RBAC.md`), so `/admin/activity`
+  and any future protected HTML page is reachable without per-resource grant
+  maintenance.
+- Lifetime: only ever exists in dev images. The CI container is
+  `docker compose down -v`-ed at the end of every nightly run, wiping the
+  whole DB; outside the container the credentials grant access to nothing.
 
-Hardcoded credentials are acceptable because the user has zero privileges
-outside the throwaway container, and committing them lets a local developer
-reproduce the smoke setup byte-for-byte. No GitHub secret involved.
+Hardcoding the password in the repo is acceptable because **the container is
+the privilege boundary** — the user is Admin inside it, nothing outside it.
+Committing the password (instead of stashing it in a GitHub secret) lets a
+local developer reproduce the smoke setup byte-for-byte.
 
 ### 2. Seed script — `scripts/seed_e2e_user.py`
 
-Idempotent — running twice is a no-op (creates user only if absent, ensures
-Admin membership only if missing). Uses `UserRepository` + `UserGroupsRepository`
-via the same DuckDB connection the app uses. Exits 0 on success, non-zero with
-a clear stderr message on failure.
+Idempotent re-runnable. Direct invocation (not `-m`) — matches the existing
+`scripts/seed_corporate_memory.py` / `seed_dummy_tables.py` precedent;
+`scripts/` is intentionally not a Python package.
 
-Invoked from the workflow via:
+    docker compose exec -T app python scripts/seed_e2e_user.py
 
-    docker compose exec -T app python -m scripts.seed_e2e_user
+Idempotency rules:
 
-The `-T` disables TTY (no pty in CI). Local developers run the same command
-before invoking a smoke script.
+- **User absent** → create with the hashed password and Admin membership.
+- **User present with same email** → overwrite the `password_hash` to the
+  hardcoded value (so a stale local-dev row with a forgotten password doesn't
+  leave the smoke broken). Re-assert Admin membership.
+- **`Admin` group missing** (DB in a half-init state — should never happen
+  on a healthy image, but defensive) → exit non-zero with a clear stderr
+  message like `Admin group not seeded — refusing to create orphan user`. No
+  silent broken state.
+
+Exit codes: `0` on success (user existed or was created), `1` on
+unrecoverable error.
+
+Uses `src.repositories.users.UserRepository` for the user row and
+`src.repositories.user_groups.UserGroupsRepository` for the Admin membership
+(both verified — see file:line refs above). Password hashing via the same
+`argon2-cffi` `PasswordHasher` used by `app/auth/providers/password.py`.
 
 ### 3. Login helper — `scripts/e2e/_login.sh`
 
@@ -57,23 +73,33 @@ Sourced by both `smoke_catalog.sh` and `smoke_admin_activity.sh` _after_ the
 `SESSION` variable is exported and _before_ any `agent-browser open` against a
 protected URL.
 
-    agent-browser --session "$SESSION" open "${BASE_URL}/login"
-    agent-browser --session "$SESSION" fill 'input[name=email]' 'e2e@example.com'
-    agent-browser --session "$SESSION" fill 'input[name=password]' 'E2eSmokePass!'
-    agent-browser --session "$SESSION" click 'button[type=submit]'
+Target URL is `/login/password` (NOT `/login` — `/login` is a dispatcher per
+`app/web/router.py:539-587` that redirects to whichever provider is
+configured; the password form is at `/login/password`, served by
+`app/web/router.py:596` which renders `login_email.html`).
+
+All selectors scoped to the form's action attribute, which uniquely identifies
+the Sign-In form among the three nested forms in `#signin-tab` (Sign In,
+Forgot Password) and the sibling `#signup-tab`:
+
+    LOGIN_FORM='form[action="/auth/password/login/web"]'
+
+    agent-browser --session "$SESSION" open "${BASE_URL}/login/password"
+    agent-browser --session "$SESSION" fill "${LOGIN_FORM} input[name=email]"    'e2e@example.com'
+    agent-browser --session "$SESSION" fill "${LOGIN_FORM} input[name=password]" 'E2eSmokePass!'
+    agent-browser --session "$SESSION" click "${LOGIN_FORM} button[type=submit]"
     agent-browser --session "$SESSION" wait --load networkidle
 
-The agent-browser session naturally inherits the cookie set by the form POST —
-no manual cookie injection needed. Selectors (`input[name=email]`,
-`input[name=password]`, `button[type=submit]`) are stable because they map to
-`app/web/templates/login_email.html:26-46`, which uses the actual form-field
-names the password provider reads (`name="email"`, `name="password"` —
-verified in source).
+Why scope by form action: `login_email.html:26-46` shows the Sign-In `<form>`
+with `action="/auth/password/login/web"`, sibling Forgot-Password `<form>`
+with `action="/auth/password/reset"`, and presumably a Sign-Up `<form>` in
+`#signup-tab`. Unscoped `button[type=submit]` would match multiple submits and
+the click would be non-deterministic. The form action is the stable contract
+between template and password router (`password.py:229`) — if it changes,
+both ends update together.
 
-If a future redesign of the login form breaks these selectors, that's the
-right time to discover it: login is a critical surface, and a smoke failure
-that points at the login step is far easier to diagnose than a downstream
-assertion against half-rendered content.
+The agent-browser session naturally inherits the `Set-Cookie` from the form
+POST — no manual cookie injection needed.
 
 ### 4. Workflow changes — `.github/workflows/e2e-nightly.yml`
 
@@ -81,7 +107,7 @@ Insert one step between "Build + start agnes stack" and "Run smoke":
 
     - name: Seed E2E test user
       if: env.SKIP_MATRIX != '1'
-      run: docker compose exec -T app python -m scripts.seed_e2e_user
+      run: docker compose exec -T app python scripts/seed_e2e_user.py
 
 No new env vars, no new secrets, no rerun-loop changes.
 
@@ -96,18 +122,32 @@ Everything below that line is unchanged.
 
 ### 6. Local-dev documentation
 
-`scripts/e2e/README.md` gets a "Prerequisites" section noting the seed
-command must run once after `docker compose up` and before the first
-smoke script.
+`scripts/e2e/README.md` gets a "Prerequisites" section noting that after
+`docker compose up` the operator must run the seed once:
+
+    docker compose exec -T app python scripts/seed_e2e_user.py
+
+…before any `bash scripts/e2e/smoke_*.sh`.
+
+### 7. CHANGELOG + release-cut
+
+- `### Internal` bullet under `[Unreleased]` summarizing the seed user +
+  sign-in helper, with explicit "credentials are hardcoded; container is the
+  privilege boundary" justification so future readers don't think it's a
+  security regression.
+- Per the CLAUDE.md release-cut rule, the patch bump
+  `0.55.9 → 0.55.10` (pyproject.toml + CHANGELOG rename + new empty
+  `[Unreleased]`) ships in the final commit of the same PR.
 
 ## Failure modes
 
 | Failure | Symptom | Diagnosis |
 |---|---|---|
-| Seed script fails (DB locked, migration mismatch) | Workflow stops before "Run smoke" | Step log shows the exact Python traceback. |
-| Login form selectors change | `agent-browser fill 'input[name=email]'` exits non-zero | `set -euo pipefail` in smoke script propagates; failure points at the login step, not at a downstream assertion. |
-| Login cookie expires mid-script | A later `agent-browser open` redirects to `/login` | Existing snapshot-assert behavior — clear failure message. |
-| `docker compose exec` finds no `app` service | Workflow stops at seed step | Step log shows compose error. The new `Dump docker logs on stack failure` step from #389 runs (if `failure()` triggers). |
+| Seed script fails (DB locked, migration mismatch, missing Admin group) | Workflow stops before "Run smoke" | Step log shows the exact Python traceback / stderr message. |
+| Login form selectors change | `agent-browser fill 'form[...] input[name=email]'` exits non-zero | `set -euo pipefail` in smoke script propagates; failure points at the login step, not at a downstream assertion. |
+| Login click succeeds but cookie not set (form rejected — e.g. seed step skipped or password drift) | `agent-browser open /catalog` follows the 401 redirect to `/login?next=/catalog`; `grep -qi 'Browse'` against the snapshot fails | Screenshot shows the login page, snapshot lacks "Browse"; clear hint to inspect the seed step / login click logs above. |
+| Cookie expires mid-script | Same as above, mid-run | Same as above. |
+| `docker compose exec` finds no `app` service | Workflow stops at seed step | Step log shows compose error. The "Dump docker logs on stack failure" step from #389 fires. |
 
 ## Non-goals
 
@@ -135,8 +175,12 @@ introduces a secret-rotation chore.
 
 ## Acceptance
 
-- Nightly workflow on `main`: `gh workflow run e2e-nightly.yml` → both smoke
-  jobs succeed.
-- Run locally after `docker compose up` + seed: both smoke scripts pass.
-- Removing the seed step: both smoke scripts fail at the login step with a
-  clear `Invalid email or password` artifact in the screenshot.
+1. Nightly workflow on `main`: `gh workflow run e2e-nightly.yml` → both smoke
+   jobs succeed.
+2. Run locally after `docker compose up` + seed: both smoke scripts pass.
+3. Skipping the seed step (or seeding with wrong password): smoke fails at
+   the `/catalog` `Browse` snapshot assert because the session never got a
+   cookie; the artifact screenshot shows the login page. Failure log clearly
+   points at the missing seed step.
+4. Running the seed twice in a row: second invocation is a no-op (no
+   duplicate user row, no error).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.55.10"
+version = "0.55.11"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -28,6 +28,20 @@ Each script:
 - Stores screenshots into `$ARTIFACTS_DIR` if set; the nightly
   workflow uploads them as build artifacts.
 
+### Prerequisites — sign-in seed
+
+The smoke scripts authenticate against the running stack via
+`/auth/password/login/web` before hitting any protected page. The
+helper expects a fixed `e2e@example.com` Admin user to exist. After
+`docker compose up` (or in any newly-`down -v`-ed environment), seed
+it once:
+
+```bash
+docker compose exec -T app python scripts/seed_e2e_user.py
+```
+
+Idempotent — re-running is safe. The CI workflow does this automatically.
+
 ## Adding a new smoke script
 
 Add `smoke_<area>.sh` and append its filename to the `script:` matrix

--- a/scripts/e2e/_login.sh
+++ b/scripts/e2e/_login.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Sourced by every scripts/e2e/smoke_*.sh after $SESSION is set, before any
+# agent-browser open against a protected URL. Logs the agent-browser session
+# in via the email/password form so the next page load carries the cookie.
+#
+# Counterpart: scripts/seed_e2e_user.py must have been run against the same
+# stack first (workflow handles this; locally see scripts/e2e/README.md).
+
+set -euo pipefail
+
+if [[ -z "${SESSION:-}" ]]; then
+  echo "::error::_login.sh requires \$SESSION to be set by the caller" >&2
+  exit 2
+fi
+if [[ -z "${BASE_URL:-}" ]]; then
+  echo "::error::_login.sh requires \$BASE_URL to be set by the caller" >&2
+  exit 2
+fi
+
+E2E_USER_EMAIL='e2e@example.com'
+E2E_USER_PASSWORD='E2eSmokePass!'
+# Scope every selector by the unique form action — disambiguates Sign In
+# from the sibling Forgot Password and Sign Up forms in login_email.html.
+LOGIN_FORM='form[action="/auth/password/login/web"]'
+
+echo "→ sign in as ${E2E_USER_EMAIL}"
+agent-browser --session "$SESSION" open "${BASE_URL}/login/password"
+agent-browser --session "$SESSION" fill "${LOGIN_FORM} input[name=email]"    "$E2E_USER_EMAIL"
+agent-browser --session "$SESSION" fill "${LOGIN_FORM} input[name=password]" "$E2E_USER_PASSWORD"
+agent-browser --session "$SESSION" click "${LOGIN_FORM} button[type=submit]"
+agent-browser --session "$SESSION" wait --load networkidle

--- a/scripts/e2e/smoke_admin_activity.sh
+++ b/scripts/e2e/smoke_admin_activity.sh
@@ -15,6 +15,10 @@ fi
 SESSION="agnes-e2e-$$"
 trap 'agent-browser --session "$SESSION" close >/dev/null 2>&1 || true' EXIT
 
+# Sign the session in before hitting a protected page — /admin/activity otherwise
+# 401-redirects to /login.
+source "$(dirname "$0")/_login.sh"
+
 echo "→ open ${BASE_URL}/admin/activity"
 agent-browser --session "$SESSION" open "${BASE_URL}/admin/activity"
 agent-browser --session "$SESSION" wait --load networkidle

--- a/scripts/e2e/smoke_catalog.sh
+++ b/scripts/e2e/smoke_catalog.sh
@@ -19,6 +19,10 @@ fi
 SESSION="agnes-e2e-$$"
 trap 'agent-browser --session "$SESSION" close >/dev/null 2>&1 || true' EXIT
 
+# Sign the session in before hitting a protected page — /catalog otherwise
+# 401-redirects to /login.
+source "$(dirname "$0")/_login.sh"
+
 echo "→ open ${BASE_URL}/catalog"
 agent-browser --session "$SESSION" open "${BASE_URL}/catalog"
 agent-browser --session "$SESSION" wait --load networkidle

--- a/scripts/seed_e2e_user.py
+++ b/scripts/seed_e2e_user.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Idempotent seed for the e2e smoke test user.
+
+Creates ``e2e@example.com`` (Admin group member) with a hardcoded
+dev-only password. The user exists ONLY in dev/CI containers -- the
+container is the privilege boundary; see
+docs/superpowers/specs/2026-05-25-smoke-login-flow-design.md.
+
+Usage:
+    python scripts/seed_e2e_user.py
+
+Exits 0 on success (whether the user was newly created or already
+existed), 1 if the system Admin group is missing (DB in half-init
+state -- refuses to create an orphan user).
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+
+from argon2 import PasswordHasher
+
+E2E_USER_EMAIL = "e2e@example.com"
+E2E_USER_NAME = "E2E Smoke Test"
+E2E_USER_ID = "e2e-smoke-user"
+E2E_USER_PASSWORD = "E2eSmokePass!"
+
+
+def seed() -> bool:
+    """Idempotent. Returns True on success; SystemExit(1) on missing Admin group."""
+    from src.db import SYSTEM_ADMIN_GROUP, get_system_db
+    from src.repositories.user_group_members import UserGroupMembersRepository
+    from src.repositories.users import UserRepository
+
+    conn = get_system_db()
+    try:
+        admin_row = conn.execute(
+            "SELECT id FROM user_groups WHERE name = ?", [SYSTEM_ADMIN_GROUP]
+        ).fetchone()
+        if not admin_row:
+            print(
+                f"error: {SYSTEM_ADMIN_GROUP!r} group not seeded -- refusing to "
+                "create orphan e2e user. Run the app once so the bootstrap "
+                "seeds the system groups, then re-run this script.",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+        admin_gid = admin_row[0]
+
+        users = UserRepository(conn)
+        memberships = UserGroupMembersRepository(conn)
+        password_hash = PasswordHasher().hash(E2E_USER_PASSWORD)
+        existing = users.get_by_email(E2E_USER_EMAIL)
+        now = datetime.now(timezone.utc)
+
+        if existing is None:
+            users.create(
+                id=E2E_USER_ID,
+                email=E2E_USER_EMAIL,
+                name=E2E_USER_NAME,
+                password_hash=password_hash,
+            )
+            user_id = E2E_USER_ID
+        else:
+            # Overwrite hash so a stale row with a forgotten password
+            # doesn't leave the smoke broken.
+            conn.execute(
+                "UPDATE users SET password_hash = ?, updated_at = ? WHERE id = ?",
+                [password_hash, now, existing["id"]],
+            )
+            user_id = existing["id"]
+
+        # Re-assert Admin membership (no-op if already present).
+        # list_members_for_group joins users, so the user id column is "id".
+        current_members = {
+            m["id"] for m in memberships.list_members_for_group(admin_gid)
+        }
+        if user_id not in current_members:
+            memberships.add_member(user_id, admin_gid, source="system_seed")
+
+        print(f"seeded: {E2E_USER_EMAIL} (id={user_id}) in Admin group")
+        return True
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    seed()

--- a/scripts/seed_e2e_user.py
+++ b/scripts/seed_e2e_user.py
@@ -20,6 +20,7 @@ import sys
 from datetime import datetime, timezone
 
 from argon2 import PasswordHasher
+from argon2.exceptions import VerifyMismatchError
 
 E2E_USER_EMAIL = "e2e@example.com"
 E2E_USER_NAME = "E2E Smoke Test"
@@ -27,8 +28,8 @@ E2E_USER_ID = "e2e-smoke-user"
 E2E_USER_PASSWORD = "E2eSmokePass!"
 
 
-def seed() -> bool:
-    """Idempotent. Returns True on success; SystemExit(1) on missing Admin group."""
+def seed() -> None:
+    """Idempotent. SystemExit(1) on missing Admin group."""
     from src.db import SYSTEM_ADMIN_GROUP, get_system_db
     from src.repositories.user_group_members import UserGroupMembersRepository
     from src.repositories.users import UserRepository
@@ -50,11 +51,11 @@ def seed() -> bool:
 
         users = UserRepository(conn)
         memberships = UserGroupMembersRepository(conn)
-        password_hash = PasswordHasher().hash(E2E_USER_PASSWORD)
         existing = users.get_by_email(E2E_USER_EMAIL)
         now = datetime.now(timezone.utc)
 
         if existing is None:
+            password_hash = PasswordHasher().hash(E2E_USER_PASSWORD)
             users.create(
                 id=E2E_USER_ID,
                 email=E2E_USER_EMAIL,
@@ -63,24 +64,25 @@ def seed() -> bool:
             )
             user_id = E2E_USER_ID
         else:
-            # Overwrite hash so a stale row with a forgotten password
-            # doesn't leave the smoke broken.
-            conn.execute(
-                "UPDATE users SET password_hash = ?, updated_at = ? WHERE id = ?",
-                [password_hash, now, existing["id"]],
-            )
             user_id = existing["id"]
+            # Verify the stored hash. Skip the UPDATE on the common case
+            # (hash already matches) to avoid a needless ~100 ms re-hash +
+            # DB write. If verification fails (stale password or corrupt row),
+            # re-hash and heal the row.
+            try:
+                PasswordHasher().verify(existing["password_hash"], E2E_USER_PASSWORD)
+            except (VerifyMismatchError, Exception):
+                password_hash = PasswordHasher().hash(E2E_USER_PASSWORD)
+                conn.execute(
+                    "UPDATE users SET password_hash = ?, updated_at = ? WHERE id = ?",
+                    [password_hash, now, user_id],
+                )
 
-        # Re-assert Admin membership (no-op if already present).
-        # list_members_for_group joins users, so the user id column is "id".
-        current_members = {
-            m["id"] for m in memberships.list_members_for_group(admin_gid)
-        }
-        if user_id not in current_members:
-            memberships.add_member(user_id, admin_gid, source="system_seed")
+        # Re-assert Admin membership. add_member is idempotent on
+        # (user_id, group_id) per the repository contract.
+        memberships.add_member(user_id, admin_gid, source="system_seed")
 
         print(f"seeded: {E2E_USER_EMAIL} (id={user_id}) in Admin group")
-        return True
     finally:
         conn.close()
 

--- a/tests/test_seed_e2e_user.py
+++ b/tests/test_seed_e2e_user.py
@@ -1,0 +1,97 @@
+"""Idempotency + safety contract tests for scripts/seed_e2e_user.py."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+# scripts/ is not a Python package; load by path
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SEED_PATH = REPO_ROOT / "scripts" / "seed_e2e_user.py"
+
+
+def _load_seed_module():
+    spec = importlib.util.spec_from_file_location("seed_e2e_user", SEED_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def seed_module():
+    return _load_seed_module()
+
+
+def test_seed_creates_admin_user_on_fresh_db(e2e_env, seed_module):
+    """Fresh DB -> user is created with password hash + Admin membership."""
+    from src.db import SYSTEM_ADMIN_GROUP, get_system_db
+    from src.repositories.user_group_members import UserGroupMembersRepository
+    from src.repositories.users import UserRepository
+
+    seed_module.seed()
+
+    conn = get_system_db()
+    user = UserRepository(conn).get_by_email(seed_module.E2E_USER_EMAIL)
+    assert user is not None
+    assert user["password_hash"], "password_hash must be set"
+
+    admin_gid = conn.execute(
+        "SELECT id FROM user_groups WHERE name = ?", [SYSTEM_ADMIN_GROUP]
+    ).fetchone()[0]
+
+    member_ids = [
+        m["id"]
+        for m in UserGroupMembersRepository(conn).list_members_for_group(admin_gid)
+    ]
+    assert user["id"] in member_ids
+    conn.close()
+
+
+def test_seed_is_idempotent(e2e_env, seed_module):
+    """Running seed twice does not duplicate the user or fail."""
+    from src.db import SYSTEM_ADMIN_GROUP, get_system_db
+    from src.repositories.user_group_members import UserGroupMembersRepository
+    from src.repositories.users import UserRepository
+
+    seed_module.seed()
+    seed_module.seed()  # must not raise, must not duplicate
+
+    conn = get_system_db()
+    matches = conn.execute(
+        "SELECT COUNT(*) FROM users WHERE email = ?",
+        [seed_module.E2E_USER_EMAIL],
+    ).fetchone()[0]
+    assert matches == 1
+
+    admin_gid = conn.execute(
+        "SELECT id FROM user_groups WHERE name = ?", [SYSTEM_ADMIN_GROUP]
+    ).fetchone()[0]
+    members = UserGroupMembersRepository(conn).list_members_for_group(admin_gid)
+    e2e_member_rows = [m for m in members if m["id"] == seed_module.E2E_USER_ID]
+    assert len(e2e_member_rows) == 1
+    conn.close()
+
+
+def test_seed_refuses_when_admin_group_missing(e2e_env, seed_module):
+    """If the Admin system group is absent, seed exits 1 -- never an orphan user."""
+    from src.db import SYSTEM_ADMIN_GROUP, get_system_db
+    from src.repositories.users import UserRepository
+
+    # Drop the Admin group to simulate half-init DB
+    conn = get_system_db()
+    conn.execute("DELETE FROM user_groups WHERE name = ?", [SYSTEM_ADMIN_GROUP])
+    conn.close()
+
+    with pytest.raises(SystemExit) as excinfo:
+        seed_module.seed()
+    assert excinfo.value.code == 1
+
+    # And no orphan user was created.
+    conn = get_system_db()
+    user = UserRepository(conn).get_by_email(seed_module.E2E_USER_EMAIL)
+    assert user is None
+    conn.close()


### PR DESCRIPTION
Closes #417. Follows #389 (which unblocked the workflow far enough to surface this).

## Why

After #389 the nightly agent-browser smoke gets past `docker compose up` but lands on the login wall when it opens `/catalog` and `/admin/activity` — the global 401 handler in `app/main.py:898-907` redirects unauthenticated HTML GETs to `/login?next=…`, so both smoke scripts grep against a login snapshot and fail.

## Fix

Sign the smoke session in via the existing email/password provider before navigating to protected pages — no production code path touched.

- New `scripts/seed_e2e_user.py` — idempotent: creates `e2e@example.com` (Admin group) with a hardcoded dev-only password. Overwrites the hash on re-run only when verify fails (no per-run Argon2 cost on the common idempotent path); refuses to create an orphan user if the Admin group is missing.
- New `scripts/e2e/_login.sh` — sourced by both `smoke_*.sh`; uses agent-browser to fill the form at `/login/password` and POSTs against `/auth/password/login/web`. Selectors scoped to the form action (`form[action='/auth/password/login/web']`) to disambiguate the three nested forms in the tabbed login UI.
- One new step in `.github/workflows/e2e-nightly.yml` — runs the seed via `docker compose exec` between stack-up and smoke.
- Three unit tests in `tests/test_seed_e2e_user.py` — fresh-create, idempotency, Admin-missing-refusal.

The hardcoded password is committed in the repo. **The container is the privilege boundary, not the credentials** — the user only exists inside an ephemeral container (`docker compose down -v` at end of every run), the container has no external exposure, and committing the password lets a local developer reproduce the smoke setup byte-for-byte.

## Spec + plan

- Spec: `docs/superpowers/specs/2026-05-25-smoke-login-flow-design.md`
- Plan: `docs/superpowers/plans/2026-05-25-smoke-login-flow.md`

## Release-cut

Patch `0.55.9 → 0.55.10` in the same PR per the CLAUDE.md release-cut rule.

## Verification

- Full test suite green locally: **5252 passed, 35 skipped** (`pytest tests/ -n auto -q`, 1m47s — 3 new tests added by this PR over the 5249 baseline).
- End-to-end smoke run **not** performed locally (Docker daemon down on the dev machine); dispatched `gh workflow run e2e-nightly.yml` after merge will be the final gate.
- Re-running the seed is verified by the idempotency unit test and by reading the verify-before-rehash code path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->