### PR TITLE
ci: bump 3 GH actions in e2e-nightly.yml (#422 #423 #424) + release 0.55.13

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Set up Node (for agent-browser)
         if: env.SKIP_MATRIX != '1'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 
@@ -115,7 +115,7 @@ jobs:
 
       - name: Upload screenshots
         if: always() && env.SKIP_MATRIX != '1'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-artifacts-${{ matrix.script }}
           path: e2e-artifacts/${{ matrix.script }}/
@@ -131,7 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: File a tracking issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.55.13] — 2026-05-26
+
 ### Internal
 - `.github/workflows/e2e-nightly.yml` GitHub Actions bumped: `actions/setup-node@v4 → v6`, `actions/github-script@v7 → v9`, `actions/upload-artifact@v4 → v7`. Consolidates dependabot PRs #422, #423, #424 into one merge. Standard usage paths unchanged; the bump tracks the Node 24 runtime + ESM upgrades the actions ecosystem moved to since these were last pinned.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Internal
+- `.github/workflows/e2e-nightly.yml` GitHub Actions bumped: `actions/setup-node@v4 → v6`, `actions/github-script@v7 → v9`, `actions/upload-artifact@v4 → v7`. Consolidates dependabot PRs #422, #423, #424 into one merge. Standard usage paths unchanged; the bump tracks the Node 24 runtime + ESM upgrades the actions ecosystem moved to since these were last pinned.
+
 ## [0.55.12] — 2026-05-26
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.55.12"
+version = "0.55.13"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"


### PR DESCRIPTION
Closes dependabot PRs #422, #423, #424 by consolidating their three non-overlapping single-line bumps in `.github/workflows/e2e-nightly.yml` into one merge.

## What

- `actions/setup-node@v4 → v6` (#422 — Node 24 runtime; we pin `node-version: "22"` so the runtime bump is transparent)
- `actions/github-script@v7 → v9` (#423 — Node 24 runtime; the `github.rest.issues.create` API the open-tracking-issue job uses is stable across these majors)
- `actions/upload-artifact@v4 → v7` (#424 — v5: Node 24 support, v6: Actions Runner ≥2.327.1 default, v7: ESM + opt-in `archive: false` for single-file uploads. Our usage is standard directory upload of `e2e-artifacts/${{ matrix.script }}/` — `name` + `path` API unchanged)

## Why one PR

Three non-overlapping single-line changes in the same file. Bundling = one CI run, one release tag, one CHANGELOG bullet, one main commit, one post-merge smoke-test instead of three.

## Verification

The actual end-to-end behavior gate is `e2e-nightly.yml` itself — workflow-dispatching it on this branch post-merge confirms the runner picks up the new action versions cleanly. PR CI exercises pytest + docker-build but not the e2e-nightly steps.

## Release-cut

Patch `0.55.12 → 0.55.13` per the CLAUDE.md release-cut rule.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->