### PR TITLE
feat(infra): per-VM OAuth client secrets via naming template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Added
+- **`customer-instance` module: per-VM OAuth client secrets via naming
+  template.** New module-level variable `oauth_secret_name_template` lets
+  callers declare a single convention (e.g.
+  `"agnes-google-oauth-client-{kind}-{role}"`) that the module expands across
+  every VM in the call to derive Secret Manager secret names. Placeholders:
+  `{kind}` (id|secret — REQUIRED), `{role}` (from `dev_instances[*].role`,
+  defaulting to `"dev"`; always `"prod"` for the prod VM), `{name}` (VM
+  name). Empty default (`""`) keeps the legacy shared
+  `google-oauth-client-{id,secret}` behavior, so existing callers see zero
+  plan changes. Set the template once to give prod and dev their own OAuth
+  clients (recommended for prod isolation — different redirect URIs,
+  separate blast radius from Google's end); the per-role grouping means a
+  new env (`stage`, `perf`) lands by creating Secret Manager entries that
+  match the template and setting `role = "stage"` on a `dev_instances`
+  entry, with no Terraform diff in the module surface. Resolved names get
+  `secretAccessor` IAM via the new
+  `google_secret_manager_secret_iam_member.vm_oauth` resource
+  (de-duplicated across colliding `{role}` expansions). All VMs share one
+  SA, so this buys isolation at Google's OAuth client layer but not at-rest
+  in Secret Manager — a per-VM SA refactor is tracked for a future cut.
+- **`customer-instance` module: `role` is now a first-class field on
+  `dev_instances` items** (optional, default `"dev"`). Previously the role
+  was added solely by `local.dev_defaults` and any caller-supplied `role`
+  was silently dropped by Terraform's object-type conversion before reaching
+  the merge — so the `{role}` placeholder above could only ever resolve to
+  `dev` for any dev VM, defeating the stage/perf extensibility claim. Adding
+  the field to the type lets callers set `role = "stage"` per VM and have
+  it propagate. No change is needed for callers that don't set it; the
+  default keeps every existing dev VM on `role = "dev"`.
+
+  Bump to `infra-v1.10.0`.
+
 ## [0.55.21] — 2026-05-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.55.22] — 2026-05-27
+
 ### Added
 - **`customer-instance` module: per-VM OAuth client secrets via naming
   template.** New module-level variable `oauth_secret_name_template` lets

--- a/infra/examples/per-vm-oauth/main.tf
+++ b/infra/examples/per-vm-oauth/main.tf
@@ -1,0 +1,108 @@
+# Per-VM OAuth client example: prod + dev VMs, each with its own Google
+# Sign-In OAuth client (separate redirect URIs, separate blast radius).
+#
+# Preconditions:
+#
+#   1. Four Secret Manager secrets pre-created (Console can't manage OAuth
+#      clients via public API, so the secret values themselves are uploaded
+#      out-of-band):
+#
+#        gcloud secrets create agnes-google-oauth-client-id-prod     ...
+#        gcloud secrets create agnes-google-oauth-client-secret-prod ...
+#        gcloud secrets create agnes-google-oauth-client-id-dev      ...
+#        gcloud secrets create agnes-google-oauth-client-secret-dev  ...
+#
+#   2. Two OAuth 2.0 Web Application client IDs created in Cloud Console,
+#      each with its own Authorized redirect URI:
+#
+#        prod client -> https://<prod-domain>/auth/google/callback
+#        dev client  -> https://<dev-domain>/auth/google/callback
+#
+#      The {id, secret} pairs are loaded into the four secrets above.
+#
+# The module grants the VM SA secretAccessor on each resolved name
+# automatically — no need to wire them via `runtime_secrets`.
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.gcp_project_id
+  region  = "europe-west1"
+}
+
+variable "gcp_project_id" {
+  type = string
+}
+
+variable "admin_email" {
+  type = string
+}
+
+variable "prod_domain" {
+  description = "Public hostname for the prod VM (must resolve to its static IP before apply for Caddy + Let's Encrypt to succeed)."
+  type        = string
+}
+
+variable "dev_domain" {
+  description = "Public hostname for the dev VM."
+  type        = string
+}
+
+module "agnes" {
+  source = "../../modules/customer-instance"
+
+  gcp_project_id   = var.gcp_project_id
+  customer_name    = "example"
+  seed_admin_email = var.admin_email
+
+  prod_instance = {
+    name      = "agnes-prod"
+    image_tag = "stable"
+    tls_mode  = "caddy"
+    domain    = var.prod_domain
+  }
+
+  dev_instances = [
+    {
+      name      = "agnes-dev"
+      image_tag = "stable"
+      tls_mode  = "caddy"
+      domain    = var.dev_domain
+      # role defaults to "dev" — left implicit here. Override below for stage.
+    },
+    # Stage VM — same module, just a different role. Requires four extra
+    # secrets in Secret Manager:
+    #   agnes-google-oauth-client-{id,secret}-stage
+    # and an OAuth Web Application client with redirect URI
+    #   https://<stage-domain>/auth/google/callback
+    # already loaded into them. No module-side code change needed.
+    # {
+    #   name      = "agnes-stage"
+    #   image_tag = "stable"
+    #   tls_mode  = "caddy"
+    #   domain    = "agnes-stage.example.com"
+    #   role      = "stage"
+    # },
+  ]
+
+  # The module expands this per VM at plan time:
+  #   agnes-prod  (role=prod)  -> agnes-google-oauth-client-{id,secret}-prod
+  #   agnes-dev   (role=dev)   -> agnes-google-oauth-client-{id,secret}-dev
+  #   agnes-stage (role=stage) -> agnes-google-oauth-client-{id,secret}-stage
+  oauth_secret_name_template = "agnes-google-oauth-client-{kind}-{role}"
+
+  # `runtime_secrets` is kept strictly for OTHER secrets; the OAuth ones are
+  # bound automatically by the template-derived IAM resource.
+  runtime_secrets = []
+}
+
+output "prod_ip" {
+  value = module.agnes.prod_ip
+}

