### PR TITLE
fix(ops): flock single-instance guard on agnes-auto-upgrade.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Fixed
+- **`scripts/ops/agnes-auto-upgrade.sh` is now single-instance** via
+  `flock` on `/var/lock/agnes-auto-upgrade.lock`. GCE live migration /
+  clock-jump events make cron deliver several catch-up ticks in a
+  single second (observed 4 ticks in ≤2s on a freshly-migrated VM),
+  and parallel runs of this script raced on `docker compose pull` +
+  `docker images --digest`: different runners saw different digest
+  values for the same tag, the diff tripped the "image digest moved"
+  branch, and a `docker compose up -d` fired for an upgrade that
+  hadn't actually happened — manifesting as ~30s app unreachability
+  every ~20–30 min on VMs caught in a migration window even when no
+  release had landed. Non-blocking `flock -n` means the second runner
+  exits cleanly; the next regular tick handles whatever real change
+  is pending.
+
 ### Added
 - `docs/ecosystem-map.md` — operator-facing bird's-eye view of the 5 repo tiers around an Agnes deployment (OSS app, per-customer infra in two patterns A/B, curated marketplace, initial-workspace template, legacy/glue), with a cross-tier checklist for new customer onboarding. Linked from `docs/README.md` operator index.
 

--- a/scripts/ops/agnes-auto-upgrade.sh
+++ b/scripts/ops/agnes-auto-upgrade.sh
@@ -14,6 +14,25 @@
 # (sdb at /data, sdc parallel at /data-state) — see docs/state-dir.md.
 set -euo pipefail
 cd /opt/agnes
+
+# Single-instance guard. GCE live migration / clock-jump events make
+# cron deliver several catch-up ticks in a single second (saw 4 ticks
+# in ≤2s on a freshly-migrated VM), and parallel runs of this script
+# race on `docker compose pull` + `docker images --digest` — different
+# runners observe different digest values for the same tag, the diff
+# trips the "image digest moved" branch, and a `docker compose up -d`
+# fires for an upgrade that hasn't actually happened. flock with -n
+# (non-blocking) means the second runner exits cleanly without
+# log-spamming; the next regular 5-min tick handles whatever real
+# change is pending. /var/lock survives reboots on Ubuntu (tmpfs is
+# recreated at boot, but that's fine — the lock only needs to be
+# unique among concurrently-running processes).
+exec 9>/var/lock/agnes-auto-upgrade.lock
+flock -n 9 || {
+  logger -t agnes-auto-upgrade "another instance holds the lock — exiting"
+  exit 0
+}
+
 # shellcheck disable=SC1091
 set -a; . /opt/agnes/.env; set +a
 


### PR DESCRIPTION
## Summary

GCE live migration / clock-jump events make cron deliver several catch-up ticks of `agnes-auto-upgrade.sh` in a single second. Parallel runs race on `docker compose pull` + `docker images --digest`: different runners observe different digest values for the same tag, the diff trips the "image digest moved" branch, and `docker compose up -d` fires for an upgrade that hasn't actually happened.

Net effect: ~30s app unreachability every 20–30 min on VMs caught in a GCE migration window, even when no release landed.

## Repro (observed today on agnes-dev)

Two `gap → burst` patterns in cron logs:
```
... 16:00:40, 16:05:01, 16:10:02
[GAP 25min]
16:35:10, 16:35:10, 16:35:11    ← 3 ticks in ≤1s
...
[GAP 21min]
17:26:22, 17:26:22, 17:26:24, 17:26:24    ← 4 ticks in ≤2s
```
RestartCount for `agnes-app-1`: **3** since boot. Each burst → one false-positive recreate. Prod (no migration in the same window) had **RestartCount: 0**.

## Fix

`flock -n` on `/var/lock/agnes-auto-upgrade.lock` at the top of the script (after `set -euo pipefail` + `cd /opt/agnes`, before any work):

```bash
exec 9>/var/lock/agnes-auto-upgrade.lock
flock -n 9 || {
  logger -t agnes-auto-upgrade "another instance holds the lock — exiting"
  exit 0
}
```

Non-blocking — the second concurrent runner exits cleanly (logged for audit via `logger -t`). The next regular 5-min tick handles whatever real change is pending.

`/var/lock` survives the cron tick (tmpfs recreated at boot, but the lock only needs uniqueness among concurrently-running processes; a fresh tmpfs at boot is fine because no two ticks straddle a boot).

## Test plan

- [x] `bash -n scripts/ops/agnes-auto-upgrade.sh` — syntax clean.
- [x] Full pytest suite (shell-only diff; suite verifies no Python regression).
- [ ] After merge: `:stable` rebuild → auto-upgrade self-update on existing VMs will land the new script within ~5 min, no admin action required.

## Out of scope

- Cron timing itself (`*/5 * * * *`) and the catch-up policy live in `/var/spool/cron/crontabs/root`, written by the upstream `customer-instance` Terraform module's startup-script. Tightening that to e.g. `RANDOM_DELAY=0` or anchored timestamps is a separate concern; this PR addresses the race the catch-up triggers, not the catch-up itself.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->