### PR TITLE
fix(setup): user-centric install-location decision tree in paste-script Step 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.55.19] — 2026-05-27
+
 ### Fixed
 - **Profile pass in `_run_sync` now runs each `profile_table` call in a
   fresh Python subprocess** (`src/_profiler_worker.py`, new generic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,28 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 - **`/admin/corporate-memory` button family migrated to the canonical `.btn-*` vocabulary.** The bespoke moderation-specific variants (`.btn-mandate`, `.btn-approve`, `.btn-reject`, `.btn-revoke`) are retired in favor of the canonical four — `.btn-mandate` → `.btn-primary` (Save / Apply / Confirm / Mark-as-Required / Mark-as-duplicate), `.btn-approve` → `.btn-secondary` (Approve / Keep / Different), `.btn-reject` → `.btn-danger` (Reject / Delete), `.btn-revoke` → `.btn-ghost` (Dismiss). The variant-choice hierarchy (primary > secondary > danger > ghost) continues to encode the semantic priority; the green-on-approve / red-on-reject solid color cues from the bespoke palette are lost but visual hierarchy is preserved. Page-local `.btn` base rule deleted — the canonical `.btn` family in `style-custom.css` supplies the same contract. 29 button class-name swaps across Jinja static markup + JS template-literal contexts. Closes one of the four dedicated follow-up PRs called out by #427.
 - **`/admin/tables` shadowing `.btn` CSS deleted; buttons inherit canonical visual contract.** The markup on this page already used canonical `.btn` / `.btn-primary` / `.btn-secondary` / `.btn-sm` class names (migrated piecemeal across prior commits), but the template carried its own `.btn` family rules that shadowed canonical — most visibly, `.btn-secondary` rendered with a filled grey background (`var(--border-light)`) rather than the canonical white-bg + grey-border outline. Those page-local rules are gone (`.btn`, `.btn-primary`, `.btn-primary:hover`, `.btn-primary:disabled`, `.btn-secondary`, `.btn-secondary:hover`, `.btn-danger`, `.btn-danger:hover`, `.btn-sm`); buttons now match the unified admin look. Two surviving bare `<button class="btn">` sites (Remove-from-package + Delete-package destructive actions, which had inline `color:#b91c1c` overrides) were upgraded to canonical `.btn-danger` (the second commit on #437 fixed the same hazard there). `.btn-icon` (28×28 icon-only button family with `[data-tooltip]:hover::after` chip styling) stays page-local because canonical `.btn--icon` is just a size modifier with no tooltip behavior — flagged for a later pass once a canonical tooltip primitive exists. Visible delta: toolbar + modal secondary buttons shift from filled-grey to outlined-white; destructive buttons shift from filled-red to outlined-red (canonical "calm — committed to by hover" treatment).
 - **`/dashboard` page-local `.btn-register` rule retired; the four other bespoke button families stay page-local with documented rationale.** The "Create Account" submit button on the Telegram verify form (`<button class="btn-register">`) now renders via canonical `.btn .btn-primary`; its page-local rule and `:hover` variant are gone. The remaining bespoke button classes on this page — `.btn-setup` / `.btn-setup-secondary` (hero CTA using `--ds-hero-cta-*` tokens for the navy-hero context), `.notif-link` / `.notif-unlink` (soft-pill micro-actions inside the notification card's `.notif-managing` mode), and `.btn-copy-term` (dark-surface terminal-mock copy buttons; `system.md`-explicit carve-out for Catppuccin-themed dark-surface copy buttons) — stay page-local because each carries page-specific semantics canonical doesn't model. The decision matrix is documented at the top of `app/web/static/css/dashboard.css`. Closes the last of the four dedicated follow-up PRs from #427.
+- Setup-script Step 2 ("Confirm the install location") no longer treats
+  the user's current `cwd` as a mistake whenever it isn't exactly
+  `~/Desktop/{workspace_dir}`. Before, any other path triggered a "you
+  are in the wrong place" warning whose only escape hatch was the magic
+  keyword `install here` — which silently accepted `$HOME` and other
+  destructive defaults. New three-branch decision tree replaces it:
+  (a) **REFUSE** if `pwd` is `$HOME` exactly or any system dir (`/`,
+  `/tmp`, `/etc`, `/usr`, `/var`, `/opt`, `/root`, `/bin`, `/sbin`,
+  `/boot`, `/sys`, `/proc`) — no override, the install would scatter
+  `.claude/`, `.agnes/`, `AGNES_WORKSPACE.md`, marketplace clones into a
+  directory that already has unrelated meaning. (b) **PROCEED
+  SILENTLY** if `cwd` is empty or contains only a whitelist of
+  workspace artefacts (`.git`, `.claude`, `.agnes`, `AGNES_WORKSPACE.md`,
+  `README.md`) — the user clearly created+cd'd into a workspace, no
+  prompt needed. (c) **CONFIRM ONCE** for everything else, with neutral
+  phrasing: *"I'll install Agnes in `<pwd>`. Reply 'ok' to continue here,
+  'default' to install in `~/Desktop/Agnes` instead, or 'abort'."*. The
+  `default` branch runs `mkdir -p ~/Desktop/{workspace_dir} && cd …`
+  itself, so users opting back into the recommended path don't have to
+  re-paste. Legacy `install here` keyword still works as an `ok`
+  synonym for muscle-memory compatibility, and Step 9's restart cue
+  keeps the same wording.
 
 ## [0.55.17] — 2026-05-27
 

--- a/app/web/setup_instructions.py
+++ b/app/web/setup_instructions.py
@@ -334,28 +334,48 @@ def _install_cli_lines(*, has_ca: bool, server_url_placeholder: str = "{server_u
 
 
 def _init_lines(server_url_placeholder: str = "{server_url}") -> list[str]:
-    """Steps 2-4 — workspace folder check, then `agnes init` + smoke verify.
+    """Steps 2-4 — install-location decision, then `agnes init` + smoke verify.
 
-    Step 2 verifies the user is already cd'd into the workspace folder
-    that the /home onboarding page's visible "Step 2 — pick a folder"
-    told them to create manually (`mkdir -p ~/Desktop/{workspace_dir}
-    && cd ~/Desktop/{workspace_dir}`). The pasted script DOES NOT
-    auto-create the folder — that would silently override an
-    intentional choice to install at a different path (e.g. the user
-    cd'd to `~/work/agnes-prod` on purpose). Instead we `pwd`, compare
-    to `$HOME/Desktop/{workspace_dir}`, and on mismatch warn loudly and
-    ask the user to either re-paste from the right folder or explicitly
-    confirm "install here" in the current cwd.
+    Step 2 picks the install directory using a three-way decision tree on
+    the user's current cwd instead of demanding a specific "expected"
+    path. Earlier flows hard-coded `~/Desktop/{workspace_dir}` as the
+    Right Answer and treated every other cwd as a recoverable mistake —
+    which scolded users who intentionally `cd`'d into a project folder
+    (e.g. `~/Devel/acme-data-app/`) before pasting the script.
+
+    The new tree:
+
+    - **REFUSE** if cwd is `$HOME` exactly, or a system path (`/`,
+      `/tmp`, `/etc`, `/usr`, `/var`, `/opt`, `/root`, `/bin`, `/sbin`,
+      `/boot`, `/sys`, `/proc`). Installing into any of these dumps
+      `.claude/`, `.agnes/`, `AGNES_WORKSPACE.md`, marketplace clones,
+      etc. into a directory that already has unrelated meaning. The old
+      flow's `'install here'` keyword silently accepted `$HOME` — this
+      one refuses.
+    - **PROCEED SILENTLY** if cwd is empty, or contains only the
+      whitelisted artefacts a prepared workspace might already hold
+      (`.git`, `.claude`, `.agnes`, `AGNES_WORKSPACE.md`, `README.md`).
+      The user clearly created+cd'd into a workspace folder before
+      pasting; no need to interrupt them.
+    - **CONFIRM ONCE** for anything else (cwd has unrelated content).
+      Neutral framing: *"I'll install {brand} in <pwd>. Reply 'ok' to
+      continue here, 'default' to install in ~/Desktop/{workspace_dir}
+      instead, or 'abort'."* The 'default' branch runs the `mkdir + cd`
+      itself so the user doesn't have to re-paste. Anything else stops
+      cleanly without touching the filesystem. Users who want a
+      different custom path /exit, `cd` to their preferred location,
+      restart `claude`, and re-paste — Claude Code can't change the
+      parent shell's cwd from inside a session anyway.
 
     `{workspace_dir}` and `{instance_brand}` are placeholders pre-substituted
     by :func:`resolve_lines` from the operator-configured brand. Defaults
     keep `~/Desktop/Agnes` behavior for instances that don't set the brand knob.
 
     `agnes init --workspace .` continues to use the current cwd, so once
-    step 2 has confirmed (or the user has explicitly accepted) the
-    install dir, step 3 lands in the right place. Step 9's restart-claude
-    cue references "this same directory" so users on a custom path see
-    accurate guidance.
+    step 2 has confirmed (or auto-accepted) the install dir, step 3
+    lands in the right place. Step 9's restart-claude cue references
+    "this same directory" so users on a custom path see accurate
+    guidance.
 
     `agnes init` is the workspace-rails delivery mechanism for everyone:
     it authenticates with the PAT, fetches CLAUDE.md (RBAC-filtered),
@@ -372,36 +392,64 @@ def _init_lines(server_url_placeholder: str = "{server_url}") -> list[str]:
     """
     return [
         "",
-        "2) Verify the user is already in the workspace folder.",
-        "   The /home page's visible \"Step 2 — pick a folder\"",
-        "   already asked the user to run",
+        "2) Confirm the install location.",
+        "   The /home page's \"Step 2 — pick a folder\" recommended",
         "       mkdir -p ~/Desktop/{workspace_dir} && cd ~/Desktop/{workspace_dir}",
-        "   in their terminal BEFORE pasting this script. Do NOT silently",
-        "   re-create the folder here — the user may have intentionally cd'd",
-        "   to a different location to install {instance_brand} there instead.",
+        "   but the install works in any workspace folder the user prepared.",
+        "   Decide where to install using the three branches below — do NOT",
+        "   silently `mkdir`/`cd` anywhere, and do NOT treat the user's current",
+        "   cwd as a mistake unless it lands in the REFUSE list.",
         "",
         "   Run:",
         "       pwd",
-        "   Expected: $HOME/Desktop/{workspace_dir}  (i.e. ~/Desktop/{workspace_dir})",
         "",
-        "   If `pwd` matches the expected path: continue silently to step 3.",
+        "   2a) REFUSE — these paths are never safe to install into. STOP and",
+        "       tell the user verbatim:",
         "",
-        "   If `pwd` does NOT match, STOP and tell the user verbatim:",
+        "           \"I won't install {instance_brand} into <pwd> — it's a home or",
+        "           system directory and the install would scatter .claude/,",
+        "           .agnes/, AGNES_WORKSPACE.md and marketplace clones across",
+        "           it. Please pick a workspace folder (e.g. ~/Desktop/{workspace_dir}",
+        "           or ~/work/{workspace_dir}), cd into it, and re-paste this",
+        "           script from there.\"",
         "",
-        "       \"You are in <current-pwd>, but {instance_brand} is normally",
-        "       installed in ~/Desktop/{workspace_dir} (see /home Step 2). Either run",
-        "           mkdir -p ~/Desktop/{workspace_dir} && cd ~/Desktop/{workspace_dir}",
-        "       in your terminal now and re-paste this setup script, OR reply",
-        "       'install here' to install {instance_brand} in <current-pwd>",
-        "       instead. Reply 'abort' to stop.\"",
+        "       Then stop — no `mkdir`, no `cd`, no further steps. The refuse",
+        "       list is exact match on:",
+        "           $HOME    /    /tmp    /etc    /usr    /var    /opt",
+        "           /root    /bin    /sbin    /boot    /sys    /proc",
         "",
-        "   Wait for the user's reply.",
-        "     - 'install here'  → continue to step 3 in the current cwd.",
-        "                         The cwd you saw from `pwd` is the install",
-        "                         directory; remember it for step 9.",
-        "     - 'abort' / anything else → stop without making any changes.",
-        "                         Do NOT run `mkdir`, do NOT `cd`, do NOT",
-        "                         continue to step 3.",
+        "   2b) PROCEED SILENTLY — if the cwd is a prepared workspace, just",
+        "       continue to step 3 without prompting. The whitelisted artefacts",
+        "       a prepared workspace may already hold are:",
+        "           .git    .claude    .agnes    AGNES_WORKSPACE.md    README.md",
+        "       To check, run (fixed-string match, no regex):",
+        "",
+        "           ls -A | grep -Fxv -e .git -e .claude -e .agnes -e AGNES_WORKSPACE.md -e README.md | head -1",
+        "",
+        "       If the output is empty (cwd is empty OR contains only the",
+        "       whitelisted artefacts above) → the user clearly prepared this",
+        "       folder; continue to step 3 in <pwd>. Remember <pwd> as the",
+        "       install dir for step 9.",
+        "",
+        "   2c) CONFIRM — for any other cwd (unrelated content present), tell",
+        "       the user verbatim, exactly once:",
+        "",
+        "           \"I'll install {instance_brand} in <pwd>. Reply 'ok' to",
+        "           continue here, 'default' to install in ~/Desktop/{workspace_dir}",
+        "           instead, or 'abort' to stop. (For a different custom path:",
+        "           type /exit, `cd` to where you want it, then run `claude`",
+        "           again and re-paste this script.)\"",
+        "",
+        "       Wait for the user's reply.",
+        "         - 'ok' / 'yes' / 'install here' / Enter → continue to step 3",
+        "                       in <pwd>. Remember <pwd> as the install dir.",
+        "         - 'default' → run:",
+        "                       mkdir -p ~/Desktop/{workspace_dir} && cd ~/Desktop/{workspace_dir}",
+        "                       Then continue to step 3 in the new cwd.",
+        "                       Remember ~/Desktop/{workspace_dir} as the install",
+        "                       dir for step 9.",
+        "         - 'abort' / anything else → stop without making any changes.",
+        "                       Do NOT run `mkdir`, do NOT `cd`, do NOT continue.",
         "",
         "3) Bootstrap your {instance_brand} workspace in this directory.",
         "   Write the PAT to a file FIRST, then run `agnes init` with",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.55.18"
+version = "0.55.19"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/tests/test_instance_config.py
+++ b/tests/test_instance_config.py
@@ -135,9 +135,12 @@ class TestInstanceBrand:
             workspace_dir="FoundryAI",
         ))
         assert "Set up the Foundry AI CLI on this machine." in joined
-        # Step 2 is a pwd-check now (no auto-mkdir); brand + workspace_dir
-        # thread through the warning copy + expected-path string.
-        assert "$HOME/Desktop/FoundryAI" in joined
+        # Step 2 is the user-centric decision tree (#442); brand +
+        # workspace_dir thread through the 2a "pick a workspace folder
+        # (e.g. ~/Desktop/{workspace_dir})" copy, the 2c "default" hint,
+        # and the manual-mkdir example. The default-path mention now
+        # renders as `~/Desktop/...` (tilde), not `$HOME/Desktop/...`.
+        assert "~/Desktop/FoundryAI" in joined
         assert "mkdir -p ~/Desktop/FoundryAI && cd ~/Desktop/FoundryAI" in joined
         assert "Bootstrap your Foundry AI workspace" in joined
         assert "Foundry AI workspace is ready" in joined
@@ -153,9 +156,10 @@ class TestInstanceBrand:
         from app.web.setup_instructions import resolve_lines
         joined = "\n".join(resolve_lines("agnes.whl"))
         assert "Set up the Agnes CLI on this machine." in joined
-        # Step 2 is a pwd-check (no auto-mkdir); default path threads
-        # through as `$HOME/Desktop/Agnes` + the warning's manual-mkdir example.
-        assert "$HOME/Desktop/Agnes" in joined
+        # Step 2 is the user-centric decision tree (#442); default path
+        # renders as `~/Desktop/Agnes` (tilde) inside the 2c "default"
+        # branch + the manual-mkdir example.
+        assert "~/Desktop/Agnes" in joined
         assert "mkdir -p ~/Desktop/Agnes && cd ~/Desktop/Agnes" in joined
         assert "Bootstrap your Agnes workspace" in joined
         assert "Agnes workspace is ready" in joined

--- a/tests/test_setup_instructions.py
+++ b/tests/test_setup_instructions.py
@@ -1003,55 +1003,78 @@ def test_gws_prompt_emits_pass_fail_contract():
 
 
 # ---------------------------------------------------------------------------
-# Step 2 — workspace folder check (no auto-mkdir).
+# Step 2 — install location decision tree (refuse / silent / confirm).
 # ---------------------------------------------------------------------------
 
-def test_step_2_checks_pwd_does_not_auto_mkdir():
-    """Step 2 must verify the user is already in the workspace folder
-    (the /home page Step 3 manual mkdir+cd) instead of silently re-running
-    `mkdir -p "$HOME/<dir>" && cd …` which would override an intentional
-    alternate install path.
+def test_step_2_uses_three_branch_decision_tree():
+    """Step 2 must use a refuse / proceed-silently / confirm-once tree
+    instead of hard-coding `~/Desktop/<workspace_dir>` as the only
+    acceptable path. The old flow scolded any user who cd'd into a
+    project folder before pasting; the new flow respects intentional cwd
+    and only protects against destructive defaults ($HOME / system dirs).
 
     Contract:
-      - Step 2 runs `pwd` and compares against `$HOME/<workspace_dir>`.
-      - Emits a warning message naming both the expected path and the
-        manual mkdir line the user already saw on /home.
-      - Does NOT emit `mkdir -p "$HOME/<workspace_dir>"` or the equivalent
-        PowerShell `New-Item -ItemType Directory -Force` line.
-      - Asks the user to reply 'install here' to proceed in a non-default
-        cwd, or 'abort' to stop. No automatic folder creation.
+      - Step header renamed to "Confirm the install location".
+      - All three branches (REFUSE, PROCEED SILENTLY, CONFIRM) are
+        documented in the script.
+      - `pwd` check is still emitted.
+      - The refuse list explicitly names `$HOME` plus the system dirs
+        the install must never touch.
+      - The silent-proceed branch whitelists the workspace artefacts a
+        prepared folder might already hold (`.git`, `.claude`, `.agnes`,
+        `AGNES_WORKSPACE.md`, `README.md`) so a re-paste into an
+        already-initialised workspace doesn't prompt.
+      - The confirm branch offers 'ok'/'default'/'abort' (instead of the
+        old 'install here'/'abort' pair) — 'default' lets the user opt
+        into the recommended `~/Desktop/<workspace_dir>` path without
+        re-pasting, and the legacy 'install here' phrasing remains as a
+        synonym for 'ok' for muscle-memory compatibility.
+      - The script never auto-runs `mkdir` for the user except inside
+        the 'default' branch of the confirm prompt.
     """
     from app.web.setup_instructions import resolve_lines
 
     joined = "\n".join(resolve_lines("agnes.whl"))
 
-    # The new check-only step header.
-    assert "2) Verify the user is already in the workspace folder." in joined
+    # New step header.
+    assert "2) Confirm the install location." in joined
 
-    # `pwd` check + expected-path comparison must be present.
+    # `pwd` check still present.
     assert "pwd" in joined
-    assert "$HOME/Desktop/Agnes" in joined  # default workspace_dir under Desktop
-    assert "~/Desktop/Agnes" in joined
 
-    # Warning copy that references the /home Step 2 manual mkdir line.
-    assert "/home Step 2" in joined
-    assert "mkdir -p ~/Desktop/Agnes && cd ~/Desktop/Agnes" in joined
+    # All three branches documented.
+    assert "2a) REFUSE" in joined
+    assert "2b) PROCEED SILENTLY" in joined
+    assert "2c) CONFIRM" in joined
 
-    # Explicit "install here" / "abort" decision tree.
-    assert "'install here'" in joined
+    # Refuse list explicitly names $HOME + the system paths.
+    for path in ("$HOME", "/tmp", "/etc", "/usr", "/var", "/opt", "/root"):
+        assert path in joined, f"refuse list missing {path!r}"
+
+    # Silent-proceed whitelist contains the workspace artefacts.
+    for artefact in (".git", ".claude", ".agnes", "AGNES_WORKSPACE.md", "README.md"):
+        assert artefact in joined, f"silent-proceed whitelist missing {artefact!r}"
+
+    # Confirm prompt offers the new three-way decision.
+    assert "'ok'" in joined
+    assert "'default'" in joined
     assert "'abort'" in joined
 
-    # The auto-mkdir lines from the previous step 2 must be GONE.
+    # Legacy 'install here' phrasing kept as an 'ok' synonym (muscle memory).
+    assert "'install here'" in joined
+
+    # The 'default' branch is the only place mkdir runs automatically.
+    assert "mkdir -p ~/Desktop/Agnes && cd ~/Desktop/Agnes" in joined
+
+    # No auto-mkdir from the very-old flow.
     assert 'mkdir -p "$HOME/Agnes"' not in joined
-    assert 'mkdir -p "$HOME/{workspace_dir}"' not in joined
     assert 'New-Item -ItemType Directory -Force -Path "$HOME\\Agnes"' not in joined
     assert "Set-Location \"$HOME\\Agnes\"" not in joined
 
 
-def test_step_2_warning_substitutes_custom_brand():
-    """Custom brand + workspace_dir must thread through the new step 2
-    warning copy — no leftover placeholders, expected path matches the
-    operator's configured workspace dir."""
+def test_step_2_substitutes_custom_brand_and_workspace_dir():
+    """Brand + workspace_dir threading: every visible reference resolves
+    against the operator's configured values, no placeholders leak."""
     from app.web.setup_instructions import resolve_lines
 
     joined = "\n".join(resolve_lines(
@@ -1059,24 +1082,40 @@ def test_step_2_warning_substitutes_custom_brand():
         instance_brand="Foundry AI",
         workspace_dir="FoundryAI",
     ))
-    assert "2) Verify the user is already in the workspace folder." in joined
-    assert "$HOME/Desktop/FoundryAI" in joined
+    assert "2) Confirm the install location." in joined
+    # Default path threads through both the silent-proceed reference and
+    # the confirm-prompt 'default' branch.
     assert "~/Desktop/FoundryAI" in joined
     assert "mkdir -p ~/Desktop/FoundryAI && cd ~/Desktop/FoundryAI" in joined
-    # Brand + workspace_dir thread through the warning copy (the text
-    # wraps across two lines so we check the substrings separately).
-    assert "but Foundry AI is normally" in joined
-    assert "installed in ~/Desktop/FoundryAI" in joined
-    # No placeholders survive into the rendered text.
+    # Brand surfaces in the refuse + confirm copy.
+    assert "I won't install Foundry AI" in joined
+    assert "I'll install Foundry AI in <pwd>" in joined
+    # No placeholders survive.
     assert "{workspace_dir}" not in joined
     assert "{instance_brand}" not in joined
 
 
+def test_step_2_refuse_branch_lists_home_and_system_paths():
+    """REFUSE must explicitly enumerate $HOME plus the system dirs.
+    Without this list a model might decide an OS path is 'fine' and
+    install into /etc or /root, scattering files where they don't belong."""
+    from app.web.setup_instructions import resolve_lines
+
+    joined = "\n".join(resolve_lines("agnes.whl"))
+    # All paths the refuse line claims to block must appear in the
+    # rendered script so the AI follower can match against pwd output.
+    for path in (
+        "$HOME", "/tmp", "/etc", "/usr", "/var",
+        "/opt", "/root", "/bin", "/sbin", "/boot", "/sys", "/proc",
+    ):
+        assert path in joined, f"refuse path {path!r} missing"
+
+
 def test_step_9_restart_references_install_dir_not_hardcoded():
-    """Step 9 must describe the restart cwd as the directory confirmed in
-    step 2 (mentioning the default path) rather than a bare hardcoded
-    `~/{workspace_dir}`. This keeps the wording accurate when the user
-    chose an alternate install path via 'install here' in step 2."""
+    """Step 9 must describe the restart cwd as the directory confirmed
+    in step 2 (mentioning the default path) rather than a bare hardcoded
+    `~/{workspace_dir}`. The phrasing keeps the user-flow connection
+    visible across step 2's three branches and step 9's restart cue."""
     from app.web.setup_instructions import resolve_lines
 
     joined = "\n".join(resolve_lines("agnes.whl"))
@@ -1085,6 +1124,6 @@ def test_step_9_restart_references_install_dir_not_hardcoded():
     assert "install dir confirmed in step 2" in joined
     # Default path still mentioned as the expected baseline.
     assert "~/Desktop/Agnes" in joined
-    # The "install here" callout in the restart step keeps the user-flow
-    # connection visible.
+    # Step 9 still mentions 'install here' as the legacy synonym so
+    # users who learned the old flow recognise it.
     assert "'install here'" in joined


### PR DESCRIPTION
## Summary

Step 2 of the paste-script (`app/web/setup_instructions.py::_init_lines`) hard-coded `~/Desktop/{workspace_dir}` as the only "expected" install location. Any other `pwd` triggered a "you are in the wrong place" warning whose only override was the magic keyword `install here` — which silently accepted `$HOME` and other destructive defaults. Users who intentionally `cd`'d into a project folder (e.g. `~/Devel/acme-data-app/`) before pasting were treated as having made a mistake.

This PR replaces that single-branch flow with a three-way decision tree that **respects the user's intentional cwd** and **protects against destructive defaults** at the same time.

### The new tree

**(2a) REFUSE** — `$HOME` exactly or any system dir: `/`, `/tmp`, `/etc`, `/usr`, `/var`, `/opt`, `/root`, `/bin`, `/sbin`, `/boot`, `/sys`, `/proc`. Installing into any of these scatters `.claude/`, `.agnes/`, `AGNES_WORKSPACE.md`, marketplace clones into a directory that already has unrelated meaning. **No override keyword** — the user picks a workspace folder and re-pastes from there.

**(2b) PROCEED SILENTLY** — `cwd` is empty, OR contains only whitelisted workspace artefacts: `.git`, `.claude`, `.agnes`, `AGNES_WORKSPACE.md`, `README.md`. A user who created + `cd`'d into a workspace folder gets no interruption. Detected by `ls -A | grep -Fxv -e .git -e .claude -e .agnes -e AGNES_WORKSPACE.md -e README.md | head -1` returning empty.

**(2c) CONFIRM ONCE** — everything else (cwd has unrelated content). Neutral phrasing:

> "I'll install Agnes in `<pwd>`. Reply `ok` to continue here, `default` to install in `~/Desktop/Agnes` instead, or `abort`. (For a different custom path: type `/exit`, `cd` to where you want it, then run `claude` again and re-paste this script.)"

The `default` branch runs `mkdir + cd` itself so the user doesn't have to re-paste. Custom paths route through `/exit + cd + restart claude` because Claude Code can't change the parent shell's cwd from inside a session anyway.

### Backward compatibility

The legacy `install here` keyword stays as an `ok` synonym so users who learned the old flow recognise it. Step 9's restart cue still mentions it. No behavior change for users who were already pasting into `~/Desktop/{workspace_dir}` — they hit branch 2b and proceed silently.

### Why this matters

The trigger for the change: a user with their workspace at `/home/coder/Devel/acl/ai-companion/` pasted the script there intentionally and got told to either move to `~/Desktop/Agnes` or chant the magic phrase `install here`. Meanwhile, `install here` would silently accept `$HOME` itself — which the user probably doesn't actually want.

The new flow inverts the priority: protect against destructive defaults strictly, and trust the user's intentional cwd by default.

## Test plan

- [ ] CI pytest green (43/43 tests in `tests/test_setup_instructions.py` pass locally inside an `agnes-app-1` container).
- [ ] Smoke: paste the script in `~/Desktop/Agnes` (default path) → branch 2b, silent proceed.
- [ ] Smoke: paste in an empty `~/work/agnes-prod` → branch 2b, silent proceed.
- [ ] Smoke: paste in `$HOME` directly → branch 2a refuses, asks user to pick a workspace folder.
- [ ] Smoke: paste in a non-empty project folder → branch 2c prompts for `ok`/`default`/`abort`.

Pre-existing flaky test (`test_install_page_uses_versioned_wheel_url`) hits a DuckDB lock conflict whenever pytest runs inside an `agnes-app-1` container that's also serving the live app (PID 1 holds `/data/state/system.duckdb`). Verified the failure reproduces on unpatched `main` — not caused by this PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->