### PR TITLE
fix(materialize): cap DuckDB memory_limit on consolidation conns + pre-flight disk check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,43 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 ## [Unreleased]
 
 ### Fixed
+- **DuckDB consolidation connections in `materialize_query` now cap
+  `memory_limit` + `threads`** (`connectors/keboola/extractor.py`,
+  `connectors/bigquery/extractor.py`). DuckDB's default `memory_limit`
+  is 80 % of system RAM, which on a 4 GiB cgroup container resolves to
+  ~3.2 GiB of process-resident buffer pool. With Python objects +
+  sidecar containers that exceeds the cgroup cap and triggers OOM
+  during slice consolidation of any non-trivial table — observed on
+  the live dev VM with the `gcp_cost` Keboola table: uvicorn anon
+  RSS climbed from ~350 MiB to ~3.5 GiB in minutes, then SIGKILL.
+  New `_open_consolidation_conn()` helper in the Keboola extractor
+  applies `SET memory_limit='2GB'` + `SET threads=2` +
+  `SET preserve_insertion_order=false` immediately after each
+  `duckdb.connect()` on the materialize path; matching inline `SET`s
+  on the BQ side run inside the materialize `bq.duckdb_session()`
+  block. The 2 GiB ceiling leaves headroom for the legacy CSV path
+  (DuckDB pre-allocates a ~1 GiB sliding-window buffer for
+  `read_csv(max_line_size=64MB)`); the parquet path's streaming
+  row-group COPY rarely needs more than ~100 MiB, so the cap binds
+  only when something goes wrong. `preserve_insertion_order=false`
+  matches DuckDB's own out-of-memory hint and is safe here — the
+  materialize output is a single parquet that downstream consumers
+  re-sort however they like.
+- **`connectors/keboola/storage_api.py::_download_single` adds a
+  pre-flight disk-space check.** Storage API signed-URL responses
+  carry `Content-Length` (the compressed transfer size); compare
+  against `shutil.disk_usage(dest.parent).free` and raise
+  `StorageApiError` early when available space is below 5x the
+  payload for `gunzip_on_read=True` (decompressed dest typically
+  3-5x the wire bytes) or 1.25x otherwise. Skipping the check when
+  `Content-Length` is absent leaves mid-write `errno 28 No space
+  left on device` as a possibility; the common case now fails
+  fast with an actionable message instead of triggering the
+  multi-GiB Python traceback retention path that compounded into
+  a cascading cgroup OOM on the live dev VM (the retained `chunk`
+  buffer + response object references in the `_download_single`
+  failure frame multiplied across `download_file_slices`'
+  per-slice loop).
 - **`scripts/ops/agnes-auto-upgrade.sh` is now single-instance** via
   `flock` on `/var/lock/agnes-auto-upgrade.lock`. GCE live migration /
   clock-jump events make cron deliver several catch-up ticks in a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   ~3.2 GiB of process-resident buffer pool. With Python objects +
   sidecar containers that exceeds the cgroup cap and triggers OOM
   during slice consolidation of any non-trivial table — observed on
-  the live dev VM with the `gcp_cost` Keboola table: uvicorn anon
-  RSS climbed from ~350 MiB to ~3.5 GiB in minutes, then SIGKILL.
+  a 4 GiB dev container against a multi-GiB Keboola table: uvicorn
+  anon RSS climbed from ~350 MiB to ~3.5 GiB in minutes, then SIGKILL.
   New `_open_consolidation_conn()` helper in the Keboola extractor
   applies `SET memory_limit='2GB'` + `SET threads=2` +
   `SET preserve_insertion_order=false` immediately after each
