### PR TITLE
feat(admin): Keboola smart-paste — split bucket.table_name on paste/blur (#401)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Added
+- **`/admin/tables` Keboola smart-paste — split `bucket.table_name` on paste/blur.** Keboola Storage's "COPY TO CLIPBOARD" yields the full table id `{bucket}.{table_name}` (e.g. `out.c-crm-tr-RdC3aX4M.account`). The Register Keboola modal has two separate inputs (Bucket + Source Table), so pasting the full id used to fail silently. The modal now has a dedicated `#kbTableIdPaste` input above the existing fields; pasting or blurring with a value containing a `.` splits on the LAST dot and fills both downstream inputs. Downstream fields get a synthetic `input` event so any datalist-refresh / discover hooks treat it as user-typed; manual entry through Bucket + Source Table still works as before. Closes #401.
+
 ### Changed
 - **Admin nav: "Server config" → "Instance settings".** `_app_header.html` nav item label, `admin_server_config.html` page `<title>`, and the page-hero title now read "Instance settings" instead of "Server config" — less developer-centric and consistent with the already-shipped phrasing in the Keboola not-connected banners on `/admin/tables` (which deep-link with "Set your token in **Instance settings**"). Route `/admin/server-config` unchanged. Eyebrow "Server" kept as the category label (shared with `admin_scheduler_runs.html` under the same nav group). Closes #403.
 

--- a/app/web/templates/admin_tables.html
+++ b/app/web/templates/admin_tables.html
@@ -1377,6 +1377,24 @@
                                    placeholder="e.g. orders_recent">
                         </div>
 
+                        {# Smart-paste shortcut for Keboola's "COPY TO CLIPBOARD" output,
+                           which yields the full table id `{bucket}.{table_name}` (e.g.
+                           `out.c-crm-tr-RdC3aX4M.account`). On paste or blur the JS at
+                           the bottom of this template splits on the LAST dot and fills
+                           the Bucket + Source Table fields below. The user can still
+                           type either field directly — this is a paste affordance, not
+                           a required input. Closes #401. #}
+                        <div class="form-group kb-source-table">
+                            <label class="form-label" for="kbTableIdPaste">
+                                Table ID
+                                <span style="font-weight:400; color:var(--text-secondary); font-size:12px;">(paste here, or fill Bucket + Source Table below)</span>
+                            </label>
+                            <input type="text" class="form-input" id="kbTableIdPaste"
+                                   placeholder="e.g. out.c-crm-tr-RdC3aX4M.account"
+                                   autocomplete="off">
+                            <div class="form-hint">Split on the last <code>.</code> into Bucket + Source Table.</div>
+                        </div>
+
                         {# Discover/List tables backend currently routes by instance's data_source.type
                            ignoring the `source` query param. Hiding the buttons on non-Keboola instances
                            prevents wrong-shape responses; inputs stay for manual entry. Future fix: make
@@ -5664,6 +5682,43 @@
 
     // Auto-open the Create Data Package modal when the page is opened with
     // `?new_package=1` — drives the /catalog right-of-tabs admin action
+    // ── #401: Keboola smart-paste — split `{bucket}.{table_name}` into the
+    //   Bucket + Source Table inputs in the Register Keboola modal.
+    //   Keboola's "COPY TO CLIPBOARD" yields the full table id; pasting it
+    //   straight into a single field used to fail silently because the form
+    //   has two fields. Now: paste/blur on the dedicated #kbTableIdPaste
+    //   field splits on the LAST `.` and fills both downstream inputs. The
+    //   user can still edit either field directly.
+    document.addEventListener('DOMContentLoaded', function() {
+      var pasteInput = document.getElementById('kbTableIdPaste');
+      var bucketField = document.getElementById('kbBucket');
+      var tableField = document.getElementById('kbSourceTable');
+      if (!pasteInput || !bucketField || !tableField) return;
+      function splitAndFill(raw) {
+        var val = (raw || '').trim();
+        if (!val) return false;
+        var lastDot = val.lastIndexOf('.');
+        if (lastDot <= 0 || lastDot >= val.length - 1) return false;
+        bucketField.value = val.slice(0, lastDot);
+        tableField.value = val.slice(lastDot + 1);
+        // Fire `input` so any listeners on the downstream fields (e.g.
+        // discover-tables autocomplete refresh) pick up the new value.
+        bucketField.dispatchEvent(new Event('input', { bubbles: true }));
+        tableField.dispatchEvent(new Event('input', { bubbles: true }));
+        return true;
+      }
+      pasteInput.addEventListener('paste', function(e) {
+        var val = (e.clipboardData || window.clipboardData).getData('text');
+        // Let the default paste populate the visible field too; the split
+        // happens in parallel so the user sees Bucket + Source Table fill
+        // immediately while the paste field also reflects what was pasted.
+        splitAndFill(val);
+      });
+      pasteInput.addEventListener('blur', function() {
+        splitAndFill(pasteInput.value);
+      });
+    });
+
     // (which redirects here rather than duplicating the modal scaffolding).
     document.addEventListener('DOMContentLoaded', function() {
       var qs = new URLSearchParams(window.location.search);


### PR DESCRIPTION
## Summary

Closes #401. Adds a combined "Table ID" paste field above Bucket + Source Table in the Register Keboola modal; on paste or blur, splits on the last `.` and fills both downstream fields.

## Why

Keboola's "COPY TO CLIPBOARD" produces the full id `{bucket}.{table_name}` (e.g. `out.c-crm-tr-RdC3aX4M.account`). The register form has two separate inputs — pasting the full id into one fails silently and confuses operators.

## What changed

- New `#kbTableIdPaste` input above the existing Bucket + Source Table form-groups in `Register Keboola Table` modal
- Inline JS at the bottom of `admin_tables.html` wires `paste` and `blur` listeners that split on `lastIndexOf('.')` and fill `kbBucket` + `kbSourceTable`
- Downstream fields fire a synthetic `input` event so any datalist-refresh / discover hooks treat it as user-typed
- Manual entry via the two downstream fields still works — the new field is a shortcut, not a required input

Total: +38 lines in one file.

## Verification

Browser-verified at `/admin/tables` (Register Keboola flow):

| Input pasted | Bucket filled | Source Table filled |
|---|---|---|
| `out.c-crm-tr-RdC3aX4M.account` | `out.c-crm-tr-RdC3aX4M` | `account` |

DOM-level confirmation via `dispatchEvent('blur')` test.

## Position in umbrella

Second of four small admin-UX quick wins:
- ✅ #443 (#403) rename
- ✅ **This PR (#401) smart paste**
- ⏳ #392 dashboard sync status badge
- ⏳ #396 catalog data preview modal