### PR TITLE
fix(profiler): lower DuckDB memory_limit 4GB → 2GB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Fixed
+- **`src/profiler.py::profile_table` lowers DuckDB `memory_limit` from
+  `4GB` to `2GB` + adds `preserve_insertion_order=false`.** The prior
+  4 GiB cap matched typical container cgroup limits exactly, leaving
+  zero headroom for the host Python interpreter + ATTACHed orchestrator
+  state + sidecar processes. Observed on a 4 GiB dev container: the
+  profiler ran right up to the cap during `[SYNC] Profiled N tables`,
+  then the cgroup OOM killer reaped uvicorn within seconds of
+  orchestrator rebuild completing (anon_rss: 4180352 kB ≈ exact
+  cgroup cap). 2 GiB matches the materialize-path caps from
+  PR #431/#433 and leaves ~2 GiB of headroom for the rest of the
+  process. Profiler peak is normally a few hundred MiB (streaming
+  row-group scans + in-memory `SAMPLE`); the cap binds only when
+  something goes wrong.
+
 ## [0.55.15] — 2026-05-26
 
 ### Fixed

--- a/src/profiler.py
+++ b/src/profiler.py
@@ -761,10 +761,23 @@ def profile_table(
     con = duckdb.connect()
 
     # Limit DuckDB memory to avoid OOM on servers with limited RAM.
-    # DuckDB defaults to using all available memory, which can trigger
-    # the OOM killer when profiling large tables alongside other services.
-    con.execute("SET memory_limit = '4GB'")
+    # DuckDB defaults to using all available memory; the prior 4 GiB
+    # cap matched typical container cgroup limits exactly, leaving zero
+    # headroom for the host Python interpreter + ATTACHed orchestrator
+    # state + sidecar processes — empirically on a 4 GiB cgroup
+    # container the profiler ran right up to the cap during
+    # ``[SYNC] Profiled N tables``, then the OOM killer reaped the
+    # uvicorn process within seconds of orchestrator rebuild completing.
+    # 2 GiB matches the materialize-path cap in
+    # ``connectors/{keboola,bigquery}/extractor.py`` (PR #431/#433) and
+    # leaves ~2 GiB for the rest of the process. Streaming row-group
+    # reads + the in-memory SAMPLE cap mean the profiler rarely needs
+    # more than a few hundred MiB; ``preserve_insertion_order=false``
+    # follows DuckDB's own out-of-memory hint and is safe — profiler
+    # output is per-column statistics, not row-ordered data.
+    con.execute("SET memory_limit = '2GB'")
     con.execute("SET threads = 2")
+    con.execute("SET preserve_insertion_order=false")
 
     # Determine read expression
     if parquet_path.is_dir():


### PR DESCRIPTION
## Summary

Third memory cap (after PR #431 Keboola materialize + PR #433 BQ pool). `src/profiler.py::profile_table` had `SET memory_limit = '4GB'` — **exactly the cgroup limit** of a 4 GiB container, leaving zero headroom for the host Python interpreter + ATTACHed orchestrator state + sidecar processes.

## Empirical evidence

Caught live this morning during a manual sync trigger on a 4 GiB cgroup container post-PR431/433:

```
04:48:37  download_file_slices in py-spy (~6 min into sync, materialize streaming)
04:49:01  services.corporate_memory.collector (idle service activity)
04:49:09  [SYNC] Orchestrator rebuild: {keboola: 30}      ← rebuild done
[GAP 25s — profiler runs against 30 keboola tables]
04:49:34  Memory cgroup out of memory: Killed process 146431 (uvicorn)
          anon-rss: 4180352 kB ≈ exact cgroup cap
04:49:42  new container started — 0.55.15
```

RestartCount climbed from 5 → 6 in that single trigger. Profiler is the only DuckDB-using subsystem running between rebuild-done and OOM that had `memory_limit = '4GB'`; materialize and BQ paths were already capped to 2 GiB.

## Change

`src/profiler.py:766`: `4GB` → `2GB`, add `preserve_insertion_order=false`. Matches the materialize-path pattern.

Profiler peak is normally a few hundred MiB (streaming row-group scans + in-memory `SAMPLE`); the cap binds only when something goes wrong (large UNION-by-name across N parquet partitions, or a column with extreme cardinality).

## Test plan

- [x] `tests/test_*profiler*.py` — 26 passed, 2 skipped.
- [ ] Post-merge: trigger another sync on the dev VM that's been OOM-cycling every 30-90 min through the night → confirm the cycle breaks.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->