### PR TITLE
fix(sync): run profile_table in memory-isolated subprocess per call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Fixed
+- **Profile pass in `_run_sync` now runs each `profile_table` call in a
+  fresh Python subprocess** (`src/_profiler_worker.py`, new generic
+  helper `src/_subprocess_runner.py`). Running the profile loop in-
+  process drifted resident memory by ~100-300 MiB per iteration even
+  though each `profile_table` cleaned up its DuckDB session correctly
+  — Python's allocator keeps freed anon mmap arenas in its free-list
+  and libc's heap doesn't return them to the OS. After ~10-30 iterations
+  the cgroup OOM killer reaped uvicorn at ~4.18 GiB anon-rss (observed
+  on dev with the materialize-cap fixes from PR #431/#433/#434/#436
+  already in place; smaller caps shipped but the leak path was the
+  loop itself, not any individual call). Process exit guarantees full
+  memory return to the OS, so the per-iteration accumulation pattern
+  is broken regardless of how many tables are in scope. The parent
+  still owns the `ProfileRepository.save(...)` write so system.duckdb
+  stays single-writer.
+
 ## [0.55.18] — 2026-05-27
 
 ### Changed

--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -679,10 +679,24 @@ sys.exit(compute_exit_code(result, len(configs)))
         views = orch.rebuild()
         print(f"[SYNC] Orchestrator rebuild: {{{', '.join(f'{k}: {len(v)}' for k, v in views.items())}}}", file=_sys.stderr, flush=True)
 
-        # Auto-profile synced tables (best-effort, don't fail sync on profile error)
+        # Auto-profile synced tables (best-effort, don't fail sync on profile error).
+        #
+        # Each profile runs in a fresh Python subprocess (``src._profiler_worker``)
+        # so all DuckDB allocator state — including the anon mmap arenas that
+        # ``profile_table`` accumulates per call — is reliably reclaimed by the
+        # OS on subprocess exit. Pre-subprocess, running this loop in-process
+        # against ~30 tables would drift the resident set up by ~100-300 MiB
+        # per iteration (Python's malloc keeps freed arenas, libc keeps the
+        # heap), eventually tripping the cgroup OOM around 4 GiB even though
+        # each individual ``profile_table`` cleaned up its DuckDB session
+        # correctly. See PR notes for the empirical traces.
+        #
+        # The parent still owns the ``ProfileRepository.save(...)`` write so
+        # the system.duckdb lock semantics stay single-writer: the worker
+        # returns the profile dict, the parent persists it.
         try:
-            from src.profiler import profile_table, TableInfo
             from src.repositories.profiles import ProfileRepository
+            from src._subprocess_runner import run_subprocess_job, SubprocessJobError
 
             data_dir = Path(os.environ.get("DATA_DIR", "./data"))
             extracts_dir = data_dir / "extracts"
@@ -697,10 +711,25 @@ sys.exit(compute_exit_code(result, len(configs)))
                         if not pq_path.exists():
                             continue
                         try:
-                            table_info = TableInfo(name=table_name, table_id=table_name)
-                            profile = profile_table(table_info, pq_path, [], {}, {})
+                            profile = run_subprocess_job(
+                                "src._profiler_worker",
+                                {
+                                    "table_name": table_name,
+                                    "table_id": table_name,
+                                    "parquet_path": str(pq_path),
+                                },
+                                timeout_sec=600,
+                            )
                             profile_repo.save(table_name, profile)
                             profiled += 1
+                        except SubprocessJobError as pe:
+                            # Worker-side failure — log subprocess stderr tail
+                            # to surface the actual traceback to operators.
+                            print(
+                                f"[SYNC] Profile {table_name}: {pe}\n"
+                                f"  stderr tail: {pe.stderr[-500:]}",
+                                file=_sys.stderr, flush=True,
+                            )
                         except Exception as pe:
                             print(f"[SYNC] Profile {table_name}: {pe}", file=_sys.stderr, flush=True)
                 print(f"[SYNC] Profiled {profiled} tables", file=_sys.stderr, flush=True)

