### PR TITLE
feat(chat): in-product chat agent backend (#459, 1/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Added
+- **In-product chat agent — backend (#459, PR 1/3).** New `POST /api/chat`
+  SSE endpoint backed by an Anthropic tool-use loop (Haiku 4.5 default)
+  with six read-only tools: `list_catalog`, `get_schema`, `describe_table`,
+  `run_query`, `lookup_metric`, `get_memory_bundle`. Every tool re-checks
+  RBAC against the caller's identity; `run_query` refuses
+  `query_mode='remote'` tables in v1 (snapshots come later). Schema v60
+  adds `chat_sessions` + `chat_messages` (full-content storage, no
+  redaction). Companion endpoints: `GET /api/chat/sessions`,
+  `GET /api/chat/sessions/{id}`, `DELETE /api/chat/sessions/{id}`
+  (soft-archive). Step #1 for the planned Slack/Telegram messaging
+  gateways. Web UI ships in PR 2/3.
+
 ## [0.55.24] — 2026-05-28
 
 ### Fixed

--- a/app/api/chat.py
+++ b/app/api/chat.py
@@ -1,0 +1,324 @@
+"""HTTP surface for the in-product chat agent (#459).
+
+Endpoints
+---------
+POST   /api/chat                       Stream a turn (SSE).
+GET    /api/chat/sessions              List the caller's sessions.
+GET    /api/chat/sessions/{id}         Full transcript for one session.
+DELETE /api/chat/sessions/{id}         Soft-archive a session.
+
+Every endpoint is gated by ``get_current_user``. Sessions are scoped
+to ``user_email`` — a caller never sees another user's chat. Tool
+invocations are RBAC-checked inside each handler (see ``app/chat/tools.py``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from typing import Any, AsyncIterator, Optional
+
+import duckdb
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+
+from app.auth.dependencies import get_current_user, _get_db
+from app.chat.loop import ChatTurnConfig, run_turn
+from app.chat.persistence import ChatRepository, ChatSession, ChatMessage
+from src.repositories.audit import AuditRepository
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/chat", tags=["chat"])
+
+
+DEFAULT_CHAT_MODEL = "claude-haiku-4-5-20251001"
+
+
+def _resolve_model() -> str:
+    """Pick the model for the chat loop. ``AGNES_CHAT_MODEL`` overrides;
+    otherwise the Haiku 4.5 default. Tests monkeypatch this."""
+    return os.environ.get("AGNES_CHAT_MODEL", "").strip() or DEFAULT_CHAT_MODEL
+
+
+def _build_anthropic_client():
+    """Lazily build the Anthropic async client. Raises ``HTTPException(500)``
+    if no API key is configured — handled at request time so the rest of
+    the app doesn't fail to import when running without an LLM key."""
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+    if not api_key:
+        # Fall back to the same secondary var the LLM factory accepts.
+        api_key = os.environ.get("LLM_API_KEY", "").strip()
+    if not api_key:
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                "chat is unavailable: set ANTHROPIC_API_KEY (or LLM_API_KEY) "
+                "in the environment, or configure the ai: block in instance.yaml"
+            ),
+        )
+    import anthropic
+    return anthropic.AsyncAnthropic(api_key=api_key)
+
+
+# --------------------------------------------------------------------------- #
+# Schemas
+# --------------------------------------------------------------------------- #
+
+
+class ChatRequest(BaseModel):
+    message: str = Field(..., min_length=1, max_length=8000)
+    session_id: Optional[str] = None
+
+
+class SessionSummary(BaseModel):
+    id: str
+    title: Optional[str]
+    started_at: Optional[str]
+    last_message_at: Optional[str]
+    message_count: int
+    archived: bool
+
+
+class SessionsListResponse(BaseModel):
+    sessions: list[SessionSummary]
+
+
+class SessionMessage(BaseModel):
+    id: str
+    role: str
+    content: str
+    tool_calls: list[dict[str, Any]] = []
+    tokens_in: Optional[int] = None
+    tokens_out: Optional[int] = None
+    model: Optional[str] = None
+    created_at: Optional[str] = None
+
+
+class SessionDetailResponse(BaseModel):
+    session: SessionSummary
+    messages: list[SessionMessage]
+
+
+# --------------------------------------------------------------------------- #
+# Endpoints
+# --------------------------------------------------------------------------- #
+
+
+@router.get("/sessions", response_model=SessionsListResponse)
+def list_sessions(
+    user: dict = Depends(get_current_user),
+    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
+):
+    email = user.get("email")
+    if not email:
+        raise HTTPException(status_code=401, detail="missing user email")
+    repo = ChatRepository(conn)
+    sessions = [_session_to_model(s) for s in repo.list_sessions(email)]
+    return {"sessions": sessions}
+
+
+@router.get("/sessions/{session_id}", response_model=SessionDetailResponse)
+def get_session(
+    session_id: str,
+    user: dict = Depends(get_current_user),
+    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
+):
+    repo = ChatRepository(conn)
+    session = _require_owned_session(repo, session_id, user)
+    messages = [_message_to_model(m) for m in repo.list_messages(session_id)]
+    return {"session": _session_to_model(session), "messages": messages}
+
+
+@router.delete("/sessions/{session_id}", status_code=204)
+def archive_session(
+    session_id: str,
+    user: dict = Depends(get_current_user),
+    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
+):
+    repo = ChatRepository(conn)
+    _require_owned_session(repo, session_id, user)
+    repo.archive_session(session_id)
+    return None
+
+
+@router.post("")
+async def chat_turn(
+    request: ChatRequest,
+    user: dict = Depends(get_current_user),
+    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
+):
+    """SSE stream of one chat turn.
+
+    Frame format::
+
+        event: token          data: {"text": "..."}
+        event: tool_call      data: {"tool": "...", "args": {...}}
+        event: tool_result    data: {"tool": "...", "ok": true, "result": {...}}
+        event: assistant_message  data: {"content": "...", "tool_calls": [...], ...}
+        event: done           data: {"session_id": "...", "last_message_id": "..."}
+        event: error          data: {"error": "..."}
+
+    """
+    email = user.get("email")
+    if not email:
+        raise HTTPException(status_code=401, detail="missing user email")
+
+    repo = ChatRepository(conn)
+    if request.session_id:
+        session = _require_owned_session(repo, request.session_id, user)
+    else:
+        session = repo.create_session(email, title=_auto_title(request.message))
+
+    repo.add_message(session.id, role="user", content=request.message)
+
+    config = ChatTurnConfig(model=_resolve_model())
+    client = _build_anthropic_client()
+    history = _build_history_for_replay(repo, session.id, exclude_last_user=True)
+
+    async def event_stream() -> AsyncIterator[bytes]:
+        # The async generator runs in a request-scoped task; we capture
+        # everything we need before the stream takes over (the DI-injected
+        # ``conn`` stays alive for the request lifetime via FastAPI).
+        last_message_id: Optional[str] = None
+        try:
+            async for event in run_turn(
+                client=client,
+                config=config,
+                history=history,
+                user_message=request.message,
+                user=user,
+                conn=conn,
+            ):
+                etype = event.get("type", "")
+                if etype == "assistant_message":
+                    persisted = repo.add_message(
+                        session.id,
+                        role="assistant",
+                        content=event.get("content", ""),
+                        tool_calls=event.get("tool_calls") or None,
+                        tokens_in=(event.get("usage") or {}).get("input_tokens"),
+                        tokens_out=(event.get("usage") or {}).get("output_tokens"),
+                        model=config.model,
+                    )
+                    last_message_id = persisted.id
+                elif etype == "tool_result":
+                    repo.add_message(
+                        session.id,
+                        role="tool_result",
+                        content=json.dumps(event.get("result", {}), default=str),
+                        tool_calls=[{"tool": event.get("tool"), "ok": event.get("ok")}],
+                    )
+                yield _sse_frame(etype or "message", event)
+            # Final done frame so the client knows the SSE is closing cleanly.
+            yield _sse_frame(
+                "done",
+                {"session_id": session.id, "last_message_id": last_message_id},
+            )
+        except Exception as exc:
+            logger.exception("chat: stream failed")
+            yield _sse_frame("error", {"error": str(exc)})
+
+        # Audit row — emitted once per turn, regardless of outcome.
+        try:
+            AuditRepository(conn).log(
+                user_id=user.get("id"),
+                action="chat.turn",
+                resource=f"chat_session:{session.id}",
+                params={
+                    "session_id": session.id,
+                    "message_chars": len(request.message),
+                    "model": config.model,
+                },
+                result="success" if last_message_id else "no_terminal_message",
+            )
+        except Exception:
+            logger.exception("chat: audit log write failed (non-fatal)")
+
+    headers = {
+        "Cache-Control": "no-cache",
+        "X-Accel-Buffering": "no",  # nginx: do not buffer
+    }
+    return StreamingResponse(event_stream(), media_type="text/event-stream", headers=headers)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _sse_frame(event_name: str, payload: dict[str, Any]) -> bytes:
+    return (
+        f"event: {event_name}\n"
+        f"data: {json.dumps(payload, ensure_ascii=False, default=str)}\n\n"
+    ).encode("utf-8")
+
+
+def _auto_title(message: str) -> str:
+    title = message.strip().splitlines()[0]
+    return title[:80] if title else "(empty)"
+
+
+def _require_owned_session(
+    repo: ChatRepository, session_id: str, user: dict,
+) -> ChatSession:
+    session = repo.get_session(session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="session not found")
+    if session.user_email != user.get("email"):
+        # 404 — don't leak existence of another user's session.
+        raise HTTPException(status_code=404, detail="session not found")
+    return session
+
+
+def _build_history_for_replay(
+    repo: ChatRepository, session_id: str, exclude_last_user: bool,
+) -> list[dict[str, Any]]:
+    """Return a messages array suitable as Anthropic ``messages=`` input.
+
+    The DB stores three role values (``user``, ``assistant``, ``tool_result``)
+    but only ``user`` and ``assistant`` belong in the Anthropic history —
+    tool_result blocks live inside a user turn alongside the matching
+    tool_use ids, and we don't have those ids persisted yet. For v1 we
+    therefore drop ``tool_result`` rows from replay; the new turn always
+    starts with a fresh tool-use loop, and any prior tool calls live as
+    informational text in the preceding assistant message's ``content``.
+    """
+    out: list[dict[str, Any]] = []
+    msgs = repo.list_messages(session_id)
+    if exclude_last_user and msgs and msgs[-1].role == "user":
+        msgs = msgs[:-1]
+    for m in msgs:
+        if m.role == "user":
+            out.append({"role": "user", "content": m.content})
+        elif m.role == "assistant":
+            out.append({"role": "assistant", "content": m.content})
+        # tool_result rows are skipped (see docstring).
+    return out
+
+
+def _session_to_model(session: ChatSession) -> SessionSummary:
+    return SessionSummary(
+        id=session.id,
+        title=session.title,
+        started_at=session.started_at,
+        last_message_at=session.last_message_at,
+        message_count=session.message_count,
+        archived=session.archived,
+    )
+
+
+def _message_to_model(msg: ChatMessage) -> SessionMessage:
+    return SessionMessage(
+        id=msg.id,
+        role=msg.role,
+        content=msg.content,
+        tool_calls=msg.tool_calls,
+        tokens_in=msg.tokens_in,
+        tokens_out=msg.tokens_out,
+        model=msg.model,
+        created_at=msg.created_at,
+    )

--- a/app/chat/__init__.py
+++ b/app/chat/__init__.py
@@ -1,0 +1,4 @@
+"""In-product chat agent (#459) — Anthropic tool-use loop over a fixed,
+read-only Agnes toolset. See ``app/api/chat.py`` for the HTTP surface
+and ``docs/`` for the user-facing description.
+"""