--- a/infra/modules/customer-instance/main.tf
+++ b/infra/modules/customer-instance/main.tf
@@ -28,6 +28,35 @@ locals {
     [merge(var.prod_instance, { role = "prod" })],
     [for d in var.dev_instances : merge(local.dev_defaults, d)]
   )
+  # Per-VM OAuth (Sign-in with Google) secret names, derived from
+  # var.oauth_secret_name_template. Empty template -> empty map ->
+  # startup-script falls back to legacy `google-oauth-client-{id,secret}`.
+  #
+  # The {kind}/{role}/{name} substitution is done in HCL so the resolved
+  # names are visible to the IAM resource (it needs the literal strings to
+  # set secretAccessor on each).
+  per_vm_oauth = var.oauth_secret_name_template == "" ? {} : {
+    for inst in local.all_instances : inst.name => {
+      id = replace(replace(replace(
+        var.oauth_secret_name_template,
+        "{kind}", "id"),
+        "{role}", inst.role),
+        "{name}", inst.name
+      )
+      secret = replace(replace(replace(
+        var.oauth_secret_name_template,
+        "{kind}", "secret"),
+        "{role}", inst.role),
+        "{name}", inst.name
+      )
+    }
+  }
+  # Deduplicated union — multiple VMs with the same role collapse to the
+  # same name when the template uses {role}, and the toset() makes the
+  # IAM resource for_each idempotent across those collisions.
+  per_instance_oauth_secrets = toset(flatten([
+    for k, v in local.per_vm_oauth : [v.id, v.secret]
+  ]))
 }
 
 # --- Secrets ---
