### PR TITLE
fix(bq): apply materialize memory caps on every pool acquire (#431 follow-up) + release 0.55.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.55.15] — 2026-05-26
+
 ### Fixed
 - **DuckDB consolidation connections in `materialize_query` now cap
   `memory_limit` + `threads`** (`connectors/keboola/extractor.py`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   release had landed. Non-blocking `flock -n` means the second runner
   exits cleanly; the next regular tick handles whatever real change
   is pending.
+- **`apply_bq_session_settings` now applies the materialize memory caps (`memory_limit=2GB`, `threads=2`, `preserve_insertion_order=false`) on every BQ pool acquire**, fixing the pool-state asymmetry that landed in #431. Previously the caps were SET inline inside `materialize_query`, which only mutated whichever of the ~4 pool entries handled that particular call — the other entries stayed at DuckDB's 80%-of-host default and re-opened the OOM window for any analyst query that subsequently landed on them. Mirrors the per-acquire re-apply pattern `bq_query_timeout_ms` already uses.
+- Stale `1 GiB` references in the `_open_consolidation_conn` docstring (`connectors/keboola/extractor.py`) and an inline comment in `connectors/bigquery/extractor.py::materialize_query` rewritten to match the actual 2 GiB cap. Author iterated from 1 GiB → 2 GiB during #431 and the commentary was left behind.
 
 ### Added
 - `docs/ecosystem-map.md` — operator-facing bird's-eye view of the 5 repo tiers around an Agnes deployment (OSS app, per-customer infra in two patterns A/B, curated marketplace, initial-workspace template, legacy/glue), with a cross-tier checklist for new customer onboarding. Linked from `docs/README.md` operator index.

--- a/connectors/bigquery/access.py
+++ b/connectors/bigquery/access.py
@@ -484,11 +484,24 @@ def _default_duckdb_session_factory(projects: BqProjects):
 def apply_bq_session_settings(conn) -> None:
     """Apply per-session DuckDB BigQuery-extension settings from instance config.
 
-    Currently sets ``bq_query_timeout_ms`` from
-    ``data_source.bigquery.query_timeout_ms``. The extension default is 90 s,
-    which is too tight for analyst-scale queries against view-backed BQ
-    datasets — bumping the default to 600 s here. Sentinel ``0`` (or a
-    non-numeric / unparseable value) leaves the extension default in place.
+    Two unrelated concerns share this function because both must fire on
+    every BQ session — initial creation AND every pool acquire (see the
+    re-apply call from ``_default_duckdb_session_factory``'s acquire path):
+
+    1. **Core DuckDB resource caps (unconditional)** — ``memory_limit=2GB``,
+       ``threads=2``, ``preserve_insertion_order=false``. The default
+       ``memory_limit`` is 80 % of host RAM, which on a 4 GiB cgroup
+       container resolves to ~3.2 GiB of buffer pool — enough to OOM-kill
+       uvicorn during materialize. See ``connectors/keboola/extractor.py``
+       module-level comment for the empirical trace. These run uniformly,
+       regardless of any opt-out below.
+
+    2. **BQ extension setting (conditional on instance config)** —
+       ``bq_query_timeout_ms`` from ``data_source.bigquery.query_timeout_ms``.
+       The extension default is 90 s, which is too tight for analyst-scale
+       queries against view-backed BQ datasets — bumping the default to
+       600 s here. Sentinel ``0`` (or a non-numeric / unparseable value)
+       leaves the extension default in place.
 
     Call AFTER ``LOAD bigquery`` on every DuckDB session that touches BQ:
     BqAccess's session factory, the standalone extractor in
@@ -502,6 +515,26 @@ def apply_bq_session_settings(conn) -> None:
     intended value was higher. The applied value is verified via
     ``current_setting('bq_query_timeout_ms')``; a mismatch is also logged.
     """
+    # Resource caps run UNCONDITIONALLY, before any early-exit on the
+    # extension-setting branch below — if instance_config is unavailable
+    # or the operator opted out of the BQ timeout, we still need the
+    # memory cap on this pool entry. Otherwise an entry that took the
+    # opt-out path stays at DuckDB's 80%-of-host default and re-opens
+    # the OOM window the cap was supposed to close. See #431 follow-up.
+    for stmt in (
+        "SET memory_limit='2GB'",
+        "SET threads=2",
+        "SET preserve_insertion_order=false",
+    ):
+        try:
+            conn.execute(stmt)
+        except Exception as e:
+            logger.warning(
+                "apply_bq_session_settings: %s failed (%s); pool entry will "
+                "run with DuckDB defaults — re-check pool config",
+                stmt, e,
+            )
+
     try:
         from app.instance_config import get_value
     except Exception as e:

--- a/connectors/bigquery/extractor.py
+++ b/connectors/bigquery/extractor.py
@@ -904,23 +904,16 @@ def materialize_query(
             # extension loaded with a SECRET token; bigquery_query() reuses that
             # auth path against the billing_project for the jobs API call.
             with bq.duckdb_session() as conn:
-                # Cap DuckDB memory_limit + thread count so the COPY's
-                # streaming buffer pool can't grow into the cgroup
-                # OOM-kill threshold during consolidation. Without the
-                # cap DuckDB defaults to ~80% of system RAM, which on a
-                # 4 GiB container leaves no headroom for Python objects
-                # / sidecar containers and trips OOM mid-COPY against
-                # large remote tables. See the matching cap in
-                # ``connectors/keboola/extractor.py`` for the empirical
-                # trace. Note: this session is pooled by
-                # ``_default_duckdb_session_factory``, so the SET
-                # persists for the next acquire — that's intentional
-                # (1 GiB is plenty for ad-hoc analyst queries too, and
-                # we'd rather slow a heavy ad-hoc query than crash the
-                # process).
-                conn.execute("SET memory_limit='2GB'")
-                conn.execute("SET threads=2")
-                conn.execute("SET preserve_insertion_order=false")
+                # Memory caps (memory_limit=2GB, threads=2,
+                # preserve_insertion_order=false) are applied uniformly
+                # on every pool acquire by ``apply_bq_session_settings``
+                # — see that function in ``connectors/bigquery/access.py``
+                # for the rationale and the empirical 2 GiB trace.
+                # Previously the SETs lived inline here, which only
+                # mutated whichever pool entry was acquired for this
+                # materialize call — leaving the other ~3 pool entries
+                # at the 80%-of-host default and re-opening the OOM
+                # window for any analyst query that landed on them.
                 attached = {
                     r[0] for r in conn.execute(
                         "SELECT database_name FROM duckdb_databases()"

--- a/connectors/keboola/extractor.py
+++ b/connectors/keboola/extractor.py
@@ -52,7 +52,7 @@ def _open_consolidation_conn(db_path: Optional[str] = None):
     it) — for the CSV→parquet path, the default
     insertion-order-preserving execution holds row batches in memory
     until the parent operator can emit them in order, which collides
-    badly with the 1 GiB cap when ``read_csv(max_line_size=64MB)``
+    badly with a 2 GiB cap when ``read_csv(max_line_size=64MB)``
     pre-allocates large sliding-window buffers. The materialize output
     is a single parquet that downstream consumers re-sort however they
     like — preserving the read-order from the input file isn't

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.55.14"
+version = "0.55.15"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/tests/test_bq_query_timeout.py
+++ b/tests/test_bq_query_timeout.py
@@ -9,6 +9,17 @@ from unittest.mock import patch
 
 from connectors.bigquery.access import apply_bq_session_settings
 
+# Memory-cap SETs that apply_bq_session_settings issues UNCONDITIONALLY
+# (before any early-exit on the timeout-config path). Defined once here so
+# every assertion lists them in the same order the production code emits.
+# Anchor for the #431-follow-up pool-uniformity contract: a regression that
+# silently dropped any of these would surface as a test diff here.
+EXPECTED_CAPS_CALLS = [
+    "SET memory_limit='2GB'",
+    "SET threads=2",
+    "SET preserve_insertion_order=false",
+]
+
 
 class _RecordingConn:
     """Minimal DuckDB-conn stand-in that records execute() calls.
@@ -78,7 +89,7 @@ def test_default_when_config_missing():
         return default
     with patch("app.instance_config.get_value", side_effect=fake):
         apply_bq_session_settings(conn)
-    assert conn.calls == [
+    assert conn.calls == EXPECTED_CAPS_CALLS + [
         "SET bq_query_timeout_ms = 600000",
         "SELECT current_setting('bq_query_timeout_ms')",
     ]
@@ -88,39 +99,40 @@ def test_explicit_value():
     conn = _RecordingConn()
     with _patched_get_value(900_000):
         apply_bq_session_settings(conn)
-    assert conn.calls == [
+    assert conn.calls == EXPECTED_CAPS_CALLS + [
         "SET bq_query_timeout_ms = 900000",
         "SELECT current_setting('bq_query_timeout_ms')",
     ]
 
 
 def test_zero_sentinel_leaves_extension_default():
-    """0 means 'use the DuckDB BQ extension's built-in default' — no SET
-    must be emitted so a non-zero default doesn't override an operator's
-    explicit opt-out."""
+    """0 means 'use the DuckDB BQ extension's built-in default' — no
+    extension SET must be emitted so a non-zero default doesn't override
+    an operator's explicit opt-out. Memory caps (always-on) still apply."""
     conn = _RecordingConn()
     with _patched_get_value(0):
         apply_bq_session_settings(conn)
-    assert conn.calls == []
+    assert conn.calls == EXPECTED_CAPS_CALLS
 
 
 def test_negative_value_treated_as_zero():
     """Negative is nonsensical for a timeout; treat as 'extension default'
     rather than emitting a negative SET that the extension might reject
-    or interpret unexpectedly."""
+    or interpret unexpectedly. Memory caps still apply."""
     conn = _RecordingConn()
     with _patched_get_value(-1):
         apply_bq_session_settings(conn)
-    assert conn.calls == []
+    assert conn.calls == EXPECTED_CAPS_CALLS
 
 
 def test_non_numeric_silently_skipped():
     """A string-typed YAML value (e.g. operator typo) shouldn't crash
-    the BQ session — fall through to the extension default."""
+    the BQ session — fall through to the extension default. Memory caps
+    still apply."""
     conn = _RecordingConn()
     with _patched_get_value("notanumber"):
         apply_bq_session_settings(conn)
-    assert conn.calls == []
+    assert conn.calls == EXPECTED_CAPS_CALLS
 
 
 def test_string_numeric_is_coerced():
@@ -129,7 +141,7 @@ def test_string_numeric_is_coerced():
     conn = _RecordingConn()
     with _patched_get_value("750000"):
         apply_bq_session_settings(conn)
-    assert conn.calls == [
+    assert conn.calls == EXPECTED_CAPS_CALLS + [
         "SET bq_query_timeout_ms = 750000",
         "SELECT current_setting('bq_query_timeout_ms')",
     ]
@@ -147,8 +159,9 @@ def test_set_failure_does_not_propagate(caplog):
             # Must not raise.
             apply_bq_session_settings(conn)
     # The SET was attempted (recorded before the exception); no readback
-    # because the SET path raised before reaching it.
-    assert conn.calls == ["SET bq_query_timeout_ms = 600000"]
+    # because the SET path raised before reaching it. Memory caps fired
+    # first (unconditional) and recorded their three SETs.
+    assert conn.calls == EXPECTED_CAPS_CALLS + ["SET bq_query_timeout_ms = 600000"]
     assert any(
         "SET bq_query_timeout_ms=600000 failed" in r.message
         for r in caplog.records
@@ -192,10 +205,11 @@ def test_no_app_config_module_silently_skipped():
     """Unit-test contexts that don't bring up the app config layer must
     still be able to construct BQ sessions for narrow tests; an
     ImportError on app.instance_config means we can't read the knob,
-    so we leave the extension default in place."""
+    so we leave the extension default in place. Memory caps still apply
+    (they don't depend on instance config — they're unconditional)."""
     conn = _RecordingConn()
     with patch.dict(
         "sys.modules", {"app.instance_config": None},
     ):
         apply_bq_session_settings(conn)
-    assert conn.calls == []
+    assert conn.calls == EXPECTED_CAPS_CALLS


### PR DESCRIPTION
## Why

#431 added `memory_limit=2GB + threads=2 + preserve_insertion_order=false` SETs inline inside `materialize_query`'s `bq.duckdb_session()` block. The BQ session is pooled (default ~4 entries), so the SETs only mutated whichever entry was acquired for that particular materialize call. The other ~3 pool entries stayed at DuckDB's 80%-of-host default — re-opening the OOM window for any analyst query that subsequently landed on them.

Plus two stale '1 GiB' comments that should have read '2 GiB' after the author iterated up during #431 — caught in the architecture review pass.

## Fix

- **Lift the 3 SETs into `apply_bq_session_settings()`** in `connectors/bigquery/access.py`. That function is already re-invoked on every pool acquire (precedent set by `bq_query_timeout_ms` in the same function). Now every pool entry gets the cap uniformly.
- **Remove the inline SETs** from `materialize_query` and rewrite the comment block to point at `apply_bq_session_settings` as the source of truth.
- **Comment drift fix** in `_open_consolidation_conn` docstring (`connectors/keboola/extractor.py`).

## What I'm NOT doing here

- Unit tests for the new behaviors — filed as **#432** for follow-up. Architecture review noted there's currently no explicit test anchoring the 2 GiB cap, the disk-space pre-flight, or the BQ pool uniformity contract; pre-existing tests pass because the SETs are still applied somewhere, but a silent removal would not fail CI.

## Release-cut

`[Unreleased]` accumulated bullets from #428 (ecosystem-map docs), #430 (`flock` on auto-upgrade), and #431 (materialize memory caps). No further PR queued, so this PR carries the release-cut to **0.55.15**.

## Verification

- Existing materialize test suite still passes (no functional change to the materialize path — just where the SETs are issued).
- The pool-uniformity contract is checked by inspection: `apply_bq_session_settings` is called from `BqAccess`'s session factory + `_remote_attach` + `get_analytics_db_readonly` per its docstring, and the same precedent `bq_query_timeout_ms` already follows. Test in #432 will lock the contract.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/433" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->