### PR TITLE
fix(scripts): make generate_sample_data.py size=l finish in minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.55.17] — 2026-05-27
+
 ### Fixed
 - `scripts/generate_sample_data.py` size `l` preset went from
   unfinishable (>2h wall-clock, ~30 min on `_generate_orders_and_items`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Fixed
+- `scripts/generate_sample_data.py` size `l` preset went from
+  unfinishable (>2h wall-clock, ~30 min on `_generate_orders_and_items`
+  alone, then ~1.5h+ on `_generate_support_tickets`) to ~3m24s
+  end-to-end. Two O(N×M) hotspots:
+  (a) `_generate_orders_and_items` called
+  `rng.choices(self._customer_ids, weights=activity, k=1)` once per
+  order — `random.choices` rebuilds cumulative weights internally on
+  every call, so for 50K customers × 200K orders that's ~10B ops.
+  Fix: precompute `cum_activity = list(accumulate(activity))` once and
+  pass `cum_weights=` to the per-order call → O(log N) bisect.
+  (b) `_generate_support_tickets` ran
+  `[o for o in self._order_ids if self._order_customers[o] == cust_id]`
+  per ticket — 50K tickets × 200K orders = ~10B comparisons. Fix:
+  precompute a `customer_id → list[order_id]` index dict once before
+  the loop, O(1) lookup per ticket. Both fixes preserve byte-exact
+  output for the same `--seed` (verified at size `s`; same number of
+  `random()` draws in the same order). Sizes `s` and `m` are also
+  faster but the bug was only catastrophic at `l`.
+
 ## [0.55.16] — 2026-05-27
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.55.16"
+version = "0.55.17"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/scripts/generate_sample_data.py
+++ b/scripts/generate_sample_data.py
@@ -20,6 +20,7 @@ import random
 import sys
 import time
 from datetime import date, timedelta
+from itertools import accumulate
 from pathlib import Path
 from typing import Any, Generator
 
@@ -832,8 +833,12 @@ class SampleDataGenerator:
         n_orders = self.cfg["orders"]
         logger.info(f"  Generating {n_orders:,} orders + order items...")
 
-        # Customer activity weights (Pareto-like distribution)
+        # Customer activity weights (Pareto-like distribution). Pre-compute
+        # cumulative weights once so the per-order ``rng.choices`` call below
+        # is O(log N) bisect, not O(N) cumulative rebuild — at size 'l' the
+        # per-call rebuild took ~36 min for this step alone.
         activity = [self.rng.paretovariate(1.2) for _ in self._customer_ids]
+        cum_activity = list(accumulate(activity))
 
         order_fields = [
             "order_id",
@@ -862,7 +867,7 @@ class SampleDataGenerator:
 
         for i in range(n_orders):
             oid = f"ORD-{i + 1:07d}"
-            cust_id = self.rng.choices(self._customer_ids, weights=activity, k=1)[0]
+            cust_id = self.rng.choices(self._customer_ids, cum_weights=cum_activity, k=1)[0]
             reg_date = self._customer_reg_dates[cust_id]
             segment = self._customer_segments[cust_id]
 
@@ -1018,6 +1023,17 @@ class SampleDataGenerator:
             "satisfaction_score",
         ]
 
+        # Pre-build customer → ordered list of their order_ids so the
+        # per-ticket "pick an order from this customer if possible" lookup
+        # is O(1) instead of a linear scan over every order. At size 'l'
+        # the original per-ticket scan ran for ~1.5h+ with no progress.
+        # Append order in iteration order of ``self._order_ids`` so
+        # ``rng.choice(cust_orders)`` selects the same element as the old
+        # filter-comprehension for any given seed.
+        cust_orders_index: dict[str, list[str]] = {}
+        for oid in self._order_ids:
+            cust_orders_index.setdefault(self._order_customers[oid], []).append(oid)
+
         rows = []
         for i in range(n):
             tid = f"TKT-{i + 1:06d}"
@@ -1031,7 +1047,7 @@ class SampleDataGenerator:
             order_id = ""
             if self.rng.random() < 0.60 and self._order_ids:
                 # Pick an order from this customer if possible
-                cust_orders = [o for o in self._order_ids if self._order_customers[o] == cust_id]
+                cust_orders = cust_orders_index.get(cust_id)
                 if cust_orders:
                     order_id = self.rng.choice(cust_orders)
                 else:


### PR DESCRIPTION
## Summary
Two O(N×M) hotspots in `scripts/generate_sample_data.py` drop size=`l` from "unfinishable" to ~3.5 min.

| Size | Before (main) | After | Speedup |
|---|---|---|---|
| `s` (15K rows) | 1.9 s | 1.7 s | ~1× |
| `m` (216K rows) | ~36 s | 13 s | ~2.8× |
| `l` (2.15M rows) | killed at 1h53m (projected 2-3h) | **3 m 24 s** | ~40-50× |

### What was slow

**`_generate_orders_and_items`** — called once per order:

```python
cust_id = self.rng.choices(self._customer_ids, weights=activity, k=1)[0]
```

`random.choices(..., weights=…)` rebuilds the cumulative-weights list on every call. At size `l` that's 50K customers × 200K orders = ~10B ops just for customer assignment.

**`_generate_support_tickets`** — called once per ticket (60% of them):

```python
cust_orders = [o for o in self._order_ids if self._order_customers[o] == cust_id]
```

50K tickets × 200K orders = another ~10B comparisons.

### Fix

**Orders:** precompute `cum_activity = list(accumulate(activity))` once and pass `cum_weights=` to the per-order call. `random.choices` then skips the cumulative-rebuild branch and goes straight to O(log N) bisect.

**Support tickets:** precompute a `customer_id → list[order_id]` dict once before the loop. Per-ticket lookup is now O(1).

Both fixes are designed to keep the **same number of `random()` draws in the same order**, which makes the patched output byte-exact for any given `--seed`. Verified by `diff -r` of all 9 CSVs at size `s` between main and patched (identical except `_manifest.json` timestamp).

### Verification

- `pytest tests/test_generate_sample_data.py -v` → 18 passed (includes `TestDeterminism::test_same_seed_produces_same_output` and the 5 `TestReferentialIntegrity` checks that exercise the support-tickets customer/order linkage).
- `diff -r` of size=s CSV outputs between main and patched → identical.
- Manual size=`l` benchmark on a 2 vCPU / 4 GB VM: 3m24s, 9 tables, 2,154,605 rows.

## Test plan
- [ ] CI pytest green
- [ ] Smoke: `python scripts/generate_sample_data.py --size m --format parquet --output /tmp/sample --seed 42` finishes <20 s with 216K rows total
- [ ] Smoke: `python scripts/generate_sample_data.py --size l --format parquet --output /tmp/sample-l --seed 42` finishes <10 min on a 2 vCPU host
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->