--- a/src/_profiler_worker.py
+++ b/src/_profiler_worker.py
@@ -1,0 +1,71 @@
+"""Worker entry point for memory-isolated `profile_table` execution.
+
+Invoked from `app/api/sync.py` profile loop via
+``python -m src._profiler_worker`` with JSON args on stdin.
+
+Why a separate worker process: ``profile_table`` opens a DuckDB
+connection that allocates anon mmap arenas for query buffers (capped at
+2 GiB by ``SET memory_limit`` since PR #434). When called repeatedly in
+a loop inside the same Python interpreter, those arenas don't reliably
+return to the OS between iterations — Python's allocator keeps them in
+its free-list, libc's malloc keeps them in its heap, and after N
+iterations the resident set has grown by ~N × peak-per-call even though
+each individual call cleaned up its DuckDB session correctly. Running
+each call as a separate subprocess means the OS reclaims **all** memory
+on process exit, no fragmentation, no anon-arena retention.
+
+Protocol:
+- Reads a single JSON object from stdin with the keys:
+    - ``table_name`` (str): logical name for the profile output
+    - ``table_id`` (str): id field for the synthetic TableInfo
+    - ``parquet_path`` (str): absolute path to the parquet file
+      (single file or directory of partitioned parquets)
+- Writes a single JSON object to stdout: the profile dict returned by
+  ``profile_table``.
+- Logs human-readable progress / errors to stderr (parent forwards).
+- Exit code 0 on success, non-zero on failure (Python traceback on
+  stderr + the parent's ``SubprocessJobError`` will surface it).
+
+The caller (sync.py) is responsible for persisting the returned profile
+via ``ProfileRepository.save(...)`` — the worker stays out of the
+system.duckdb write path so DuckDB locking semantics remain simple
+(one writer per file, all in the parent process).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(levelname)s [profiler_worker]: %(message)s",
+        stream=sys.stderr,
+    )
+    try:
+        args = json.load(sys.stdin)
+    except json.JSONDecodeError as e:
+        print(f"FATAL: stdin is not valid JSON: {e}", file=sys.stderr)
+        return 2
+
+    # Lazy import — keeps the cold-start light when this module is
+    # discovered by tooling (e.g. mypy, ruff) without actually being
+    # invoked.
+    from src.profiler import profile_table, TableInfo
+
+    table_name = args["table_name"]
+    table_id = args["table_id"]
+    parquet_path = Path(args["parquet_path"])
+
+    table_info = TableInfo(name=table_name, table_id=table_id)
+    profile = profile_table(table_info, parquet_path, [], {}, {})
+    print(json.dumps(profile))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/_subprocess_runner.py
+++ b/src/_subprocess_runner.py
@@ -1,0 +1,179 @@
+"""Generic Python subprocess helper for memory-isolated job execution.
+
+Spawns a Python subprocess that imports the requested entry module, feeds
+arguments as JSON via stdin, and reads back a JSON result from stdout.
+The subprocess exits after writing its result — **all memory returns to
+the OS**, bypassing the anon-arena retention that compounds when
+DuckDB-heavy jobs run in-process across many iterations of a loop (see
+`app/api/sync.py` profile / materialize loops).
+
+Why a worker module instead of `multiprocessing`:
+- `multiprocessing.Process` forks the current interpreter; child inherits
+  the parent's anon mmap arenas via copy-on-write. Memory cleanup on
+  child exit is reliable, but the cold-start cost of importing app
+  modules is amortized only weakly because each child re-pickles the
+  shared state from the parent. For the bursty per-table calls these
+  loops make, `python -m <worker_module>` with a clean Python interpreter
+  is simpler to reason about and isolates true OS-process boundaries.
+- The trade-off is a fixed ~300-500 ms cold-start tax per call. The
+  materialize / profile work itself takes seconds-to-minutes against
+  real tables, so the overhead is in the noise; the memory headroom is
+  what matters.
+
+Contract for worker modules:
+- They MUST read a single JSON value from stdin and produce a single JSON
+  value on stdout. Anything else on stdout (debug prints, etc.) breaks
+  the protocol; route human-readable logs to stderr.
+- Non-zero exit code propagates as `SubprocessJobError` with stderr
+  attached. Workers can use specific exit codes to signal categories
+  (1 = generic failure, 2 = partial — see the extractor's exit code
+  convention in `app/api/sync.py:_run_sync`).
+
+Error / timeout behavior mirrors the extractor subprocess pattern in
+``app/api/sync.py`` (SIGTERM grace window then SIGKILL on timeout) so
+the operational experience stays consistent.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import signal
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class SubprocessJobError(RuntimeError):
+    """Raised when a subprocess job fails (non-zero exit, JSON parse error,
+    timeout). Carries the stderr tail for caller-side logging."""
+
+    def __init__(self, message: str, *, stderr: str = "", exit_code: Optional[int] = None):
+        super().__init__(message)
+        self.stderr = stderr
+        self.exit_code = exit_code
+
+
+def run_subprocess_job(
+    module: str,
+    args: dict,
+    *,
+    timeout_sec: int = 300,
+    env_extra: Optional[dict] = None,
+    cwd: Optional[Path] = None,
+) -> Any:
+    """Run a Python subprocess job and return its JSON result.
+
+    Args:
+        module: Module path callable via ``python -m <module>``.
+            Worker must implement ``main()`` (or be runnable as a module
+            entry point) that reads JSON from stdin and writes JSON to
+            stdout. See ``src/_profiler_worker.py`` for the canonical
+            example.
+        args: JSON-serializable dict passed to the worker via stdin.
+            The worker's first action is typically
+            ``args = json.load(sys.stdin)``.
+        timeout_sec: Hard upper bound on subprocess wall-time. On
+            timeout the process group is sent SIGTERM, given 10 s to
+            clean up, then SIGKILL'd. Default 300 s — appropriate for
+            the bursty per-table profile / materialize loops; raise it
+            for whole-pass jobs.
+        env_extra: Optional environment-variable overlay on top of the
+            inherited environment. Use this to pass secrets the worker
+            needs (e.g. KEBOOLA_STORAGE_TOKEN) without putting them on
+            the argv / stdin protocol.
+        cwd: Working directory for the subprocess. Defaults to the
+            repository root inferred from this file's location, which
+            matches the in-process import behavior so relative paths in
+            the worker resolve identically.
+
+    Returns:
+        The JSON value the worker wrote to stdout. Type depends on the
+        worker — typically a dict.
+
+    Raises:
+        SubprocessJobError: on any failure mode (non-zero exit, JSON
+            parse error, timeout). The exception's ``stderr`` attribute
+            carries the captured stderr tail for caller logging /
+            re-raising into the operator's view.
+    """
+    if cwd is None:
+        # Repository root — three levels up from this file
+        # (.../src/_subprocess_runner.py → .../src → .../<repo>).
+        cwd = Path(__file__).resolve().parent.parent
+
+    env = os.environ.copy()
+    if env_extra:
+        env.update(env_extra)
+
+    cmd = [sys.executable, "-m", module]
+    payload = json.dumps(args)
+
+    # start_new_session=True so a timeout can take down the worker AND
+    # any grandchild processes it might have spawned (e.g. DuckDB
+    # background threads, requests connection pool workers) in one
+    # process-group kill. Matches the extractor-subprocess pattern at
+    # app/api/sync.py:_run_sync.
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+        cwd=str(cwd),
+        start_new_session=True,
+    )
+    try:
+        stdout, stderr = proc.communicate(input=payload, timeout=timeout_sec)
+    except subprocess.TimeoutExpired:
+        # SIGTERM the whole process group first to give the worker a
+        # chance to flush stderr / release resources cleanly.
+        try:
+            os.killpg(proc.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        try:
+            stdout, stderr = proc.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(proc.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            try:
+                stdout, stderr = proc.communicate(timeout=5)
+            except subprocess.TimeoutExpired:
+                stdout, stderr = "", ""
+        raise SubprocessJobError(
+            f"subprocess timed out after {timeout_sec}s (module={module})",
+            stderr=(stderr or "")[-2000:],
+            exit_code=None,
+        )
+
+    if proc.returncode != 0:
+        raise SubprocessJobError(
+            f"subprocess exited {proc.returncode} (module={module})",
+            stderr=(stderr or "")[-2000:],
+            exit_code=proc.returncode,
+        )
+
+    if not stdout.strip():
+        raise SubprocessJobError(
+            f"subprocess produced empty stdout (module={module})",
+            stderr=(stderr or "")[-2000:],
+            exit_code=proc.returncode,
+        )
+
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError as e:
+        raise SubprocessJobError(
+            f"subprocess stdout is not valid JSON (module={module}): {e}; "
+            f"stdout tail: {stdout[-500:]!r}",
+            stderr=(stderr or "")[-2000:],
+            exit_code=proc.returncode,
+        ) from e

--- a/tests/test_profiler_worker.py
+++ b/tests/test_profiler_worker.py
@@ -1,0 +1,51 @@
+"""End-to-end test for the profiler worker subprocess.
+
+Drives ``src._profiler_worker`` over the runner — writes a tiny parquet
+to a temp dir, invokes the worker with JSON args, and asserts the
+returned profile dict has the shape downstream callers expect from
+``profile_table``.
+"""
+
+import json
+import os
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from src._subprocess_runner import run_subprocess_job
+
+
+@pytest.fixture
+def tiny_parquet(tmp_path: Path) -> Path:
+    """Materialize a 3-row, 2-column parquet ``profile_table`` can scan."""
+    pq = tmp_path / "tiny.parquet"
+    conn = duckdb.connect()
+    try:
+        safe = str(pq).replace("'", "''")
+        conn.execute(
+            f"COPY (SELECT * FROM (VALUES (1, 'a'), (2, 'b'), (3, 'c')) "
+            f"AS t(id, label)) TO '{safe}' (FORMAT PARQUET)"
+        )
+    finally:
+        conn.close()
+    return pq
+
+
+def test_worker_returns_profile_dict(tiny_parquet, tmp_path):
+    # Worker runs in the same checkout as the parent, no PYTHONPATH override
+    # required — but tests run inside the repo's venv which is on PATH.
+    result = run_subprocess_job(
+        "src._profiler_worker",
+        {
+            "table_name": "tiny",
+            "table_id": "tiny",
+            "parquet_path": str(tiny_parquet),
+        },
+        timeout_sec=60,
+    )
+    assert isinstance(result, dict)
+    # ``profile_table`` returns a structure with at least these keys; if
+    # the worker swallowed an exception or misroutes its output we'd see
+    # an empty or wrong-shape dict here.
+    assert "row_count" in result or "rows" in result or "columns" in result

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -1,0 +1,126 @@
+"""Tests for ``src/_subprocess_runner.py``.
+
+Covers the contract: JSON in / JSON out via stdin/stdout, error
+propagation, timeout handling. Uses inline ``python -c`` worker payloads
+as stand-ins for the real worker modules (the runner is connector-
+agnostic; the real workers get their own integration tests next to
+their own module).
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from src._subprocess_runner import SubprocessJobError, run_subprocess_job
+
+
+def _write_worker_module(tmp_path: Path, body: str) -> str:
+    """Create a temp module that the runner can invoke via ``python -m``.
+
+    Returns the dotted module path. Caller is responsible for invoking
+    inside the same Python interpreter; we add the tmp dir to ``PYTHONPATH``
+    via ``env_extra``.
+    """
+    mod_dir = tmp_path / "_workers"
+    mod_dir.mkdir(exist_ok=True)
+    (mod_dir / "__init__.py").write_text("")
+    name = f"_worker_{abs(hash(body)) % 100000}"
+    (mod_dir / f"{name}.py").write_text(textwrap.dedent(body))
+    return f"_workers.{name}", str(tmp_path)
+
+
+def test_returns_json_result_from_worker_stdout(tmp_path):
+    mod, parent = _write_worker_module(tmp_path, """
+        import json, sys
+        args = json.load(sys.stdin)
+        print(json.dumps({"echo": args, "doubled": args["x"] * 2}))
+    """)
+    result = run_subprocess_job(
+        mod,
+        {"x": 21},
+        env_extra={"PYTHONPATH": parent + os.pathsep + os.environ.get("PYTHONPATH", "")},
+        cwd=tmp_path,
+    )
+    assert result == {"echo": {"x": 21}, "doubled": 42}
+
+
+def test_non_zero_exit_raises_with_stderr(tmp_path):
+    mod, parent = _write_worker_module(tmp_path, """
+        import sys
+        print("something on stderr — operator should see this", file=sys.stderr)
+        sys.exit(7)
+    """)
+    with pytest.raises(SubprocessJobError) as exc:
+        run_subprocess_job(
+            mod, {}, env_extra={"PYTHONPATH": parent + os.pathsep + os.environ.get("PYTHONPATH", "")},
+            cwd=tmp_path,
+        )
+    assert exc.value.exit_code == 7
+    assert "operator should see this" in exc.value.stderr
+
+
+def test_empty_stdout_raises_even_on_zero_exit(tmp_path):
+    """A worker that exits 0 but emits nothing on stdout violates the contract."""
+    mod, parent = _write_worker_module(tmp_path, """
+        import sys
+        # No stdout write.
+        sys.exit(0)
+    """)
+    with pytest.raises(SubprocessJobError, match="empty stdout"):
+        run_subprocess_job(
+            mod, {}, env_extra={"PYTHONPATH": parent + os.pathsep + os.environ.get("PYTHONPATH", "")},
+            cwd=tmp_path,
+        )
+
+
+def test_invalid_json_on_stdout_raises(tmp_path):
+    mod, parent = _write_worker_module(tmp_path, """
+        print("not json")
+    """)
+    with pytest.raises(SubprocessJobError, match="not valid JSON"):
+        run_subprocess_job(
+            mod, {}, env_extra={"PYTHONPATH": parent + os.pathsep + os.environ.get("PYTHONPATH", "")},
+            cwd=tmp_path,
+        )
+
+
+def test_timeout_kills_worker_and_raises(tmp_path):
+    mod, parent = _write_worker_module(tmp_path, """
+        import time, sys
+        # Don't read stdin — keeps the parent's communicate() blocked on
+        # write back-pressure, simulating a hung worker.
+        time.sleep(30)
+        print("{}")
+    """)
+    with pytest.raises(SubprocessJobError, match="timed out"):
+        run_subprocess_job(
+            mod,
+            {},
+            timeout_sec=2,
+            env_extra={"PYTHONPATH": parent + os.pathsep + os.environ.get("PYTHONPATH", "")},
+            cwd=tmp_path,
+        )
+
+
+def test_env_extra_reaches_worker(tmp_path):
+    mod, parent = _write_worker_module(tmp_path, """
+        import json, os, sys
+        json.load(sys.stdin)
+        print(json.dumps({"saw_token": os.environ.get("AGNES_TEST_TOKEN")}))
+    """)
+    result = run_subprocess_job(
+        mod,
+        {},
+        env_extra={
+            "PYTHONPATH": parent + os.pathsep + os.environ.get("PYTHONPATH", ""),
+            "AGNES_TEST_TOKEN": "shh-secret",
+        },
+        cwd=tmp_path,
+    )
+    assert result == {"saw_token": "shh-secret"}


### PR DESCRIPTION
## Summary

The "forever" memory fix for the OOM cycle that #431/#433/#434/#436 only partially closed. Profile loop in `_run_sync` was drifting resident memory by ~100-300 MiB per iteration even though each `profile_table` cleaned up its DuckDB session correctly — Python's allocator keeps freed anon mmap arenas in its free-list and libc's heap doesn't return them to the OS. After ~10-30 iterations the cgroup OOM killer reaped uvicorn at ~4.18 GiB anon-rss.

## Empirical evidence

Caught live this morning with py-spy dump during peak RSS (3.0 GB):

```
Thread 108 (active): "AnyIO worker thread"
    profile_table (src/profiler.py:795)
    _run_sync (app/api/sync.py:701)
```

smaps_rollup at that moment showed `Anonymous: 3.18 GB` — Python-side, not DuckDB-cap-bound (DuckDB capped at 2 GB per #434). Pattern repeated every ~50 min through the night.

## Change

- New `src/_subprocess_runner.py` — generic JSON-in/JSON-out subprocess helper following the extractor-subprocess pattern at `app/api/sync.py:543` (start_new_session, SIGTERM grace then SIGKILL on timeout).
- New `src/_profiler_worker.py` — `python -m`-invocable worker that wraps `profile_table` per call.
- `app/api/sync.py` profile loop: each iteration now spawns the worker subprocess. Process exit guarantees full memory return to the OS; the per-iteration anon-arena accumulation pattern is broken regardless of how many tables are in scope.
- Parent retains `ProfileRepository.save(...)` so system.duckdb stays single-writer.

## Trade-off

Subprocess cold-start adds ~300-500 ms per profile call. With the per-sync cap of 10 tables, that's ~3-5 s wall-time overhead per sync cycle — negligible against the multi-minute materialize / download work that dominates a sync, and far cheaper than the alternative (cgroup OOM → container restart → reset of every in-flight job).

## Test plan

- [x] New `tests/test_subprocess_runner.py` (6 cases) — JSON contract, exit-code propagation, timeout kill, env_extra plumbing.
- [x] New `tests/test_profiler_worker.py` — end-to-end against a real 3-row parquet.
- [x] Full pytest suite: 5280 passed, 35 skipped, 0 failed.
- [ ] Post-merge: trigger sync on agnes-dev (currently OOM-cycling every ~50 min), confirm RSS no longer drifts toward 4 GiB across profile iterations.

## Follow-up (not in this PR)

- Same pattern for `materialize_query` (Keboola + BQ) — same loop-accumulation root cause, less frequently the dominant hog in current dumps. Worth doing if this PR doesn't fully resolve the cycle on dev.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->