@@ -72,6 +101,22 @@ resource "google_secret_manager_secret_iam_member" "vm_jwt" {
 # Caller specifies these via var.runtime_secrets. Each secret must already exist.
 resource "google_secret_manager_secret_iam_member" "vm_runtime" {
   for_each  = toset(var.runtime_secrets)
+  project   = var.gcp_project_id
+  secret_id = each.value
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.vm.email}"
+}
+
+# Per-VM OAuth client secrets, expanded from var.oauth_secret_name_template.
+# Granted to the same shared VM SA (all VMs in this module call use one SA, so
+# every per-VM OAuth secret is technically readable from every VM — isolation
+# comes from distinct OAuth clients with different redirect URIs at Google's
+# end, not from at-rest read scoping). A per-VM SA refactor is tracked
+# separately. When the template is empty the local resolves to an empty set
+# and this resource is a noop (legacy `google-oauth-client-{id,secret}` are
+# still listed by the caller in var.runtime_secrets and bound there).
+resource "google_secret_manager_secret_iam_member" "vm_oauth" {
+  for_each  = local.per_instance_oauth_secrets
   project   = var.gcp_project_id
   secret_id = each.value
   role      = "roles/secretmanager.secretAccessor"
@@ -218,19 +263,21 @@ resource "google_compute_instance" "vm" {
   }
 
   metadata_startup_script = templatefile("${path.module}/startup-script.sh.tpl", {
-    customer_name       = var.customer_name
-    image_repo          = var.image_repo
-    image_tag           = each.value.image_tag
-    upgrade_mode        = each.value.upgrade_mode
-    tls_mode            = each.value.tls_mode
-    domain              = each.value.domain
-    acme_email          = var.acme_email != "" ? var.acme_email : var.seed_admin_email
-    data_source         = var.data_source
-    keboola_stack_url   = var.keboola_stack_url
-    seed_admin_email    = var.seed_admin_email
-    seed_admin_password = var.enable_seed_password ? var.seed_admin_password : ""
-    role                = each.value.role
-    compose_ref         = var.compose_ref
+    customer_name                   = var.customer_name
+    image_repo                      = var.image_repo
+    image_tag                       = each.value.image_tag
+    upgrade_mode                    = each.value.upgrade_mode
+    tls_mode                        = each.value.tls_mode
+    domain                          = each.value.domain
+    acme_email                      = var.acme_email != "" ? var.acme_email : var.seed_admin_email
+    data_source                     = var.data_source
+    keboola_stack_url               = var.keboola_stack_url
+    seed_admin_email                = var.seed_admin_email
+    seed_admin_password             = var.enable_seed_password ? var.seed_admin_password : ""
+    role                            = each.value.role
+    compose_ref                     = var.compose_ref
+    oauth_client_id_secret_name     = try(local.per_vm_oauth[each.value.name].id, "")
+    oauth_client_secret_secret_name = try(local.per_vm_oauth[each.value.name].secret, "")
   })
 
   service_account {
@@ -257,6 +304,7 @@ resource "google_compute_instance" "vm" {
   depends_on = [
     google_secret_manager_secret_iam_member.vm_jwt,
     google_secret_manager_secret_iam_member.vm_runtime,
+    google_secret_manager_secret_iam_member.vm_oauth,
     google_secret_manager_secret_version.jwt,
   ]
 }

--- a/infra/modules/customer-instance/startup-script.sh.tpl
+++ b/infra/modules/customer-instance/startup-script.sh.tpl
@@ -114,13 +114,28 @@ if [ -z "$SCHEDULER_API_TOKEN" ]; then
     SCHEDULER_API_TOKEN=$(openssl rand -hex 32)
 fi
 
-# Optional Google OAuth credentials. If the operator has created
-# google-oauth-client-{id,secret} secrets in the project's Secret Manager
-# AND wired them via runtime_secrets in the calling Terraform, the VM SA can
-# read them — write into .env so the Google sign-in flow works. Missing /
-# 403 / empty → silent fallback to "" so password + email auth keep working.
-GOOGLE_CLIENT_ID=$(gcloud secrets versions access latest --secret=google-oauth-client-id 2>/dev/null || echo "")
-GOOGLE_CLIENT_SECRET=$(gcloud secrets versions access latest --secret=google-oauth-client-secret 2>/dev/null || echo "")
+# Optional Google OAuth credentials. The per-VM secret names are derived by
+# the module from `var.oauth_secret_name_template` (substituting {kind}/{role}/
+# {name} placeholders) and substituted into this script as
+# `${oauth_client_id_secret_name}` / `${oauth_client_secret_secret_name}`.
+#
+# Empty template -> empty substitution -> we fall back to the legacy shared
+# `google-oauth-client-{id,secret}` names (v1.x default — same OAuth client
+# across every VM in the module call). Setting the template gives each VM its
+# own OAuth client (different redirect URIs + separate blast radius from
+# Google's end).
+#
+# The named secrets must already exist in Secret Manager AND the VM SA must
+# have secretAccessor on them: module auto-grants for the derived per-VM names
+# via `google_secret_manager_secret_iam_member.vm_oauth`; legacy ones still
+# come via runtime_secrets. Missing / 403 / empty -> silent fallback to "" so
+# password + email auth keep working.
+OAUTH_ID_SECRET_NAME="${oauth_client_id_secret_name}"
+OAUTH_SECRET_NAME="${oauth_client_secret_secret_name}"
+if [ -z "$${OAUTH_ID_SECRET_NAME}" ]; then OAUTH_ID_SECRET_NAME="google-oauth-client-id"; fi
+if [ -z "$${OAUTH_SECRET_NAME}" ]; then OAUTH_SECRET_NAME="google-oauth-client-secret"; fi
+GOOGLE_CLIENT_ID=$(gcloud secrets versions access latest --secret="$${OAUTH_ID_SECRET_NAME}" 2>/dev/null || echo "")
+GOOGLE_CLIENT_SECRET=$(gcloud secrets versions access latest --secret="$${OAUTH_SECRET_NAME}" 2>/dev/null || echo "")
 
 # AGNES_VERSION, RELEASE_CHANNEL, AGNES_COMMIT_SHA are baked into the image
 # itself as ENV (see Dockerfile ARG/ENV + release.yml build-args). We do NOT

--- a/infra/modules/customer-instance/variables.tf
+++ b/infra/modules/customer-instance/variables.tf
@@ -65,8 +65,74 @@ variable "dev_instances" {
     image_tag    = optional(string, "dev")
     tls_mode     = optional(string, "none")
     domain       = optional(string, "")
+    # Role label used by per-VM OAuth secret naming
+    # (var.oauth_secret_name_template `{role}` placeholder), VM tagging in
+    # downstream cron/log filters, and dev_defaults selection. Defaults to
+    # "dev" so existing callers don't have to set it; override per VM to
+    # introduce `stage`, `perf`, etc. without any module-side code change
+    # (matching Secret Manager entries — `*-stage` / `*-perf` — must exist
+    # if the per-VM OAuth template uses {role}). MUST be declared on the
+    # object type, not only in dev_defaults: Terraform silently drops
+    # attributes that aren't in the object type during conversion, so a
+    # caller-supplied `role = "stage"` would never reach the merge() below
+    # if the type omits it.
+    role = optional(string, "dev")
   }))
   default = []
