### PR TITLE
feat(web): rename "Server config" nav item to "Instance settings" (#403)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Changed
+- **Admin nav: "Server config" → "Instance settings".** `_app_header.html` nav item label, `admin_server_config.html` page `<title>`, and the page-hero title now read "Instance settings" instead of "Server config" — less developer-centric and consistent with the already-shipped phrasing in the Keboola not-connected banners on `/admin/tables` (which deep-link with "Set your token in **Instance settings**"). Route `/admin/server-config` unchanged. Eyebrow "Server" kept as the category label (shared with `admin_scheduler_runs.html` under the same nav group). Closes #403.
+
 ## [0.55.17] — 2026-05-27
 
 ### Fixed

--- a/app/web/templates/_app_header.html
+++ b/app/web/templates/_app_header.html
@@ -95,7 +95,7 @@
 
                 <details class="app-nav-menu-group" data-section="server" open>
                     <summary class="app-nav-menu-section">Server</summary>
-                    <a class="app-nav-menu-item {% if _path.startswith('/admin/server-config') %}is-active{% endif %}" role="menuitem" href="/admin/server-config">Server config</a>
+                    <a class="app-nav-menu-item {% if _path.startswith('/admin/server-config') %}is-active{% endif %}" role="menuitem" href="/admin/server-config">Instance settings</a>
                     {# /admin/scheduler-runs collapsed into /admin/activity as
                        a `source=scheduler` filter — old route 308-redirects. #}
                 </details>

--- a/app/web/templates/admin_server_config.html
+++ b/app/web/templates/admin_server_config.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Server configuration — {{ config.INSTANCE_NAME }}{% endblock %}
+{% block title %}Instance settings — {{ config.INSTANCE_NAME }}{% endblock %}
 
 {% block content %}
 {# Server configuration editor — instance.yaml fields grouped by section.
@@ -238,7 +238,7 @@
 
 <div class="cfg-page" data-page="server-config">
   {% set page_hero_eyebrow = "Server" %}
-  {% set page_hero_title = "Server configuration" %}
+  {% set page_hero_title = "Instance settings" %}
   {% set page_hero_subtitle = "Edits land in <code style=&quot;color:#fff;background:rgba(255,255,255,0.15);padding:1px 6px;border-radius:4px&quot;>instance.yaml</code>. Save triggers an app restart (~10s downtime). Secret values are masked here — re-enter them to change." %}
   {% include "_page_hero.html" %}
 


### PR DESCRIPTION
## Summary

Closes #403. Renames the nav item label from "Server config" → "Instance settings" to be less developer-centric.

## Why "Instance settings"

The issue suggested "Instance settings" or "Connections & settings". I went with **"Instance settings"** because:
- It matches existing in-app phrasing — the Keboola not-connected banners on `/admin/tables` already deep-link with the label *"Set your token in Instance settings"*
- More generic than "Connections & settings" (the page also covers theme, branding, integrations, danger-zone auth, etc., not just connections)

## Diff

Updated 3 user-facing strings:
- `_app_header.html` — nav menu item label
- `admin_server_config.html` — `{% block title %}` (browser tab title)
- `admin_server_config.html` — `page_hero_title`

Eyebrow "Server" stays as the **category** label — `admin_scheduler_runs.html` also lives under the "Server" group in the admin nav, so retitling the category would need a broader review.

Route `/admin/server-config` unchanged (URL is operator/script-facing; renaming it would cascade through many cross-references and is out of scope).

## Verification

- Browser-verified: nav menu now shows "Instance settings" under SERVER category, browser tab title reads "Instance settings — AI Data Analyst", hero title reads "Instance settings"
- 56 focused tests pass (test_design_system_contract + test_web_ui)

## Position in umbrella

First of four small admin-UX quick wins targeting umbrella branch \`mf/admin-ux-quick-wins\`:
- ✅ **This PR — #403** rename
- ⏳ #401 Keboola smart paste
- ⏳ #392 dashboard sync status badge
- ⏳ #396 catalog data preview modal