### PR TITLE
fix(telemetry): collapse usage_events.username to email (v60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.55.25] — 2026-05-28
+
+### Fixed
+- **Telemetry dropdown listed the same user under both their email and
+  their UUID.** `usage_events.username` /
+  `usage_session_summary.username` had three writers disagreeing on what
+  the column means: REST emitters wrote `user.get('email')`, the session
+  pipeline wrote the `/data/user_sessions/<dir>/` directory name (OS
+  username from the legacy collector, `user["id"]` UUID from
+  `/api/upload/sessions`). The admin telemetry facet
+  (`SELECT DISTINCT username FROM usage_events`) then surfaced one user
+  as up to three rows — anonymised local-part *and* the same person's
+  UUID for sessions uploaded via the API. The session-pipeline runner
+  now resolves `(user_id, email)` together (new `resolve_user_identity`
+  helper) and writes the email as the canonical `username` (falling
+  back to the directory name only for orphaned uploads). Schema v60
+  migration backfills historical rows where `user_id` is set so the
+  dropdown collapses immediately on first start. Directory name remains
+  the filesystem lookup key via `session_file = "<dir>/<name>"` — only
+  the display/grouping identity changes.
+
 ## [0.55.24] — 2026-05-28
 
 ### Fixed

--- a/app/api/admin_sessions.py
+++ b/app/api/admin_sessions.py
@@ -130,6 +130,15 @@ def list_sessions(
             v = d.get(k)
             if isinstance(v, datetime):
                 d[k] = v.isoformat()
+        # `session_dir` is the on-disk directory name (UUID for upload-API
+        # path, OS-username for the legacy collector). The UI uses this for
+        # URL building so the transcript / download endpoints find the file
+        # — `username` is now the display email (v60), which is NOT a valid
+        # filesystem segment. Derived here rather than stored so older rows
+        # don't need a separate backfill. Empty string for rows missing the
+        # `<dir>/<file>` shape so the UI defaults to "_" instead of crashing.
+        sf = d.get("session_file") or ""
+        d["session_dir"] = sf.split("/", 1)[0] if "/" in sf else ""
         out.append(d)
     return {
         "rows":        out,

--- a/app/web/templates/admin_sessions.html
+++ b/app/web/templates/admin_sessions.html
@@ -329,9 +329,16 @@
       const errCell = r.tool_errors > 0
         ? '<span class="obs-err-chip">' + fmtN(r.tool_errors) + '</span>'
         : '<span style="color:var(--text-secondary, #6b7280)">0</span>';
-      const viewerHref = '/admin/sessions/' + encodeURIComponent(r.username || '_')
+      // URL `{username}` segment is the on-disk directory name (UUID for
+      // upload-API sessions, OS-username for the legacy collector), NOT
+      // r.username — that's now the display email (v60 collapse, #458)
+      // which the `_safe_session_path` regex on the server rejects. The
+      // listing API returns `session_dir` derived from `session_file`
+      // explicitly so the UI doesn't have to re-derive it.
+      const sessionDir = r.session_dir || '_';
+      const viewerHref = '/admin/sessions/' + encodeURIComponent(sessionDir)
                        + '/' + encodeURIComponent(r.session_file.split('/').pop());
-      const dlHref = '/api/admin/sessions/' + encodeURIComponent(r.username || '_')
+      const dlHref = '/api/admin/sessions/' + encodeURIComponent(sessionDir)
                    + '/' + encodeURIComponent(r.session_file.split('/').pop()) + '/download';
       tr.innerHTML =
         '<td>' + escapeHtml(fmtTime(r.started_at)) + '</td>' +

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.55.24"
+version = "0.55.25"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/services/session_pipeline/runner.py
+++ b/services/session_pipeline/runner.py
@@ -26,11 +26,11 @@ from src.repositories.session_processor_state import SessionProcessorStateReposi
 logger = logging.getLogger(__name__)
 
 
-def resolve_user_id(
+def resolve_user_identity(
     conn: duckdb.DuckDBPyConnection,
     username: str,
-) -> str | None:
-    """Map a session-directory name to the stable ``users.id`` UUID.
+) -> tuple[str | None, str | None]:
+    """Map a session-directory name to ``(users.id, users.email)``.
 
     Two conventions exist for the directory name under
     ``/data/user_sessions/``:
@@ -44,22 +44,44 @@ def resolve_user_id(
     2. Email local-part match: ``users.email LIKE '<username>@%'``.
        If multiple users share the same local-part (different domains),
        we pick the one most recently updated.
-    3. Fallback: return ``None`` (orphaned / deleted user).
+    3. Fallback: return ``(None, None)`` (orphaned / deleted user).
+
+    Email is returned so the runner can normalise the ``username``
+    column in ``usage_events`` / ``usage_session_summary`` to a stable
+    human-readable identity regardless of which ingestion path the
+    session arrived through — otherwise the admin telemetry dropdown
+    lists the same user under both their UUID (upload API) and their
+    email (REST event emitters).
     """
     row = conn.execute(
-        "SELECT id FROM users WHERE id = ?",
+        "SELECT id, email FROM users WHERE id = ?",
         [username],
     ).fetchone()
     if row:
-        return row[0]
+        return row[0], row[1]
     escaped = username.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
     row = conn.execute(
-        "SELECT id FROM users WHERE email LIKE ? || '@%' ESCAPE '\\' ORDER BY updated_at DESC NULLS LAST LIMIT 1",
+        "SELECT id, email FROM users WHERE email LIKE ? || '@%' ESCAPE '\\' "
+        "ORDER BY updated_at DESC NULLS LAST LIMIT 1",
         [escaped],
     ).fetchone()
     if row:
-        return row[0]
-    return None
+        return row[0], row[1]
+    return None, None
+
+
+def resolve_user_id(
+    conn: duckdb.DuckDBPyConnection,
+    username: str,
+) -> str | None:
+    """Backward-compatible wrapper returning just the resolved ``users.id``.
+
+    Existing call sites (and tests) that only need the UUID stay
+    unchanged; new code in ``run_processor`` uses
+    :func:`resolve_user_identity` to get the email too.
+    """
+    uid, _ = resolve_user_identity(conn, username)
+    return uid
 
 
 DEFAULT_SESSION_DATA_DIR = Path(os.environ.get("SESSION_DATA_DIR", "/data/user_sessions"))
@@ -97,13 +119,17 @@ def run_processor(
         logger.info("No sessions to process for processor=%s", processor.name)
         return stats
 
-    # Pre-resolve user_id per directory name so each processor can
-    # store the stable identity. Cache avoids repeated DB lookups when
-    # one user has many sessions.
-    _uid_cache: dict[str, str | None] = {}
+    # Pre-resolve (user_id, email) per directory name so each processor
+    # can store the stable identity. Cache avoids repeated DB lookups
+    # when one user has many sessions. Email is used as the canonical
+    # ``username`` written to usage_* tables so the admin telemetry
+    # dropdown surfaces one row per user regardless of whether the
+    # session arrived via /api/upload/sessions (UUID dir) or the legacy
+    # collector (OS-username dir).
+    _identity_cache: dict[str, tuple[str | None, str | None]] = {}
 
-    for username, jsonl_path in candidates:
-        session_key = f"{username}/{jsonl_path.name}"
+    for dir_name, jsonl_path in candidates:
+        session_key = f"{dir_name}/{jsonl_path.name}"
         try:
             file_hash = compute_file_hash(jsonl_path)
         except Exception as e:
@@ -126,14 +152,20 @@ def run_processor(
             stats["skipped"] += 1
             continue
 
-        if username not in _uid_cache:
-            _uid_cache[username] = resolve_user_id(conn, username)
-        resolved_uid = _uid_cache[username]
+        if dir_name not in _identity_cache:
+            _identity_cache[dir_name] = resolve_user_identity(conn, dir_name)
+        resolved_uid, resolved_email = _identity_cache[dir_name]
+        # Canonical username = email when the user resolves; fall back
+        # to the directory name otherwise (orphaned uploads, sessions
+        # for deleted users). The directory name remains the filesystem
+        # lookup key via ``session_key`` (``<dir>/<file>``); ``username``
+        # is purely the display/grouping identity for telemetry.
+        canonical_username = resolved_email or dir_name
 
         try:
             result = processor.process_session(
                 jsonl_path,
-                username,
+                canonical_username,
                 session_key,
                 conn,
                 user_id=resolved_uid,
@@ -164,7 +196,7 @@ def run_processor(
         repo.mark_processed(
             processor_name=processor.name,
             session_file=session_key,
-            username=username,
+            username=canonical_username,
             items_count=result.items_count,
             file_hash=file_hash,
         )

--- a/src/db.py
+++ b/src/db.py
@@ -40,7 +40,7 @@ def _maybe_instrument(con, db_tag: str):
 
 _SAFE_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,63}$")
 
-SCHEMA_VERSION = 59
+SCHEMA_VERSION = 60
 
 _SYSTEM_SCHEMA = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -4124,6 +4124,72 @@ def _v23_to_v24_finalize(conn: duckdb.DuckDBPyConnection) -> None:
         raise
 
 
+def _v59_to_v60(conn: duckdb.DuckDBPyConnection) -> None:
+    """Backfill ``usage_events.username`` / ``usage_session_summary.username``
+    from ``users.email`` where the row has a resolved ``user_id``.
+
+    Pre-v60 the ``username`` column was written by three writers with
+    conflicting semantics:
+
+    * REST event emitters (``sync.py``, ``stack.py``, ``memory.py``,
+      ``web/router.py``) → full email (``user.get('email')``) or
+      ``user['id']`` UUID when email empty.
+    * Session pipeline via ``/data/user_sessions/<dir>/`` → directory
+      name. From the session collector the directory is the OS
+      username (typically the email local-part); from the upload API
+      it is the user's UUID.
+
+    Result: a single user surfaces in the admin telemetry dropdown
+    under up to three different ``username`` values. The runner now
+    normalises new writes to ``users.email``; this migration cleans up
+    the historical rows so the dropdown is one row per user
+    immediately.
+
+    Only rows with a non-null ``user_id`` are touched — orphaned
+    sessions (deleted users, never-matched directories) keep whatever
+    label they had so the data isn't silently lost.
+    """
+    # Skip backfill on stub schemas (e.g. the v1→vN end-to-end test
+    # seeds ``users`` with only an ``id`` column). The required
+    # ``users.email`` plus ``usage_*.username`` / ``usage_*.user_id``
+    # columns all come from earlier migrations on every real install;
+    # if any of them is missing here, this is a synthetic fixture.
+    def _cols(table: str) -> set[str]:
+        return {
+            r[0]
+            for r in conn.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE lower(table_name) = lower(?)",
+                [table],
+            ).fetchall()
+        }
+
+    users_cols = _cols("users")
+    if "email" not in users_cols:
+        conn.execute("UPDATE schema_version SET version = 60")
+        return
+
+    for table, key_col in (
+        ("usage_events", "user_id"),
+        ("usage_session_summary", "user_id"),
+    ):
+        tcols = _cols(table)
+        if {"username", key_col} - tcols:
+            continue
+        conn.execute(
+            f"""
+            UPDATE {table}
+               SET username = u.email
+              FROM users u
+             WHERE {table}.{key_col} = u.id
+               AND u.email IS NOT NULL
+               AND u.email != ''
+               AND {table}.username IS DISTINCT FROM u.email
+            """
+        )
+    conn.execute("UPDATE schema_version SET version = 60")
+
+
 def _v58_to_v59(conn: duckdb.DuckDBPyConnection) -> None:
     """v56: extended-content columns on ``data_packages`` + structured
     per-table doc columns on ``table_registry``.
@@ -4442,6 +4508,10 @@ def _ensure_schema(conn: duckdb.DuckDBPyConnection) -> None:
             # v56 extended content columns on data_packages + structured
             # per-table doc columns on table_registry.
             _v58_to_v59(conn)
+            # v59→v60 backfills ``username`` in usage_events /
+            # usage_session_summary from users.email. Fresh installs
+            # have empty usage_* tables, so the UPDATE is a no-op.
+            _v59_to_v60(conn)
             # Fresh-install seed is handled by the unconditional
             # _seed_core_roles call at the bottom of _ensure_schema —
             # left as a no-op branch here so the migration ladder still
@@ -4613,6 +4683,8 @@ def _ensure_schema(conn: duckdb.DuckDBPyConnection) -> None:
                 _v57_to_v58(conn)
             if current < 59:
                 _v58_to_v59(conn)
+            if current < 60:
+                _v59_to_v60(conn)
             conn.execute(
                 "UPDATE schema_version SET version = ?, applied_at = current_timestamp",
                 [SCHEMA_VERSION],

--- a/tests/test_admin_sessions_listing.py
+++ b/tests/test_admin_sessions_listing.py
@@ -1,0 +1,128 @@
+"""Contract test for /api/admin/sessions/list — the listing response
+must surface a `session_dir` field derived from `session_file.split('/')[0]`
+so the UI can build transcript / download URLs that target the on-disk
+directory, NOT the display `username` (which v60 collapses to email and
+which `_safe_session_path._USERNAME_RE` rejects).
+
+Regression guard for the cross-file integration break that landed with
+v60 (PR #458 admin telemetry rewrite): every test below seeds rows with
+the post-v60 shape (username = email; session_file = `<dir>/<file>`) and
+asserts the listing API exposes `session_dir` so the UI URL builder
+doesn't try to put `@` into `_safe_session_path._USERNAME_RE`.
+"""
+
+from __future__ import annotations
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _seed_session(conn, session_file: str, username: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO usage_session_summary
+          (session_file, session_id, username, started_at, ended_at,
+           active_seconds, wall_seconds, user_messages, assistant_messages,
+           tool_calls, tool_errors, skill_invocations, subagent_dispatches,
+           mcp_calls, slash_commands, distinct_tools, distinct_skills,
+           primary_model, input_tokens, output_tokens, cache_read_tokens,
+           cache_creation_tokens, processor_version)
+        VALUES (?, ?, ?, current_timestamp, current_timestamp,
+                10, 30, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'sonnet', 0, 0, 0, 0, 2)
+        """,
+        [session_file, session_file, username],
+    )
+
+
+class TestSessionDirInListing:
+    """The listing API must surface `session_dir` so the UI URL builder
+    points at the on-disk directory, not the email-shaped `username`."""
+
+    def test_uuid_dir_emits_uuid_as_session_dir(self, seeded_app):
+        """Upload-API path: session_file = `<uuid>/<filename>`,
+        username = email (post-v60). session_dir == the UUID."""
+        from src.db import get_system_db
+
+        c = seeded_app["client"]
+        token = seeded_app["admin_token"]
+        conn = get_system_db()
+        try:
+            _seed_session(conn,
+                "b00f5e3e-aaaa-bbbb-cccc-dddddddddddd/session-001.jsonl",
+                "alice@example.com",
+            )
+        finally:
+            conn.close()
+
+        resp = c.get(
+            "/api/admin/sessions/list",
+            headers=_auth(token),
+            params={"since_minutes": 60},
+        )
+        assert resp.status_code == 200, resp.text
+        rows = resp.json()["rows"]
+        match = next((r for r in rows if r["session_file"].startswith("b00f5e3e-")), None)
+        assert match is not None, "seeded row missing from listing"
+        assert match["session_dir"] == "b00f5e3e-aaaa-bbbb-cccc-dddddddddddd"
+        # Display column carries the email; URL builder must NOT use it.
+        assert match["username"] == "alice@example.com"
+
+    def test_localpart_dir_emits_localpart_as_session_dir(self, seeded_app):
+        """Legacy collector path: session_file = `<local-part>/<filename>`,
+        username = email. session_dir == the local-part."""
+        from src.db import get_system_db
+
+        c = seeded_app["client"]
+        token = seeded_app["admin_token"]
+        conn = get_system_db()
+        try:
+            _seed_session(conn,
+                "bob/session-legacy.jsonl",
+                "bob@example.com",
+            )
+        finally:
+            conn.close()
+
+        resp = c.get(
+            "/api/admin/sessions/list",
+            headers=_auth(token),
+            params={"since_minutes": 60},
+        )
+        assert resp.status_code == 200
+        rows = resp.json()["rows"]
+        match = next((r for r in rows if r["session_file"] == "bob/session-legacy.jsonl"), None)
+        assert match is not None
+        assert match["session_dir"] == "bob"
+        assert match["username"] == "bob@example.com"
+
+    def test_orphan_row_with_dir_only_username_still_exposes_session_dir(self, seeded_app):
+        """v60 leaves orphan rows (no user_id resolvable) with the old
+        directory-name username; session_dir is still derived from
+        session_file, not from username — so the UI URL builder is
+        consistent across resolved and orphan rows."""
+        from src.db import get_system_db
+
+        c = seeded_app["client"]
+        token = seeded_app["admin_token"]
+        conn = get_system_db()
+        try:
+            _seed_session(conn,
+                "orphandir/session-orph.jsonl",
+                "orphandir",  # username still the dir-name (orphan, untouched by v60)
+            )
+        finally:
+            conn.close()
+
+        resp = c.get(
+            "/api/admin/sessions/list",
+            headers=_auth(token),
+            params={"since_minutes": 60},
+        )
+        assert resp.status_code == 200
+        rows = resp.json()["rows"]
+        match = next((r for r in rows if r["session_file"] == "orphandir/session-orph.jsonl"), None)
+        assert match is not None
+        assert match["session_dir"] == "orphandir"
+        # Orphan row's username is still the dir-name (legacy fallback).
+        assert match["username"] == "orphandir"

--- a/tests/test_db_schema_version.py
+++ b/tests/test_db_schema_version.py
@@ -14,7 +14,7 @@ import duckdb
 from src.db import SCHEMA_VERSION, _ensure_schema, get_schema_version
 
 
-def test_schema_version_is_59():
+def test_schema_version_is_60():
     # v27 → v28: explicit-install (Model B) for curated marketplace plugins.
     # user_plugin_optouts row presence flips meaning from "excluded" to
     # "subscribed"; migration wipes existing rows so the inverted reading
@@ -169,7 +169,14 @@ def test_schema_version_is_59():
     #            (grain, platforms, partition_col, history, gotchas) for
     #            the /catalog/p/<slug> rewrite per the extended-
     #            descriptions admin spec. All additive + NULLABLE.
-    assert SCHEMA_VERSION == 59
+    # v59 → v60: backfill ``usage_events.username`` and
+    #            ``usage_session_summary.username`` from ``users.email``
+    #            where ``user_id`` is non-null. Collapses the admin
+    #            telemetry dropdown which previously listed the same
+    #            user under multiple identities (email from REST writers,
+    #            UUID from upload-API sessions, OS-username from the
+    #            legacy collector).
+    assert SCHEMA_VERSION == 60
 
 
 def test_v37_marketplace_curator_columns(tmp_path):

--- a/tests/test_schema_v58_to_v59_migration.py
+++ b/tests/test_schema_v58_to_v59_migration.py
@@ -45,14 +45,17 @@ def _columns(conn, table: str) -> set[str]:
     }
 
 
-def test_schema_version_is_59():
-    assert SCHEMA_VERSION == 59
+def test_schema_version_is_at_least_59():
+    # v59 is no longer the latest (v60 added telemetry username
+    # backfill) — pin the lower bound so this test keeps catching
+    # accidental downgrades.
+    assert SCHEMA_VERSION >= 59
 
 
-def test_fresh_install_lands_at_v57(tmp_path):
+def test_fresh_install_lands_at_or_past_v59(tmp_path):
     conn = duckdb.connect(str(tmp_path / "system.duckdb"))
     _ensure_schema(conn)
-    assert get_schema_version(conn) == 59
+    assert get_schema_version(conn) >= 59
 
 
 def test_v58_to_v59_adds_data_packages_owner_columns(tmp_path):
@@ -123,7 +126,7 @@ def test_v58_to_v59_is_idempotent(tmp_path):
     conn = duckdb.connect(str(db_path))
     _ensure_schema(conn)
     _ensure_schema(conn)  # second pass — no-op
-    assert get_schema_version(conn) == 59
+    assert get_schema_version(conn) >= 59
 
 
 def test_v58_to_v59_preserves_table_registry_rows():

--- a/tests/test_schema_v59_to_v60_migration.py
+++ b/tests/test_schema_v59_to_v60_migration.py
@@ -1,0 +1,144 @@
+"""v59 → v60: backfill ``usage_events.username`` /
+``usage_session_summary.username`` from ``users.email`` where the row
+has a resolved ``user_id``.
+
+Pre-v60 the column was written by three writers with conflicting
+semantics (full email from REST emitters, UUID from upload-API
+sessions, OS-username from the legacy collector). The admin telemetry
+dropdown surfaced one user as multiple rows as a result. v60 collapses
+the historical data; the session-pipeline runner stops writing
+divergent values going forward.
+
+Asserts on the migration shape:
+
+  * fresh install lands at v60
+  * UUID rows with a known user_id get rewritten to the user's email
+  * local-part rows get rewritten to the full email
+  * orphan rows (user_id NULL or user deleted) are left intact
+  * idempotent — re-running the migration is a no-op
+  * SCHEMA_VERSION constant matches
+"""
+
+from __future__ import annotations
+
+import duckdb
+
+from src.db import SCHEMA_VERSION, _ensure_schema, _v59_to_v60, get_schema_version
+
+
+def test_schema_version_is_60():
+    assert SCHEMA_VERSION == 60
+
+
+def test_fresh_install_lands_at_v60(tmp_path):
+    conn = duckdb.connect(str(tmp_path / "system.duckdb"))
+    _ensure_schema(conn)
+    assert get_schema_version(conn) == 60
+
+
+def test_uuid_username_rewritten_to_email(tmp_path):
+    """The motivating case: a session uploaded via /api/upload/sessions
+    landed with ``usage_events.username = <user_id UUID>``. Migration
+    rewrites it to the user's email so the telemetry dropdown collapses."""
+    conn = duckdb.connect(str(tmp_path / "system.duckdb"))
+    _ensure_schema(conn)
+    conn.execute(
+        "INSERT INTO users (id, email, updated_at) VALUES (?, ?, ?)",
+        ["uuid-aaa", "alice@example.com", "2026-01-01"],
+    )
+    conn.execute(
+        """
+        INSERT INTO usage_events (
+            id, session_id, session_file, username, event_type,
+            is_error, source, occurred_at, processor_version, user_id
+        ) VALUES (
+            'evt1', 'sess1', 'uuid-aaa/sess1.jsonl',
+            'uuid-aaa', 'tool_use', FALSE, 'curated',
+            CURRENT_TIMESTAMP, 1, 'uuid-aaa'
+        )
+        """
+    )
+    _v59_to_v60(conn)
+    assert conn.execute(
+        "SELECT username FROM usage_events WHERE id = 'evt1'"
+    ).fetchone()[0] == "alice@example.com"
+
+
+def test_local_part_username_rewritten_to_email(tmp_path):
+    """Sessions from the legacy collector landed with
+    ``username = <os-username>`` (typically email local-part). Migration
+    promotes them to the full email so they group with the upload path."""
+    conn = duckdb.connect(str(tmp_path / "system.duckdb"))
+    _ensure_schema(conn)
+    conn.execute(
+        "INSERT INTO users (id, email, updated_at) VALUES (?, ?, ?)",
+        ["uuid-bbb", "bob@example.com", "2026-01-01"],
+    )
+    conn.execute(
+        """
+        INSERT INTO usage_session_summary (
+            session_file, session_id, username, started_at, user_id,
+            processor_version
+        ) VALUES (
+            'bob/sess1.jsonl', 'sess1', 'bob', CURRENT_TIMESTAMP,
+            'uuid-bbb', 1
+        )
+        """
+    )
+    _v59_to_v60(conn)
+    assert conn.execute(
+        "SELECT username FROM usage_session_summary WHERE session_file = 'bob/sess1.jsonl'"
+    ).fetchone()[0] == "bob@example.com"
+
+
+def test_orphan_row_left_intact(tmp_path):
+    """Rows whose ``user_id`` is NULL (pre-v45 backfill never reached
+    them, or user deleted) must NOT be touched — the migration has no
+    safe way to guess the intended email. They stay readable under
+    whatever label was stored."""
+    conn = duckdb.connect(str(tmp_path / "system.duckdb"))
+    _ensure_schema(conn)
+    conn.execute(
+        """
+        INSERT INTO usage_events (
+            id, session_id, session_file, username, event_type,
+            is_error, source, occurred_at, processor_version, user_id
+        ) VALUES (
+            'evt2', 'sess2', 'orphan/sess2.jsonl',
+            'orphan', 'tool_use', FALSE, 'curated',
+            CURRENT_TIMESTAMP, 1, NULL
+        )
+        """
+    )
+    _v59_to_v60(conn)
+    assert conn.execute(
+        "SELECT username FROM usage_events WHERE id = 'evt2'"
+    ).fetchone()[0] == "orphan"
+
+
+def test_v59_to_v60_is_idempotent(tmp_path):
+    """Re-running _ensure_schema must not raise or double-update."""
+    conn = duckdb.connect(str(tmp_path / "system.duckdb"))
+    _ensure_schema(conn)
+    conn.execute(
+        "INSERT INTO users (id, email, updated_at) VALUES (?, ?, ?)",
+        ["uuid-aaa", "alice@example.com", "2026-01-01"],
+    )
+    conn.execute(
+        """
+        INSERT INTO usage_events (
+            id, session_id, session_file, username, event_type,
+            is_error, source, occurred_at, processor_version, user_id
+        ) VALUES (
+            'evt1', 'sess1', 'uuid-aaa/sess1.jsonl',
+            'uuid-aaa', 'tool_use', FALSE, 'curated',
+            CURRENT_TIMESTAMP, 1, 'uuid-aaa'
+        )
+        """
+    )
+    _v59_to_v60(conn)
+    _v59_to_v60(conn)  # second pass — no-op
+    assert conn.execute(
+        "SELECT username FROM usage_events WHERE id = 'evt1'"
+    ).fetchone()[0] == "alice@example.com"
+    assert get_schema_version(conn) == 60

--- a/tests/test_session_pipeline.py
+++ b/tests/test_session_pipeline.py
@@ -20,7 +20,11 @@ import duckdb
 
 from services.session_pipeline.contract import ProcessorResult
 from services.session_pipeline.lib import compute_file_hash, parse_jsonl
-from services.session_pipeline.runner import resolve_user_id, run_processor
+from services.session_pipeline.runner import (
+    resolve_user_id,
+    resolve_user_identity,
+    run_processor,
+)
 from src.repositories.session_processor_state import SessionProcessorStateRepository
 
 
@@ -159,6 +163,49 @@ class TestResolveUserId:
         conn = _fresh_db(tmp_path, monkeypatch)
         self._seed_users(conn, [("uuid-aaa", "uuid-aaa@example.com", "2026-01-01")])
         assert resolve_user_id(conn, "uuid-aaa") == "uuid-aaa"
+        conn.close()
+
+
+class TestResolveUserIdentity:
+    """Resolver returns (uid, email) — the email is what the runner
+    writes as the canonical ``username`` so the telemetry dropdown
+    stops listing the same person under their UUID and their email."""
+
+    @staticmethod
+    def _seed(conn, rows):
+        for uid, email, updated_at in rows:
+            conn.execute(
+                "INSERT INTO users (id, email, updated_at) VALUES (?, ?, ?)",
+                [uid, email, updated_at],
+            )
+
+    def test_uuid_dir_resolves_to_email(self, tmp_path, monkeypatch):
+        """Upload API writes /data/user_sessions/<uuid>/ — resolver
+        must return the user's email so usage_events.username becomes
+        readable instead of the raw UUID."""
+        conn = _fresh_db(tmp_path, monkeypatch)
+        self._seed(conn, [("uuid-aaa", "alice@example.com", "2026-01-01")])
+        uid, email = resolve_user_identity(conn, "uuid-aaa")
+        assert uid == "uuid-aaa"
+        assert email == "alice@example.com"
+        conn.close()
+
+    def test_local_part_dir_resolves_to_email(self, tmp_path, monkeypatch):
+        """Session collector writes /data/user_sessions/<os-username>/
+        — resolver returns the matching email."""
+        conn = _fresh_db(tmp_path, monkeypatch)
+        self._seed(conn, [("uuid-bbb", "bob@example.com", "2026-01-01")])
+        uid, email = resolve_user_identity(conn, "bob")
+        assert uid == "uuid-bbb"
+        assert email == "bob@example.com"
+        conn.close()
+
+    def test_unknown_returns_none_pair(self, tmp_path, monkeypatch):
+        conn = _fresh_db(tmp_path, monkeypatch)
+        self._seed(conn, [("uuid-aaa", "alice@example.com", "2026-01-01")])
+        uid, email = resolve_user_identity(conn, "nobody")
+        assert uid is None
+        assert email is None
         conn.close()
 
 
@@ -317,9 +364,13 @@ class _FakeProcessor:
         self.return_value = return_value if return_value is not None else ProcessorResult(items_count=0)
         self.raise_on_session = raise_on_session
         self.calls: list[str] = []
+        self.call_kwargs: list[dict] = []
+        self.call_usernames: list[str] = []
 
     def process_session(self, session_path: Path, username: str, session_key: str, conn, **kwargs: object):
         self.calls.append(session_key)
+        self.call_usernames.append(username)
+        self.call_kwargs.append(dict(kwargs))
         if self.raise_on_session is not None and session_key == self.raise_on_session:
             raise RuntimeError("simulated processor failure")
         return self.return_value
@@ -415,6 +466,61 @@ class TestRunProcessor:
         stats2 = run_processor(conn, proc, session_data_dir=sessions)
         assert stats2["processed"] == 1
         assert proc.calls == ["alice/s.jsonl", "alice/s.jsonl"]
+        conn.close()
+
+    def test_uuid_dir_passes_email_as_username(self, tmp_path, monkeypatch):
+        """Sessions uploaded via /api/upload/sessions land in
+        /data/user_sessions/<uuid>/. The runner must resolve the email
+        and pass that to the processor as ``username`` — otherwise
+        usage_events.username gets a UUID and the admin telemetry
+        dropdown lists the same user under two identities."""
+        conn = _fresh_db(tmp_path, monkeypatch)
+        conn.execute(
+            "INSERT INTO users (id, email, updated_at) VALUES (?, ?, ?)",
+            ["uuid-aaa", "alice@example.com", "2026-01-01"],
+        )
+        sessions = tmp_path / "sessions"
+        _seed_session(sessions, "uuid-aaa", "s.jsonl")
+
+        proc = _FakeProcessor(return_value=ProcessorResult(items_count=1))
+        run_processor(conn, proc, session_data_dir=sessions)
+
+        assert proc.call_usernames == ["alice@example.com"]
+        assert proc.call_kwargs[0]["user_id"] == "uuid-aaa"
+        conn.close()
+
+    def test_localpart_dir_passes_email_as_username(self, tmp_path, monkeypatch):
+        """Sessions from the legacy collector land under the OS
+        username (typically the email local-part). The runner must
+        still write the full email so the dropdown collapses."""
+        conn = _fresh_db(tmp_path, monkeypatch)
+        conn.execute(
+            "INSERT INTO users (id, email, updated_at) VALUES (?, ?, ?)",
+            ["uuid-bbb", "bob@example.com", "2026-01-01"],
+        )
+        sessions = tmp_path / "sessions"
+        _seed_session(sessions, "bob", "s.jsonl")
+
+        proc = _FakeProcessor(return_value=ProcessorResult(items_count=1))
+        run_processor(conn, proc, session_data_dir=sessions)
+
+        assert proc.call_usernames == ["bob@example.com"]
+        assert proc.call_kwargs[0]["user_id"] == "uuid-bbb"
+        conn.close()
+
+    def test_orphan_dir_falls_back_to_dir_name(self, tmp_path, monkeypatch):
+        """If the directory name doesn't resolve to any user (deleted
+        user, stray upload), keep the directory name as ``username``
+        so the data isn't silently relabelled to a bogus identity."""
+        conn = _fresh_db(tmp_path, monkeypatch)
+        sessions = tmp_path / "sessions"
+        _seed_session(sessions, "orphan-uuid", "s.jsonl")
+
+        proc = _FakeProcessor(return_value=ProcessorResult(items_count=1))
+        run_processor(conn, proc, session_data_dir=sessions)
+
+        assert proc.call_usernames == ["orphan-uuid"]
+        assert proc.call_kwargs[0]["user_id"] is None
         conn.close()
 
     def test_processors_isolated(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- The admin telemetry user dropdown listed the same person under up to three different `username` values (full email from REST emitters, UUID from `/api/upload/sessions`, OS-username from the legacy session collector).
- Session-pipeline runner now resolves `(user_id, email)` together and writes the email as the canonical `username` to processors; falls back to the directory name only for orphans.
- Schema v60 migration backfills historical rows in `usage_events` and `usage_session_summary` where `user_id` is set, so the dropdown collapses on first start.
- Cuts release `0.55.25`.

## Why three writers diverged

| Writer | Wrote to `usage_*.username` |
|---|---|
| `sync.py`, `stack.py`, `memory.py`, `web/router.py` | `user.get("email") or user["id"]` |
| Session pipeline ← session-collector | OS-username (email local-part) |
| Session pipeline ← `/api/upload/sessions` | `user["id"]` UUID (`upload.py:78`) |

`/api/admin/telemetry/facets` groups `DISTINCT username` → mixed list.

`usage_events.user_id` was already correct for both paths; only `username` was inconsistent.

## What did NOT change

- Directory layout under `/data/user_sessions/<dir>/` — still UUID for upload-API, OS-username for collector.
- `session_file` column — still `<dir>/<filename>`, so transcript URLs and `_safe_session_path` keep working.
- RBAC scoping in `connectors/internal/access.py` — already matches on `user_id` with `username` as legacy fallback.

## Test plan

- [x] `tests/test_session_pipeline.py` — 3 new TestResolveUserIdentity tests + 3 TestRunProcessor tests (UUID dir → email, local-part → email, orphan → fallback)
- [x] `tests/test_schema_v59_to_v60_migration.py` — fresh install, UUID rewrite, local-part rewrite, orphan untouched, idempotency
- [x] `tests/test_db_schema_version.py` — bumped to `== 60` with v60 ladder note
- [x] Full suite green for touched code; 6 unrelated pre-existing failures (catalog_export fixture dirs, missing `jsonschema` module, stale `da` symlink) reproduce on `main`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->