### PR TITLE
fix(db): refuse stale pre-migrate auto-recovery in _try_open_system_db (#379) + release 0.55.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.55.12] — 2026-05-26
+
 ### Fixed
 - **`src/db.py::_try_open_system_db` no longer silently drops post-migration data on WAL-replay recovery (#379).** The auto-recovery path used to copy `system.duckdb.pre-migrate` over the broken DB and re-run the migration ladder unconditionally — but the snapshot is captured once per migration transition and never refreshed, so any rows added since that transition vanished without warning. The function now opens the snapshot read-only to peek its `schema_version`; if it does not match the current `SCHEMA_VERSION` exactly (either direction — stale OR future, the latter catching the operator-rolled-the-code-back split-brain case), the broken DB + WAL are preserved at `.broken.<ts>` (chmod `0o600` because `system.duckdb` holds argon2 password hashes + PAT rows + audit log) and a `RuntimeError` is raised with the explicit manual-recovery `cp` command operators can run if they choose to accept the snapshot's data state. The happy-path (HEAD-version snapshot) and the "no snapshot file" path are unchanged.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Fixed
+- **`src/db.py::_try_open_system_db` no longer silently drops post-migration data on WAL-replay recovery (#379).** The auto-recovery path used to copy `system.duckdb.pre-migrate` over the broken DB and re-run the migration ladder unconditionally — but the snapshot is captured once per migration transition and never refreshed, so any rows added since that transition vanished without warning. The function now opens the snapshot read-only to peek its `schema_version`; if it does not match the current `SCHEMA_VERSION` exactly (either direction — stale OR future, the latter catching the operator-rolled-the-code-back split-brain case), the broken DB + WAL are preserved at `.broken.<ts>` (chmod `0o600` because `system.duckdb` holds argon2 password hashes + PAT rows + audit log) and a `RuntimeError` is raised with the explicit manual-recovery `cp` command operators can run if they choose to accept the snapshot's data state. The happy-path (HEAD-version snapshot) and the "no snapshot file" path are unchanged.
+
 ## [0.55.11] — 2026-05-25
 
 ### Fixed

--- a/docs/superpowers/plans/2026-05-26-wal-recovery-refuse-stale.md
+++ b/docs/superpowers/plans/2026-05-26-wal-recovery-refuse-stale.md
@@ -25,7 +25,7 @@
 
 ## Conventions used across multiple tasks
 
-- pytest invocation: `/Users/zdeneksrotyr/Sources/VsCode/component_factory/tmp_oss/.venv/bin/pytest` (the worktree has no `.venv` of its own; use the parent checkout's).
+- pytest invocation: `.venv/bin/pytest` (the worktree has no `.venv` of its own; use the parent checkout's).
 - The test file uses `tmp_path` (built-in pytest fixture) for DB-on-disk fixtures. No mocks for DuckDB — real files end-to-end so the read-only peek path is actually exercised.
 - The `_try_open_system_db` function lives at `src/db.py:1103-1154` today; current `SCHEMA_VERSION` is `59` (`src/db.py:43`).
 
@@ -127,7 +127,7 @@ def test_recovery_proceeds_when_snapshot_is_at_head(tmp_path, monkeypatch):
 - [ ] **Step 1.2: Run test and confirm it passes against current code**
 
 ```bash
-/Users/zdeneksrotyr/Sources/VsCode/component_factory/tmp_oss/.venv/bin/pytest tests/test_db_wal_recovery.py::test_recovery_proceeds_when_snapshot_is_at_head -v
+.venv/bin/pytest tests/test_db_wal_recovery.py::test_recovery_proceeds_when_snapshot_is_at_head -v
 ```
 
 Expected: PASS. If it fails, that's a real defect in current behavior — surface it before continuing.
@@ -193,7 +193,7 @@ def test_recovery_refuses_when_snapshot_is_stale(tmp_path, monkeypatch):
 - [ ] **Step 2.2: Run the test and confirm it fails**
 
 ```bash
-/Users/zdeneksrotyr/Sources/VsCode/component_factory/tmp_oss/.venv/bin/pytest tests/test_db_wal_recovery.py::test_recovery_refuses_when_snapshot_is_stale -v
+.venv/bin/pytest tests/test_db_wal_recovery.py::test_recovery_refuses_when_snapshot_is_stale -v
 ```
 
 Expected: FAIL. Current code copies the snapshot over `db_path` and returns a connection — no RuntimeError. The assertion either `pytest.raises(RuntimeError)` fails or `assert not db_path.exists()` fails depending on which check fires first.
@@ -302,7 +302,7 @@ Insert the freshness gate immediately AFTER `wal_path = Path(db_path + ".wal")` 
 - [ ] **Step 2.5: Run both tests and confirm both pass**
 
 ```bash
-/Users/zdeneksrotyr/Sources/VsCode/component_factory/tmp_oss/.venv/bin/pytest tests/test_db_wal_recovery.py -v
+.venv/bin/pytest tests/test_db_wal_recovery.py -v
 ```
 
 Expected: 2 passed.
@@ -358,7 +358,7 @@ def test_recovery_refuses_when_snapshot_has_no_schema_version_table(
 - [ ] **Step 3.2: Run all three tests**
 
 ```bash
-/Users/zdeneksrotyr/Sources/VsCode/component_factory/tmp_oss/.venv/bin/pytest tests/test_db_wal_recovery.py -v
+.venv/bin/pytest tests/test_db_wal_recovery.py -v
 ```
 
 Expected: 3 passed.
@@ -381,7 +381,7 @@ git commit -m "test(db): lock contract — corrupt snapshot treated as stale (#3
 - [ ] **Step 4.1: Run the full pytest suite**
 
 ```bash
-/Users/zdeneksrotyr/Sources/VsCode/component_factory/tmp_oss/.venv/bin/pytest tests/ --tb=short -n auto -q
+.venv/bin/pytest tests/ --tb=short -n auto -q
 ```
 
 Expected: full suite green. Should be 5252 baseline + 3 new tests = 5255 passed (give or take if other changes have landed in main since). Failures in code you touched: fix before moving on. Failures unrelated to your diff: confirm with `git stash` they reproduce on a clean branch.
@@ -426,7 +426,7 @@ version = "0.55.11"
 - [ ] **Step 4.4: Re-run the full suite as a final sanity check**
 
 ```bash
-/Users/zdeneksrotyr/Sources/VsCode/component_factory/tmp_oss/.venv/bin/pytest tests/ --tb=short -n auto -q
+.venv/bin/pytest tests/ --tb=short -n auto -q
 ```
 
 Expected: still green.

--- a/docs/superpowers/plans/2026-05-26-wal-recovery-refuse-stale.md
+++ b/docs/superpowers/plans/2026-05-26-wal-recovery-refuse-stale.md
@@ -1,0 +1,535 @@
+# WAL recovery — refuse stale snapshot (#379) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop silent data loss in `src/db.py::_try_open_system_db` by refusing auto-recovery when the `system.duckdb.pre-migrate` snapshot is older than the current `SCHEMA_VERSION`.
+
+**Architecture:** Add a `_peek_schema_version()` helper that opens the snapshot read-only (bypassing WAL replay), reads its schema version, and returns it. Inline a check in `_try_open_system_db` before the snapshot-copy step: if the snapshot is older than `SCHEMA_VERSION`, preserve both broken files (DB + WAL) and raise `RuntimeError` with both version numbers in the message. Happy path (HEAD-version snapshot) and the "no snapshot" path are unchanged.
+
+**Tech Stack:** Python 3.13 / DuckDB / pytest (existing repo deps).
+
+**Spec:** `docs/superpowers/specs/2026-05-26-wal-recovery-refuse-stale-design.md`
+
+---
+
+## File map
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Modify | `src/db.py` (≈10 lines for helper near `_try_open_system_db`, ≈18 lines inline in the function) | Add `_peek_schema_version()` helper; gate snapshot restore by version check |
+| Create | `tests/test_db_wal_recovery.py` (≈100 lines, 3 tests + fixtures) | Regression guard for happy path + verify refusal-with-preserve behavior on stale or unreadable snapshots |
+| Modify | `CHANGELOG.md` (1 bullet, then promote `[Unreleased]` → `[0.55.11]` at the end) | Per CLAUDE.md release-cut rule |
+| Modify | `pyproject.toml` (1 line) | `version = "0.55.10"` → `"0.55.11"` |
+
+---
+
+## Conventions used across multiple tasks
+
+- pytest invocation: `/Users/zdeneksrotyr/Sources/VsCode/component_factory/tmp_oss/.venv/bin/pytest` (the worktree has no `.venv` of its own; use the parent checkout's).
+- The test file uses `tmp_path` (built-in pytest fixture) for DB-on-disk fixtures. No mocks for DuckDB — real files end-to-end so the read-only peek path is actually exercised.
+- The `_try_open_system_db` function lives at `src/db.py:1103-1154` today; current `SCHEMA_VERSION` is `59` (`src/db.py:43`).
+
+---
+
+## Task 1 — Test fixtures + first failing test (happy path regression guard)
+
+**Files:**
+- Create: `tests/test_db_wal_recovery.py`
+
+We start with the happy-path test even though it should already pass against current code, because:
+1. It's a regression guard — Task 2's stale-snapshot change must not break it.
+2. The fixtures it introduces (`_make_db_with_schema_version`, `_corrupt_wal_so_replay_fails`) are reused by the next two tests.
+
+- [ ] **Step 1.1: Create `tests/test_db_wal_recovery.py` with fixtures + happy-path test**
+
+```python
+"""Contract tests for src/db.py::_try_open_system_db.
+
+Covers the schema-version-aware refusal added for issue #379:
+auto-recovery proceeds when the pre-migrate snapshot is at HEAD, but
+raises RuntimeError when the snapshot is stale (older than
+SCHEMA_VERSION) or unreadable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+import pytest
+
+
+def _make_db_with_schema_version(path: Path, version: int) -> None:
+    """Create a fresh DuckDB file containing a `schema_version` table
+    with the given version row. Mirrors the shape `_peek_schema_version`
+    expects."""
+    conn = duckdb.connect(str(path))
+    try:
+        conn.execute(
+            "CREATE TABLE schema_version (version INTEGER, applied_at TIMESTAMP)"
+        )
+        conn.execute(
+            "INSERT INTO schema_version VALUES (?, current_timestamp)", [version]
+        )
+    finally:
+        conn.close()
+
+
+def _make_db_no_schema_version_table(path: Path) -> None:
+    """Create a DuckDB file with some other table but no `schema_version`
+    — simulates a pre-v1 / structurally-foreign snapshot."""
+    conn = duckdb.connect(str(path))
+    try:
+        conn.execute("CREATE TABLE other (id INTEGER)")
+    finally:
+        conn.close()
+
+
+def _corrupt_wal_so_replay_fails(db_path: Path) -> None:
+    """Write garbage to <db_path>.wal so DuckDB's WAL replay aborts on
+    next open with one of the error strings `_try_open_system_db`
+    recognises ('Failure while replaying WAL', 'ReplayAlter', or
+    'GetDefaultDatabase with no default database set')."""
+    wal = Path(str(db_path) + ".wal")
+    wal.write_bytes(b"\x00" * 64)
+
+
+def test_recovery_proceeds_when_snapshot_is_at_head(tmp_path, monkeypatch):
+    """Regression guard: with a HEAD-version snapshot, recovery returns
+    a working connection, preserves the broken DB at .broken.<ts>, and
+    replaces the main DB with the snapshot."""
+    from src import db as db_module
+
+    db_path = tmp_path / "system.duckdb"
+    snapshot_path = tmp_path / "system.duckdb.pre-migrate"
+
+    _make_db_with_schema_version(db_path, db_module.SCHEMA_VERSION)
+    _make_db_with_schema_version(snapshot_path, db_module.SCHEMA_VERSION)
+    _corrupt_wal_so_replay_fails(db_path)
+
+    conn = db_module._try_open_system_db(str(db_path))
+    try:
+        # The recovered DB carries the snapshot's schema_version row.
+        version = conn.execute(
+            "SELECT MAX(version) FROM schema_version"
+        ).fetchone()[0]
+        assert version == db_module.SCHEMA_VERSION
+    finally:
+        conn.close()
+
+    # Broken DB was preserved alongside.
+    broken_files = list(tmp_path.glob("system.duckdb.broken.*"))
+    assert len(broken_files) == 1, broken_files
+    # Snapshot file is left in place (not consumed).
+    assert snapshot_path.exists()
+```
+
+- [ ] **Step 1.2: Run test and confirm it passes against current code**
+
+```bash
+/Users/zdeneksrotyr/Sources/VsCode/component_factory/tmp_oss/.venv/bin/pytest tests/test_db_wal_recovery.py::test_recovery_proceeds_when_snapshot_is_at_head -v
+```
+
+Expected: PASS. If it fails, that's a real defect in current behavior — surface it before continuing.
+
+- [ ] **Step 1.3: Commit fixtures + regression guard**
+
+```bash
+git add tests/test_db_wal_recovery.py
+git commit -m "test(db): regression guard for WAL recovery happy path (#379)"
+```
+
+---
+
+## Task 2 — Stale-snapshot test + implementation (TDD)
+
+**Files:**
+- Modify: `tests/test_db_wal_recovery.py` (append second test)
+- Modify: `src/db.py` (add helper + inline check)
+
+- [ ] **Step 2.1: Append the failing test for stale snapshot**
+
+Add to `tests/test_db_wal_recovery.py`:
+
+```python
+def test_recovery_refuses_when_snapshot_is_stale(tmp_path, monkeypatch):
+    """Snapshot at SCHEMA_VERSION - 1 → recovery raises RuntimeError,
+    preserves both broken files, leaves snapshot untouched, does NOT
+    create a fresh DB at db_path."""
+    from src import db as db_module
+
+    db_path = tmp_path / "system.duckdb"
+    snapshot_path = tmp_path / "system.duckdb.pre-migrate"
+
+    _make_db_with_schema_version(db_path, db_module.SCHEMA_VERSION)
+    _make_db_with_schema_version(snapshot_path, db_module.SCHEMA_VERSION - 1)
+    _corrupt_wal_so_replay_fails(db_path)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        db_module._try_open_system_db(str(db_path))
+
+    # The error message identifies both versions so the operator can act.
+    msg = str(excinfo.value)
+    assert str(db_module.SCHEMA_VERSION - 1) in msg
+    assert str(db_module.SCHEMA_VERSION) in msg
+
+    # Broken DB preserved.
+    broken_dbs = list(tmp_path.glob("system.duckdb.broken.*"))
+    broken_dbs = [p for p in broken_dbs if not p.name.endswith(".wal")]
+    assert len(broken_dbs) == 1, broken_dbs
+
+    # Broken WAL preserved alongside.
+    broken_wals = list(tmp_path.glob("system.duckdb.broken.*.wal"))
+    assert len(broken_wals) == 1, broken_wals
+
+    # Snapshot was not consumed.
+    assert snapshot_path.exists()
+
+    # Main DB path no longer exists (it was moved aside, NOT overwritten
+    # by the snapshot).
+    assert not db_path.exists()
+```
+
+- [ ] **Step 2.2: Run the test and confirm it fails**
+
+```bash
+/Users/zdeneksrotyr/Sources/VsCode/component_factory/tmp_oss/.venv/bin/pytest tests/test_db_wal_recovery.py::test_recovery_refuses_when_snapshot_is_stale -v
+```
+
+Expected: FAIL. Current code copies the snapshot over `db_path` and returns a connection — no RuntimeError. The assertion either `pytest.raises(RuntimeError)` fails or `assert not db_path.exists()` fails depending on which check fires first.
+
+- [ ] **Step 2.3: Add `_peek_schema_version` helper to `src/db.py`**
+
+Locate `_try_open_system_db` at `src/db.py:1103` (search for `def _try_open_system_db`). Insert this helper immediately ABOVE it (so the function order reads helper → user):
+
+```python
+def _peek_schema_version(snapshot_path: Path) -> int:
+    """Open a DuckDB snapshot read-only and return its
+    ``MAX(schema_version.version)``.
+
+    Read-only mode bypasses WAL replay entirely — even if the snapshot
+    has its own stale WAL, the read-only handle ignores it. Any
+    ``duckdb.Error`` (table missing, file corrupt, permission denied)
+    is treated conservatively as version 0, so an unreadable snapshot
+    fails the freshness check in :func:`_try_open_system_db` and ends
+    in the refusal path. Defensive: never returns -1 / None / raises.
+    """
+    try:
+        conn = duckdb.connect(str(snapshot_path), read_only=True)
+        try:
+            row = conn.execute(
+                "SELECT MAX(version) FROM schema_version"
+            ).fetchone()
+            return int(row[0]) if row and row[0] is not None else 0
+        finally:
+            conn.close()
+    except duckdb.Error:
+        return 0
+```
+
+- [ ] **Step 2.4: Add the inline freshness check inside `_try_open_system_db`**
+
+Find this block at `src/db.py:1136-1151`:
+
+```python
+        wal_path = Path(db_path + ".wal")
+        logger.warning(
+            "WAL replay failed (%s) — auto-restoring from pre-migrate "
+            "snapshot %s. The migration ladder will re-run on this start.",
+            msg.split("\n", 1)[0][:200],
+            snapshot,
+        )
+        # Move (not copy) the broken DB aside so an operator can post-
+        # mortem if needed. The pre-migrate snapshot becomes the new
+        # main DB; the WAL is dropped (its content is what failed to
+        # replay).
+        broken = Path(db_path + f".broken.{int(time.time())}")
+        shutil.move(db_path, str(broken))
+        if wal_path.exists():
+            shutil.move(str(wal_path), str(broken) + ".wal")
+        shutil.copy2(str(snapshot), db_path)
+```
+
+Insert the freshness gate immediately AFTER `wal_path = Path(db_path + ".wal")` and BEFORE the `logger.warning(...)` happy-path log. The full replacement block for the section becomes:
+
+```python
+        wal_path = Path(db_path + ".wal")
+
+        # #379: refuse auto-recovery if the snapshot is older than the
+        # current SCHEMA_VERSION. The migration ladder is idempotent
+        # for schema but not for data; re-running it against a stale
+        # snapshot silently drops every row added since the snapshot
+        # was captured. Better to fail loudly and let an operator
+        # decide. The broken DB + WAL are preserved either way.
+        snapshot_version = _peek_schema_version(snapshot)
+        if snapshot_version < SCHEMA_VERSION:
+            broken = Path(db_path + f".broken.{int(time.time())}")
+            shutil.move(db_path, str(broken))
+            if wal_path.exists():
+                shutil.move(str(wal_path), str(broken) + ".wal")
+            logger.critical(
+                "REFUSING auto-recovery: pre-migrate snapshot is at "
+                "schema v%d, target is v%d. Auto-recovery would re-run "
+                "the migration ladder and silently drop all rows added "
+                "since v%d. Broken DB preserved at %s; broken WAL at "
+                "%s.wal if it existed. Manual intervention required.",
+                snapshot_version, SCHEMA_VERSION, snapshot_version,
+                broken, broken,
+            )
+            raise RuntimeError(
+                f"pre-migrate snapshot stale "
+                f"(v{snapshot_version} < target v{SCHEMA_VERSION}); "
+                f"auto-recovery refused. Broken DB at {broken}."
+            )
+
+        logger.warning(
+            "WAL replay failed (%s) — auto-restoring from pre-migrate "
+            "snapshot %s. The migration ladder will re-run on this start.",
+            msg.split("\n", 1)[0][:200],
+            snapshot,
+        )
+        # Move (not copy) the broken DB aside so an operator can post-
+        # mortem if needed. The pre-migrate snapshot becomes the new
+        # main DB; the WAL is dropped (its content is what failed to
+        # replay).
+        broken = Path(db_path + f".broken.{int(time.time())}")
+        shutil.move(db_path, str(broken))
+        if wal_path.exists():
+            shutil.move(str(wal_path), str(broken) + ".wal")
+        shutil.copy2(str(snapshot), db_path)
+```
+
+- [ ] **Step 2.5: Run both tests and confirm both pass**
+
+```bash
+/Users/zdeneksrotyr/Sources/VsCode/component_factory/tmp_oss/.venv/bin/pytest tests/test_db_wal_recovery.py -v
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add src/db.py tests/test_db_wal_recovery.py
+git commit -m "fix(db): refuse WAL auto-recovery when pre-migrate snapshot is stale (#379)"
+```
+
+---
+
+## Task 3 — Unreadable snapshot test (TDD; behavior already covered)
+
+**Files:**
+- Modify: `tests/test_db_wal_recovery.py` (append third test)
+
+The implementation in Task 2 handles this case (because `_peek_schema_version` returns `0` on any `duckdb.Error`, and `0 < SCHEMA_VERSION` always). We add the explicit test to lock that contract.
+
+- [ ] **Step 3.1: Append the test**
+
+```python
+def test_recovery_refuses_when_snapshot_has_no_schema_version_table(
+    tmp_path, monkeypatch
+):
+    """If the snapshot is a DuckDB file with no `schema_version` table
+    at all (pre-v1 / unrelated DB), _peek_schema_version returns 0;
+    recovery refuses via the same code path as test_..._is_stale."""
+    from src import db as db_module
+
+    db_path = tmp_path / "system.duckdb"
+    snapshot_path = tmp_path / "system.duckdb.pre-migrate"
+
+    _make_db_with_schema_version(db_path, db_module.SCHEMA_VERSION)
+    _make_db_no_schema_version_table(snapshot_path)
+    _corrupt_wal_so_replay_fails(db_path)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        db_module._try_open_system_db(str(db_path))
+
+    # v0 surfaces in the message (the conservative fallback value).
+    msg = str(excinfo.value)
+    assert "v0" in msg
+    assert str(db_module.SCHEMA_VERSION) in msg
+
+    # Same preservation contract as the stale case.
+    assert not db_path.exists()
+    assert snapshot_path.exists()
+    assert any(tmp_path.glob("system.duckdb.broken.*"))
+```
+
+- [ ] **Step 3.2: Run all three tests**
+
+```bash
+/Users/zdeneksrotyr/Sources/VsCode/component_factory/tmp_oss/.venv/bin/pytest tests/test_db_wal_recovery.py -v
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add tests/test_db_wal_recovery.py
+git commit -m "test(db): lock contract — corrupt snapshot treated as stale (#379)"
+```
+
+---
+
+## Task 4 — Full test suite + CHANGELOG + release-cut
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `pyproject.toml`
+
+- [ ] **Step 4.1: Run the full pytest suite**
+
+```bash
+/Users/zdeneksrotyr/Sources/VsCode/component_factory/tmp_oss/.venv/bin/pytest tests/ --tb=short -n auto -q
+```
+
+Expected: full suite green. Should be 5252 baseline + 3 new tests = 5255 passed (give or take if other changes have landed in main since). Failures in code you touched: fix before moving on. Failures unrelated to your diff: confirm with `git stash` they reproduce on a clean branch.
+
+- [ ] **Step 4.2: Edit `CHANGELOG.md`**
+
+Find the `[Unreleased]` section and the `[0.55.10] — 2026-05-25` heading below it. Replace this block:
+
+```markdown
+## [Unreleased]
+
+## [0.55.10] — 2026-05-25
+```
+
+with:
+
+```markdown
+## [Unreleased]
+
+## [0.55.11] — 2026-05-26
+
+### Fixed
+- **`src/db.py::_try_open_system_db` no longer silently drops post-migration data on WAL-replay recovery (#379).** The auto-recovery path used to copy `system.duckdb.pre-migrate` over the broken DB and re-run the migration ladder unconditionally — but the snapshot is captured once per migration transition and never refreshed, so any rows added since that transition vanished without warning. The function now opens the snapshot read-only to peek its `schema_version`; if it is older than the current `SCHEMA_VERSION`, the broken DB + WAL are preserved at `.broken.<ts>` (forensic artifact) and a `RuntimeError` is raised so operators see the failure instead of an empty DB. The happy-path (HEAD-version snapshot) and the "no snapshot file" path are unchanged.
+
+## [0.55.10] — 2026-05-25
+```
+
+- [ ] **Step 4.3: Edit `pyproject.toml`**
+
+Change line 3 from:
+
+```toml
+version = "0.55.10"
+```
+
+to:
+
+```toml
+version = "0.55.11"
+```
+
+- [ ] **Step 4.4: Re-run the full suite as a final sanity check**
+
+```bash
+/Users/zdeneksrotyr/Sources/VsCode/component_factory/tmp_oss/.venv/bin/pytest tests/ --tb=short -n auto -q
+```
+
+Expected: still green.
+
+- [ ] **Step 4.5: Commit the release-cut**
+
+```bash
+git add CHANGELOG.md pyproject.toml
+git commit -m "release: 0.55.11 — refuse stale WAL-recovery snapshot"
+```
+
+---
+
+## Task 5 — Push + PR
+
+**Files:** none modified.
+
+- [ ] **Step 5.1: Push the branch under a clean name**
+
+```bash
+git push -u origin worktree-zs+wal-recovery-fix:zs/wal-recovery-fix
+```
+
+- [ ] **Step 5.2: Open the PR**
+
+```bash
+gh pr create --base main --head zs/wal-recovery-fix \
+  --title "fix(db): refuse stale pre-migrate auto-recovery in _try_open_system_db (#379) + release 0.55.11" \
+  --body "Closes #379.
+
+## Why
+
+\`src/db.py::_try_open_system_db\` auto-restores from \`system.duckdb.pre-migrate\` whenever WAL replay fails on DB open. The snapshot is captured **once** per migration transition and never refreshed, so any row data added between that moment and the WAL-recovery event is silently dropped when the recovery path copies the snapshot over the broken DB and re-runs the migration ladder.
+
+A deployer hit this on 2026-05-21: 12 + 29 rows lost, \`schema_version.applied_at\` rewrite masking the destructive moment in forensics.
+
+## Fix
+
+Inspect the snapshot's \`schema_version\` before copying. If it is older than the current \`SCHEMA_VERSION\`, preserve both broken files (DB + WAL at \`.broken.<ts>\`) and raise \`RuntimeError\` with both version numbers in the message. Happy path (HEAD-version snapshot) and the \"no snapshot\" path are unchanged.
+
+- New \`_peek_schema_version()\` helper opens the snapshot read-only (bypasses WAL replay), reads \`MAX(version)\`, returns 0 conservatively on any \`duckdb.Error\` (so corrupt / pre-v1 snapshots also fail the freshness check).
+- Inline check in \`_try_open_system_db\` between the existing \`snapshot.exists()\` guard and the existing \`shutil.move\` / \`shutil.copy2\` block.
+- Three unit tests in \`tests/test_db_wal_recovery.py\`: happy-path regression guard, stale-snapshot refusal, corrupt-snapshot refusal.
+
+## Out of scope (separate issues)
+
+- #380 — rolling pre-migrate refresh (tightens the recovery RPO).
+- #381 — WAL salvage before fallback (per-table parquet for manual reconciliation).
+- #383 — operator runbook at \`docs/runbooks/wal-recovery.md\`.
+- #382 — \`stop_grace_period: 60s\` + CHECKPOINT-on-SIGTERM: closed during audit; both are already in place (\`docker-compose.yml:50,93\` + \`close_system_db\` CHECKPOINT in \`src/db.py:4538-4565\` runs from the FastAPI lifespan teardown that uvicorn invokes on SIGTERM).
+
+## Spec + plan
+
+- Spec: \`docs/superpowers/specs/2026-05-26-wal-recovery-refuse-stale-design.md\`
+- Plan: \`docs/superpowers/plans/2026-05-26-wal-recovery-refuse-stale.md\`
+
+## Release-cut
+
+Patch \`0.55.10 → 0.55.11\` in the same PR per the CLAUDE.md release-cut rule.
+
+## Verification
+
+- Full pytest suite green locally (3 new tests added).
+- The refusal path was exercised end-to-end via the stale-snapshot test (real DuckDB files on \`tmp_path\`, real read-only peek, real \`shutil.move\`)."
+```
+
+- [ ] **Step 5.3: Confirm PR opened cleanly**
+
+```bash
+gh pr view --json url --jq .url
+gh pr checks
+```
+
+If \`release.yml\` reports the cancelled-by-concurrency artefact from the create+push double-trigger (same pattern as #389 and #420 had), re-run the cancelled run:
+
+```bash
+RUN_ID=$(gh run list --workflow=release.yml --branch=zs/wal-recovery-fix --limit 5 --json databaseId,event,conclusion --jq '[.[] | select(.event == "push" and .conclusion == "cancelled")][0].databaseId')
+if [[ -n "$RUN_ID" ]]; then gh run rerun "$RUN_ID"; fi
+```
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- ✅ `_peek_schema_version` helper (spec §1) → Task 2 Step 2.3.
+- ✅ Inline freshness check (spec §2) → Task 2 Step 2.4.
+- ✅ `RuntimeError`, not `SystemExit(1)` (spec §"Why `RuntimeError`") → Task 2 Step 2.4 (raise RuntimeError) + Task 2 Step 2.1 (test asserts `pytest.raises(RuntimeError)`).
+- ✅ `logger.critical(...)` with both versions + broken-file path (spec §"Logging level") → Task 2 Step 2.4.
+- ✅ Test 1 (happy path) → Task 1.
+- ✅ Test 2 (stale snapshot) → Task 2 Step 2.1.
+- ✅ Test 3 (unreadable / missing schema_version table) → Task 3.
+- ✅ Fixture sketch (`_make_db_with_schema_version`, `_corrupt_wal_so_replay_fails`) → Task 1 Step 1.1.
+- ✅ Failure-modes table (spec §"Failure modes") → exercised by Tests 1-3.
+- ✅ Non-goals (no #380/#381/#383) → out-of-scope in PR body and noted in commit messages.
+- ✅ CHANGELOG `### Fixed` bullet + `0.55.10 → 0.55.11` (spec §"CHANGELOG + release-cut") → Task 4.
+
+**Placeholder scan:** None. Every code block is complete and copy-pasteable. Commit messages are concrete.
+
+**Type / name consistency:**
+- `_peek_schema_version(snapshot_path: Path) -> int` — same name and signature in Task 2 Step 2.3 (helper) and Task 2 Step 2.4 (call site).
+- `snapshot_version` — same variable name in implementation (Task 2 Step 2.4), the spec, and the test assertion (Task 2 Step 2.1 asserts on `str(db_module.SCHEMA_VERSION - 1)` in the error message, which the implementation produces).
+- `SCHEMA_VERSION` — imported once at module level in `src/db.py:43`; tests reference `db_module.SCHEMA_VERSION` consistently.
+- `system.duckdb.pre-migrate`, `.broken.<ts>`, `.broken.<ts>.wal` — filename forms identical across implementation, tests, CHANGELOG bullet, PR body.
+
+**File paths:** all absolute or repo-relative-from-root, no `../` traversal.

--- a/docs/superpowers/specs/2026-05-26-wal-recovery-refuse-stale-design.md
+++ b/docs/superpowers/specs/2026-05-26-wal-recovery-refuse-stale-design.md
@@ -1,0 +1,131 @@
+# `_try_open_system_db` — refuse stale pre-migrate auto-recovery
+
+Date: 2026-05-26
+Issue: [#379](https://github.com/keboola/agnes-the-ai-analyst/issues/379)
+Related (out of scope for this PR): #380 (rolling pre-migrate refresh), #381 (WAL salvage), #383 (operator runbook).
+Related (confirmed fixed during audit): #382 — `stop_grace_period: 60s` is in `docker-compose.yml:50,93` and `close_system_db()` (`src/db.py:4538-4565`) CHECKPOINTs on shutdown, which uvicorn invokes via the FastAPI lifespan teardown on SIGTERM.
+
+## Problem
+
+`src/db.py::_try_open_system_db()` (lines 1103-1154) auto-restores from `system.duckdb.pre-migrate` whenever DuckDB raises a WAL-replay error class. The doc comment claims "The migration ladder is idempotent, so the second start re-runs it and ends up at the same SCHEMA_VERSION cleanly."
+
+That is true for **schema**, false for **data**. `system.duckdb.pre-migrate` is captured once per migration transition (`src/db.py:4216`, inside the migration ladder) and never refreshed. After v(N-1)→v(N) ran, the snapshot is frozen at v(N-1). Any row data added between that moment and the WAL-recovery event is silently dropped when the recovery code copies the snapshot over the broken DB and re-runs the ladder.
+
+A deployer hit this on 2026-05-21: 12 + 29 user-created rows lost when a fresh container start tripped WAL replay against a 2-days-old snapshot. The `schema_version.applied_at` rewrite also masked the destructive moment in forensics.
+
+## Approach
+
+Before unconditionally copying the snapshot over the broken DB, **inspect the snapshot's `schema_version` and refuse auto-recovery if it is older than the current `SCHEMA_VERSION` constant**. Move the broken DB + WAL aside as today (so the operator has the forensic artifact), but raise a `RuntimeError` instead of producing a fresh empty DB.
+
+This converts "recover at any cost, lose data silently" into "recover when safe; otherwise fail loudly and let an operator decide." It is the single defensive change `#379` calls for. The rolling-refresh (#380), WAL salvage (#381), and operator runbook (#383) are out of scope — separate PRs each.
+
+## Components
+
+### 1. `_peek_schema_version(snapshot_path: Path) -> int`
+
+New helper, defined in `src/db.py` near `_try_open_system_db`. Opens the snapshot **read-only** (`duckdb.connect(str(path), read_only=True)`) so DuckDB's WAL replay path is bypassed entirely — even if the snapshot itself has a stale WAL, the read-only handle ignores it. Selects `MAX(version) FROM schema_version`, returns the integer.
+
+Conservative on error: any `duckdb.Error` (table missing, file corrupt, permission denied) returns `0`. `0` < `SCHEMA_VERSION` always, so an unreadable snapshot is treated as stale and refuses recovery. The operator gets the same loud failure either way.
+
+The handle is closed in a `try/finally` so a partially-opened connection doesn't leak.
+
+### 2. Inline check in `_try_open_system_db`
+
+After the existing `snapshot.exists()` guard and before the existing `shutil.move(...) / shutil.copy2(...)` block, insert:
+
+```python
+snapshot_version = _peek_schema_version(snapshot)
+if snapshot_version < SCHEMA_VERSION:
+    # Preserve the broken DB + WAL the same way the happy path does,
+    # so the operator gets a forensic artifact even when we refuse to
+    # restore. The snapshot file is left untouched at its original path.
+    broken = Path(db_path + f".broken.{int(time.time())}")
+    shutil.move(db_path, str(broken))
+    if wal_path.exists():
+        shutil.move(str(wal_path), str(broken) + ".wal")
+    logger.critical(
+        "REFUSING auto-recovery: pre-migrate snapshot is at schema v%d, "
+        "target is v%d. Auto-recovery would re-run the migration ladder "
+        "and silently drop all rows added since v%d. Broken DB preserved "
+        "at %s; broken WAL at %s.wal if it existed. Manual intervention "
+        "required.",
+        snapshot_version, SCHEMA_VERSION, snapshot_version,
+        broken, broken,
+    )
+    raise RuntimeError(
+        f"pre-migrate snapshot stale "
+        f"(v{snapshot_version} < target v{SCHEMA_VERSION}); "
+        f"auto-recovery refused. Broken DB at {broken}."
+    )
+```
+
+Then the existing happy-path code runs (snapshot is at HEAD; safe to restore).
+
+### Why `RuntimeError`, not `SystemExit(1)`
+
+The existing function already raises `duckdb.Error` on the "no snapshot file" branch (line 1135). Using `RuntimeError` keeps the function's contract uniform: "I either return a connection or raise." The decision of whether to exit the process or render a graceful error page belongs to the caller, not the recovery routine.
+
+### Logging level
+
+`logger.critical(...)` — the highest level — because this is a data-loss-avoidance event. Operators relying on log-level alerting should see this immediately. The structured message includes both versions and the preserved broken-file paths so the operator can act without re-reading the source.
+
+## Tests — `tests/test_db_wal_recovery.py`
+
+Three tests, all using a `tmp_path` to fabricate a controlled (db_path + snapshot) pair. None of them need a real running app.
+
+### Test 1: snapshot at HEAD → recovery proceeds (regression guard)
+
+Set up: copy a synthetic DB (created by writing `schema_version` table with `SCHEMA_VERSION`) to both `db_path` and `db_path + ".pre-migrate"`, then corrupt the main DB's `.wal` with garbage to trigger the WAL-replay branch. Call `_try_open_system_db(db_path)`. Assert: returns a connection (no exception), broken DB is preserved at `.broken.<ts>`, main `db_path` is now a copy of the snapshot.
+
+### Test 2: snapshot at v(N-1) → refuse with RuntimeError
+
+Same fabrication, but write `SCHEMA_VERSION - 1` into the snapshot's `schema_version` table. Call `_try_open_system_db`. Assert: raises `RuntimeError` whose message mentions both version numbers; broken DB is preserved at `.broken.<ts>`; main `db_path` no longer exists (it was moved); snapshot file is untouched at its original location.
+
+### Test 3: snapshot has no `schema_version` table → treat as stale
+
+Same fabrication, but the snapshot is a DuckDB file with no `schema_version` table at all (simulates a pre-v1 / corrupt snapshot). `_peek_schema_version` returns 0 conservatively → 0 < SCHEMA_VERSION → same refusal path as Test 2.
+
+### Fixture sketch
+
+```python
+def _make_db_with_schema_version(path: Path, version: int) -> None:
+    conn = duckdb.connect(str(path))
+    conn.execute("CREATE TABLE schema_version (version INTEGER, applied_at TIMESTAMP)")
+    conn.execute("INSERT INTO schema_version VALUES (?, current_timestamp)", [version])
+    conn.close()
+
+
+def _corrupt_wal_so_replay_fails(db_path: Path) -> None:
+    """Write garbage to .wal that DuckDB will reject on replay."""
+    (db_path.with_suffix(db_path.suffix + ".wal")).write_bytes(b"\x00" * 64)
+```
+
+Tests instantiate the fixtures, invoke the function, assert on the post-state. No mocks for DuckDB — uses real files end-to-end, which exercises the actual `read_only=True` peek path.
+
+## Failure modes covered by this change
+
+| Today | After this change |
+|---|---|
+| Stale snapshot + WAL replay fail → ladder re-runs against snapshot → all post-snapshot rows lost, `schema_version.applied_at` rewritten | RuntimeError raised, broken DB preserved, ops alerted |
+| HEAD snapshot + WAL replay fail → ladder re-runs, no data loss (no-op replay) | Unchanged — happy path preserved |
+| No snapshot file at all → `logger.error` + re-raise | Unchanged |
+| Snapshot file exists but is corrupt / unreadable | NEW: `_peek_schema_version` returns 0 → refused as stale |
+
+## Non-goals
+
+- **Rolling pre-migrate refresh** — covered by #380; orthogonal fix that tightens the recovery RPO. Out of scope here.
+- **WAL salvage before fallback** — covered by #381; gives operators per-table parquet to reconcile. Out of scope here.
+- **Operator runbook** — covered by #383; the error message in this PR points the operator at the preserved file paths but doesn't reference a non-existent runbook.
+- **Replacing the auto-recovery mechanism entirely** — keeping it as a safety net for the genuine in-migration-crash case it was built for.
+
+## CHANGELOG + release-cut
+
+- `### Fixed` bullet under `[Unreleased]`.
+- Patch bump `0.55.10 → 0.55.11` in the final commit of the PR per CLAUDE.md.
+
+## Acceptance
+
+1. With a HEAD-version snapshot, the recovery path still produces a working DB (Test 1).
+2. With a v(N-1) snapshot, the recovery refuses, preserves both broken files, and surfaces both version numbers in the log (Test 2).
+3. With an unreadable snapshot, behavior collapses to the refusal path (Test 3).
+4. Full pytest suite green on this branch.

--- a/docs/superpowers/specs/2026-05-26-wal-recovery-refuse-stale-design.md
+++ b/docs/superpowers/specs/2026-05-26-wal-recovery-refuse-stale-design.md
@@ -102,6 +102,17 @@ def _corrupt_wal_so_replay_fails(db_path: Path) -> None:
 
 Tests instantiate the fixtures, invoke the function, assert on the post-state. No mocks for DuckDB — uses real files end-to-end, which exercises the actual `read_only=True` peek path.
 
+**On the "no mocks for DuckDB" intent.** The pre-existing tests in this file
+already use `monkeypatch.setattr(duckdb, "connect", ...)` to inject the
+WAL-replay error class — DuckDB 1.5 is resilient to short garbage WAL
+content, so a file-level corruption alone doesn't reliably trigger the
+recovery branch across DuckDB versions. Following that established pattern,
+the new tests use a `make_wal_error` context-manager fixture that patches
+only the first `duckdb.connect` call against `db_path`; subsequent calls
+(including the read-only peek of the snapshot path the new code exercises)
+hit real DuckDB. The "real files end-to-end" goal is preserved for the
+peek path — only the corruption-trigger is mocked.
+
 ## Failure modes covered by this change
 
 | Today | After this change |

--- a/docs/superpowers/specs/2026-05-26-wal-recovery-refuse-stale-design.md
+++ b/docs/superpowers/specs/2026-05-26-wal-recovery-refuse-stale-design.md
@@ -140,3 +140,55 @@ peek path — only the corruption-trigger is mocked.
 2. With a v(N-1) snapshot, the recovery refuses, preserves both broken files, and surfaces both version numbers in the log (Test 2).
 3. With an unreadable snapshot, behavior collapses to the refusal path (Test 3).
 4. Full pytest suite green on this branch.
+
+---
+
+## Amendment 2026-05-26 — review pass: symmetric refusal + mode 0o600 + manual-recovery hint
+
+Three review findings addressed during the release-cut pass for `0.55.12`:
+
+1. **Symmetric refusal (architecture review).** Original check was
+   `peek_version < SCHEMA_VERSION`. The mirror case — operator rolls
+   the binary back from v60 to v59, snapshot was captured at the
+   v59→v60 transition (so snapshot.peek = v60) — would pass the
+   one-sided check and let `shutil.copy2(snapshot, db_path)` land a
+   v60-schema DB under a v59 binary. The next start's `_ensure_schema`
+   would then hit the split-brain `current > target` branch (which is
+   itself a no-op per `src/db.py:4251`, leaving the DB in an unsupported
+   state). Both directions mean corruption; the check is now `peek_version
+   != SCHEMA_VERSION` with a `direction` ("stale" / "future") tag in
+   both the log line and the `RuntimeError` message so operators can
+   tell which incident class they hit.
+
+2. **`os.chmod(0o600)` on `.broken.<ts>` artifacts (RBAC review).**
+   `system.duckdb` holds argon2 password hashes (`users.password_hash`),
+   personal-access-token rows (`personal_access_tokens`), and the audit
+   log. `shutil.move` inherits the source mode (typically `0o644` under
+   default umask), so the preserved broken file was world-readable on
+   its way out. The new `_move_to_broken(db_path, wal_path)` helper
+   (extracted from the inline duplication of the same move pattern in
+   the refusal path and the happy auto-recovery path) chmods both the
+   `.broken.<ts>` and `.broken.<ts>.wal` to `0o600` via best-effort
+   `try/except OSError: pass`. The containing `state/` directory is
+   typically `0o700` already, but defense in depth matters because
+   backups, container volumes, and tab-completion mistakes can all
+   surface the file. The helper is exercised by a new test
+   `test_recovery_broken_files_are_chmod_0600`.
+
+3. **Manual-recovery escape hatch (architecture review).** Original
+   `RuntimeError` named the broken-DB path but not the recovery
+   action; an operator had to read the source to figure out the manual
+   `cp` step. Both the `logger.critical` message and the
+   `RuntimeError` text now include `cp {snapshot} {db_path}` verbatim
+   so the operator's runbook is in the failure itself.
+
+The new `test_recovery_refuses_when_snapshot_is_from_future_version`
+test locks in the symmetric-refusal contract; the existing
+`test_recovery_refuses_when_snapshot_has_no_schema_version_table` test
+assertion was tightened from `"v0 <"` (no longer matches the new
+direction-tagged format) to `"v0" + "stale"` checks on the message.
+
+A separate follow-up is worth filing for `.broken.<ts>` retention
+policy: argon2 hashes don't expire, so indefinite retention of broken
+artifacts becomes a long-lived credential archive. Currently undocumented;
+likely future issue.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.55.11"
+version = "0.55.12"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/src/db.py
+++ b/src/db.py
@@ -1100,6 +1100,30 @@ def _get_state_dir() -> Path:
     return _get_data_dir() / "state"
 
 
+def _peek_schema_version(snapshot_path: Path) -> int:
+    """Open a DuckDB snapshot read-only and return its
+    ``MAX(schema_version.version)``.
+
+    Read-only mode bypasses WAL replay entirely — even if the snapshot
+    has its own stale WAL, the read-only handle ignores it. Any
+    ``duckdb.Error`` (table missing, file corrupt, permission denied)
+    is treated conservatively as version 0, so an unreadable snapshot
+    fails the freshness check in :func:`_try_open_system_db` and ends
+    in the refusal path. Defensive: never returns -1 / None / raises.
+    """
+    try:
+        conn = duckdb.connect(str(snapshot_path), read_only=True)
+        try:
+            row = conn.execute(
+                "SELECT MAX(version) FROM schema_version"
+            ).fetchone()
+            return int(row[0]) if row and row[0] is not None else 0
+        finally:
+            conn.close()
+    except duckdb.Error:
+        return 0
+
+
 def _try_open_system_db(db_path: str) -> duckdb.DuckDBPyConnection:
     """Open ``system.duckdb``. If DuckDB's WAL replay raises an
     ``INTERNAL Error`` from ``ReplayAlter`` (a known failure mode when a
@@ -1134,6 +1158,35 @@ def _try_open_system_db(db_path: str) -> duckdb.DuckDBPyConnection:
             )
             raise
         wal_path = Path(db_path + ".wal")
+
+        # #379: refuse auto-recovery if the snapshot is older than the
+        # current SCHEMA_VERSION. The migration ladder is idempotent
+        # for schema but not for data; re-running it against a stale
+        # snapshot silently drops every row added since the snapshot
+        # was captured. Better to fail loudly and let an operator
+        # decide. The broken DB + WAL are preserved either way.
+        snapshot_version = _peek_schema_version(snapshot)
+        if snapshot_version < SCHEMA_VERSION:
+            broken = Path(db_path + f".broken.{int(time.time())}")
+            shutil.move(db_path, str(broken))
+            if wal_path.exists():
+                shutil.move(str(wal_path), str(broken) + ".wal")
+            logger.critical(
+                "REFUSING auto-recovery: pre-migrate snapshot is at "
+                "schema v%d, target is v%d. Auto-recovery would re-run "
+                "the migration ladder and silently drop all rows added "
+                "since v%d. Broken DB preserved at %s; broken WAL at "
+                "%s.wal if it existed. Manual intervention required.",
+                snapshot_version, SCHEMA_VERSION, snapshot_version,
+                broken, broken,
+                exc_info=e,
+            )
+            raise RuntimeError(
+                f"pre-migrate snapshot stale "
+                f"(v{snapshot_version} < target v{SCHEMA_VERSION}); "
+                f"auto-recovery refused. Broken DB at {broken}."
+            )
+
         logger.warning(
             "WAL replay failed (%s) — auto-restoring from pre-migrate "
             "snapshot %s. The migration ladder will re-run on this start.",

--- a/src/db.py
+++ b/src/db.py
@@ -1159,32 +1159,50 @@ def _try_open_system_db(db_path: str) -> duckdb.DuckDBPyConnection:
             raise
         wal_path = Path(db_path + ".wal")
 
-        # #379: refuse auto-recovery if the snapshot is older than the
-        # current SCHEMA_VERSION. The migration ladder is idempotent
-        # for schema but not for data; re-running it against a stale
-        # snapshot silently drops every row added since the snapshot
-        # was captured. Better to fail loudly and let an operator
-        # decide. The broken DB + WAL are preserved either way.
+        # #379: refuse auto-recovery if the snapshot version doesn't
+        # match SCHEMA_VERSION exactly. The migration ladder is
+        # idempotent for schema but not for data; re-running it against
+        # a stale snapshot (peek < SCHEMA_VERSION) silently drops every
+        # row added since the snapshot was captured. The mirror case
+        # (peek > SCHEMA_VERSION) is just as bad: an operator rolled
+        # the code back, but the snapshot was captured at a later
+        # migration transition — auto-recovery would copy the future
+        # snapshot in and the next start's _ensure_schema would land
+        # in the split-brain "current > target" branch. Both directions
+        # mean data corruption; the only safe move is to refuse and
+        # surface the version mismatch loudly. The broken DB + WAL are
+        # preserved either way for forensics.
         snapshot_version = _peek_schema_version(snapshot)
-        if snapshot_version < SCHEMA_VERSION:
-            broken = Path(db_path + f".broken.{int(time.time())}")
-            shutil.move(db_path, str(broken))
-            if wal_path.exists():
-                shutil.move(str(wal_path), str(broken) + ".wal")
+        if snapshot_version != SCHEMA_VERSION:
+            broken = _move_to_broken(db_path, wal_path)
+            direction = (
+                "stale" if snapshot_version < SCHEMA_VERSION else "future"
+            )
+            risk = (
+                "would re-run the migration ladder and silently drop all "
+                f"rows added since v{snapshot_version}"
+                if snapshot_version < SCHEMA_VERSION
+                else (
+                    f"would land the DB at v{snapshot_version} under a "
+                    f"v{SCHEMA_VERSION} binary (split-brain)"
+                )
+            )
             logger.critical(
-                "REFUSING auto-recovery: pre-migrate snapshot is at "
-                "schema v%d, target is v%d. Auto-recovery would re-run "
-                "the migration ladder and silently drop all rows added "
-                "since v%d. Broken DB preserved at %s; broken WAL at "
-                "%s.wal if it existed. Manual intervention required.",
-                snapshot_version, SCHEMA_VERSION, snapshot_version,
+                "REFUSING auto-recovery: pre-migrate snapshot %s "
+                "(snapshot v%d, target v%d). Auto-recovery %s. Broken "
+                "DB preserved at %s; broken WAL at %s.wal if it existed. "
+                "To accept the snapshot anyway and discard the broken "
+                "files, manually run: cp %s %s",
+                direction, snapshot_version, SCHEMA_VERSION, risk,
                 broken, broken,
+                snapshot, db_path,
                 exc_info=e,
             )
             raise RuntimeError(
-                f"pre-migrate snapshot stale "
-                f"(v{snapshot_version} < target v{SCHEMA_VERSION}); "
-                f"auto-recovery refused. Broken DB at {broken}."
+                f"pre-migrate snapshot {direction} "
+                f"(v{snapshot_version} vs target v{SCHEMA_VERSION}); "
+                f"auto-recovery refused. Broken DB at {broken}. "
+                f"Manual recovery: cp {snapshot} {db_path}"
             )
 
         logger.warning(
@@ -1197,14 +1215,40 @@ def _try_open_system_db(db_path: str) -> duckdb.DuckDBPyConnection:
         # mortem if needed. The pre-migrate snapshot becomes the new
         # main DB; the WAL is dropped (its content is what failed to
         # replay).
-        broken = Path(db_path + f".broken.{int(time.time())}")
-        shutil.move(db_path, str(broken))
-        if wal_path.exists():
-            shutil.move(str(wal_path), str(broken) + ".wal")
+        _move_to_broken(db_path, wal_path)
         shutil.copy2(str(snapshot), db_path)
         # Re-open. If THIS also fails, propagate — auto-recovery has
         # exhausted its options.
         return duckdb.connect(db_path)
+
+
+def _move_to_broken(db_path: str, wal_path: Path) -> Path:
+    """Move the broken DB (+ WAL if present) aside to ``.broken.<ts>``.
+
+    Shared by both branches of :func:`_try_open_system_db` (refusal and
+    happy-path recovery). The preserved files are chmod'd to ``0o600``
+    because ``system.duckdb`` holds argon2 password hashes, personal-
+    access-token rows, and the audit log — ``shutil.move`` inherits the
+    source mode (typically ``0o644`` under default umask), so a stale
+    ``.broken.*`` would be world-readable on its way out. The
+    containing ``state/`` directory is usually ``0o700``, but defense
+    in depth matters: backups, container volumes, and tab-completion
+    mistakes can all surface the file. Returns the chosen broken path.
+    """
+    broken = Path(db_path + f".broken.{int(time.time())}")
+    shutil.move(db_path, str(broken))
+    try:
+        os.chmod(broken, 0o600)
+    except OSError:
+        pass  # best-effort; preservation is more important than mode
+    if wal_path.exists():
+        broken_wal = str(broken) + ".wal"
+        shutil.move(str(wal_path), broken_wal)
+        try:
+            os.chmod(broken_wal, 0o600)
+        except OSError:
+            pass
+    return broken
 
 
 def get_system_db() -> duckdb.DuckDBPyConnection:

--- a/tests/test_db_wal_recovery.py
+++ b/tests/test_db_wal_recovery.py
@@ -264,11 +264,13 @@ def test_recovery_propagates_when_no_snapshot_exists(state_dir):
 
 def test_recovery_re_raises_if_snapshot_also_broken(state_dir):
     """Edge case: snapshot exists but is itself corrupted (operator
-    edited it / disk error). The first recovery ``duckdb.connect``
-    succeeds (via the mock) so the function returns, but the second
-    call would still fail. We assert the re-attempted connect's error
-    propagates rather than being swallowed."""
-    from src.db import _try_open_system_db
+    edited it / disk error). ``_peek_schema_version`` catches the
+    ``duckdb.Error`` from the corrupt snapshot and returns 0, which
+    is below ``SCHEMA_VERSION``. The stale-snapshot refusal path fires,
+    preserving the broken DB and raising ``RuntimeError`` so the
+    operator is forced to intervene rather than silently recovering
+    against a snapshot of unknown version."""
+    from src.db import _try_open_system_db, SCHEMA_VERSION
 
     db_path = state_dir / "system.duckdb"
     snapshot_path = state_dir / "system.duckdb.pre-migrate"
@@ -289,8 +291,13 @@ def test_recovery_re_raises_if_snapshot_also_broken(state_dir):
         raise snapshot_error
 
     with patch("src.db.duckdb.connect", side_effect=fake):
-        with pytest.raises(duckdb.Error, match="malformed"):
+        with pytest.raises(RuntimeError) as excinfo:
             _try_open_system_db(str(db_path))
+
+    # Error message must mention the detected version (0) and the target.
+    msg = str(excinfo.value)
+    assert "v0 <" in msg
+    assert str(SCHEMA_VERSION) in msg
 
 
 def test_recovery_proceeds_when_snapshot_is_at_head(tmp_path, make_wal_error):
@@ -327,3 +334,40 @@ def test_recovery_proceeds_when_snapshot_is_at_head(tmp_path, make_wal_error):
     assert db_path.exists()
     # Snapshot file itself was left in place (not consumed).
     assert snapshot_path.exists()
+
+
+def test_recovery_refuses_when_snapshot_is_stale(tmp_path, make_wal_error):
+    """Snapshot at SCHEMA_VERSION - 1 → recovery raises RuntimeError,
+    preserves both broken files, leaves snapshot untouched, does NOT
+    create a fresh DB at db_path."""
+    from src import db as db_module
+
+    db_path = tmp_path / "system.duckdb"
+    snapshot_path = tmp_path / "system.duckdb.pre-migrate"
+
+    _make_db_with_schema_version(db_path, db_module.SCHEMA_VERSION)
+    _make_db_with_schema_version(snapshot_path, db_module.SCHEMA_VERSION - 1)
+    _corrupt_wal_so_replay_fails(db_path)
+
+    with make_wal_error(db_path):
+        with pytest.raises(RuntimeError) as excinfo:
+            db_module._try_open_system_db(str(db_path))
+
+    # The error message identifies both versions so the operator can act.
+    msg = str(excinfo.value)
+    assert str(db_module.SCHEMA_VERSION - 1) in msg
+    assert str(db_module.SCHEMA_VERSION) in msg
+
+    # Both broken files preserved (DB + WAL split — same pattern as
+    # the pre-existing test_recovery_restores_... test).
+    all_broken = sorted(tmp_path.glob("system.duckdb.broken.*"))
+    broken_dbs = [p for p in all_broken if not p.name.endswith(".wal")]
+    broken_wals = [p for p in all_broken if p.name.endswith(".wal")]
+    assert len(broken_dbs) == 1, all_broken
+    assert len(broken_wals) == 1, all_broken
+
+    # Snapshot was not consumed.
+    assert snapshot_path.exists()
+
+    # Main DB path no longer exists — moved aside, NOT overwritten.
+    assert not db_path.exists()

--- a/tests/test_db_wal_recovery.py
+++ b/tests/test_db_wal_recovery.py
@@ -18,6 +18,11 @@ The fix is two-pronged:
   2. ``_try_open_system_db`` catches the WAL-replay error class and
      falls back to ``system.duckdb.pre-migrate``. That's the path
      this file exercises.
+
+Additional coverage (issue #379): schema-version-aware refusal —
+auto-recovery proceeds when the pre-migrate snapshot is at HEAD, but
+raises RuntimeError when the snapshot is stale (older than
+SCHEMA_VERSION) or unreadable.
 """
 from __future__ import annotations
 
@@ -28,6 +33,10 @@ from unittest.mock import patch
 import duckdb
 import pytest
 
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
 
 @pytest.fixture
 def state_dir(monkeypatch, tmp_path):
@@ -44,6 +53,93 @@ def state_dir(monkeypatch, tmp_path):
     db_mod._system_db_conn = None
     db_mod._system_db_path = None
 
+
+@pytest.fixture
+def make_wal_error():
+    """Return a context-manager factory that patches ``src.db.duckdb.connect``
+    so the first call to ``db_path`` raises a WAL-replay error (the class
+    ``_try_open_system_db`` specifically handles) and subsequent calls
+    delegate to the real ``duckdb.connect``.
+
+    Usage inside a test::
+
+        def test_foo(tmp_path, make_wal_error):
+            db_path = tmp_path / "system.duckdb"
+            ...
+            with make_wal_error(db_path):
+                conn = db_module._try_open_system_db(str(db_path))
+    """
+    real_connect = duckdb.connect
+
+    def _factory(db_path: Path):
+        call_count = {"n": 0}
+        fake_error = duckdb.Error(
+            "INTERNAL Error: Failure while replaying WAL file: "
+            "Calling DatabaseManager::GetDefaultDatabase with no default "
+            "database set"
+        )
+
+        def flaky_connect(path, *args, **kwargs):
+            if str(path) == str(db_path) and call_count["n"] == 0:
+                call_count["n"] += 1
+                raise fake_error
+            return real_connect(path, *args, **kwargs)
+
+        return patch("src.db.duckdb.connect", side_effect=flaky_connect)
+
+    return _factory
+
+
+# ---------------------------------------------------------------------------
+# Shared test helpers (plain functions reused across tests).
+# ---------------------------------------------------------------------------
+
+def _make_db_with_schema_version(path: Path, version: int) -> None:
+    """Create a fresh DuckDB file containing a ``schema_version`` table
+    with the given version row.  Mirrors the shape ``_peek_schema_version``
+    expects."""
+    conn = duckdb.connect(str(path))
+    try:
+        conn.execute(
+            "CREATE TABLE schema_version (version INTEGER, applied_at TIMESTAMP)"
+        )
+        conn.execute(
+            "INSERT INTO schema_version VALUES (?, current_timestamp)", [version]
+        )
+    finally:
+        conn.close()
+
+
+def _make_db_no_schema_version_table(path: Path) -> None:
+    """Create a DuckDB file with some other table but no ``schema_version``
+    — simulates a pre-v1 / structurally-foreign snapshot."""
+    conn = duckdb.connect(str(path))
+    try:
+        conn.execute("CREATE TABLE other (id INTEGER)")
+    finally:
+        conn.close()
+
+
+def _corrupt_wal_so_replay_fails(db_path: Path) -> None:
+    """Write a sentinel .wal file next to *db_path*.
+
+    DuckDB 1.5 is resilient enough to ignore a short garbage WAL, so
+    this helper writes the file as a forensic marker for the recovery
+    path (``_try_open_system_db`` moves it aside when it exists) but
+    does NOT rely on actually triggering a WAL-replay exception from
+    DuckDB itself.  The actual IOError/InternalError that drives
+    recovery is injected via ``patch("src.db.duckdb.connect", ...)``
+    in each test that needs it — keeping the exception injection
+    co-located with the test expectation while still exercising the
+    real ``shutil.move`` / ``shutil.copy2`` file-system operations.
+    """
+    wal = Path(str(db_path) + ".wal")
+    wal.write_bytes(b"\x00" * 64)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
 
 def test_recovery_restores_pre_migrate_snapshot_on_wal_replay_error(
     state_dir,
@@ -195,3 +291,39 @@ def test_recovery_re_raises_if_snapshot_also_broken(state_dir):
     with patch("src.db.duckdb.connect", side_effect=fake):
         with pytest.raises(duckdb.Error, match="malformed"):
             _try_open_system_db(str(db_path))
+
+
+def test_recovery_proceeds_when_snapshot_is_at_head(tmp_path, make_wal_error):
+    """Regression guard: with a HEAD-version snapshot, recovery returns
+    a working connection, preserves the broken DB at .broken.<ts>, and
+    replaces the main DB with the snapshot."""
+    from src import db as db_module
+
+    db_path = tmp_path / "system.duckdb"
+    snapshot_path = tmp_path / "system.duckdb.pre-migrate"
+
+    _make_db_with_schema_version(db_path, db_module.SCHEMA_VERSION)
+    _make_db_with_schema_version(snapshot_path, db_module.SCHEMA_VERSION)
+    _corrupt_wal_so_replay_fails(db_path)
+
+    with make_wal_error(db_path):
+        conn = db_module._try_open_system_db(str(db_path))
+    try:
+        # The recovered DB carries the snapshot's schema_version row.
+        version = conn.execute(
+            "SELECT MAX(version) FROM schema_version"
+        ).fetchone()[0]
+        assert version == db_module.SCHEMA_VERSION
+    finally:
+        conn.close()
+
+    # Both the broken DB and the broken WAL must be preserved.
+    all_broken = sorted(tmp_path.glob("system.duckdb.broken.*"))
+    broken_dbs = [p for p in all_broken if not p.name.endswith(".wal")]
+    broken_wals = [p for p in all_broken if p.name.endswith(".wal")]
+    assert len(broken_dbs) == 1, all_broken
+    assert len(broken_wals) == 1, all_broken
+    # Snapshot was copied into the main DB path.
+    assert db_path.exists()
+    # Snapshot file itself was left in place (not consumed).
+    assert snapshot_path.exists()

--- a/tests/test_db_wal_recovery.py
+++ b/tests/test_db_wal_recovery.py
@@ -371,3 +371,33 @@ def test_recovery_refuses_when_snapshot_is_stale(tmp_path, make_wal_error):
 
     # Main DB path no longer exists — moved aside, NOT overwritten.
     assert not db_path.exists()
+
+
+def test_recovery_refuses_when_snapshot_has_no_schema_version_table(
+    tmp_path, make_wal_error
+):
+    """If the snapshot is a DuckDB file with no `schema_version` table
+    at all (pre-v1 / unrelated DB), _peek_schema_version returns 0;
+    recovery refuses via the same code path as test_..._is_stale."""
+    from src import db as db_module
+
+    db_path = tmp_path / "system.duckdb"
+    snapshot_path = tmp_path / "system.duckdb.pre-migrate"
+
+    _make_db_with_schema_version(db_path, db_module.SCHEMA_VERSION)
+    _make_db_no_schema_version_table(snapshot_path)
+    _corrupt_wal_so_replay_fails(db_path)
+
+    with make_wal_error(db_path):
+        with pytest.raises(RuntimeError) as excinfo:
+            db_module._try_open_system_db(str(db_path))
+
+    # v0 surfaces in the message (the conservative fallback value).
+    msg = str(excinfo.value)
+    assert "v0 <" in msg
+    assert str(db_module.SCHEMA_VERSION) in msg
+
+    # Same preservation contract as the stale case.
+    assert not db_path.exists()
+    assert snapshot_path.exists()
+    assert any(tmp_path.glob("system.duckdb.broken.*"))

--- a/tests/test_db_wal_recovery.py
+++ b/tests/test_db_wal_recovery.py
@@ -294,9 +294,11 @@ def test_recovery_re_raises_if_snapshot_also_broken(state_dir):
         with pytest.raises(RuntimeError) as excinfo:
             _try_open_system_db(str(db_path))
 
-    # Error message must mention the detected version (0) and the target.
+    # Error message must mention the detected version (0), the target,
+    # and the direction (peek=0 < target → stale).
     msg = str(excinfo.value)
-    assert "v0 <" in msg
+    assert "v0" in msg
+    assert "stale" in msg
     assert str(SCHEMA_VERSION) in msg
 
 
@@ -392,12 +394,76 @@ def test_recovery_refuses_when_snapshot_has_no_schema_version_table(
         with pytest.raises(RuntimeError) as excinfo:
             db_module._try_open_system_db(str(db_path))
 
-    # v0 surfaces in the message (the conservative fallback value).
+    # v0 surfaces in the message (the conservative fallback value);
+    # treated as stale since 0 < SCHEMA_VERSION.
     msg = str(excinfo.value)
-    assert "v0 <" in msg
+    assert "v0" in msg
+    assert "stale" in msg
     assert str(db_module.SCHEMA_VERSION) in msg
 
     # Same preservation contract as the stale case.
     assert not db_path.exists()
     assert snapshot_path.exists()
     assert any(tmp_path.glob("system.duckdb.broken.*"))
+
+
+def test_recovery_refuses_when_snapshot_is_from_future_version(
+    tmp_path, make_wal_error
+):
+    """Snapshot at SCHEMA_VERSION + 1 → recovery raises with 'future'
+    direction. Mirror of the stale case: operator rolled the binary
+    back, so auto-recovery would land the DB in the split-brain
+    'current > target' branch. Must refuse symmetrically."""
+    from src import db as db_module
+
+    db_path = tmp_path / "system.duckdb"
+    snapshot_path = tmp_path / "system.duckdb.pre-migrate"
+
+    _make_db_with_schema_version(db_path, db_module.SCHEMA_VERSION)
+    _make_db_with_schema_version(snapshot_path, db_module.SCHEMA_VERSION + 1)
+    _corrupt_wal_so_replay_fails(db_path)
+
+    with make_wal_error(db_path):
+        with pytest.raises(RuntimeError) as excinfo:
+            db_module._try_open_system_db(str(db_path))
+
+    msg = str(excinfo.value)
+    assert "future" in msg
+    assert str(db_module.SCHEMA_VERSION + 1) in msg
+    assert str(db_module.SCHEMA_VERSION) in msg
+
+    # Same preservation contract — broken DB moved aside, snapshot kept.
+    assert not db_path.exists()
+    assert snapshot_path.exists()
+    assert any(tmp_path.glob("system.duckdb.broken.*"))
+
+
+def test_recovery_broken_files_are_chmod_0600(tmp_path, make_wal_error):
+    """``system.duckdb`` holds argon2 password hashes + PAT secrets;
+    the broken-aside files must be chmod 0o600 on the refusal path so
+    they don't outlive the incident with default-umask ``0o644``."""
+    import stat
+
+    from src import db as db_module
+
+    db_path = tmp_path / "system.duckdb"
+    snapshot_path = tmp_path / "system.duckdb.pre-migrate"
+
+    _make_db_with_schema_version(db_path, db_module.SCHEMA_VERSION)
+    _make_db_with_schema_version(snapshot_path, db_module.SCHEMA_VERSION - 1)
+    _corrupt_wal_so_replay_fails(db_path)
+
+    with make_wal_error(db_path):
+        with pytest.raises(RuntimeError):
+            db_module._try_open_system_db(str(db_path))
+
+    broken = list(tmp_path.glob("system.duckdb.broken.*"))
+    assert broken, "no broken-aside files were created"
+    for path in broken:
+        mode = stat.S_IMODE(path.stat().st_mode)
+        # 0o600 owner-only RW. We accept any subset that's ≤ 0o600 in
+        # practice (some filesystems mask group/other bits even on
+        # 0o644 source files), but ANY group/other bit set is a fail.
+        assert mode & 0o077 == 0, (
+            f"{path.name}: mode {oct(mode)} has group/other bits set"
+        )


### PR DESCRIPTION
Closes #379.

## Why

`src/db.py::_try_open_system_db` auto-restores from `system.duckdb.pre-migrate` whenever WAL replay fails on DB open. The snapshot is captured **once** per migration transition and never refreshed, so any row data added between that moment and the WAL-recovery event is silently dropped when the recovery path copies the snapshot over the broken DB and re-runs the migration ladder.

A deployer hit this on 2026-05-21: 12 + 29 rows lost, `schema_version.applied_at` rewrite masking the destructive moment in forensics.

## Fix

Inspect the snapshot's `schema_version` before copying. If it is older than the current `SCHEMA_VERSION`, preserve both broken files (DB + WAL at `.broken.<ts>`) and raise `RuntimeError` with both version numbers in the message. Happy path (HEAD-version snapshot) and the "no snapshot" path are unchanged.

- New `_peek_schema_version()` helper opens the snapshot read-only (bypasses WAL replay), reads `MAX(version)`, returns 0 conservatively on any `duckdb.Error` (so corrupt / pre-v1 snapshots also fail the freshness check).
- Inline check in `_try_open_system_db` between the existing `snapshot.exists()` guard and the existing `shutil.move` / `shutil.copy2` block.
- `logger.critical(...)` with both version numbers, both broken-file paths, and `exc_info=e` so the WAL-replay traceback travels with the refusal message.
- Three new unit tests in `tests/test_db_wal_recovery.py` covering the happy-path regression guard, stale-snapshot refusal, and corrupt-snapshot refusal. One pre-existing test (`test_recovery_re_raises_if_snapshot_also_broken`) was updated — the freshness check now intercepts the "snapshot also broken" scenario earlier and raises `RuntimeError` instead of letting through a generic `duckdb.Error`. Net: 7 tests pass in the file (4 pre-existing semantics preserved, 3 added).

## Out of scope (separate issues)

- #380 — rolling pre-migrate refresh (tightens the recovery RPO).
- #381 — WAL salvage before fallback (per-table parquet for manual reconciliation).
- #383 — operator runbook at `docs/runbooks/wal-recovery.md`.
- #382 — `stop_grace_period: 60s` + CHECKPOINT-on-SIGTERM: closed during audit; both are already in place (`docker-compose.yml:50,93` + `close_system_db` CHECKPOINT in `src/db.py:4538-4565` runs from the FastAPI lifespan teardown that uvicorn invokes on SIGTERM).

## Spec + plan

- Spec: `docs/superpowers/specs/2026-05-26-wal-recovery-refuse-stale-design.md`
- Plan: `docs/superpowers/plans/2026-05-26-wal-recovery-refuse-stale.md`

## Release-cut

Patch `0.55.10 → 0.55.11` in the same PR per the CLAUDE.md release-cut rule.

## Verification

- Full pytest suite green locally: **5254 passed, 35 skipped** (`pytest tests/ -n auto -q`, 1m53s).
- The refusal path is exercised end-to-end (real DuckDB files on `tmp_path`, real read-only peek, real `shutil.move`); the WAL-replay error itself is mock-injected via the same `monkeypatch.setattr(duckdb, 'connect', ...)` pattern the file's pre-existing tests already use (DuckDB 1.5 is resilient to short garbage WAL content; rationale captured in the spec under "On the no mocks for DuckDB intent").
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->