### PR TITLE
fix(catalog): stack-card status pill no longer overlaps curated/new badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Fixed
+- **Data Package card: the lifecycle status pill (POC / Coming soon / Draft) overlapped the curated/new badges.** Both the status pill (`.stack-card__status-pill`) and the derived-badge row (`.stack-card__badges`) were absolute-positioned at the same `top:8px; left:8px` corner of the card cover, so a package that had a non-default status *and* a derived badge rendered the two stacked on top of each other. The badge row now drops just below the status pill when one is present; placement is unchanged (top-left) when there's no pill. Macro: `app/web/templates/macros/_stack_card.html`.
+
 ## [0.55.25] — 2026-05-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.55.26] — 2026-06-01
+
 ### Fixed
 - **Data Package card: the lifecycle status pill (POC / Coming soon / Draft) overlapped the curated/new badges.** Both the status pill (`.stack-card__status-pill`) and the derived-badge row (`.stack-card__badges`) were absolute-positioned at the same `top:8px; left:8px` corner of the card cover, so a package that had a non-default status *and* a derived badge rendered the two stacked on top of each other. The badge row now drops just below the status pill when one is present; placement is unchanged (top-left) when there's no pill. Macro: `app/web/templates/macros/_stack_card.html`.
 

--- a/app/web/templates/macros/_stack_card.html
+++ b/app/web/templates/macros/_stack_card.html
@@ -76,10 +76,13 @@
   {% endif %}
 
   {# v56 derived badges (curated / new). Render top-left of the card
-     when present; multiple stack horizontally. Class hooks
-     ``data-badge="<name>"`` let the visual audit test pin them. #}
+     when present; multiple stack horizontally. When a lifecycle status
+     pill is also shown (poc / coming-soon / draft), it occupies the same
+     top-left corner, so drop the badge row just below it to avoid the two
+     overlapping. Class hooks ``data-badge="<name>"`` let the visual audit
+     test pin them. #}
   {% if entry.badges %}
-  <div class="stack-card__badges" style="position:absolute; top:8px; left:8px;
+  <div class="stack-card__badges" style="position:absolute; top:{{ '32px' if _status_meta else '8px' }}; left:8px;
        display:flex; gap:4px; z-index:2;">
     {% for b in entry.badges %}
     <span class="stack-card__derived-badge stack-card__derived-badge--{{ b }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.55.25"
+version = "0.55.26"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"


### PR DESCRIPTION
## What

On the Data Package card, the lifecycle **status pill** (POC / Coming soon / Draft) and the v56 **derived badges** (curated / new) were both absolute-positioned at the same `top:8px; left:8px` corner of the card cover. A package that has a non-default status *and* a derived badge rendered the two stacked on top of each other in the top-left corner.

The status pill (`.stack-card__status-pill`, v51) and the derived-badge row (`.stack-card__badges`, v56) were added separately and both independently claimed the top-left corner; the `Required` / `In stack` req-badge sits top-right and the cover glyph bottom-right, so only top-left was double-booked.

## Fix

When a status pill is shown (`_status_meta` truthy → poc / coming-soon / draft), drop the derived-badge row just below it (`top:32px` instead of `top:8px`). Placement is unchanged (top-left, `top:8px`) when there is no pill. One conditional in `app/web/templates/macros/_stack_card.html`; the badge markup and `data-badge` hooks are untouched.

## Tests

- Targeted macro tests pass — `test_web_stack_card_macro.py`, `test_web_stack_card_v56_metadata.py`, `test_web_catalog_package_detail_v56.py`, `test_design_system_contract.py` (42 passed); the `data-badge="curated"` / `data-badge="new"` assertions still hold.
- Full suite: **5335 passed, 35 skipped**.

## Release

Includes the **0.55.26** release-cut (CHANGELOG rename + new empty `[Unreleased]` + `pyproject.toml` bump) per the release-cut-in-PR rule, since `[Unreleased]` was empty and `v0.55.25` is already tagged.