--- a/app/chat/loop.py
+++ b/app/chat/loop.py
@@ -1,0 +1,202 @@
+"""Anthropic tool-use loop for the chat agent.
+
+The loop streams a single user turn into:
+
+  - 0..N ``tool_use`` blocks (assistant) → handler invocations →
+    ``tool_result`` blocks (user)
+  - 1 terminal assistant ``text`` block once the model stops calling
+    tools.
+
+Events are yielded as plain dicts. ``app/api/chat.py`` converts them
+to SSE frames; tests consume them directly.
+
+Streaming model: we call ``messages.stream`` per turn and accumulate the
+final assistant message (text + tool_use blocks). The Anthropic SDK
+exposes ``stream.text_stream`` for token-level deltas; we forward each
+delta as a ``token`` event so the UI sees the answer materialize in
+real time, then re-emit the full block for persistence.
+
+We use a hard cap on tool-use iterations (``MAX_TOOL_ITERATIONS``) so
+a runaway tool-loop can never burn an unbounded number of model calls.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, Optional
+
+import duckdb
+
+from .prompts import SYSTEM_PROMPT
+from .tools import TOOL_DEFINITIONS, dispatch
+
+logger = logging.getLogger(__name__)
+
+
+MAX_TOOL_ITERATIONS = 12
+DEFAULT_MAX_TOKENS = 4096
+
+
+@dataclass
+class ChatTurnConfig:
+    model: str
+    max_tokens: int = DEFAULT_MAX_TOKENS
+    system: str = SYSTEM_PROMPT
+
+
+def _format_tool_use_summary(block: Any) -> dict[str, Any]:
+    """Compact dict describing one tool_use block for persistence."""
+    return {
+        "tool": getattr(block, "name", ""),
+        "id": getattr(block, "id", ""),
+        "args": getattr(block, "input", {}) or {},
+    }
+
+
+async def run_turn(
+    *,
+    client: Any,
+    config: ChatTurnConfig,
+    history: list[dict[str, Any]],
+    user_message: str,
+    user: dict,
+    conn: duckdb.DuckDBPyConnection,
+) -> AsyncIterator[dict[str, Any]]:
+    """Run one user turn end-to-end.
+
+    Yields events:
+      {"type": "token", "text": "..."}                                  per assistant token delta
+      {"type": "tool_call", "tool": "...", "args": {...}}               about to invoke a tool
+      {"type": "tool_result", "tool": "...", "result": {...}, "ok": bool}  tool returned
+      {"type": "assistant_message", "content": "...", "tool_calls": [...], "usage": {...}}  per assistant turn
+      {"type": "done"}                                                  final turn complete
+      {"type": "error", "error": "..."}                                 fatal — loop aborted
+
+    The caller is responsible for persisting the user message + every
+    emitted ``assistant_message`` and ``tool_result`` block.
+    """
+    # Start from caller-provided history + the new user message. We don't
+    # mutate ``history`` in place; the caller may want to keep its own copy.
+    messages: list[dict[str, Any]] = list(history) + [
+        {"role": "user", "content": user_message},
+    ]
+
+    for iteration in range(MAX_TOOL_ITERATIONS):
+        try:
+            async with client.messages.stream(
+                model=config.model,
+                max_tokens=config.max_tokens,
+                system=config.system,
+                tools=TOOL_DEFINITIONS,
+                messages=messages,
+            ) as stream:
+                async for token in stream.text_stream:
+                    if token:
+                        yield {"type": "token", "text": token}
+                final_message = await stream.get_final_message()
+        except Exception as exc:
+            logger.exception("chat: model call failed")
+            yield {"type": "error", "error": f"model call failed: {exc}"}
+            return
+
+        # Persist the assistant turn (text + tool_use blocks).
+        text_parts: list[str] = []
+        tool_use_blocks: list[Any] = []
+        for block in final_message.content:
+            btype = getattr(block, "type", None)
+            if btype == "text":
+                text_parts.append(getattr(block, "text", ""))
+            elif btype == "tool_use":
+                tool_use_blocks.append(block)
+
+        usage = {
+            "input_tokens": getattr(final_message.usage, "input_tokens", None),
+            "output_tokens": getattr(final_message.usage, "output_tokens", None),
+        }
+
+        yield {
+            "type": "assistant_message",
+            "content": "".join(text_parts),
+            "tool_calls": [_format_tool_use_summary(b) for b in tool_use_blocks],
+            "usage": usage,
+            "stop_reason": getattr(final_message, "stop_reason", None),
+        }
+
+        # Append the assistant turn to messages for the next loop iteration.
+        messages.append(
+            {"role": "assistant", "content": _content_for_replay(final_message.content)}
+        )
+
+        if not tool_use_blocks:
+            # Model produced a terminal answer — we're done.
+            yield {"type": "done"}
+            return
+
+        # Run every tool_use in this turn (Anthropic packs many into one
+        # assistant turn for batchable work) and feed them all back as a
+        # single user turn containing one ``tool_result`` per id.
+        tool_result_blocks: list[dict[str, Any]] = []
+        for block in tool_use_blocks:
+            tool_name = getattr(block, "name", "")
+            tool_id = getattr(block, "id", "")
+            tool_args = getattr(block, "input", {}) or {}
+            yield {"type": "tool_call", "tool": tool_name, "args": tool_args}
+            result = await dispatch(tool_name, tool_args, user, conn)
+            yield {
+                "type": "tool_result",
+                "tool": tool_name,
+                "ok": result.ok,
+                "result": result.data,
+            }
+            tool_result_blocks.append(
+                {
+                    "type": "tool_result",
+                    "tool_use_id": tool_id,
+                    "content": _stringify_tool_result(result.data),
+                    "is_error": not result.ok,
+                }
+            )
+        messages.append({"role": "user", "content": tool_result_blocks})
+
+    yield {
+        "type": "error",
+        "error": (
+            f"reached MAX_TOOL_ITERATIONS={MAX_TOOL_ITERATIONS} without a "
+            "terminal answer — the loop has been stopped to avoid runaway "
+            "cost; rephrase the question or split it into smaller asks"
+        ),
+    }
+
+
+def _content_for_replay(blocks: list[Any]) -> list[dict[str, Any]]:
+    """Convert SDK content blocks into the dict shape the API expects when
+    replaying as message history."""
+    out: list[dict[str, Any]] = []
+    for b in blocks:
+        btype = getattr(b, "type", None)
+        if btype == "text":
+            out.append({"type": "text", "text": getattr(b, "text", "")})
+        elif btype == "tool_use":
+            out.append(
+                {
+                    "type": "tool_use",
+                    "id": getattr(b, "id", ""),
+                    "name": getattr(b, "name", ""),
+                    "input": getattr(b, "input", {}) or {},
+                }
+            )
+    return out
+
+
+def _stringify_tool_result(data: dict[str, Any]) -> str:
+    """Serialize a tool result for the ``tool_result.content`` field.
+
+    Anthropic accepts either str or a list of content blocks. For
+    simplicity (and because the LLM is good at reading JSON), we always
+    emit a JSON-encoded string."""
+    import json
+    try:
+        return json.dumps(data, ensure_ascii=False, default=str)
+    except Exception:
+        return repr(data)

--- a/app/chat/persistence.py
+++ b/app/chat/persistence.py
@@ -1,0 +1,196 @@
+"""DuckDB CRUD for chat_sessions + chat_messages.
+
+The two tables are simple — no soft-delete, no fancy indexing — so a
+small repository module is sufficient. We don't put this under
+``src/repositories/`` because it is only consumed by ``app/chat/`` and
+``app/api/chat.py`` (the chat agent is self-contained); promoting it
+later if anything else grows a dependency is a one-line move.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import duckdb
+
+
+_SESSION_ID_PREFIX = "chat_"
+_MESSAGE_ID_PREFIX = "msg_"
+_ID_HEX_BYTES = 6  # 12 hex chars
+
+
+def _new_id(prefix: str) -> str:
+    return f"{prefix}{secrets.token_hex(_ID_HEX_BYTES)}"
+
+
+@dataclass
+class ChatMessage:
+    id: str
+    session_id: str
+    role: str  # 'user' | 'assistant' | 'tool_result'
+    content: str
+    tool_calls: list[dict[str, Any]] = field(default_factory=list)
+    tokens_in: Optional[int] = None
+    tokens_out: Optional[int] = None
+    model: Optional[str] = None
+    created_at: Optional[str] = None
+
+
+@dataclass
+class ChatSession:
+    id: str
+    user_email: str
+    title: Optional[str]
+    started_at: Optional[str]
+    last_message_at: Optional[str]
+    message_count: int
+    archived: bool
+
+
+class ChatRepository:
+    """Thin DuckDB-backed CRUD for chat sessions + messages."""
+
+    def __init__(self, conn: duckdb.DuckDBPyConnection) -> None:
+        self.conn = conn
+
+    # ------------------------------ sessions
+
+    def create_session(self, user_email: str, title: Optional[str] = None) -> ChatSession:
+        sid = _new_id(_SESSION_ID_PREFIX)
+        self.conn.execute(
+            """INSERT INTO chat_sessions (id, user_email, title, message_count, archived)
+               VALUES (?, ?, ?, 0, FALSE)""",
+            [sid, user_email, title],
+        )
+        return self.get_session(sid)  # type: ignore[return-value]
+
+    def get_session(self, session_id: str) -> Optional[ChatSession]:
+        row = self.conn.execute(
+            """SELECT id, user_email, title, started_at, last_message_at,
+                      message_count, archived
+                 FROM chat_sessions WHERE id = ?""",
+            [session_id],
+        ).fetchone()
+        return _row_to_session(row) if row else None
+
+    def list_sessions(
+        self, user_email: str, include_archived: bool = False, limit: int = 200
+    ) -> list[ChatSession]:
+        where = ["user_email = ?"]
+        params: list[Any] = [user_email]
+        if not include_archived:
+            where.append("archived = FALSE")
+        sql = (
+            "SELECT id, user_email, title, started_at, last_message_at, "
+            "message_count, archived "
+            "FROM chat_sessions "
+            f"WHERE {' AND '.join(where)} "
+            "ORDER BY COALESCE(last_message_at, started_at) DESC "
+            "LIMIT ?"
+        )
+        params.append(limit)
+        rows = self.conn.execute(sql, params).fetchall()
+        return [_row_to_session(r) for r in rows]
+
+    def archive_session(self, session_id: str) -> None:
+        self.conn.execute(
+            "UPDATE chat_sessions SET archived = TRUE WHERE id = ?",
+            [session_id],
+        )
+
+    def set_title(self, session_id: str, title: str) -> None:
+        self.conn.execute(
+            "UPDATE chat_sessions SET title = ? WHERE id = ?",
+            [title, session_id],
+        )
+
+    # ------------------------------ messages
+
+    def add_message(
+        self,
+        session_id: str,
+        role: str,
+        content: str,
+        tool_calls: Optional[list[dict[str, Any]]] = None,
+        tokens_in: Optional[int] = None,
+        tokens_out: Optional[int] = None,
+        model: Optional[str] = None,
+    ) -> ChatMessage:
+        mid = _new_id(_MESSAGE_ID_PREFIX)
+        self.conn.execute(
+            """INSERT INTO chat_messages
+               (id, session_id, role, content, tool_calls,
+                tokens_in, tokens_out, model)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            [
+                mid,
+                session_id,
+                role,
+                content,
+                json.dumps(tool_calls) if tool_calls else None,
+                tokens_in,
+                tokens_out,
+                model,
+            ],
+        )
+        # Bump session counters in the same transaction so list_sessions
+        # ordering reflects the new message immediately.
+        self.conn.execute(
+            """UPDATE chat_sessions
+                  SET message_count = message_count + 1,
+                      last_message_at = current_timestamp
+                WHERE id = ?""",
+            [session_id],
+        )
+        return ChatMessage(
+            id=mid,
+            session_id=session_id,
+            role=role,
+            content=content,
+            tool_calls=tool_calls or [],
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            model=model,
+        )
+
+    def list_messages(self, session_id: str) -> list[ChatMessage]:
+        rows = self.conn.execute(
+            """SELECT id, session_id, role, content, tool_calls,
+                      tokens_in, tokens_out, model, created_at
+                 FROM chat_messages
+                WHERE session_id = ?
+                ORDER BY created_at ASC, id ASC""",
+            [session_id],
+        ).fetchall()
+        return [_row_to_message(r) for r in rows]
+
+
+def _row_to_session(row: tuple) -> ChatSession:
+    return ChatSession(
+        id=row[0],
+        user_email=row[1],
+        title=row[2],
+        started_at=row[3].isoformat() if row[3] else None,
+        last_message_at=row[4].isoformat() if row[4] else None,
+        message_count=row[5],
+        archived=bool(row[6]),
+    )
+
+
+def _row_to_message(row: tuple) -> ChatMessage:
+    tool_calls_json = row[4]
+    tool_calls = json.loads(tool_calls_json) if tool_calls_json else []
+    return ChatMessage(
+        id=row[0],
+        session_id=row[1],
+        role=row[2],
+        content=row[3],
+        tool_calls=tool_calls,
+        tokens_in=row[5],
+        tokens_out=row[6],
+        model=row[7],
+        created_at=row[8].isoformat() if row[8] else None,
+    )

--- a/app/chat/prompts.py
+++ b/app/chat/prompts.py
@@ -1,0 +1,49 @@
+"""System prompt for the in-product chat agent.
+
+Mirrors the analyst rails in ``CLAUDE.md`` so the LLM behaves like a
+well-trained Agnes analyst — discovery before query, metric lookup
+before composition, memory bundle before assumptions.
+"""
+
+SYSTEM_PROMPT = """\
+You are Agnes, an in-product data assistant. You answer the user's
+data questions by calling the tools available to you against the
+caller's identity. You DO NOT have ambient knowledge of this team's
+schema, metrics, or conventions — you must fetch them.
+
+# Discovery protocol (follow in order)
+
+1. On the FIRST tool call of a conversation, call `get_memory_bundle`
+   to load the caller's audience-filtered Corporate Memory. Treat
+   `mandatory` items as non-negotiable context.
+2. Before writing any SELECT, call `list_catalog` to find the relevant
+   table id, then `get_schema(table_id)` for its columns + types,
+   then (when needed) `describe_table(table_id, n=5)` for a small
+   sample so you can see the real shape of the data.
+3. When the user mentions a named business metric (revenue, MRR, etc.),
+   call `lookup_metric(metric_id)` first. Use the canonical SQL or
+   expression from that row — never invent metric math.
+4. Only then call `run_query(sql)`. The result is row-capped; if you
+   need a different aggregation, run a new query rather than
+   reinterpreting the rows.
+
+# Read-only and local-only
+
+- `run_query` is **local + materialized tables only**. Remote
+  (BigQuery) tables return an error — apologize, point the user at
+  `agnes snapshot create` (which materializes a filtered subset
+  locally), and stop. Do NOT attempt to work around this.
+- You cannot write, modify, or schedule anything. If the user asks
+  for a write, explain you're read-only.
+
+# Answering style
+
+- One short paragraph + numbers. Prefer concrete values over hedging.
+- When a query result is small, show it as a markdown table.
+- When a result is large or truncated, summarize the top rows and
+  note the truncation.
+- Always reference the table id you queried so the user can audit
+  your answer.
+- If a tool returns an error, surface the message verbatim to the
+  user (it's actionable) — do not retry blindly.
+"""

--- a/app/chat/tools.py
+++ b/app/chat/tools.py
@@ -1,0 +1,492 @@
+"""Tool handlers exposed to the chat agent.
+
+Each tool is a thin wrapper over an existing Agnes capability:
+
+  - ``list_catalog``       → table_registry filtered by per-user RBAC
+  - ``get_schema``         → DuckDB DESCRIBE against the analytics view
+  - ``describe_table``     → SELECT ... LIMIT N sample rows
+  - ``run_query``          → local-mode SELECT against analytics.duckdb
+  - ``lookup_metric``      → metric_definitions row
+  - ``get_memory_bundle``  → Corporate Memory bundle for the caller
+
+Every handler validates RBAC against the caller's identity before
+touching data. ``run_query`` parses the submitted SQL for table refs
+and refuses execution if any referenced table is ``query_mode='remote'``
+or outside the caller's access — chat v1 is read-only and local-only by
+design (#459).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Optional
+
+import duckdb
+
+from src.db import get_analytics_db_readonly
+from src.rbac import can_access_table, get_accessible_tables
+from src.repositories.table_registry import TableRegistryRepository
+from src.repositories.metrics import MetricRepository
+
+logger = logging.getLogger(__name__)
+
+
+# Anthropic tool definitions ---------------------------------------------------
+
+TOOL_DEFINITIONS: list[dict[str, Any]] = [
+    {
+        "name": "list_catalog",
+        "description": (
+            "List every Agnes table the caller has access to. Use this "
+            "first when the user asks about 'what data we have' or before "
+            "composing a query. Returns id, name, description, source_type, "
+            "and query_mode for each table."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "get_schema",
+        "description": (
+            "Return the column names and types of a single table. Use this "
+            "before composing any SELECT so you reference real columns. "
+            "RBAC-checked: returns an error for tables the caller cannot read."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "table_id": {"type": "string"},
+            },
+            "required": ["table_id"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "describe_table",
+        "description": (
+            "Return a small sample of rows from a table so you can see the "
+            "real shape of the data (string casing, units, null patterns). "
+            "Use this after get_schema and before writing aggregates. "
+            "Max 20 rows; default 5."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "table_id": {"type": "string"},
+                "n": {"type": "integer", "minimum": 1, "maximum": 20, "default": 5},
+            },
+            "required": ["table_id"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "run_query",
+        "description": (
+            "Execute a read-only SELECT against the Agnes analytics database. "
+            "Local-mode and materialized tables only — remote (BigQuery) "
+            "tables are NOT supported in chat v1 and will return an error. "
+            "RBAC is re-checked for every table referenced. Result is "
+            "capped at 1000 rows."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "sql": {"type": "string", "description": "A single SELECT statement."},
+            },
+            "required": ["sql"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "lookup_metric",
+        "description": (
+            "Return the canonical definition of a business metric — SQL, "
+            "grain, business rules, synonyms. Use this BEFORE composing any "
+            "query that touches a named metric (revenue, MRR, active users, "
+            "etc.) so you never invent metric math."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "metric_id": {"type": "string"},
+            },
+            "required": ["metric_id"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "get_memory_bundle",
+        "description": (
+            "Return the caller's Corporate Memory bundle — admin-approved "
+            "facts about tables, metrics, and team conventions. Always call "
+            "this once at the start of a conversation; the bundle reflects "
+            "audience-filtered organizational knowledge that supersedes "
+            "any general assumption you may have."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+    },
+]
+
+
+# Public dispatcher ------------------------------------------------------------
+
+ToolHandler = Callable[[dict[str, Any], dict, duckdb.DuckDBPyConnection], Awaitable[dict[str, Any]]]
+
+
+@dataclass
+class ToolResult:
+    """Result of a tool invocation. ``ok=False`` carries an error message
+    the LLM will see and can act on."""
+    ok: bool
+    data: dict[str, Any]
+
+    def as_dict(self) -> dict[str, Any]:
+        if self.ok:
+            return self.data
+        return {"error": self.data.get("error", "tool failed")} | self.data
+
+
+async def dispatch(
+    name: str,
+    args: dict[str, Any],
+    user: dict,
+    conn: duckdb.DuckDBPyConnection,
+) -> ToolResult:
+    """Invoke a named tool. Returns ``ToolResult`` — the loop is responsible
+    for turning this into a ``tool_result`` block for the next assistant turn.
+    """
+    handler = _HANDLERS.get(name)
+    if handler is None:
+        return ToolResult(ok=False, data={"error": f"unknown tool: {name}"})
+    try:
+        result = await handler(args or {}, user, conn)
+        return ToolResult(ok=True, data=result)
+    except _ToolError as exc:
+        return ToolResult(ok=False, data={"error": str(exc)})
+    except Exception:
+        logger.exception("chat tool %s crashed", name)
+        return ToolResult(ok=False, data={"error": f"{name} failed internally"})
+
+
+class _ToolError(Exception):
+    """Tools raise this for user-actionable errors (bad input, RBAC denial,
+    etc.). The message is sent back to the LLM verbatim."""
+
+
+# Individual tool handlers -----------------------------------------------------
+
+
+async def _list_catalog(
+    args: dict[str, Any], user: dict, conn: duckdb.DuckDBPyConnection,
+) -> dict[str, Any]:
+    repo = TableRegistryRepository(conn)
+    rows = repo.list_all()
+    accessible = get_accessible_tables(user, conn)
+    if accessible is None:
+        visible = rows
+    else:
+        accessible_set = set(accessible)
+        visible = [r for r in rows if r["id"] in accessible_set]
+
+    return {
+        "tables": [
+            {
+                "id": r["id"],
+                "name": r.get("name"),
+                "description": r.get("description"),
+                "source_type": r.get("source_type"),
+                "query_mode": r.get("query_mode", "local"),
+            }
+            for r in visible
+        ],
+        "count": len(visible),
+    }
+
+
+async def _get_schema(
+    args: dict[str, Any], user: dict, conn: duckdb.DuckDBPyConnection,
+) -> dict[str, Any]:
+    table_id = _require_str(args, "table_id")
+    if not can_access_table(user, table_id, conn):
+        raise _ToolError(f"access denied to table '{table_id}'")
+    row = TableRegistryRepository(conn).get(table_id)
+    if not row:
+        raise _ToolError(f"table not registered: '{table_id}'")
+    columns = _describe_view_columns(table_id)
+    return {
+        "table_id": table_id,
+        "name": row.get("name"),
+        "description": row.get("description"),
+        "source_type": row.get("source_type"),
+        "query_mode": row.get("query_mode", "local"),
+        "columns": columns,
+        "partition_col": row.get("partition_col"),
+    }
+
+
+async def _describe_table(
+    args: dict[str, Any], user: dict, conn: duckdb.DuckDBPyConnection,
+) -> dict[str, Any]:
+    table_id = _require_str(args, "table_id")
+    n = int(args.get("n", 5))
+    n = max(1, min(n, 20))
+    if not can_access_table(user, table_id, conn):
+        raise _ToolError(f"access denied to table '{table_id}'")
+    row = TableRegistryRepository(conn).get(table_id)
+    if not row:
+        raise _ToolError(f"table not registered: '{table_id}'")
+    if row.get("query_mode") == "remote":
+        raise _ToolError(
+            f"table '{table_id}' is query_mode='remote' (BigQuery); sampling "
+            "remote tables is not supported in chat v1 — ask the analyst to "
+            "create a snapshot first (agnes snapshot create)"
+        )
+    analytics = get_analytics_db_readonly()
+    try:
+        analytics.execute(f'SELECT * FROM "{table_id}" LIMIT ?', [n])
+        columns = [d[0] for d in analytics.description]
+        rows = analytics.fetchall()
+    finally:
+        analytics.close()
+    return {
+        "table_id": table_id,
+        "columns": columns,
+        "rows": [_serialize_row(r) for r in rows],
+        "row_count": len(rows),
+    }
+
+
+# Identifiers that look like table refs after FROM / JOIN. Accepts bare
+# identifiers (orders) and double-quoted ones ("Some Table"). Schema-
+# qualified refs (kbc.bucket.tbl) are intentionally rejected here —
+# they're either remote-attach views (refuse with a clear message) or
+# system-internal (out of scope for chat v1).
+_TABLE_REF_PATTERN = re.compile(
+    r'\b(?:FROM|JOIN)\s+(?:"([^"]+)"|([a-zA-Z_][\w]*))',
+    re.IGNORECASE,
+)
+
+# Statements / keywords we refuse outright. Lifted from app/api/query.py's
+# blocklist but narrower: chat is exclusively SELECT, no DDL, no I/O.
+_BLOCKED_SQL_KEYWORDS = (
+    "drop ", "delete ", "insert ", "update ", "alter ", "create ",
+    "copy ", "attach ", "detach ", "load ", "install ",
+    "export ", "import ", "pragma ", "call ",
+    "read_csv", "read_json", "read_parquet", "read_text",
+    "write_csv", "write_parquet", "read_blob", "read_ndjson",
+    "parquet_scan", "json_scan", "csv_scan",
+    "query_table", "iceberg_scan", "delta_scan", "bigquery_query",
+    "glob(", "list_files",
+    "information_schema", "duckdb_tables", "duckdb_columns",
+    "duckdb_databases", "duckdb_settings", "duckdb_functions",
+    "duckdb_views", "duckdb_indexes", "duckdb_schemas",
+    "pragma_table_info", "pragma_storage_info",
+    # Path-traversal & multi-statement.
+    "'../", '"../',
+    ";",
+)
+
+_RUN_QUERY_ROW_LIMIT = 1000
+
+
+async def _run_query(
+    args: dict[str, Any], user: dict, conn: duckdb.DuckDBPyConnection,
+) -> dict[str, Any]:
+    sql_raw = _require_str(args, "sql").strip()
+    if not sql_raw:
+        raise _ToolError("sql is required")
+    sql_lower = sql_raw.lower()
+
+    # Must start with SELECT or WITH (CTE).
+    if not (sql_lower.startswith("select") or sql_lower.startswith("with ")):
+        raise _ToolError("only SELECT statements are allowed in chat v1")
+
+    for kw in _BLOCKED_SQL_KEYWORDS:
+        if kw in sql_lower:
+            raise _ToolError(f"SQL keyword/function not allowed in chat v1: {kw.strip()!r}")
+
+    referenced = _extract_table_refs(sql_raw)
+    if not referenced:
+        raise _ToolError(
+            "could not identify any table reference in the SQL — chat v1 "
+            "requires explicit FROM/JOIN against a registered table id"
+        )
+
+    registry = TableRegistryRepository(conn)
+    for ref in referenced:
+        row = registry.get(ref)
+        if not row:
+            raise _ToolError(
+                f"table '{ref}' is not registered — call list_catalog to "
+                "see available tables"
+            )
+        if row.get("query_mode") == "remote":
+            raise _ToolError(
+                f"table '{ref}' is query_mode='remote' (BigQuery); chat v1 "
+                "only supports local + materialized tables — ask the user "
+                "to create a snapshot (agnes snapshot create) and try again"
+            )
+        if not can_access_table(user, ref, conn):
+            raise _ToolError(f"access denied to table '{ref}'")
+
+    analytics = get_analytics_db_readonly()
+    try:
+        analytics.execute(sql_raw)
+        columns = [d[0] for d in analytics.description]
+        rows = analytics.fetchmany(_RUN_QUERY_ROW_LIMIT + 1)
+    except duckdb.Error as exc:
+        raise _ToolError(f"DuckDB rejected the query: {exc}")
+    finally:
+        analytics.close()
+
+    truncated = len(rows) > _RUN_QUERY_ROW_LIMIT
+    if truncated:
+        rows = rows[:_RUN_QUERY_ROW_LIMIT]
+    return {
+        "columns": columns,
+        "rows": [_serialize_row(r) for r in rows],
+        "row_count": len(rows),
+        "truncated": truncated,
+        "row_limit": _RUN_QUERY_ROW_LIMIT,
+        "tables_referenced": sorted(referenced),
+    }
+
+
+async def _lookup_metric(
+    args: dict[str, Any], user: dict, conn: duckdb.DuckDBPyConnection,
+) -> dict[str, Any]:
+    metric_id = _require_str(args, "metric_id")
+    row = MetricRepository(conn).get(metric_id)
+    if not row:
+        raise _ToolError(f"metric '{metric_id}' not found in metric_definitions")
+    return {
+        "id": row.get("id"),
+        "name": row.get("name"),
+        "display_name": row.get("display_name"),
+        "description": row.get("description"),
+        "category": row.get("category"),
+        "type": row.get("type"),
+        "unit": row.get("unit"),
+        "grain": row.get("grain"),
+        "table_name": row.get("table_name"),
+        "tables": row.get("tables"),
+        "expression": row.get("expression"),
+        "sql": row.get("sql"),
+        "time_column": row.get("time_column"),
+        "dimensions": row.get("dimensions"),
+        "filters": row.get("filters"),
+        "synonyms": row.get("synonyms"),
+        "notes": row.get("notes"),
+    }
+
+
+async def _get_memory_bundle(
+    args: dict[str, Any], user: dict, conn: duckdb.DuckDBPyConnection,
+) -> dict[str, Any]:
+    # Reuse the same audience-filtering helpers as /api/memory/bundle so the
+    # chat agent and the existing endpoint never diverge.
+    from app.api.memory import _effective_groups, _caller_granted_memory_domains
+    from src.repositories.knowledge import KnowledgeRepository
+
+    repo = KnowledgeRepository(conn)
+    effective_groups = _effective_groups(user, conn)
+    granted_domains = _caller_granted_memory_domains(user, conn)
+    dismissed_by = user.get("id")
+
+    mandatory = repo.list_items(
+        is_required=True,
+        exclude_personal=True,
+        user_groups=effective_groups,
+        granted_domains=granted_domains,
+        dismissed_by_user=dismissed_by,
+        hide_dismissed=True,
+        limit=1000,
+        offset=0,
+    )
+    approved = repo.list_items(
+        statuses=["approved"],
+        is_required=False,
+        exclude_personal=True,
+        user_groups=effective_groups,
+        granted_domains=granted_domains,
+        dismissed_by_user=dismissed_by,
+        hide_dismissed=True,
+        limit=1000,
+        offset=0,
+    )
+
+    return {
+        "mandatory": [_compact_memory_item(it) for it in mandatory],
+        "approved": [_compact_memory_item(it) for it in approved],
+        "mandatory_count": len(mandatory),
+        "approved_count": len(approved),
+    }
+
+
+_HANDLERS: dict[str, ToolHandler] = {
+    "list_catalog":      _list_catalog,
+    "get_schema":        _get_schema,
+    "describe_table":    _describe_table,
+    "run_query":         _run_query,
+    "lookup_metric":     _lookup_metric,
+    "get_memory_bundle": _get_memory_bundle,
+}
+
+
+# Helpers ----------------------------------------------------------------------
+
+
+def _require_str(args: dict[str, Any], key: str) -> str:
+    val = args.get(key)
+    if not isinstance(val, str) or not val.strip():
+        raise _ToolError(f"missing required argument: {key}")
+    return val.strip()
+
+
+def _extract_table_refs(sql: str) -> set[str]:
+    refs: set[str] = set()
+    for m in _TABLE_REF_PATTERN.finditer(sql):
+        ref = m.group(1) or m.group(2)
+        if ref:
+            refs.add(ref)
+    return refs
+
+
+def _describe_view_columns(table_id: str) -> list[dict[str, str]]:
+    analytics = get_analytics_db_readonly()
+    try:
+        rows = analytics.execute(f'DESCRIBE "{table_id}"').fetchall()
+        # DuckDB DESCRIBE returns (column_name, column_type, null, key, default, extra).
+        return [{"name": r[0], "type": r[1]} for r in rows]
+    finally:
+        analytics.close()
+
+
+def _serialize_row(row: tuple) -> list[Any]:
+    out: list[Any] = []
+    for v in row:
+        if v is None or isinstance(v, (int, float, bool, str)):
+            out.append(v)
+        else:
+            out.append(str(v))
+    return out
+
+
+def _compact_memory_item(item: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": item.get("id"),
+        "title": item.get("title"),
+        "content": item.get("content"),
+        "category": item.get("category"),
+        "confidence": item.get("confidence"),
+        "is_required": item.get("is_required"),
+    }

--- a/app/chat/tools.py
+++ b/app/chat/tools.py
@@ -221,7 +221,13 @@ async def _get_schema(
     row = TableRegistryRepository(conn).get(table_id)
     if not row:
         raise _ToolError(f"table not registered: '{table_id}'")
-    columns = _describe_view_columns(table_id)
+    # Single analytics-DB round trip: DESCRIBE the view to get columns.
+    analytics = get_analytics_db_readonly()
+    try:
+        described = analytics.execute(f'DESCRIBE "{table_id}"').fetchall()
+    finally:
+        analytics.close()
+    columns = [{"name": r[0], "type": r[1]} for r in described]
     return {
         "table_id": table_id,
         "name": row.get("name"),
@@ -275,17 +281,22 @@ _TABLE_REF_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
-# Statements / keywords we refuse outright. Lifted from app/api/query.py's
-# blocklist but narrower: chat is exclusively SELECT, no DDL, no I/O.
+# Statements / keywords we refuse outright. Mirrors ``app/api/query.py``'s
+# blocklist — chat is exclusively SELECT, no DDL, no I/O. The URL-scheme
+# entries (``http://``, ``s3://``, …) catch the ``SELECT * FROM
+# 'https://example.com/x.parquet'`` exfiltration shape that ``httpfs``
+# would otherwise allow even on a read-only DuckDB connection.
 _BLOCKED_SQL_KEYWORDS = (
     "drop ", "delete ", "insert ", "update ", "alter ", "create ",
     "copy ", "attach ", "detach ", "load ", "install ",
     "export ", "import ", "pragma ", "call ",
     "read_csv", "read_json", "read_parquet", "read_text",
     "write_csv", "write_parquet", "read_blob", "read_ndjson",
-    "parquet_scan", "json_scan", "csv_scan",
+    "parquet_scan", "parquet_metadata", "parquet_schema",
+    "json_scan", "csv_scan",
     "query_table", "iceberg_scan", "delta_scan", "bigquery_query",
     "glob(", "list_files",
+    "'/", '"/', "http://", "https://", "s3://", "gcs://",
     "information_schema", "duckdb_tables", "duckdb_columns",
     "duckdb_databases", "duckdb_settings", "duckdb_functions",
     "duckdb_views", "duckdb_indexes", "duckdb_schemas",
@@ -459,16 +470,6 @@ def _extract_table_refs(sql: str) -> set[str]:
         if ref:
             refs.add(ref)
     return refs
-
-
-def _describe_view_columns(table_id: str) -> list[dict[str, str]]:
-    analytics = get_analytics_db_readonly()
-    try:
-        rows = analytics.execute(f'DESCRIBE "{table_id}"').fetchall()
-        # DuckDB DESCRIBE returns (column_name, column_type, null, key, default, extra).
-        return [{"name": r[0], "type": r[1]} for r in rows]
-    finally:
-        analytics.close()
 
 
 def _serialize_row(row: tuple) -> list[Any]:

--- a/app/main.py
+++ b/app/main.py
@@ -134,6 +134,7 @@ from app.api.news import router as news_router
 from app.api.cache_warmup import router as cache_warmup_router
 from app.api.bq_metadata_refresh import router as bq_metadata_refresh_router
 from app.api.activity import router as activity_router
+from app.api.chat import router as chat_router
 from app.api.observability import router as observability_router
 from app.api.admin_user_sessions import router as admin_user_sessions_router
 from app.api.admin_sessions import router as admin_sessions_router
@@ -711,6 +712,7 @@ def create_app() -> FastAPI:
     app.include_router(query_router)
     app.include_router(users_router)
     app.include_router(memory_router)
+    app.include_router(chat_router)
     app.include_router(upload_router)
     app.include_router(scripts_router)
     app.include_router(settings_router)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -214,7 +214,7 @@ Files NOT to modify: `connectors/jira/file_lock.py`, `connectors/jira/transform.
 
 ### system.duckdb — `{DATA_DIR}/state/system.duckdb`
 
-Current schema version: **59** (auto-migrated from any earlier version on startup — see `src/db.py`).
+Current schema version: **60** (auto-migrated from any earlier version on startup — see `src/db.py`).
 
 | Table | Purpose |
 |-------|---------|

--- a/src/db.py
+++ b/src/db.py
@@ -40,7 +40,7 @@ def _maybe_instrument(con, db_tag: str):
 
 _SAFE_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,63}$")
 
-SCHEMA_VERSION = 59
+SCHEMA_VERSION = 60
 
 _SYSTEM_SCHEMA = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -1057,6 +1057,44 @@ CREATE TABLE IF NOT EXISTS usage_marketplace_item_window (
     PRIMARY KEY (period_label, source, type, parent_plugin, name)
 );
 CREATE INDEX IF NOT EXISTS idx_miw_lookup ON usage_marketplace_item_window(period_label, source, type);
+
+-- v60: in-product chat agent (#459). Two-table model — sessions hold
+-- thread metadata, messages hold the conversation transcript including
+-- assistant tool-call payloads. Full content is stored deliberately
+-- (no redaction) so the existing audit + future Corporate Memory
+-- extraction pipeline can read chat the same way they read session
+-- transcripts today.
+CREATE TABLE IF NOT EXISTS chat_sessions (
+    id              VARCHAR PRIMARY KEY,
+    user_email      VARCHAR NOT NULL,
+    title           VARCHAR,
+    started_at      TIMESTAMP NOT NULL DEFAULT current_timestamp,
+    last_message_at TIMESTAMP,
+    message_count   INTEGER NOT NULL DEFAULT 0,
+    archived        BOOLEAN NOT NULL DEFAULT FALSE
+);
+CREATE INDEX IF NOT EXISTS idx_chat_sessions_user
+    ON chat_sessions(user_email, last_message_at DESC);
+
+-- No FK from session_id → chat_sessions(id). DuckDB 1.5.x mis-fires
+-- "still referenced by a foreign key" on parent UPDATEs that touch
+-- columns participating in a non-unique secondary index — which the
+-- ``idx_chat_sessions_user`` index above does. App-level integrity is
+-- the actual enforcement: chat_messages are only written via
+-- ChatRepository.add_message, which always has a valid session_id.
+CREATE TABLE IF NOT EXISTS chat_messages (
+    id          VARCHAR PRIMARY KEY,
+    session_id  VARCHAR NOT NULL,
+    role        VARCHAR NOT NULL,   -- 'user' | 'assistant' | 'tool_result'
+    content     TEXT    NOT NULL,
+    tool_calls  JSON,               -- assistant turns: [{tool, args, result_summary}]
+    tokens_in   INTEGER,
+    tokens_out  INTEGER,
+    model       VARCHAR,
+    created_at  TIMESTAMP NOT NULL DEFAULT current_timestamp
+);
+CREATE INDEX IF NOT EXISTS idx_chat_messages_session
+    ON chat_messages(session_id, created_at);
 """
 
 
@@ -4124,6 +4162,51 @@ def _v23_to_v24_finalize(conn: duckdb.DuckDBPyConnection) -> None:
         raise
 
 
+def _v59_to_v60(conn: duckdb.DuckDBPyConnection) -> None:
+    """v60: in-product chat agent (#459) — ``chat_sessions`` +
+    ``chat_messages`` tables.
+
+    Fresh installs already get the tables from ``_SYSTEM_SCHEMA``; this
+    migration covers the sequential-upgrade path from a v59 instance.
+    Idempotent (CREATE TABLE / INDEX IF NOT EXISTS).
+    """
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS chat_sessions (
+            id              VARCHAR PRIMARY KEY,
+            user_email      VARCHAR NOT NULL,
+            title           VARCHAR,
+            started_at      TIMESTAMP NOT NULL DEFAULT current_timestamp,
+            last_message_at TIMESTAMP,
+            message_count   INTEGER NOT NULL DEFAULT 0,
+            archived        BOOLEAN NOT NULL DEFAULT FALSE
+        )
+    """)
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_chat_sessions_user "
+        "ON chat_sessions(user_email, last_message_at DESC)"
+    )
+    # No FK on session_id — see ``_SYSTEM_SCHEMA`` for the DuckDB FK
+    # workaround rationale.
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS chat_messages (
+            id          VARCHAR PRIMARY KEY,
+            session_id  VARCHAR NOT NULL,
+            role        VARCHAR NOT NULL,
+            content     TEXT    NOT NULL,
+            tool_calls  JSON,
+            tokens_in   INTEGER,
+            tokens_out  INTEGER,
+            model       VARCHAR,
+            created_at  TIMESTAMP NOT NULL DEFAULT current_timestamp
+        )
+    """)
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_chat_messages_session "
+        "ON chat_messages(session_id, created_at)"
+    )
+    conn.execute("UPDATE schema_version SET version = 60")
+
+
 def _v58_to_v59(conn: duckdb.DuckDBPyConnection) -> None:
     """v56: extended-content columns on ``data_packages`` + structured
     per-table doc columns on ``table_registry``.
@@ -4442,6 +4525,10 @@ def _ensure_schema(conn: duckdb.DuckDBPyConnection) -> None:
             # v56 extended content columns on data_packages + structured
             # per-table doc columns on table_registry.
             _v58_to_v59(conn)
+            # v60 chat agent tables (chat_sessions + chat_messages).
+            # _SYSTEM_SCHEMA already creates them on fresh installs;
+            # this call is a no-op there (CREATE TABLE IF NOT EXISTS).
+            _v59_to_v60(conn)
             # Fresh-install seed is handled by the unconditional
             # _seed_core_roles call at the bottom of _ensure_schema —
             # left as a no-op branch here so the migration ladder still
@@ -4613,6 +4700,8 @@ def _ensure_schema(conn: duckdb.DuckDBPyConnection) -> None:
                 _v57_to_v58(conn)
             if current < 59:
                 _v58_to_v59(conn)
+            if current < 60:
+                _v59_to_v60(conn)
             conn.execute(
                 "UPDATE schema_version SET version = ?, applied_at = current_timestamp",
                 [SCHEMA_VERSION],

--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -1,0 +1,222 @@
+"""HTTP-level tests for /api/chat.
+
+The SSE streaming path is exercised by mocking ``_build_anthropic_client``
+to return a fake client. We don't go end-to-end on streaming bytes —
+``test_chat_loop.py`` already covers the event sequence; here we focus
+on the surfaces specific to the HTTP layer (auth, persistence side
+effects, session-ownership boundaries).
+"""
+
+from dataclasses import dataclass, field
+
+import pytest
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# --------------------------------------------------------------------------- #
+# Fake Anthropic client (re-used from test_chat_loop)
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class _FakeBlock:
+    type: str
+    text: str = ""
+    name: str = ""
+    id: str = ""
+    input: dict = field(default_factory=dict)
+
+
+@dataclass
+class _FakeUsage:
+    input_tokens: int = 10
+    output_tokens: int = 4
+
+
+@dataclass
+class _FakeMessage:
+    content: list
+    usage: _FakeUsage = field(default_factory=_FakeUsage)
+    stop_reason: str = "end_turn"
+
+
+class _FakeStreamContext:
+    def __init__(self, text_chunks, final_message):
+        self._chunks = text_chunks
+        self._final = final_message
+
+    async def __aenter__(self):
+        async def _gen():
+            for c in self._chunks:
+                yield c
+        self.text_stream = _gen()
+        return self
+
+    async def __aexit__(self, *exc):
+        return None
+
+    async def get_final_message(self):
+        return self._final
+
+
+class _FakeMessages:
+    def __init__(self, scripted):
+        self._scripted = list(scripted)
+
+    def stream(self, **kwargs):
+        chunks, msg = self._scripted.pop(0)
+        return _FakeStreamContext(chunks, msg)
+
+
+class _FakeClient:
+    def __init__(self, scripted):
+        self.messages = _FakeMessages(scripted)
+
+
+def _terminal_text(text: str) -> tuple[list[str], _FakeMessage]:
+    return (list(text), _FakeMessage(content=[_FakeBlock(type="text", text=text)]))
+
+
+# --------------------------------------------------------------------------- #
+# Session CRUD
+# --------------------------------------------------------------------------- #
+
+
+class TestSessionsList:
+    def test_empty_for_new_user(self, seeded_app):
+        c = seeded_app["client"]
+        resp = c.get("/api/chat/sessions", headers=_auth(seeded_app["analyst_token"]))
+        assert resp.status_code == 200
+        assert resp.json() == {"sessions": []}
+
+    def test_requires_auth(self, seeded_app):
+        c = seeded_app["client"]
+        resp = c.get("/api/chat/sessions")
+        assert resp.status_code == 401
+
+
+class TestSessionGet:
+    def test_returns_404_for_unknown(self, seeded_app):
+        c = seeded_app["client"]
+        resp = c.get(
+            "/api/chat/sessions/chat_does_not_exist",
+            headers=_auth(seeded_app["analyst_token"]),
+        )
+        assert resp.status_code == 404
+
+
+class TestSessionArchive:
+    def test_returns_404_for_unknown(self, seeded_app):
+        c = seeded_app["client"]
+        resp = c.delete(
+            "/api/chat/sessions/chat_does_not_exist",
+            headers=_auth(seeded_app["analyst_token"]),
+        )
+        assert resp.status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# POST /api/chat (SSE)
+# --------------------------------------------------------------------------- #
+
+
+class TestChatTurn:
+    def test_creates_session_and_persists_messages(self, seeded_app, monkeypatch):
+        """First request with no session_id creates a fresh session and
+        returns a stream that includes the new session_id in the done event."""
+        scripted = [_terminal_text("Hello!")]
+        monkeypatch.setattr(
+            "app.api.chat._build_anthropic_client",
+            lambda: _FakeClient(scripted),
+        )
+        c = seeded_app["client"]
+        token = seeded_app["analyst_token"]
+        with c.stream("POST", "/api/chat", json={"message": "hi"}, headers=_auth(token)) as resp:
+            assert resp.status_code == 200
+            body = b"".join(resp.iter_bytes()).decode()
+        assert "event: token" in body
+        assert "event: assistant_message" in body
+        assert "event: done" in body
+        # Session row exists in DB and is owned by the caller.
+        sessions = c.get("/api/chat/sessions", headers=_auth(token)).json()["sessions"]
+        assert len(sessions) == 1
+        sid = sessions[0]["id"]
+        # Detail endpoint returns both user message + assistant message.
+        detail = c.get(f"/api/chat/sessions/{sid}", headers=_auth(token)).json()
+        roles = [m["role"] for m in detail["messages"]]
+        assert roles == ["user", "assistant"]
+        assert detail["messages"][0]["content"] == "hi"
+        assert detail["messages"][1]["content"] == "Hello!"
+        assert detail["messages"][1]["tokens_in"] == 10
+        assert detail["messages"][1]["tokens_out"] == 4
+
+    def test_requires_auth(self, seeded_app):
+        c = seeded_app["client"]
+        resp = c.post("/api/chat", json={"message": "hi"})
+        assert resp.status_code == 401
+
+    def test_continues_existing_session(self, seeded_app, monkeypatch):
+        scripted = [_terminal_text("First"), _terminal_text("Second")]
+        monkeypatch.setattr(
+            "app.api.chat._build_anthropic_client",
+            lambda: _FakeClient(scripted),
+        )
+        c = seeded_app["client"]
+        token = seeded_app["analyst_token"]
+        with c.stream("POST", "/api/chat", json={"message": "one"}, headers=_auth(token)) as resp:
+            list(resp.iter_bytes())
+        sid = c.get("/api/chat/sessions", headers=_auth(token)).json()["sessions"][0]["id"]
+        with c.stream(
+            "POST", "/api/chat",
+            json={"message": "two", "session_id": sid},
+            headers=_auth(token),
+        ) as resp:
+            list(resp.iter_bytes())
+        detail = c.get(f"/api/chat/sessions/{sid}", headers=_auth(token)).json()
+        # 4 messages: user/assistant for turn1, user/assistant for turn2.
+        assert [m["role"] for m in detail["messages"]] == [
+            "user", "assistant", "user", "assistant",
+        ]
+
+    def test_cannot_post_to_other_users_session(self, seeded_app, monkeypatch):
+        """Alice creates a session, Bob tries to use her session_id —
+        the server treats it as a 404 (don't leak existence)."""
+        scripted = [_terminal_text("Hi")]
+        monkeypatch.setattr(
+            "app.api.chat._build_anthropic_client",
+            lambda: _FakeClient(scripted),
+        )
+        c = seeded_app["client"]
+        with c.stream(
+            "POST", "/api/chat", json={"message": "hi"},
+            headers=_auth(seeded_app["analyst_token"]),
+        ) as resp:
+            list(resp.iter_bytes())
+        alice_sid = c.get(
+            "/api/chat/sessions",
+            headers=_auth(seeded_app["analyst_token"]),
+        ).json()["sessions"][0]["id"]
+        # Bob (viewer) tries to continue Alice's (analyst) session.
+        resp = c.post(
+            "/api/chat",
+            json={"message": "intrude", "session_id": alice_sid},
+            headers=_auth(seeded_app["viewer_token"]),
+        )
+        assert resp.status_code == 404
+
+    def test_missing_api_key_returns_500(self, seeded_app, monkeypatch):
+        """If no LLM key is configured, /api/chat responds with a clear
+        500 rather than crashing mid-stream."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("LLM_API_KEY", raising=False)
+        c = seeded_app["client"]
+        resp = c.post(
+            "/api/chat",
+            json={"message": "hi"},
+            headers=_auth(seeded_app["analyst_token"]),
+        )
+        assert resp.status_code == 500
+        assert "ANTHROPIC_API_KEY" in resp.json()["detail"]

--- a/tests/test_chat_loop.py
+++ b/tests/test_chat_loop.py
@@ -1,0 +1,267 @@
+"""Multi-turn tool-use loop tests using a fake Anthropic client.
+
+The fake mimics the SDK's ``messages.stream(...)`` async context manager,
+yielding canned token deltas and a final message with the requested
+content blocks. We use this to drive the loop deterministically without
+hitting the real API.
+"""
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+import duckdb
+import pytest
+
+from src.db import _ensure_schema
+from app.chat.loop import ChatTurnConfig, run_turn, MAX_TOOL_ITERATIONS
+
+
+# --------------------------------------------------------------------------- #
+# Fake Anthropic client
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class _FakeBlock:
+    type: str
+    text: str = ""
+    name: str = ""
+    id: str = ""
+    input: dict = field(default_factory=dict)
+
+
+@dataclass
+class _FakeUsage:
+    input_tokens: int = 5
+    output_tokens: int = 3
+
+
+@dataclass
+class _FakeMessage:
+    content: list
+    usage: _FakeUsage = field(default_factory=_FakeUsage)
+    stop_reason: str = "end_turn"
+
+
+class _FakeStreamContext:
+    """Async context manager mimicking client.messages.stream(...)."""
+
+    def __init__(self, text_chunks: list[str], final_message: _FakeMessage):
+        self._text_chunks = text_chunks
+        self._final_message = final_message
+
+    async def __aenter__(self):
+        async def _gen():
+            for chunk in self._text_chunks:
+                yield chunk
+        self.text_stream = _gen()
+        return self
+
+    async def __aexit__(self, *exc):
+        return None
+
+    async def get_final_message(self):
+        return self._final_message
+
+
+class _FakeMessages:
+    def __init__(self, scripted_turns: list[tuple[list[str], _FakeMessage]]):
+        # Each call to .stream(...) consumes the next scripted turn.
+        self._turns = list(scripted_turns)
+        self.calls = []
+
+    def stream(self, **kwargs):
+        self.calls.append(kwargs)
+        if not self._turns:
+            raise RuntimeError("scripted turns exhausted")
+        chunks, msg = self._turns.pop(0)
+        return _FakeStreamContext(chunks, msg)
+
+
+class _FakeClient:
+    def __init__(self, scripted_turns: list[tuple[list[str], _FakeMessage]]):
+        self.messages = _FakeMessages(scripted_turns)
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def conn():
+    c = duckdb.connect(":memory:")
+    _ensure_schema(c)
+    return c
+
+
+@pytest.fixture
+def user():
+    return {"id": "alice", "email": "alice@example.com"}
+
+
+def _collect(coro_gen):
+    async def _run():
+        out = []
+        async for ev in coro_gen:
+            out.append(ev)
+        return out
+    return asyncio.run(_run())
+
+
+# --------------------------------------------------------------------------- #
+# Tests
+# --------------------------------------------------------------------------- #
+
+
+class TestSingleTurn:
+    def test_terminal_text_only(self, conn, user):
+        """No tool calls — the model returns plain text. The loop should
+        emit token deltas + one assistant_message + done."""
+        client = _FakeClient([(
+            ["Hello", " there"],
+            _FakeMessage(content=[_FakeBlock(type="text", text="Hello there")]),
+        )])
+        events = _collect(run_turn(
+            client=client,
+            config=ChatTurnConfig(model="test-model"),
+            history=[],
+            user_message="hi",
+            user=user,
+            conn=conn,
+        ))
+        types = [e["type"] for e in events]
+        assert types == ["token", "token", "assistant_message", "done"]
+        assert events[-2]["content"] == "Hello there"
+        assert events[-2]["usage"]["input_tokens"] == 5
+        assert events[-2]["usage"]["output_tokens"] == 3
+
+
+class TestToolUseLoop:
+    def test_tool_call_then_answer(self, conn, user):
+        """Turn 1: model calls list_catalog. Turn 2: model answers with text."""
+        turn1 = (
+            [],
+            _FakeMessage(
+                content=[
+                    _FakeBlock(
+                        type="tool_use",
+                        name="list_catalog",
+                        id="tu_1",
+                        input={},
+                    ),
+                ],
+                stop_reason="tool_use",
+            ),
+        )
+        turn2 = (
+            ["You have", " no tables"],
+            _FakeMessage(content=[_FakeBlock(type="text", text="You have no tables")]),
+        )
+        client = _FakeClient([turn1, turn2])
+        events = _collect(run_turn(
+            client=client,
+            config=ChatTurnConfig(model="test-model"),
+            history=[],
+            user_message="what tables?",
+            user=user,
+            conn=conn,
+        ))
+        types = [e["type"] for e in events]
+        # Expected order: assistant_message (turn1 with tool_use) → tool_call →
+        # tool_result → tokens (turn2) → assistant_message (turn2) → done.
+        assert types == [
+            "assistant_message",  # turn1 with tool_use
+            "tool_call",
+            "tool_result",
+            "token", "token",
+            "assistant_message",  # terminal
+            "done",
+        ]
+        # The tool_call payload was list_catalog.
+        tool_call_ev = next(e for e in events if e["type"] == "tool_call")
+        assert tool_call_ev["tool"] == "list_catalog"
+        # The tool_result was ok (returns empty list of tables on a fresh DB).
+        tool_result_ev = next(e for e in events if e["type"] == "tool_result")
+        assert tool_result_ev["ok"]
+        assert "tables" in tool_result_ev["result"]
+
+    def test_tool_call_with_error_passes_message_to_model(self, conn, user):
+        """A failing tool returns ok=False but the loop continues — the
+        next assistant turn sees the error in its tool_result block."""
+        turn1 = (
+            [],
+            _FakeMessage(
+                content=[_FakeBlock(
+                    type="tool_use",
+                    name="get_schema",
+                    id="tu_1",
+                    input={"table_id": "nonexistent"},
+                )],
+                stop_reason="tool_use",
+            ),
+        )
+        turn2 = (
+            ["Sorry"],
+            _FakeMessage(content=[_FakeBlock(type="text", text="Sorry")]),
+        )
+        client = _FakeClient([turn1, turn2])
+        events = _collect(run_turn(
+            client=client,
+            config=ChatTurnConfig(model="test-model"),
+            history=[],
+            user_message="schema?",
+            user=user,
+            conn=conn,
+        ))
+        tool_result_ev = next(e for e in events if e["type"] == "tool_result")
+        assert not tool_result_ev["ok"]
+        # Order of checks: access first (doesn't leak existence), then
+        # registry. Either way the loop should see a non-empty error.
+        assert tool_result_ev["result"]["error"]
+
+
+class TestRunawayProtection:
+    def test_max_iterations_triggers_error(self, conn, user):
+        """If the model never stops calling tools, the loop bails after
+        MAX_TOOL_ITERATIONS with an error event."""
+        # Every turn is a tool_use → 12 turns produced, then the loop bails.
+        forever_tool = _FakeMessage(
+            content=[_FakeBlock(
+                type="tool_use", name="list_catalog", id="tu_1", input={},
+            )],
+            stop_reason="tool_use",
+        )
+        client = _FakeClient([([] , forever_tool)] * (MAX_TOOL_ITERATIONS + 1))
+        events = _collect(run_turn(
+            client=client,
+            config=ChatTurnConfig(model="test-model"),
+            history=[],
+            user_message="loop",
+            user=user,
+            conn=conn,
+        ))
+        types = [e["type"] for e in events]
+        assert types.count("assistant_message") == MAX_TOOL_ITERATIONS
+        assert types[-1] == "error"
+        assert "MAX_TOOL_ITERATIONS" in events[-1]["error"]
+
+
+class TestModelFailure:
+    def test_model_call_exception_yields_error_event(self, conn, user):
+        class _BoomClient:
+            class messages:
+                @staticmethod
+                def stream(**kwargs):
+                    raise RuntimeError("API down")
+        events = _collect(run_turn(
+            client=_BoomClient(),
+            config=ChatTurnConfig(model="test-model"),
+            history=[],
+            user_message="hi",
+            user=user,
+            conn=conn,
+        ))
+        assert events[-1]["type"] == "error"
+        assert "API down" in events[-1]["error"]

--- a/tests/test_chat_persistence.py
+++ b/tests/test_chat_persistence.py
@@ -1,0 +1,107 @@
+"""CRUD-level tests for app/chat/persistence.py (chat_sessions + chat_messages)."""
+
+import duckdb
+import pytest
+
+from src.db import _ensure_schema
+from app.chat.persistence import ChatRepository
+
+
+@pytest.fixture
+def conn():
+    c = duckdb.connect(":memory:")
+    _ensure_schema(c)
+    return c
+
+
+@pytest.fixture
+def repo(conn):
+    return ChatRepository(conn)
+
+
+class TestSessions:
+    def test_create_returns_session_with_id_and_zero_count(self, repo):
+        session = repo.create_session("alice@example.com", title="Q4 revenue")
+        assert session.id.startswith("chat_")
+        assert session.user_email == "alice@example.com"
+        assert session.title == "Q4 revenue"
+        assert session.message_count == 0
+        assert session.archived is False
+        assert session.started_at is not None
+
+    def test_create_with_null_title(self, repo):
+        session = repo.create_session("alice@example.com")
+        assert session.title is None
+
+    def test_get_returns_none_for_unknown_id(self, repo):
+        assert repo.get_session("chat_doesnotexist") is None
+
+    def test_list_sessions_scoped_by_email(self, repo):
+        a1 = repo.create_session("alice@example.com", title="A1")
+        b1 = repo.create_session("bob@example.com", title="B1")
+        a2 = repo.create_session("alice@example.com", title="A2")
+        alice_sessions = repo.list_sessions("alice@example.com")
+        assert {s.id for s in alice_sessions} == {a1.id, a2.id}
+        bob_sessions = repo.list_sessions("bob@example.com")
+        assert {s.id for s in bob_sessions} == {b1.id}
+
+    def test_list_sessions_excludes_archived_by_default(self, repo):
+        a = repo.create_session("alice@example.com", title="Active")
+        b = repo.create_session("alice@example.com", title="Archived")
+        repo.archive_session(b.id)
+        visible = repo.list_sessions("alice@example.com")
+        assert {s.id for s in visible} == {a.id}
+        all_sessions = repo.list_sessions("alice@example.com", include_archived=True)
+        assert {s.id for s in all_sessions} == {a.id, b.id}
+
+    def test_set_title_persists(self, repo):
+        session = repo.create_session("alice@example.com")
+        repo.set_title(session.id, "Renamed thread")
+        reloaded = repo.get_session(session.id)
+        assert reloaded is not None
+        assert reloaded.title == "Renamed thread"
+
+
+class TestMessages:
+    def test_add_message_bumps_counter_and_last_at(self, repo):
+        session = repo.create_session("alice@example.com")
+        msg = repo.add_message(session.id, role="user", content="hello")
+        assert msg.id.startswith("msg_")
+        assert msg.content == "hello"
+
+        reloaded = repo.get_session(session.id)
+        assert reloaded is not None
+        assert reloaded.message_count == 1
+        assert reloaded.last_message_at is not None
+
+    def test_add_message_with_tool_calls_roundtrips(self, repo):
+        session = repo.create_session("alice@example.com")
+        tc = [{"tool": "run_query", "args": {"sql": "SELECT 1"}}]
+        repo.add_message(
+            session.id,
+            role="assistant",
+            content="here it is",
+            tool_calls=tc,
+            tokens_in=12,
+            tokens_out=8,
+            model="claude-haiku-4-5-20251001",
+        )
+        msgs = repo.list_messages(session.id)
+        assert len(msgs) == 1
+        m = msgs[0]
+        assert m.role == "assistant"
+        assert m.tool_calls == tc
+        assert m.tokens_in == 12
+        assert m.tokens_out == 8
+        assert m.model == "claude-haiku-4-5-20251001"
+
+    def test_list_messages_ordered_chronologically(self, repo):
+        session = repo.create_session("alice@example.com")
+        repo.add_message(session.id, role="user", content="first")
+        repo.add_message(session.id, role="assistant", content="second")
+        repo.add_message(session.id, role="user", content="third")
+        contents = [m.content for m in repo.list_messages(session.id)]
+        assert contents == ["first", "second", "third"]
+
+    def test_list_messages_empty_for_unknown_session(self, repo):
+        assert repo.list_messages("chat_nope") == []

--- a/tests/test_chat_tools.py
+++ b/tests/test_chat_tools.py
@@ -224,6 +224,23 @@ class TestRunQuery:
         assert not result.ok
         assert "select" in result.data["error"].lower()
 
+    @pytest.mark.parametrize("url", [
+        "https://evil.example.com/data.parquet",
+        "http://evil.example.com/data.parquet",
+        "s3://bucket/data.parquet",
+        "gcs://bucket/data.parquet",
+    ])
+    def test_refuses_url_scheme_exfiltration(self, chat_env, url):
+        """An LLM-composed SELECT against a remote URL would otherwise
+        slip past the registry-based table check — `httpfs` reads the
+        URL as if it were a local file. Block on the scheme literal."""
+        result = _run(chat_tools.dispatch(
+            "run_query", {"sql": f"SELECT * FROM '{url}'"},
+            chat_env["admin_user"], chat_env["conn"],
+        ))
+        assert not result.ok
+        assert "not allowed" in result.data["error"]
+
     def test_refuses_semicolon_chained(self, chat_env):
         result = _run(chat_tools.dispatch(
             "run_query",

--- a/tests/test_chat_tools.py
+++ b/tests/test_chat_tools.py
@@ -1,0 +1,312 @@
+"""Tool-handler tests for the chat agent.
+
+These exercise the six tool handlers directly (no FastAPI, no Anthropic
+client) and verify RBAC + content shape.
+"""
+
+import asyncio
+import os
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from app.chat import tools as chat_tools
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def chat_env(tmp_path, monkeypatch):
+    """A clean DATA_DIR with system + analytics DBs and two tables registered:
+    one local (ok) + one remote (refused by run_query / describe_table).
+
+    The analytics DB has a tiny "orders" parquet so SELECTs return real data.
+    """
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    (tmp_path / "analytics").mkdir(exist_ok=True)
+    (tmp_path / "state").mkdir(exist_ok=True)
+    (tmp_path / "extracts").mkdir(exist_ok=True)
+
+    # Force schema migration on a fresh system.duckdb.
+    from src.db import get_system_db
+    sys_conn = get_system_db()
+    # Seed an admin user (so RBAC bypass triggers in tools that consult it).
+    sys_conn.execute(
+        "INSERT INTO users (id, email, name, active) VALUES (?, ?, ?, TRUE)",
+        ["alice", "alice@example.com", "Alice"],
+    )
+    sys_conn.execute(
+        "INSERT INTO users (id, email, name, active) VALUES (?, ?, ?, TRUE)",
+        ["bob", "bob@example.com", "Bob"],
+    )
+    # Make alice an admin.
+    from src.db import SYSTEM_ADMIN_GROUP
+    admin_gid = sys_conn.execute(
+        "SELECT id FROM user_groups WHERE name = ?", [SYSTEM_ADMIN_GROUP],
+    ).fetchone()[0]
+    sys_conn.execute(
+        "INSERT INTO user_group_members (user_id, group_id, source) VALUES (?, ?, ?)",
+        ["alice", admin_gid, "system_seed"],
+    )
+
+    # Register two tables: a local one (orders) and a remote one (events).
+    sys_conn.execute(
+        """INSERT INTO table_registry
+               (id, name, source_type, query_mode, description, registered_at)
+           VALUES (?, ?, ?, ?, ?, current_timestamp)""",
+        ["orders", "orders", "keboola", "local", "Orders fact table"],
+    )
+    sys_conn.execute(
+        """INSERT INTO table_registry
+               (id, name, source_type, query_mode, description, registered_at)
+           VALUES (?, ?, ?, ?, ?, current_timestamp)""",
+        ["events", "events", "bigquery", "remote", "Web events (BigQuery)"],
+    )
+    sys_conn.close()
+
+    # Build the analytics DB with a real view over a tiny parquet.
+    parquet = tmp_path / "extracts" / "kbc" / "data" / "orders.parquet"
+    parquet.parent.mkdir(parents=True, exist_ok=True)
+    pq_conn = duckdb.connect(":memory:")
+    pq_conn.execute(
+        f"COPY (SELECT * FROM (VALUES "
+        f"('o1', 100, 'CZ'), ('o2', 250, 'CZ'), ('o3', 50, 'US')"
+        f") AS t(id, total, country)) TO '{parquet}' (FORMAT PARQUET)"
+    )
+    pq_conn.close()
+
+    analytics_path = tmp_path / "analytics" / "server.duckdb"
+    an_conn = duckdb.connect(str(analytics_path))
+    an_conn.execute(
+        f'CREATE OR REPLACE VIEW "orders" AS '
+        f"SELECT * FROM read_parquet('{parquet}')"
+    )
+    # Remote view: just an empty placeholder so the registry row resolves.
+    an_conn.execute(
+        'CREATE OR REPLACE VIEW "events" AS '
+        "SELECT 1 AS id WHERE FALSE"
+    )
+    an_conn.close()
+
+    # Re-open system DB for the test body so it picks up the seeded rows.
+    sys_conn = get_system_db()
+    yield {"conn": sys_conn, "admin_user": {"id": "alice", "email": "alice@example.com"},
+           "non_admin_user": {"id": "bob", "email": "bob@example.com"}}
+    sys_conn.close()
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# --------------------------------------------------------------------------- #
+# list_catalog
+# --------------------------------------------------------------------------- #
+
+
+class TestListCatalog:
+    def test_admin_sees_all_tables(self, chat_env):
+        result = _run(chat_tools.dispatch(
+            "list_catalog", {}, chat_env["admin_user"], chat_env["conn"],
+        ))
+        assert result.ok
+        ids = {t["id"] for t in result.data["tables"]}
+        assert {"orders", "events"} <= ids
+        assert result.data["count"] >= 2
+
+    def test_non_admin_sees_only_granted_tables(self, chat_env):
+        result = _run(chat_tools.dispatch(
+            "list_catalog", {}, chat_env["non_admin_user"], chat_env["conn"],
+        ))
+        assert result.ok
+        # bob has no data-package grants → no external tables visible.
+        ids = {t["id"] for t in result.data["tables"]}
+        assert "orders" not in ids
+        assert "events" not in ids
+
+
+# --------------------------------------------------------------------------- #
+# get_schema
+# --------------------------------------------------------------------------- #
+
+
+class TestGetSchema:
+    def test_admin_can_read_local_schema(self, chat_env):
+        result = _run(chat_tools.dispatch(
+            "get_schema", {"table_id": "orders"},
+            chat_env["admin_user"], chat_env["conn"],
+        ))
+        assert result.ok
+        assert result.data["table_id"] == "orders"
+        assert any(c["name"] == "total" for c in result.data["columns"])
+
+    def test_non_admin_denied(self, chat_env):
+        result = _run(chat_tools.dispatch(
+            "get_schema", {"table_id": "orders"},
+            chat_env["non_admin_user"], chat_env["conn"],
+        ))
+        assert not result.ok
+        assert "access denied" in result.data["error"].lower()
+
+    def test_unknown_table(self, chat_env):
+        result = _run(chat_tools.dispatch(
+            "get_schema", {"table_id": "nonexistent"},
+            chat_env["admin_user"], chat_env["conn"],
+        ))
+        assert not result.ok
+        assert "not registered" in result.data["error"]
+
+    def test_missing_arg(self, chat_env):
+        result = _run(chat_tools.dispatch(
+            "get_schema", {}, chat_env["admin_user"], chat_env["conn"],
+        ))
+        assert not result.ok
+
+
+# --------------------------------------------------------------------------- #
+# describe_table
+# --------------------------------------------------------------------------- #
+
+
+class TestDescribeTable:
+    def test_returns_sample_rows(self, chat_env):
+        result = _run(chat_tools.dispatch(
+            "describe_table", {"table_id": "orders", "n": 2},
+            chat_env["admin_user"], chat_env["conn"],
+        ))
+        assert result.ok
+        assert result.data["row_count"] == 2
+        assert "id" in result.data["columns"]
+
+    def test_n_capped_at_20(self, chat_env):
+        result = _run(chat_tools.dispatch(
+            "describe_table", {"table_id": "orders", "n": 9999},
+            chat_env["admin_user"], chat_env["conn"],
+        ))
+        assert result.ok
+        # Only 3 rows in fixture, but cap should not crash.
+        assert result.data["row_count"] <= 20
+
+    def test_refuses_remote(self, chat_env):
+        result = _run(chat_tools.dispatch(
+            "describe_table", {"table_id": "events"},
+            chat_env["admin_user"], chat_env["conn"],
+        ))
+        assert not result.ok
+        assert "remote" in result.data["error"]
+
+
+# --------------------------------------------------------------------------- #
+# run_query
+# --------------------------------------------------------------------------- #
+
+
+class TestRunQuery:
+    def test_select_returns_rows(self, chat_env):
+        result = _run(chat_tools.dispatch(
+            "run_query", {"sql": "SELECT country, COUNT(*) AS n FROM orders GROUP BY 1"},
+            chat_env["admin_user"], chat_env["conn"],
+        ))
+        assert result.ok
+        assert result.data["columns"] == ["country", "n"]
+        assert result.data["row_count"] == 2  # CZ + US
+        assert "orders" in result.data["tables_referenced"]
+
+    def test_refuses_drop(self, chat_env):
+        result = _run(chat_tools.dispatch(
+            "run_query", {"sql": "DROP TABLE orders"},
+            chat_env["admin_user"], chat_env["conn"],
+        ))
+        assert not result.ok
+        assert "select" in result.data["error"].lower()
+
+    def test_refuses_semicolon_chained(self, chat_env):
+        result = _run(chat_tools.dispatch(
+            "run_query",
+            {"sql": "SELECT 1; SELECT 2"},
+            chat_env["admin_user"], chat_env["conn"],
+        ))
+        assert not result.ok
+
+    def test_refuses_remote_table(self, chat_env):
+        result = _run(chat_tools.dispatch(
+            "run_query", {"sql": "SELECT * FROM events LIMIT 5"},
+            chat_env["admin_user"], chat_env["conn"],
+        ))
+        assert not result.ok
+        assert "remote" in result.data["error"]
+
+    def test_refuses_unregistered_table(self, chat_env):
+        result = _run(chat_tools.dispatch(
+            "run_query", {"sql": "SELECT * FROM users LIMIT 1"},
+            chat_env["admin_user"], chat_env["conn"],
+        ))
+        # `users` exists in system.duckdb but is not in table_registry — refuse.
+        assert not result.ok
+        assert "not registered" in result.data["error"]
+
+    def test_refuses_non_admin_without_grant(self, chat_env):
+        result = _run(chat_tools.dispatch(
+            "run_query", {"sql": "SELECT * FROM orders LIMIT 1"},
+            chat_env["non_admin_user"], chat_env["conn"],
+        ))
+        assert not result.ok
+        assert "access denied" in result.data["error"].lower()
+
+    def test_requires_from_clause(self, chat_env):
+        result = _run(chat_tools.dispatch(
+            "run_query", {"sql": "SELECT 1"},
+            chat_env["admin_user"], chat_env["conn"],
+        ))
+        assert not result.ok
+        # Without FROM/JOIN we can't determine RBAC scope — refuse.
+        assert "table reference" in result.data["error"]
+
+
+# --------------------------------------------------------------------------- #
+# lookup_metric
+# --------------------------------------------------------------------------- #
+
+
+class TestLookupMetric:
+    def test_returns_not_found_for_unknown(self, chat_env):
+        result = _run(chat_tools.dispatch(
+            "lookup_metric", {"metric_id": "no.such.metric"},
+            chat_env["admin_user"], chat_env["conn"],
+        ))
+        assert not result.ok
+        assert "not found" in result.data["error"]
+
+
+# --------------------------------------------------------------------------- #
+# get_memory_bundle
+# --------------------------------------------------------------------------- #
+
+
+class TestGetMemoryBundle:
+    def test_returns_empty_bundle_for_fresh_install(self, chat_env):
+        result = _run(chat_tools.dispatch(
+            "get_memory_bundle", {},
+            chat_env["admin_user"], chat_env["conn"],
+        ))
+        assert result.ok
+        assert result.data["mandatory_count"] == 0
+        assert result.data["approved_count"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# dispatcher
+# --------------------------------------------------------------------------- #
+
+
+class TestDispatcher:
+    def test_unknown_tool_returns_error(self, chat_env):
+        result = _run(chat_tools.dispatch(
+            "no_such_tool", {}, chat_env["admin_user"], chat_env["conn"],
+        ))
+        assert not result.ok
+        assert "unknown tool" in result.data["error"]

--- a/tests/test_db_schema_version.py
+++ b/tests/test_db_schema_version.py
@@ -14,7 +14,7 @@ import duckdb
 from src.db import SCHEMA_VERSION, _ensure_schema, get_schema_version
 
 
-def test_schema_version_is_59():
+def test_schema_version_is_60():
     # v27 → v28: explicit-install (Model B) for curated marketplace plugins.
     # user_plugin_optouts row presence flips meaning from "excluded" to
     # "subscribed"; migration wipes existing rows so the inverted reading
@@ -169,7 +169,10 @@ def test_schema_version_is_59():
     #            (grain, platforms, partition_col, history, gotchas) for
     #            the /catalog/p/<slug> rewrite per the extended-
     #            descriptions admin spec. All additive + NULLABLE.
-    assert SCHEMA_VERSION == 59
+    # v59 → v60: ``chat_sessions`` + ``chat_messages`` tables backing the
+    #            in-product chat agent (#459). Two-table model with
+    #            full-content storage (no redaction).
+    assert SCHEMA_VERSION == 60
 
 
 def test_v37_marketplace_curator_columns(tmp_path):

--- a/tests/test_schema_v58_to_v59_migration.py
+++ b/tests/test_schema_v58_to_v59_migration.py
@@ -45,14 +45,16 @@ def _columns(conn, table: str) -> set[str]:
     }
 
 
-def test_schema_version_is_59():
-    assert SCHEMA_VERSION == 59
+def test_schema_version_is_60():
+    # Bumped to 60 by #459 (chat agent tables). The data_packages /
+    # table_registry assertions below still cover the v58 → v59 step.
+    assert SCHEMA_VERSION == 60
 
 
-def test_fresh_install_lands_at_v57(tmp_path):
+def test_fresh_install_lands_at_v60(tmp_path):
     conn = duckdb.connect(str(tmp_path / "system.duckdb"))
     _ensure_schema(conn)
-    assert get_schema_version(conn) == 59
+    assert get_schema_version(conn) == 60
 
 
 def test_v58_to_v59_adds_data_packages_owner_columns(tmp_path):
@@ -123,7 +125,7 @@ def test_v58_to_v59_is_idempotent(tmp_path):
     conn = duckdb.connect(str(db_path))
     _ensure_schema(conn)
     _ensure_schema(conn)  # second pass — no-op
-    assert get_schema_version(conn) == 59
+    assert get_schema_version(conn) == 60
 
 
 def test_v58_to_v59_preserves_table_registry_rows():


### PR DESCRIPTION
## Summary

PR 1 of 3 for the in-product chat agent (#459). Backend only — no web UI in this diff.

- `POST /api/chat` SSE endpoint, Anthropic tool-use loop, Haiku 4.5 default.
- Six read-only tools: `list_catalog`, `get_schema`, `describe_table`, `run_query`, `lookup_metric`, `get_memory_bundle`. RBAC re-checked per tool. `run_query` refuses `query_mode='remote'` tables in v1.
- Session CRUD endpoints: `GET /api/chat/sessions`, `GET /api/chat/sessions/{id}`, `DELETE /api/chat/sessions/{id}` (soft-archive). Sessions scoped to `user_email` — never cross-leak.
- Schema v60 adds `chat_sessions` + `chat_messages` (full-content storage, no redaction). Auto-migration in `src/db.py`.
- Audit row per turn via existing `audit_log` (`action='chat.turn'`).
- 43 new tests across persistence, tools (RBAC happy + denied), the tool-use loop (mocked Anthropic), and the SSE endpoint (session ownership, missing API key, multi-turn replay).

## What's NOT in this PR (per #459 plan)

- No web UI (PR 2/3).
- No CHANGELOG/docs polish beyond the bullet (PR 3/3).
- No Slack/Telegram gateways — see Phase 2 in #459.
- No `claude-agent-sdk` / E2B — see Phase 3 in #459.

## Implementation notes

**No FK on `chat_messages.session_id`.** DuckDB 1.5.x mis-fires "still referenced by a foreign key" when UPDATEing a parent row whose columns participate in a non-unique secondary index. We hit it on `idx_chat_sessions_user(user_email, last_message_at DESC)` + the `UPDATE chat_sessions SET last_message_at = ... WHERE id = ?` that bumps the timestamp after each message. App-level integrity is sufficient — chat_messages are only written via `ChatRepository.add_message`. Documented in both `_SYSTEM_SCHEMA` and `_v59_to_v60`.

**LLM key resolution.** Reuses the same env-var convention as `connectors/llm/factory.py`: `ANTHROPIC_API_KEY` then `LLM_API_KEY`. Missing key → `HTTPException(500, …)` at request time, not import time, so the app keeps booting without an LLM configured.

**`run_query` SQL parsing.** Same blocklist as `app/api/query.py` (DDL, file I/O, multi-statement, DuckDB metadata views) plus chat-specific: every referenced table must be in `table_registry`, none may be `query_mode='remote'`, the caller must pass `can_access_table` on every ref. Refusals come back as `{ok: false, error: "..."}` tool results so the LLM can apologize / suggest snapshots.

**Conversation history for replay.** v1 drops `tool_result` rows from the history fed to subsequent turns — tool_use_ids aren't persisted yet. Each new turn starts a fresh tool-use loop. PR 2/3 (UI) renders tool calls inline; PR 3/3 will revisit if we want the model to see prior tool dialogue.

## Test plan

- [x] `pytest tests/test_chat_*.py` — 43 tests, all green.
- [x] Full suite `.venv/bin/pytest tests/ --tb=short -n auto -q` — 5360 passed, 35 skipped, 3 failures.
- [x] **The 3 failures are pre-existing on `main`** (confirmed via `git stash`):
  - `test_cli_diagnose::test_diagnose_healthy` + `test_analyst_sees_healthy_when_only_operator_checks_warn` — `HEALTHY_HEALTH` fixture returns `degraded` overall. Unchanged by this diff.
  - `test_stack_resolver_perf::test_manifest_generation_perf_smoke` — `"Query interrupted"` under parallel xdist, passes in isolation. Flake.
- [x] Smoke: `from app.main import create_app; create_app()` boots cleanly, schema = v60, `/api/chat/*` routes registered.
- [ ] Manual smoke against a real key — defer to PR 2/3 once the UI exists; covered indirectly by the loop tests against a fake client.

## Related

- Issue: #459
- Reuses: existing RBAC (`src/rbac.py`), audit log (`src/repositories/audit.py`), Corporate Memory bundle helpers (`app/api/memory.py`).
- Pattern reuse for Phase 2 (Slack/Telegram): `services/telegram_bot/` for identity binding via verification codes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->