@@ -44,7 +44,7 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   left on device` as a possibility; the common case now fails
   fast with an actionable message instead of triggering the
   multi-GiB Python traceback retention path that compounded into
-  a cascading cgroup OOM on the live dev VM (the retained `chunk`
+  a cascading cgroup OOM on small dev containers (the retained `chunk`
   buffer + response object references in the `_download_single`
   failure frame multiplied across `download_file_slices`'
   per-slice loop).

--- a/connectors/bigquery/extractor.py
+++ b/connectors/bigquery/extractor.py
@@ -904,6 +904,23 @@ def materialize_query(
             # extension loaded with a SECRET token; bigquery_query() reuses that
             # auth path against the billing_project for the jobs API call.
             with bq.duckdb_session() as conn:
+                # Cap DuckDB memory_limit + thread count so the COPY's
+                # streaming buffer pool can't grow into the cgroup
+                # OOM-kill threshold during consolidation. Without the
+                # cap DuckDB defaults to ~80% of system RAM, which on a
+                # 4 GiB container leaves no headroom for Python objects
+                # / sidecar containers and trips OOM mid-COPY against
+                # large remote tables. See the matching cap in
+                # ``connectors/keboola/extractor.py`` for the empirical
+                # trace. Note: this session is pooled by
+                # ``_default_duckdb_session_factory``, so the SET
+                # persists for the next acquire — that's intentional
+                # (1 GiB is plenty for ad-hoc analyst queries too, and
+                # we'd rather slow a heavy ad-hoc query than crash the
+                # process).
+                conn.execute("SET memory_limit='2GB'")
+                conn.execute("SET threads=2")
+                conn.execute("SET preserve_insertion_order=false")
                 attached = {
                     r[0] for r in conn.execute(
                         "SELECT database_name FROM duckdb_databases()"

--- a/connectors/keboola/extractor.py
+++ b/connectors/keboola/extractor.py
@@ -17,6 +17,54 @@ from src.identifier_validation import (
 logger = logging.getLogger(__name__)
 
 
+# Cap DuckDB memory_limit + thread count on short-lived consolidation
+# connections inside ``materialize_query``. DuckDB's default
+# ``memory_limit`` is 80% of system RAM, which on a 4 GiB cgroup
+# container resolves to ~3.2 GiB of process-resident buffer pool. With
+# Python objects + a few hundred MiB for orchestrator state + caddy /
+# scheduler sidecars, that exceeds the cgroup cap and triggers OOM-kill
+# during slice consolidation against any non-trivial table (observed
+# on the live dev VM with the ``gcp_cost`` Keboola table: anon RSS
+# climbed from ~350 MiB to ~3.5 GiB in minutes, then SIGKILL).
+#
+# 2 GiB strikes the balance: the parquet path's streaming row-group
+# COPY rarely needs more than ~100 MiB, but the legacy CSV path's
+# ``read_csv(max_line_size=64MB)`` pre-allocates a multi-thread
+# sliding window buffer that DuckDB internally treats as a single
+# ~1 GiB allocation unit (verified empirically — a 1 GiB cap raised
+# `OutOfMemoryException` on a 2-row CSV fixture). Combined with
+# ``preserve_insertion_order=false`` the peak stays well under 2 GiB.
+# On a 4 GiB cgroup container that leaves ~1.5 GiB for Python objects
+# + sidecars; on the 8 GiB target sizing the headroom is generous.
+_CONSOLIDATION_MEMORY_LIMIT = "2GB"
+_CONSOLIDATION_THREADS = 2
+
+
+def _open_consolidation_conn(db_path: Optional[str] = None):
+    """Return a DuckDB connection with memory/thread caps applied.
+
+    Use for short-lived ``COPY (SELECT … FROM read_parquet/read_csv)``
+    consolidation queries inside the materialize path. ``db_path``
+    defaults to in-memory; pass a path for on-disk consolidation.
+
+    ``preserve_insertion_order=false`` is set alongside the memory cap
+    on DuckDB's recommendation (the OOM error message itself proposes
+    it) — for the CSV→parquet path, the default
+    insertion-order-preserving execution holds row batches in memory
+    until the parent operator can emit them in order, which collides
+    badly with the 1 GiB cap when ``read_csv(max_line_size=64MB)``
+    pre-allocates large sliding-window buffers. The materialize output
+    is a single parquet that downstream consumers re-sort however they
+    like — preserving the read-order from the input file isn't
+    something any caller depends on.
+    """
+    conn = duckdb.connect(db_path) if db_path else duckdb.connect()
+    conn.execute(f"SET memory_limit='{_CONSOLIDATION_MEMORY_LIMIT}'")
+    conn.execute(f"SET threads={_CONSOLIDATION_THREADS}")
+    conn.execute("SET preserve_insertion_order=false")
+    return conn
+
+
 def materialize_query(
     table_id: str,
     *,
@@ -165,7 +213,7 @@ def materialize_query(
                     "'" + str(p).replace("'", "''") + "'" for p in slice_paths
                 )
                 safe_tmp = str(tmp_parquet).replace("'", "''")
-                conv = duckdb.connect()
+                conv = _open_consolidation_conn()
                 try:
                     conv.execute(
                         f"COPY (SELECT * FROM read_parquet([{quoted}])) "
@@ -187,7 +235,7 @@ def materialize_query(
                 )
                 # Empty placeholder parquet so the orchestrator doesn't
                 # choke on a missing file.
-                duckdb.connect().execute(
+                _open_consolidation_conn().execute(
                     f"COPY (SELECT 1 AS _empty WHERE FALSE) TO '{tmp_parquet}' (FORMAT PARQUET)"
                 ).close()
         else:
@@ -206,7 +254,7 @@ def materialize_query(
                     "(filter may be too restrictive)",
                     full_table_id,
                 )
-                duckdb.connect().execute(
+                _open_consolidation_conn().execute(
                     f"COPY (SELECT 1 AS _empty WHERE FALSE) TO '{tmp_parquet}' (FORMAT PARQUET)"
                 ).close()
             else:
@@ -228,7 +276,7 @@ def materialize_query(
                 safe_csv = str(csv_path).replace("'", "''")
                 safe_tmp = str(tmp_parquet).replace("'", "''")
                 try:
-                    conv = duckdb.connect()
+                    conv = _open_consolidation_conn()
                     conv.execute(
                         f"COPY (SELECT * FROM read_csv('{safe_csv}', "
                         f"all_varchar=true, max_line_size=67108864)) "
@@ -244,7 +292,7 @@ def materialize_query(
     # sometimes omits totalRowsCount on small results, and the parquet is
     # the authoritative count we'll be serving downstream anyway.
     safe_tmp = str(tmp_parquet).replace("'", "''")
-    cnt_conn = duckdb.connect()
+    cnt_conn = _open_consolidation_conn()
     try:
         row_count = cnt_conn.execute(
             f"SELECT COUNT(*) FROM read_parquet('{safe_tmp}')"
@@ -841,7 +889,7 @@ def _extract_via_legacy(
             # Storage API succeeded but produced no rows. Emit an empty
             # parquet rather than crashing — same defensive behavior as
             # `materialize_query`.
-            duckdb.connect().execute(
+            _open_consolidation_conn().execute(
                 f"COPY (SELECT 1 AS _empty WHERE FALSE) TO '{pq_path}' (FORMAT PARQUET)"
             ).close()
             return

--- a/connectors/keboola/extractor.py
+++ b/connectors/keboola/extractor.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 # Python objects + a few hundred MiB for orchestrator state + caddy /
 # scheduler sidecars, that exceeds the cgroup cap and triggers OOM-kill
 # during slice consolidation against any non-trivial table (observed
-# on the live dev VM with the ``gcp_cost`` Keboola table: anon RSS
+# on a 4 GiB dev container against a multi-GiB Keboola table: anon RSS
 # climbed from ~350 MiB to ~3.5 GiB in minutes, then SIGKILL).
 #
 # 2 GiB strikes the balance: the parquet path's streaming row-group

--- a/connectors/keboola/storage_api.py
+++ b/connectors/keboola/storage_api.py
@@ -412,6 +412,42 @@ class KeboolaStorageClient:
             headers=extra_headers,
         ) as r:
             r.raise_for_status()
+
+            # Pre-flight disk-space check. Storage API's signed-URL
+            # response carries ``Content-Length`` (compressed transfer
+            # size for gzipped exports). Demand 5× headroom for gunzip
+            # cases (decompressed dest typically 3-5× the wire bytes)
+            # and 1.25× otherwise (for the ``.part`` + atomic rename
+            # window). Skipping the check when ``Content-Length`` is
+            # absent (proxies sometimes strip it) means mid-write
+            # ``OSError 28`` is still possible; the common case fails
+            # fast with an actionable message instead of leaving an
+            # orphan ``.part`` + a half-written destination behind
+            # AND triggering the Python traceback retention path that
+            # held a multi-GiB response buffer in every retained frame
+            # on agnes-dev (cascaded into a cgroup OOM via
+            # ``connectors/keboola/extractor.py`` consolidation
+            # connection — see the matching DuckDB-side cap there).
+            content_length = r.headers.get("Content-Length")
+            if content_length is not None:
+                try:
+                    expected_bytes = int(content_length)
+                except (TypeError, ValueError):
+                    expected_bytes = None
+                if expected_bytes is not None and expected_bytes > 0:
+                    headroom_mult = 5 if gunzip_on_read else 1.25
+                    needed = int(expected_bytes * headroom_mult)
+                    dest_path.parent.mkdir(parents=True, exist_ok=True)
+                    free = shutil.disk_usage(dest_path.parent).free
+                    if free < needed:
+                        raise StorageApiError(
+                            f"insufficient disk space at {dest_path.parent}: "
+                            f"have {free:,} B free, need >= {needed:,} B "
+                            f"({headroom_mult}x the {expected_bytes:,} B "
+                            f"download for gunzip_on_read={gunzip_on_read}). "
+                            f"Free space before retrying.",
+                        )
+
             tmp = dest_path.with_suffix(dest_path.suffix + ".part")
             try:
                 with open(tmp, "wb") as fh:

--- a/connectors/keboola/storage_api.py
+++ b/connectors/keboola/storage_api.py
@@ -425,7 +425,7 @@ class KeboolaStorageClient:
             # orphan ``.part`` + a half-written destination behind
             # AND triggering the Python traceback retention path that
             # held a multi-GiB response buffer in every retained frame
-            # on agnes-dev (cascaded into a cgroup OOM via
+            # on small dev containers (cascaded into a cgroup OOM via
             # ``connectors/keboola/extractor.py`` consolidation
             # connection — see the matching DuckDB-side cap there).
             content_length = r.headers.get("Content-Length")


### PR DESCRIPTION
## Summary

Caught live on agnes-dev: `uvicorn` anon RSS climbed from ~350 MiB to **~3.5 GiB in minutes** during a Keboola `materialize_query` slice consolidation of `gcp_cost`, then kernel OOM-killed the process. The trigger is DuckDB's default `memory_limit` (80% of system RAM), which on a 4 GiB cgroup container resolves to ~3.2 GiB of process-resident buffer pool — too tight when Python objects + sidecars are added.

## Three fixes

1. **`connectors/keboola/extractor.py`** — new `_open_consolidation_conn()` helper applies `SET memory_limit='2GB' + threads=2 + preserve_insertion_order=false` on every `duckdb.connect()` in the materialize path (5 sites).
2. **`connectors/bigquery/extractor.py`** — same caps applied inline inside the `bq.duckdb_session()` block in `materialize_query`. The BQ session is pooled, so the SET persists for the next acquire — intentional, 2 GiB is plenty for ad-hoc analyst queries too.
3. **`connectors/keboola/storage_api.py::_download_single`** — pre-flight disk-space check. Storage API signed-URL responses carry `Content-Length`; compare against `shutil.disk_usage(dest.parent).free` and raise `StorageApiError` early when available space is below `5x` the payload for `gunzip_on_read=True` (3-5x decompression ratio typical) or `1.25x` otherwise. Closes the path where mid-write `OSError 28` triggered Python traceback retention of the `chunk` buffer + response object refs across `download_file_slices`' per-slice loop — multiplying into the multi-GiB anon RSS spike the cgroup OOM-killer was catching too late.

## Why 2 GiB (not 1 GiB)?

Initial cap of `1GB` raised `OutOfMemoryException` on the legacy CSV path's 2-row test fixture. `read_csv(max_line_size=64MB)` pre-allocates a sliding-window buffer that DuckDB internally treats as ~1 GiB. 2 GiB gives parquet streaming (~100 MiB peak) generous headroom and keeps the CSV fallback functional. `preserve_insertion_order=false` follows DuckDB's own OOM-hint and is safe — the materialize output is a single parquet that downstream consumers re-sort however they like.

## Test plan

- [x] `tests/test_keboola_materialize.py` (12 cases) and `tests/test_bq_materialize.py` — all green.
- [x] Full pytest suite: `5272 passed, 35 skipped, 0 failed`.

## Out of scope (follow-up)

- Subprocess-isolated materialize. The pooled session pattern means a leak in one COPY can still impact subsequent queries within the same process; a `multiprocessing.Process`-per-table approach would isolate completely. Multi-file refactor + IPC / status reporting design — file a separate issue.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->