+}
+
+variable "oauth_secret_name_template" {
+  description = <<-EOT
+    Template for per-VM OAuth client (Sign-in with Google) Secret Manager
+    secret names. Supports placeholders:
+      {kind} -> "id" or "secret" (REQUIRED — otherwise both fetches resolve
+                to the same secret, which is broken)
+      {role} -> "prod" for the prod VM; for dev VMs, whatever was passed in
+                via `dev_instances[*].role` (defaults to "dev"). Set
+                `role = "stage"` / "perf" / etc. on a dev_instances entry to
+                introduce a new env class — the matching
+                <template-expanded-stage> secrets must already exist in SM.
+      {name} -> the VM name from prod_instance.name / dev_instances[*].name
+                (one OAuth client per VM, regardless of role)
+
+    Empty (default) -> legacy shared `google-oauth-client-{id,secret}`
+    (v1.x default — same OAuth client across every VM in the module call).
+
+    Examples:
+      "agnes-google-oauth-client-{kind}-{role}"  -> one client per role
+                                                    (prod, dev share across
+                                                    multiple dev VMs)
+      "agnes-oauth-{kind}-{name}"                -> one client per VM
+                                                    (every VM isolated; needed
+                                                    for per-engineer dev VMs
+                                                    on shared OAuth domain)
+
+    Resolved names must already exist in Secret Manager — the module grants
+    the VM SA secretAccessor on the resolved set; it does NOT create the
+    secret rows themselves (those carry the OAuth credentials issued in
+    Cloud Console, which has no public API).
+
+    Caveat: do NOT also list a derived name in `var.runtime_secrets` — the
+    same `google_secret_manager_secret_iam_member` would land twice for the
+    same (project, secret, role, member) tuple and apply errors with
+    "already exists". Keep `runtime_secrets` strictly for OTHER secrets the
+    VM needs (e.g. `keboola-storage-token`) when the template is in use.
+  EOT
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.oauth_secret_name_template == "" || strcontains(var.oauth_secret_name_template, "{kind}")
+    error_message = "oauth_secret_name_template must contain the {kind} placeholder when non-empty (otherwise id and secret resolve to the same Secret Manager name)."
+  }
+
+  validation {
+    condition = var.oauth_secret_name_template == "" || (
+      strcontains(var.oauth_secret_name_template, "{role}") ||
+      strcontains(var.oauth_secret_name_template, "{name}")
+    )
+    error_message = "oauth_secret_name_template should contain {role} or {name} for per-VM differentiation — otherwise every VM resolves to the same Secret Manager name and you've just renamed the legacy shared client (which is fine, but pointless to do via this variable; set runtime_secrets instead)."
+  }
 }
 
 variable "seed_admin_email" {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.55.21"
+version = "0.55.22"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"


### PR DESCRIPTION
## Why

The `customer-instance` module currently hardcodes a single OAuth client (Secret Manager secrets `google-oauth-client-{id,secret}`) shared by every VM in the module call. That convenience at v1.0 turns into three real problems once the operator has more than one VM:

- **One leak compromises every instance.** Prod and dev resolve to the same OAuth client and the same secret value.
- **Authorized redirect URIs list grows unbounded.** Every new VM with a different hostname adds an entry that's hard to retire safely.
- **Rotations are all-or-nothing.** Rolling the secret hits every VM simultaneously even when only one needs it.

## Change

Adds a single module-level variable:

```hcl
variable "oauth_secret_name_template" {
  type    = string
  default = ""    # empty -> legacy shared `google-oauth-client-{id,secret}`
}
```

Supported placeholders:

- `{kind}` — `id` or `secret` (REQUIRED, validated)
- `{role}` — `prod` or `dev` (groups multiple dev VMs under one client)
- `{name}` — the VM name (one OAuth client per VM)

Empty string (default) keeps the legacy lookup, so **existing callers see zero plan changes**. Set the template once at the module level to derive per-VM names.

Examples:

```hcl
# Caller A — one OAuth client per role (prod + dev share across multiple dev VMs)
oauth_secret_name_template = "agnes-google-oauth-client-{kind}-{role}"
# -> agnes-google-oauth-client-id-prod, agnes-google-oauth-client-secret-prod,
#    agnes-google-oauth-client-id-dev,  agnes-google-oauth-client-secret-dev

# Caller B — one OAuth client per VM (e.g. per-engineer dev VMs)
oauth_secret_name_template = "agnes-oauth-{kind}-{name}"
# -> agnes-oauth-id-foundryai-dev-alice, agnes-oauth-secret-foundryai-dev-alice, ...
```

## Why a template (not per-VM fields)

An earlier draft of this PR added two `optional(string, "")` fields on `prod_instance` / `dev_instances` to specify the secret names explicitly per VM. Pulled in favor of a template because:

- **Stage / perf / sandbox VMs ship without any Terraform code change.** Operator creates the new Secret Manager entries that match the template (`agnes-google-oauth-client-{id,secret}-stage`) and adds an instance with `role = "stage"`; the module picks it up.
- **Single source of truth in the module call.** No risk of one VM having a wired oauth secret while another forgets it.
- **Convention is explicit and discoverable** in the variable description.

The trade-off is losing per-VM mixed-naming (e.g. one VM uses convention A, another VM uses convention B). That's a genuine edge case; operators who need it can fork.

## Implementation

- `locals.per_vm_oauth = map(vm_name -> { id = ..., secret = ... })` produced by template substitution. Empty `{}` when `var.oauth_secret_name_template == ""`.
- `locals.per_instance_oauth_secrets = toset(flatten([for k, v in local.per_vm_oauth : [v.id, v.secret]]))` for IAM `for_each` (de-duplicates colliding `{role}` expansions).
- New `google_secret_manager_secret_iam_member.vm_oauth` grants `secretAccessor` to the (shared) VM SA on each derived name.
- `templatefile()` forwards the resolved names per VM via `try(local.per_vm_oauth[each.value.name].id, "")` so the noop case (empty template) yields empty strings, which the startup script reads as "fall back to legacy".
- `depends_on` on the VM resource adds the new IAM resource so secret reads at boot don't race the grant.

## Backwards compatibility

- **Callers that don't set `oauth_secret_name_template`:** zero plan diff. `terraform plan` against an existing root module pinned to this branch returns "No changes" until the operator explicitly opts in.
- **Callers that DO set it:** the legacy `google-oauth-client-{id,secret}` IAM bindings still live in `runtime_secrets` (current callers' defaults), so until they're explicitly removed from the runtime_secrets list, both old and new sets exist on the SA. Removing the legacy bindings is a clean follow-up after verifying the new OAuth clients work.

## Limitation called out

All VMs in one module call still share one service account, so at-rest read access to either secret remains pan-instance — isolation here is at Google's OAuth client layer (separate clients, separate redirect URIs, separate Google-side audit trail), not at Secret Manager IAM. A per-VM SA refactor is tracked for a future minor cut; doing it in this PR would force every existing deployment to reattach disks under a new SA name (**BREAKING**) which is well beyond the scope of "operator can isolate OAuth secrets."

## Suggested release

`infra-v1.10.0` — minor bump for the new optional variable. `propagate-infra-tag.yml` will open the template-repo bump PR automatically on tag push.

## Consumer plan

Once tagged, the consumer plan in [keboola/agnes-infra-keboola](https://github.com/keboola/agnes-infra-keboola):

1. Bump `source = "...customer-instance?ref=infra-v1.10.0"`.
2. Set `oauth_secret_name_template = "agnes-google-oauth-client-{kind}-{role}"` in the module call.
3. Drop `google-oauth-client-id` and `google-oauth-client-secret` from `runtime_secrets` (they're now redundant — the per-VM bindings cover their use).
4. `terraform apply -replace='module.agnes.google_compute_instance.vm["agnes-prod"]'` then dito for `agnes-dev` (sequential so we never lose both at once).
5. Verify Google OAuth login on both hosts, then delete the legacy secrets and the old shared OAuth client in Cloud Console.

(The new secrets — `agnes-google-oauth-client-{id,secret}-{prod,dev}` — are already in place in the keboola project as of 2026-05-27; this PR just gives the module a way to consume them.)