### PR TITLE
feat(workspace): scaffold data-semantics pack from the catalog (#469)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+<<<<<<< HEAD
 ## [0.55.31] — 2026-06-01
 
 ### Fixed
@@ -22,6 +23,11 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   - **Uncapped system connection → OOM loop.** DuckDB enforces `memory_limit` per-connection, not per-process. The analytics + read-only connections were capped (2 GiB each) but the long-lived `system.duckdb` singleton was left uncapped, so a telemetry/audit aggregation on it could grow the process past the cgroup cap and the kernel OOM-killed the worker. `get_system_db()` now applies an explicit budget via a shared `_apply_memory_caps` helper (system 1 GiB, analytics 1.5 GiB, read-only 1 GiB) plus a `temp_directory` so an over-budget query spills to disk instead of growing RSS.
   - **Destructive WAL-replay recovery.** On restart after an unclean kill, an unreplayable WAL (the FTS-index DDL drop-ordering failure below) made `_try_open_system_db` restore the `pre-migrate` snapshot — captured only at migrations, so potentially days stale — discarding the live file's far newer last checkpoint. Recovery now first **discards only the unreplayable WAL and reopens the live file at its last checkpoint** (`_salvage_discard_wal`), losing at most post-checkpoint transactions; the pre-migrate fallback (with the #379 version guard) fires only if the file itself won't open. The discarded WAL is preserved chmod 600 for forensics.
   - **FTS DDL lingering in the WAL.** `ensure_knowledge_fts_index` rebuilds the `fts_main_knowledge_items` schema on every search; those DROP/CREATE ops sat in the WAL until the next checkpoint and were what DuckDB's replay choked on after a kill. It now `CHECKPOINT`s immediately after (re)creating the index (best-effort) so the FTS DDL never lingers in the WAL.
+=======
+### Added
+- **`agnes admin data-semantics generate <dir>` — scaffold the workspace data-semantics pack from the catalog (#469, Gap 1).** Emits a *starter* pack so an operator hand-edits know-how instead of authoring the whole tree: `<pkg>/tables/*.yml` (id, fqn, partition/cluster keys, columns — from `table_registry` + `column_metadata` + `bq_metadata_cache`), `<pkg>/metrics/*.yml` (from `metric_definitions`), grouped by `data_packages`, plus seed-if-absent `_brief.md` / `_overview.md` skeletons. Provenance + 3-way merge ride the pack's native `sync:` block (`method: generated` vs `hand-authored`): re-runs refresh machine-owned fields, keep human edits, preserve human-added keys, and drop a field whose source disappears. `--check` makes drift CI-enforceable; `--dry-run` / `--json` for inspection. Engine `src/data_semantics_scaffold.py` is `app.`-free. Metrics that belong to no data package are reported, not silently dropped.
+
+>>>>>>> ff590207 (fix(workspace): address Devin review on #472 (#469))
 ## [0.55.29] — 2026-06-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
-<<<<<<< HEAD
+## [0.55.32] — 2026-06-01
+
+### Added
+- **`agnes admin data-semantics generate <dir>` — scaffold the workspace data-semantics pack from the catalog (#469, Gap 1).** Emits a *starter* pack so an operator hand-edits know-how instead of authoring the whole tree: `<pkg>/tables/*.yml` (id, fqn, partition/cluster keys, columns — from `table_registry` + `column_metadata` + `bq_metadata_cache`), `<pkg>/metrics/*.yml` (from `metric_definitions`), grouped by `data_packages`, plus seed-if-absent `_brief.md` / `_overview.md` skeletons. Provenance + 3-way merge ride the pack's native `sync:` block (`method: generated` vs `hand-authored`): re-runs refresh machine-owned fields, keep human edits, preserve human-added keys, and drop a field whose source disappears. `--check` makes drift CI-enforceable; `--dry-run` / `--json` for inspection. Engine `src/data_semantics_scaffold.py` is `app.`-free. Metrics that belong to no data package are reported, not silently dropped.
+
 ## [0.55.31] — 2026-06-01
 
 ### Fixed
@@ -23,11 +27,6 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   - **Uncapped system connection → OOM loop.** DuckDB enforces `memory_limit` per-connection, not per-process. The analytics + read-only connections were capped (2 GiB each) but the long-lived `system.duckdb` singleton was left uncapped, so a telemetry/audit aggregation on it could grow the process past the cgroup cap and the kernel OOM-killed the worker. `get_system_db()` now applies an explicit budget via a shared `_apply_memory_caps` helper (system 1 GiB, analytics 1.5 GiB, read-only 1 GiB) plus a `temp_directory` so an over-budget query spills to disk instead of growing RSS.
   - **Destructive WAL-replay recovery.** On restart after an unclean kill, an unreplayable WAL (the FTS-index DDL drop-ordering failure below) made `_try_open_system_db` restore the `pre-migrate` snapshot — captured only at migrations, so potentially days stale — discarding the live file's far newer last checkpoint. Recovery now first **discards only the unreplayable WAL and reopens the live file at its last checkpoint** (`_salvage_discard_wal`), losing at most post-checkpoint transactions; the pre-migrate fallback (with the #379 version guard) fires only if the file itself won't open. The discarded WAL is preserved chmod 600 for forensics.
   - **FTS DDL lingering in the WAL.** `ensure_knowledge_fts_index` rebuilds the `fts_main_knowledge_items` schema on every search; those DROP/CREATE ops sat in the WAL until the next checkpoint and were what DuckDB's replay choked on after a kill. It now `CHECKPOINT`s immediately after (re)creating the index (best-effort) so the FTS DDL never lingers in the WAL.
-=======
-### Added
-- **`agnes admin data-semantics generate <dir>` — scaffold the workspace data-semantics pack from the catalog (#469, Gap 1).** Emits a *starter* pack so an operator hand-edits know-how instead of authoring the whole tree: `<pkg>/tables/*.yml` (id, fqn, partition/cluster keys, columns — from `table_registry` + `column_metadata` + `bq_metadata_cache`), `<pkg>/metrics/*.yml` (from `metric_definitions`), grouped by `data_packages`, plus seed-if-absent `_brief.md` / `_overview.md` skeletons. Provenance + 3-way merge ride the pack's native `sync:` block (`method: generated` vs `hand-authored`): re-runs refresh machine-owned fields, keep human edits, preserve human-added keys, and drop a field whose source disappears. `--check` makes drift CI-enforceable; `--dry-run` / `--json` for inspection. Engine `src/data_semantics_scaffold.py` is `app.`-free. Metrics that belong to no data package are reported, not silently dropped.
-
->>>>>>> ff590207 (fix(workspace): address Devin review on #472 (#469))
 ## [0.55.29] — 2026-06-01
 
 ### Added

--- a/cli/commands/admin.py
+++ b/cli/commands/admin.py
@@ -9,6 +9,7 @@ from cli.commands.admin_activity import activity_app
 from cli.commands.admin_ask import app as admin_ask_app
 from cli.commands.admin_autodoc import autodoc_tables
 from cli.commands.admin_data_package import admin_data_package_app
+from cli.commands.admin_data_semantics import admin_data_semantics_app
 from cli.commands.admin_memory_domain import admin_memory_domain_app
 from cli.commands.admin_metrics import admin_metrics_app
 from cli.commands.admin_news import admin_news_app
@@ -32,6 +33,7 @@ admin_app.add_typer(memory_admin_app, name="memory")
 admin_app.add_typer(admin_usage_app, name="telemetry", help="Telemetry export and admin queries")
 admin_app.add_typer(admin_usage_app, name="usage", help="(deprecated alias of `telemetry`)")
 admin_app.add_typer(admin_data_package_app, name="data-package", help="Data Package CRUD (v49)")
+admin_app.add_typer(admin_data_semantics_app, name="data-semantics", help="Generate the workspace data-semantics pack (#469)")
 admin_app.add_typer(admin_memory_domain_app, name="memory-domain", help="Memory Domain CRUD (v49)")
 # Single direct command (mirrors `register-table` / `discover-and-register`):
 # LLM-generate descriptions for undescribed tables (#399).

--- a/cli/commands/admin_data_semantics.py
+++ b/cli/commands/admin_data_semantics.py
@@ -1,0 +1,255 @@
+"""`agnes admin data-semantics generate` — scaffold the workspace
+data-semantics pack from the catalog (Gap 1 / #469).
+
+Reads ``data_packages`` + ``table_registry`` (+ ``column_metadata`` and
+``bq_metadata_cache``) and ``metric_definitions`` from the system DuckDB and
+emits a *starter* pack (``<slug>/tables/*.yml``, ``<slug>/metrics/*.yml``,
+``_brief.md``, ``_overview.md``) into an output directory. Re-run any time the
+catalog changes — human-authored content always wins (see
+:mod:`src.data_semantics_scaffold`).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+import typer
+
+admin_data_semantics_app = typer.Typer(
+    help="Generate the workspace data-semantics pack from the catalog"
+)
+
+
+@admin_data_semantics_app.callback()
+def _data_semantics_main() -> None:
+    """Generate the workspace data-semantics pack from the catalog (#469).
+
+    A no-op group callback: it keeps ``generate`` an explicit subcommand
+    (``agnes admin data-semantics generate ...``) rather than letting Typer
+    hoist the single command and drop the verb.
+    """
+
+
+@admin_data_semantics_app.command("generate")
+def generate(
+    output_dir: Path = typer.Argument(
+        ...,
+        file_okay=False,
+        dir_okay=True,
+        help="Directory to emit the pack into (the workspace 'data/' root).",
+    ),
+    package: Optional[str] = typer.Option(
+        None, "--package", help="Only generate this data-package slug."
+    ),
+    check: bool = typer.Option(
+        False, "--check",
+        help="Exit non-zero if the on-disk pack is out of sync. Writes nothing (CI).",
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Print the would-be files; write nothing."
+    ),
+    json_out: bool = typer.Option(
+        False, "--json", help="With --dry-run, print {relpath: content} as JSON."
+    ),
+):
+    """Generate / refresh the workspace data-semantics pack (admin tool).
+
+    Derives table specs (columns, partition/cluster keys) and metric
+    definitions from the catalog, leaving hand-authored know-how (gotchas,
+    join contracts, query recipes) for a human. ``_brief.md`` / ``_overview.md``
+    are seeded only when absent.
+    """
+    from src.data_semantics_scaffold import (
+        ScaffoldError,
+        comparable_view,
+        scaffold_pack,
+    )
+    from src.db import get_system_db
+
+    conn = get_system_db()
+    try:
+        inputs, notes = _assemble_inputs(conn, package_filter=package)
+    finally:
+        conn.close()
+
+    if not inputs["packages"]:
+        typer.echo(
+            "No data packages found"
+            + (f" for slug {package!r}." if package else " in the catalog."),
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    existing = _read_existing(output_dir, inputs)
+
+    try:
+        files, report = scaffold_pack(inputs, existing=existing)
+    except ScaffoldError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1)
+
+    for n in notes:
+        report.warnings.append(n)
+
+    if check:
+        on_disk = _read_rendered(output_dir, files.keys())
+        if comparable_view(on_disk) != comparable_view(files):
+            typer.echo(
+                "data-semantics pack is OUT OF SYNC — run: "
+                f"agnes admin data-semantics generate {output_dir}",
+                err=True,
+            )
+            raise typer.Exit(1)
+        typer.echo("data-semantics pack is up to date.")
+        return
+
+    if dry_run:
+        if json_out:
+            import json as _json
+
+            typer.echo(_json.dumps(files, indent=2, ensure_ascii=False))
+            return
+        _print_report(report)
+        for rel in sorted(files):
+            typer.echo(f"\n--- {rel} (dry-run, not written) ---")
+            typer.echo(files[rel])
+        return
+
+    for rel, text in files.items():
+        target = output_dir / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text, encoding="utf-8")
+    _print_report(report)
+    typer.echo(f"\nWrote {len(files)} file(s) under {output_dir}")
+
+
+# --------------------------------------------------------------------------- #
+# Assembly — repositories -> the engine's pre-grouped plain-data input
+# --------------------------------------------------------------------------- #
+
+
+def _assemble_inputs(conn, *, package_filter: Optional[str] = None):
+    """Build ``{"packages": [...]}`` for :func:`scaffold_pack`.
+
+    Returns ``(inputs, notes)`` where ``notes`` are CLI-level warnings (e.g.
+    metrics that belong to no package and were dropped)."""
+    from src.repositories.bq_metadata_cache import BqMetadataCacheRepository
+    from src.repositories.column_metadata import ColumnMetadataRepository
+    from src.repositories.data_packages import DataPackagesRepository
+    from src.repositories.metrics import MetricRepository
+    from src.repositories.table_registry import TableRegistryRepository
+
+    pkg_repo = DataPackagesRepository(conn)
+    tbl_repo = TableRegistryRepository(conn)
+    col_repo = ColumnMetadataRepository(conn)
+    bq_repo = BqMetadataCacheRepository(conn)
+    met_repo = MetricRepository(conn)
+
+    members = pkg_repo.list_member_ids_bulk()  # {pkg_id: [table_id, ...]}
+    all_metrics = met_repo.list()
+
+    packages_out: List[Dict[str, Any]] = []
+    assigned_metric_ids: set = set()
+
+    for pkg in pkg_repo.list():
+        slug = pkg.get("slug")
+        if package_filter and slug != package_filter:
+            continue
+        table_ids = list(members.get(pkg.get("id"), []))
+        tid_set = set(table_ids)
+
+        tables: List[Dict[str, Any]] = []
+        for tid in table_ids:
+            row = tbl_repo.get(tid)
+            if not row:
+                continue
+            row = dict(row)
+            row["columns"] = col_repo.list_for_table(tid)
+            row["bq_cache"] = bq_repo.get(tid)
+            tables.append(row)
+
+        metrics: List[Dict[str, Any]] = []
+        for mr in all_metrics:
+            if tid_set & set(_metric_tables(mr)):
+                metrics.append(mr)
+                assigned_metric_ids.add(mr.get("id"))
+
+        packages_out.append({
+            "slug": slug,
+            "name": pkg.get("name"),
+            "description": pkg.get("description"),
+            "tables": tables,
+            "metrics": metrics,
+        })
+
+    notes: List[str] = []
+    if not package_filter:
+        unassigned = [m for m in all_metrics if m.get("id") not in assigned_metric_ids]
+        if unassigned:
+            sample = ", ".join(sorted(m.get("name", "?") for m in unassigned)[:5])
+            notes.append(
+                f"{len(unassigned)} metric(s) belong to no data package and were "
+                f"not emitted (e.g. {sample}). Add their tables to a package first."
+            )
+    return {"packages": packages_out}, notes
+
+
+def _metric_tables(metric: Dict[str, Any]) -> List[str]:
+    tables = list(metric.get("tables") or [])
+    if metric.get("table_name"):
+        tables.append(metric["table_name"])
+    return tables
+
+
+# --------------------------------------------------------------------------- #
+# Disk IO
+# --------------------------------------------------------------------------- #
+
+
+def _read_existing(output_dir: Path, inputs: Dict[str, Any]) -> Dict[str, Any]:
+    """Read + parse every on-disk pack file for the packages in scope, keyed by
+    relpath (YAML → list/dict, markdown → str)."""
+    import yaml
+
+    existing: Dict[str, Any] = {}
+    for pkg in inputs["packages"]:
+        base = output_dir / (pkg.get("slug") or "")
+        if not base.is_dir():
+            continue
+        for path in sorted(base.rglob("*")):
+            if not path.is_file():
+                continue
+            rel = path.relative_to(output_dir).as_posix()
+            if path.suffix in (".yml", ".yaml"):
+                try:
+                    existing[rel] = yaml.safe_load(path.read_text(encoding="utf-8"))
+                except yaml.YAMLError:
+                    existing[rel] = None
+            elif path.suffix == ".md":
+                existing[rel] = path.read_text(encoding="utf-8")
+    return existing
+
+
+def _read_rendered(output_dir: Path, relpaths: Iterable[str]) -> Dict[str, str]:
+    """Raw text of each generated relpath that exists on disk (for --check)."""
+    on_disk: Dict[str, str] = {}
+    for rel in relpaths:
+        p = output_dir / rel
+        if p.is_file():
+            on_disk[rel] = p.read_text(encoding="utf-8")
+    return on_disk
+
+
+def _print_report(report) -> None:
+    typer.echo(
+        f"Packages: {len(report.packages)}  "
+        f"Tables: {len(report.tables)}  Metrics: {len(report.metrics)}"
+    )
+    counts = report.status_counts()
+    if counts:
+        typer.echo("Fields: " + ", ".join(f"{k}={counts[k]}" for k in sorted(counts)))
+    if report.briefs_seeded:
+        typer.echo(f"Seeded {len(report.briefs_seeded)} brief/overview file(s).")
+    for w in report.warnings:
+        typer.echo(f"  warning: {w}", err=True)

--- a/cli/commands/admin_data_semantics.py
+++ b/cli/commands/admin_data_semantics.py
@@ -196,9 +196,13 @@ def _assemble_inputs(conn, *, package_filter: Optional[str] = None):
 
 
 def _metric_tables(metric: Dict[str, Any]) -> List[str]:
+    # Union of `tables` + `table_name`, de-duplicated — mirrors the engine's
+    # coordinate derivation (src.data_semantics_scaffold._derive_metric) so
+    # package-matching and the emitted coordinate stay consistent.
     tables = list(metric.get("tables") or [])
-    if metric.get("table_name"):
-        tables.append(metric["table_name"])
+    tn = metric.get("table_name")
+    if tn and tn not in tables:
+        tables.append(tn)
     return tables
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.55.31"
+version = "0.55.32"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/src/data_semantics_scaffold.py
+++ b/src/data_semantics_scaffold.py
@@ -8,8 +8,7 @@ holds: ``metric_definitions``, ``table_registry`` (+ ``column_metadata`` and
 *starter* pack from that data so the operator only layers hand-authored
 know-how (join contracts, gotchas, query recipes) on top.
 
-The shape mirrors the real ``FoundryAI/initial-workspace`` pack (see the
-sanitized ``groupon-sample`` example):
+The pack layout — one directory per data package:
 
     <package_slug>/
       _brief.md            AI-query instructions (prose + SQL + gotchas)

--- a/src/data_semantics_scaffold.py
+++ b/src/data_semantics_scaffold.py
@@ -1,0 +1,588 @@
+"""Scaffolder for the workspace data-semantics pack (Gap 1 / #469).
+
+An operator hand-authors the analyst workspace ``data/`` knowledge pack — per
+data package a ``_brief.md``, an ``_overview.md``, ``tables/<id>.yml`` and
+``metrics/<name>.yml``. Much of that is *derivable* from data Agnes already
+holds: ``metric_definitions``, ``table_registry`` (+ ``column_metadata`` and
+``bq_metadata_cache``), grouped into ``data_packages``. This module emits a
+*starter* pack from that data so the operator only layers hand-authored
+know-how (join contracts, gotchas, query recipes) on top.
+
+The shape mirrors the real ``FoundryAI/initial-workspace`` pack (see the
+sanitized ``groupon-sample`` example):
+
+    <package_slug>/
+      _brief.md            AI-query instructions (prose + SQL + gotchas)
+      _overview.md         short overview
+      tables/<id>.yml      table spec  (grain, partition, columns)
+      metrics/<name>.yml   metric      (list form: sql, grain, synonyms, …)
+
+Field classification (per item):
+
+  GEN    deterministically derived; regenerated each run.
+           metric : name, category, type, unit, grain
+           table  : id, fqn, partition_by, clustered_by, columns
+  DRAFT  seeded from a source as a starting point; a human edit still wins
+         (3-way merge via a content hash).
+           metric : display_name, description, synonyms, dimensions,
+                    required_filters, notes, sql, validation, coordinate*
+           table  : display_name, grain, gotchas, columns[].note
+  KEEP   anything a human adds to a generated item that we do not derive
+         (e.g. ``approx_rows_per_day``, extra prose) — preserved untouched.
+
+Provenance uses the pack's **native ``sync:`` block** rather than a bespoke
+side-car (the example files already carry ``sync.{source,last_synced,method}``):
+
+    sync:
+      source: metric_definitions
+      method: generated            # <- ownership switch
+      last_synced: 2026-06-01T...Z
+      generated_fields:            # field -> content-hash of what we wrote
+        description: 6f1c…
+
+Merge contract:
+
+  item has no ``sync`` / ``method`` != "generated"  -> KEEP whole item (human owns it)
+  item ``method`` == "generated":
+    field absent                                    -> write derived   (fill)
+    field present, hash == last generated           -> write derived   (regenerate)
+    field present, hash != last generated           -> keep existing   (human edit wins)
+    field present, never tracked by us              -> keep existing   (human-added)
+    field was ours, no longer derived, untouched    -> remove          (source gone)
+
+``_brief.md`` / ``_overview.md`` are **seed-if-absent**: written only when
+missing, never overwritten (the prose is human-owned the moment it exists).
+
+This module has no ``app.`` dependency so it stays importable and unit-testable
+on its own (mirrors ``src/marketplace_metadata_scaffold.py``). Inputs are plain
+Python data assembled by the CLI from the repositories; the engine never opens
+a database.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+import yaml
+
+GENERATOR_TAG = "agnes-data-semantics-scaffold"
+SCHEMA_VERSION = 1
+
+# Statuses that mean "the generator owns this field" (its hash is recorded).
+_OWNED_STATUSES = frozenset({"generated", "regenerated", "unchanged"})
+
+
+class ScaffoldError(Exception):
+    """Raised for unrecoverable input problems. The CLI turns this into a
+    one-line error + exit 1."""
+
+
+# --------------------------------------------------------------------------- #
+# Small helpers
+# --------------------------------------------------------------------------- #
+
+
+def humanize(slug: str) -> str:
+    """``"new_customers"`` -> ``"New Customers"``. Only the first letter of each
+    token is upper-cased so internal caps survive (``"MRR"`` stays ``"MRR"``)."""
+    parts = re.split(r"[-_\s]+", (slug or "").strip())
+    return " ".join(p[:1].upper() + p[1:] for p in parts if p)
+
+
+def _field_hash(value: Any) -> str:
+    """Stable short content hash of a JSON-able value (provenance tracking)."""
+    canon = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(canon.encode("utf-8")).hexdigest()[:16]
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _as_list(value: Any) -> List[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [v for v in value if v is not None]
+    return [value]
+
+
+def _clean(value: Any) -> bool:
+    """True if a derived value is worth writing (non-empty)."""
+    if value is None:
+        return False
+    if isinstance(value, (str, list, dict)) and len(value) == 0:
+        return False
+    return True
+
+
+def _maybe_json(value: Any) -> Any:
+    """``validation``/``sql_variants`` round-trip from DuckDB as JSON strings."""
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except (ValueError, TypeError):
+            return value
+    return value
+
+
+# --------------------------------------------------------------------------- #
+# YAML rendering (literal block scalars for multi-line strings, key order kept)
+# --------------------------------------------------------------------------- #
+
+
+class _PackDumper(yaml.SafeDumper):
+    pass
+
+
+def _str_representer(dumper: yaml.Dumper, data: str):
+    style = "|" if "\n" in data else None
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data, style=style)
+
+
+_PackDumper.add_representer(str, _str_representer)
+
+
+def _dump_yaml(obj: Any) -> str:
+    return yaml.dump(
+        obj,
+        Dumper=_PackDumper,
+        sort_keys=False,
+        allow_unicode=True,
+        default_flow_style=False,
+        width=100,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Derivation — metric_definitions row -> workspace metric item
+# --------------------------------------------------------------------------- #
+
+
+def _derive_metric(row: Dict[str, Any], package: Dict[str, Any]) -> Dict[str, Any]:
+    """Build the derived (machine-owned) fields of one ``metrics/<name>.yml``
+    item from a ``metric_definitions`` row. Order mirrors the example file."""
+    name = (row.get("name") or "").strip()
+    tables = _as_list(row.get("tables")) or _as_list(row.get("table_name"))
+    slug = package.get("slug") or ""
+
+    out: Dict[str, Any] = {}
+    out["name"] = name
+    out["data_product"] = package.get("name") or humanize(slug)
+    out["display_name"] = (row.get("display_name") or humanize(name)).strip()
+    if _clean(row.get("description")):
+        out["description"] = row["description"].strip()
+    if _clean(row.get("category")):
+        out["category"] = row["category"]
+    if tables:
+        out["coordinate"] = list(tables)
+        out["coordinate_fqn"] = [f"{slug}.{t}" if slug else str(t) for t in tables]
+    if _clean(row.get("type")):
+        out["type"] = row["type"]
+    if _clean(row.get("unit")):
+        out["unit"] = row["unit"]
+    if _clean(row.get("grain")):
+        out["grain"] = row["grain"]
+    if _clean(row.get("synonyms")):
+        out["synonyms"] = list(row["synonyms"])
+    if _clean(row.get("filters")):
+        out["required_filters"] = list(row["filters"])
+    if _clean(row.get("dimensions")):
+        out["dimensions"] = list(row["dimensions"])
+    if _clean(row.get("notes")):
+        out["notes"] = list(row["notes"])
+    if _clean(row.get("sql")):
+        out["sql"] = row["sql"]
+    variants = _maybe_json(row.get("sql_variants"))
+    if isinstance(variants, dict):
+        for vkey, vsql in variants.items():
+            out[f"sql_{vkey}"] = vsql
+    validation = _maybe_json(row.get("validation"))
+    if _clean(validation):
+        out["validation"] = validation
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Derivation — table_registry (+ columns + bq cache) -> workspace table item
+# --------------------------------------------------------------------------- #
+
+
+def _derive_columns(columns: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    for c in columns:
+        nm = (c.get("column_name") or c.get("name") or "").strip()
+        if not nm:
+            continue
+        item: Dict[str, Any] = {"name": nm}
+        typ = c.get("basetype") or c.get("type")
+        if _clean(typ):
+            item["type"] = typ
+        note = c.get("description") or c.get("note")
+        if _clean(note):
+            item["note"] = note.strip() if isinstance(note, str) else note
+        out.append(item)
+    return out
+
+
+def _derive_table(table: Dict[str, Any], package: Dict[str, Any]) -> Dict[str, Any]:
+    """Build the derived fields of one ``tables/<id>.yml`` from a
+    ``table_registry`` row plus its column_metadata + bq_metadata_cache."""
+    bq = table.get("bq_cache") or {}
+    columns = _derive_columns(table.get("columns") or [])
+    slug = package.get("slug") or ""
+
+    # fqn: explicit BigQuery fqn, else construct from bucket + source_table.
+    fqn = table.get("bq_fqn")
+    if not _clean(fqn) and _clean(table.get("bucket")) and _clean(table.get("source_table")):
+        fqn = f"{table['bucket']}.{table['source_table']}"
+
+    # partition: bq cache is freshest; fall back to the registry columns.
+    partition = bq.get("partition_by") or table.get("partition_col") or table.get("partition_by")
+
+    out: Dict[str, Any] = {}
+    out["id"] = (table.get("id") or "").strip()
+    out["display_name"] = (table.get("name") or humanize(out["id"])).strip()
+    out["data_product"] = package.get("name") or humanize(slug)
+    if _clean(fqn):
+        out["fqn"] = fqn
+    if _clean(table.get("grain")):
+        out["grain"] = table["grain"]
+    if _clean(partition):
+        out["partition_by"] = partition
+    if _clean(bq.get("clustered_by")):
+        out["clustered_by"] = list(bq["clustered_by"])
+    if columns:
+        out["columns"] = columns
+    gotchas = table.get("gotchas")
+    if _clean(gotchas):
+        out["gotchas"] = gotchas
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# sync block + 3-way merge
+# --------------------------------------------------------------------------- #
+
+
+def _build_sync(source: str, hashes: Dict[str, str], generated_at: str) -> Dict[str, Any]:
+    return {
+        "source": source,
+        "method": "generated",
+        "last_synced": generated_at,
+        "generator": GENERATOR_TAG,
+        "schema": SCHEMA_VERSION,
+        "generated_fields": {k: hashes[k] for k in sorted(hashes)},
+    }
+
+
+def _merge_item(
+    derived: Dict[str, Any],
+    existing: Optional[Dict[str, Any]],
+    *,
+    source: str,
+    generated_at: str,
+    report: "ScaffoldReport",
+    item_key: str,
+) -> Optional[Dict[str, Any]]:
+    """3-way merge one item (metric or table) using its ``sync`` block.
+
+    Returns the merged item dict. A human-owned item (no ``sync`` or
+    ``method`` != "generated") is returned unchanged."""
+    if existing is not None:
+        sync = existing.get("sync") if isinstance(existing, dict) else None
+        method = sync.get("method") if isinstance(sync, dict) else None
+        if method != "generated":
+            report.actions.append((item_key, "*", "kept-human"))
+            return copy.deepcopy(existing)
+
+    prior_sync = (existing or {}).get("sync") if isinstance(existing, dict) else None
+    prior_hashes = {}
+    if isinstance(prior_sync, dict) and isinstance(prior_sync.get("generated_fields"), dict):
+        prior_hashes = {
+            k: v for k, v in prior_sync["generated_fields"].items()
+            if isinstance(k, str) and isinstance(v, str)
+        }
+
+    merged: Dict[str, Any] = copy.deepcopy(existing) if isinstance(existing, dict) else {}
+    new_hashes: Dict[str, str] = {}
+
+    for fname, dval in derived.items():
+        ev = merged.get(fname)
+        ph = prior_hashes.get(fname)
+        if ev is None:
+            merged[fname] = dval
+            status = "generated"
+        elif ph is None:
+            status = "kept-human"          # human-added field on a generated item
+        elif _field_hash(ev) == ph:
+            if ev == dval:
+                status = "unchanged"
+            else:
+                merged[fname] = dval
+                status = "regenerated"
+        else:
+            status = "kept-edited"          # human edited since last generation
+        report.actions.append((item_key, fname, status))
+        if status in _OWNED_STATUSES:
+            new_hashes[fname] = _field_hash(merged[fname])
+
+    # Fields we generated last run but no longer derive (source removed):
+    # drop if untouched, keep if hand-edited (mirrors the marketplace scaffolder).
+    for fname, ph in prior_hashes.items():
+        if fname in derived or fname not in merged:
+            continue
+        if _field_hash(merged[fname]) == ph:
+            del merged[fname]
+            report.actions.append((item_key, fname, "removed"))
+        else:
+            report.actions.append((item_key, fname, "kept-edited"))
+
+    merged["sync"] = _build_sync(source, new_hashes, generated_at)
+    return merged
+
+
+# --------------------------------------------------------------------------- #
+# _brief.md / _overview.md skeletons (seed-if-absent)
+# --------------------------------------------------------------------------- #
+
+
+def _overview_skeleton(package: Dict[str, Any]) -> str:
+    name = package.get("name") or humanize(package.get("slug") or "")
+    desc = (package.get("description") or "").strip()
+    body = desc or "_TODO: one-paragraph overview of this data package._"
+    return f"# {name} — Overview\n\n{body}\n"
+
+
+def _brief_skeleton(
+    package: Dict[str, Any],
+    table_items: List[Dict[str, Any]],
+    metric_items: List[Dict[str, Any]],
+) -> str:
+    name = package.get("name") or humanize(package.get("slug") or "")
+    desc = (package.get("description") or "").strip()
+    lines: List[str] = []
+    lines.append(f"# {name} — AI Query Context")
+    lines.append("")
+    lines.append("## 1. Overview")
+    lines.append("")
+    lines.append(desc or "_TODO: what this package is for and when to start here._")
+    lines.append("")
+    lines.append("## 2. AI Query Instructions")
+    lines.append("")
+    lines.append("_TODO: non-negotiable filter rules, standard joins, and don'ts._")
+    lines.append("")
+    lines.append("## 3. Tables")
+    lines.append("")
+    if table_items:
+        lines.append("| Table | Grain | Partition |")
+        lines.append("|---|---|---|")
+        for t in table_items:
+            lines.append(
+                f"| `{t.get('id', '?')}` | {t.get('grain', '—')} | "
+                f"{t.get('partition_by', '—')} |"
+            )
+    else:
+        lines.append("_No registered tables in this package yet._")
+    lines.append("")
+    lines.append("## 4. Metrics")
+    lines.append("")
+    if metric_items:
+        lines.append("| Metric | Grain | Description |")
+        lines.append("|---|---|---|")
+        for m in metric_items:
+            d = (m.get("description") or "").replace("\n", " ").strip()
+            if len(d) > 80:
+                d = d[:77] + "…"
+            lines.append(f"| `{m.get('name', '?')}` | {m.get('grain', '—')} | {d or '—'} |")
+    else:
+        lines.append("_No registered metrics in this package yet._")
+    lines.append("")
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- #
+# Report
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class ScaffoldReport:
+    packages: List[str] = field(default_factory=list)
+    tables: List[str] = field(default_factory=list)
+    metrics: List[str] = field(default_factory=list)
+    briefs_seeded: List[str] = field(default_factory=list)
+    actions: List[Tuple[str, str, str]] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+
+    def status_counts(self) -> Dict[str, int]:
+        counts: Dict[str, int] = {}
+        for _key, _field, status in self.actions:
+            counts[status] = counts.get(status, 0) + 1
+        return counts
+
+    def wrote_changes(self) -> bool:
+        return bool(self.briefs_seeded) or any(
+            status in ("generated", "regenerated", "removed")
+            for _key, _field, status in self.actions
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration
+# --------------------------------------------------------------------------- #
+
+_METRIC_SOURCE = "metric_definitions"
+_TABLE_SOURCE = "table_registry+column_metadata+bq_metadata_cache"
+
+
+def _existing_metric(existing: Dict[str, Any], relpath: str) -> Optional[Dict[str, Any]]:
+    """A metrics file parses to a single-item list; return the item dict."""
+    raw = existing.get(relpath)
+    if isinstance(raw, list) and raw and isinstance(raw[0], dict):
+        return raw[0]
+    if isinstance(raw, dict):
+        return raw
+    return None
+
+
+def scaffold_pack(
+    inputs: Dict[str, Any],
+    existing: Optional[Dict[str, Any]] = None,
+    *,
+    generated_at: Optional[str] = None,
+) -> Tuple[Dict[str, str], ScaffoldReport]:
+    """Generate / refresh a workspace data-semantics pack.
+
+    ``inputs`` is pre-grouped, plain Python data (assembled by the CLI from the
+    repositories)::
+
+        {"packages": [
+            {"slug": str, "name": str, "description": str | None,
+             "tables":  [<registry row> + "columns":[...] + "bq_cache":{...}],
+             "metrics": [<metric_definitions row>, ...]},
+            ...]}
+
+    ``existing`` maps each pack relpath to its parsed on-disk content (YAML →
+    list/dict, markdown → str); missing files are simply absent.
+
+    Returns ``(files, report)`` where ``files`` maps relpath -> rendered text
+    for every file the generator (re)produced. Files it did not touch (e.g. an
+    existing ``_brief.md``) are not returned, so the caller leaves them as-is.
+    """
+    existing = existing or {}
+    ts = generated_at or _utcnow_iso()
+    report = ScaffoldReport()
+    files: Dict[str, str] = {}
+
+    packages = inputs.get("packages")
+    if not isinstance(packages, list):
+        raise ScaffoldError("inputs['packages'] must be a list")
+
+    for package in packages:
+        if not isinstance(package, dict):
+            continue
+        slug = (package.get("slug") or "").strip()
+        if not slug:
+            report.warnings.append("package with no slug — skipped")
+            continue
+        report.packages.append(slug)
+
+        # ---- tables ------------------------------------------------------ #
+        table_items: List[Dict[str, Any]] = []
+        for table in package.get("tables") or []:
+            if not isinstance(table, dict) or not (table.get("id") or "").strip():
+                continue
+            tid = table["id"].strip()
+            relpath = f"{slug}/tables/{tid}.yml"
+            derived = _derive_table(table, package)
+            existing_item = existing.get(relpath)
+            if isinstance(existing_item, list):
+                existing_item = existing_item[0] if existing_item else None
+            merged = _merge_item(
+                derived, existing_item if isinstance(existing_item, dict) else None,
+                source=_TABLE_SOURCE, generated_at=ts, report=report, item_key=relpath,
+            )
+            files[relpath] = _dump_yaml(merged)
+            table_items.append(merged)
+            report.tables.append(relpath)
+
+        # ---- metrics ----------------------------------------------------- #
+        metric_items: List[Dict[str, Any]] = []
+        for row in package.get("metrics") or []:
+            if not isinstance(row, dict) or not (row.get("name") or "").strip():
+                continue
+            mname = row["name"].strip()
+            relpath = f"{slug}/metrics/{mname}.yml"
+            derived = _derive_metric(row, package)
+            merged = _merge_item(
+                derived, _existing_metric(existing, relpath),
+                source=_METRIC_SOURCE, generated_at=ts, report=report, item_key=relpath,
+            )
+            files[relpath] = _dump_yaml([merged])
+            metric_items.append(merged)
+            report.metrics.append(relpath)
+
+        # ---- _overview.md / _brief.md (seed-if-absent) ------------------- #
+        ov_rel = f"{slug}/_overview.md"
+        if ov_rel not in existing:
+            files[ov_rel] = _overview_skeleton(package)
+            report.briefs_seeded.append(ov_rel)
+        br_rel = f"{slug}/_brief.md"
+        if br_rel not in existing:
+            files[br_rel] = _brief_skeleton(package, table_items, metric_items)
+            report.briefs_seeded.append(br_rel)
+
+    return files, report
+
+
+# --------------------------------------------------------------------------- #
+# --check support
+# --------------------------------------------------------------------------- #
+
+
+def _strip_volatile(obj: Any) -> Any:
+    """Drop the volatile ``sync.last_synced`` timestamp so a no-op re-run
+    compares equal."""
+    if isinstance(obj, dict):
+        out = {k: _strip_volatile(v) for k, v in obj.items() if k != "last_synced"}
+        return out
+    if isinstance(obj, list):
+        return [_strip_volatile(v) for v in obj]
+    return obj
+
+
+def comparable_view(files: Dict[str, str]) -> Dict[str, str]:
+    """Canonical view of rendered files for ``--check`` — YAML re-parsed with
+    the volatile ``sync.last_synced`` removed; markdown compared verbatim."""
+    out: Dict[str, str] = {}
+    for relpath, text in files.items():
+        if relpath.endswith((".yml", ".yaml")):
+            try:
+                parsed = yaml.safe_load(text)
+            except yaml.YAMLError:
+                out[relpath] = text
+                continue
+            out[relpath] = json.dumps(
+                _strip_volatile(parsed), sort_keys=True, ensure_ascii=False, default=str
+            )
+        else:
+            out[relpath] = text
+    return out
+
+
+__all__ = [
+    "GENERATOR_TAG",
+    "SCHEMA_VERSION",
+    "ScaffoldError",
+    "ScaffoldReport",
+    "humanize",
+    "scaffold_pack",
+    "comparable_view",
+]

--- a/src/data_semantics_scaffold.py
+++ b/src/data_semantics_scaffold.py
@@ -169,7 +169,14 @@ def _derive_metric(row: Dict[str, Any], package: Dict[str, Any]) -> Dict[str, An
     """Build the derived (machine-owned) fields of one ``metrics/<name>.yml``
     item from a ``metric_definitions`` row. Order mirrors the example file."""
     name = (row.get("name") or "").strip()
-    tables = _as_list(row.get("tables")) or _as_list(row.get("table_name"))
+    # Union of the metric's explicit ``tables`` and its single ``table_name``,
+    # de-duplicated + order-preserving. This must match the set the CLI uses to
+    # assign a metric to a package (``_metric_tables`` in admin_data_semantics)
+    # so a metric's coordinate always lists every table that placed it here.
+    tables = _as_list(row.get("tables"))
+    tn = row.get("table_name")
+    if tn and tn not in tables:
+        tables = [*tables, tn]
     slug = package.get("slug") or ""
 
     out: Dict[str, Any] = {}

--- a/tests/test_data_semantics_cli.py
+++ b/tests/test_data_semantics_cli.py
@@ -1,0 +1,130 @@
+"""End-to-end tests for `agnes admin data-semantics generate`.
+
+Seeds a real system DuckDB (via ``get_system_db()`` with ``DATA_DIR`` pointed at
+a temp dir, which auto-initialises the schema) through the repositories, then
+exercises the assembly grouping and the CLI command — proving the engine wires
+to the live catalog, not just to hand-built fixtures.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+
+def _seed(conn) -> None:
+    from src.repositories.bq_metadata_cache import BqMetadataCacheRepository
+    from src.repositories.column_metadata import ColumnMetadataRepository
+    from src.repositories.data_packages import DataPackagesRepository
+    from src.repositories.metrics import MetricRepository
+    from src.repositories.table_registry import TableRegistryRepository
+
+    pkgs = DataPackagesRepository(conn)
+    pid = pkgs.create(
+        name="Engagement", slug="engagement", description="UI events.",
+        icon=None, color=None, created_by="tester",
+    )
+
+    reg = TableRegistryRepository(conn)
+    reg.register(
+        id="e1_events", name="E1 — Events", source_type="bigquery",
+        bucket="analytics", source_table="E1_events",
+        bq_fqn="proj.analytics.E1_events", partition_by="event_date",
+    )
+    reg.update_docs(
+        "e1_events", grain="1 row per UI event",
+        gotchas=[{"key": True, "body": "Always filter event_date."}],
+    )
+    pkgs.add_table(pid, "e1_events", added_by="tester")
+
+    cols = ColumnMetadataRepository(conn)
+    cols.save("e1_events", "event_id", basetype="STRING", description="Unique key")
+    cols.save("e1_events", "event_date", basetype="DATE", description="Partition key")
+
+    BqMetadataCacheRepository(conn).upsert_success(
+        "e1_events", rows=1000, size_bytes=1, partition_by="event_date",
+        clustered_by=["country_code", "platform"],
+        known_columns=["event_id", "event_date"],
+    )
+
+    metrics = MetricRepository(conn)
+    metrics.create(
+        id="engagement/clicks", name="clicks", display_name="Clicks",
+        category="engagement", sql="SELECT COUNT(*) FROM e1",
+        description="Total clicks.", type="count", unit="count", grain="event",
+        tables=["e1_events"], synonyms=["clicks", "click count"],
+    )
+    # An orphan metric whose table is in no package — must be dropped + warned.
+    metrics.create(
+        id="finance/revenue", name="revenue", display_name="Revenue",
+        category="finance", sql="SELECT 1", table_name="ledger",
+    )
+
+
+@pytest.fixture
+def seeded(monkeypatch, tmp_path):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    from src.db import get_system_db
+
+    conn = get_system_db()
+    _seed(conn)
+    return tmp_path
+
+
+def test_assemble_inputs_groups_tables_and_metrics(seeded):
+    from cli.commands.admin_data_semantics import _assemble_inputs
+    from src.db import get_system_db
+
+    conn = get_system_db()
+    try:
+        inputs, notes = _assemble_inputs(conn)
+    finally:
+        conn.close()
+
+    pkgs = {p["slug"]: p for p in inputs["packages"]}
+    assert "engagement" in pkgs
+    eng = pkgs["engagement"]
+    assert [t["id"] for t in eng["tables"]] == ["e1_events"]
+    table = eng["tables"][0]
+    assert {c["column_name"] for c in table["columns"]} == {"event_id", "event_date"}
+    assert table["bq_cache"]["clustered_by"] == ["country_code", "platform"]
+    assert [m["name"] for m in eng["metrics"]] == ["clicks"]  # only the in-package metric
+    # The orphan metric is reported, not silently dropped.
+    assert any("belong to no data package" in n for n in notes)
+
+
+def test_cli_generate_dry_run_then_write_then_check(seeded):
+    from cli.commands.admin_data_semantics import admin_data_semantics_app
+
+    out = seeded / "pack"
+    runner = CliRunner()
+
+    # --dry-run --json: prints the would-be files, writes nothing.
+    r = runner.invoke(admin_data_semantics_app, ["generate", str(out), "--dry-run", "--json"])
+    assert r.exit_code == 0, r.output
+    files = json.loads(r.output)
+    assert "engagement/tables/e1_events.yml" in files
+    assert "engagement/metrics/clicks.yml" in files
+    assert "engagement/_brief.md" in files
+    assert not out.exists()
+
+    # Write the pack.
+    rw = runner.invoke(admin_data_semantics_app, ["generate", str(out)])
+    assert rw.exit_code == 0, rw.output
+    assert (out / "engagement" / "tables" / "e1_events.yml").is_file()
+    assert (out / "engagement" / "metrics" / "clicks.yml").is_file()
+
+    # A freshly-written pack is in sync → --check exits 0 (timestamp ignored).
+    rc = runner.invoke(admin_data_semantics_app, ["generate", str(out), "--check"])
+    assert rc.exit_code == 0, rc.output
+
+
+def test_cli_check_detects_drift_before_write(seeded):
+    from cli.commands.admin_data_semantics import admin_data_semantics_app
+
+    out = seeded / "pack"
+    # Nothing written yet → --check must fail (exit 1).
+    r = CliRunner().invoke(admin_data_semantics_app, ["generate", str(out), "--check"])
+    assert r.exit_code == 1

--- a/tests/test_data_semantics_scaffold.py
+++ b/tests/test_data_semantics_scaffold.py
@@ -1,0 +1,317 @@
+"""Unit tests for the workspace data-semantics pack scaffolder (Gap 1 / #469).
+
+The engine is a pure transformation over plain Python data (the CLI assembles
+that data from the repositories), so these tests need no database — they feed
+dicts shaped like ``metric_definitions`` / ``table_registry`` rows and assert
+on the emitted YAML/markdown and the ``sync``-block merge contract.
+"""
+
+from __future__ import annotations
+
+import yaml
+
+from src.data_semantics_scaffold import (
+    ScaffoldError,
+    comparable_view,
+    humanize,
+    scaffold_pack,
+)
+
+FIXED_TS = "2026-06-01T00:00:00Z"
+
+
+# --------------------------------------------------------------------------- #
+# Builders
+# --------------------------------------------------------------------------- #
+
+
+def _table(tid="e1_events", name="E1 — Events", **kw):
+    base = {"id": tid, "name": name, "columns": [], "bq_cache": None}
+    base.update(kw)
+    return base
+
+
+def _metric(name="clicks", **kw):
+    base = {"name": name}
+    base.update(kw)
+    return base
+
+
+def _pkg(slug="engagement", name="Engagement", description="UI events.",
+         tables=None, metrics=None):
+    return {
+        "slug": slug, "name": name, "description": description,
+        "tables": list(tables or []), "metrics": list(metrics or []),
+    }
+
+
+def _inputs(*packages):
+    return {"packages": list(packages)}
+
+
+def _reparse(files):
+    """Build a parsed ``existing`` map from rendered files, as the CLI does."""
+    out = {}
+    for rel, text in files.items():
+        out[rel] = yaml.safe_load(text) if rel.endswith((".yml", ".yaml")) else text
+    return out
+
+
+def _full_metric():
+    return _metric(
+        "clicks", display_name="Clicks", category="engagement",
+        description="Total clicks.", type="count", unit="count", grain="event",
+        tables=["e1_events"], synonyms=["clicks", "click count"],
+        filters=["e1.event_date BETWEEN <s> AND <e>"], notes=["Use COUNT(*)."],
+        dimensions=["event_date", "widget_id"],
+        sql="SELECT COUNT(*)\nFROM e1\nWHERE event_type='click'",
+        validation='{"method": "reconcile", "status": "ok"}',
+    )
+
+
+def _full_table():
+    return _table(
+        "e1_events", "E1 — Events", bq_fqn="proj.analytics.E1_events",
+        grain="1 row per UI event", partition_col="event_date",
+        gotchas=["Always filter event_date."],
+        columns=[
+            {"column_name": "event_id", "basetype": "STRING", "description": "Unique key"},
+            {"column_name": "event_date", "basetype": "DATE", "description": "Partition key"},
+        ],
+        bq_cache={"partition_by": "event_date", "clustered_by": ["country_code", "platform"]},
+    )
+
+
+def _generate(*, tables=None, metrics=None, existing=None, ts=FIXED_TS):
+    pkg = _pkg(tables=tables, metrics=metrics)
+    return scaffold_pack(_inputs(pkg), existing=existing or {}, generated_at=ts)
+
+
+# --------------------------------------------------------------------------- #
+# humanize
+# --------------------------------------------------------------------------- #
+
+
+def test_humanize():
+    assert humanize("new_customers") == "New Customers"
+    assert humanize("pipeline-value") == "Pipeline Value"
+    assert humanize("MRR") == "MRR"  # internal caps preserved
+
+
+# --------------------------------------------------------------------------- #
+# Fresh derivation
+# --------------------------------------------------------------------------- #
+
+
+def test_fresh_metric_derivation(tmp_path=None):
+    files, report = _generate(metrics=[_full_metric()])
+    rel = "engagement/metrics/clicks.yml"
+    assert rel in files
+    doc = yaml.safe_load(files[rel])
+    assert isinstance(doc, list) and len(doc) == 1  # list form
+    m = doc[0]
+    assert m["name"] == "clicks"
+    assert m["data_product"] == "Engagement"
+    assert m["display_name"] == "Clicks"
+    assert m["type"] == "count" and m["unit"] == "count" and m["grain"] == "event"
+    assert m["coordinate"] == ["e1_events"]
+    assert m["coordinate_fqn"] == ["engagement.e1_events"]
+    assert m["required_filters"] == ["e1.event_date BETWEEN <s> AND <e>"]
+    assert m["validation"] == {"method": "reconcile", "status": "ok"}  # JSON parsed
+    assert m["sync"]["method"] == "generated"
+    assert m["sync"]["source"] == "metric_definitions"
+
+
+def test_fresh_table_derivation():
+    files, _ = _generate(tables=[_full_table()])
+    rel = "engagement/tables/e1_events.yml"
+    doc = yaml.safe_load(files[rel])
+    assert doc["id"] == "e1_events"
+    assert doc["fqn"] == "proj.analytics.E1_events"
+    assert doc["partition_by"] == "event_date"        # from bq_cache
+    assert doc["clustered_by"] == ["country_code", "platform"]
+    assert [c["name"] for c in doc["columns"]] == ["event_id", "event_date"]
+    assert doc["columns"][0] == {"name": "event_id", "type": "STRING", "note": "Unique key"}
+    assert doc["gotchas"] == ["Always filter event_date."]
+    assert doc["sync"]["method"] == "generated"
+
+
+def test_sync_block_records_owned_fields():
+    files, _ = _generate(metrics=[_full_metric()])
+    m = yaml.safe_load(files["engagement/metrics/clicks.yml"])[0]
+    gf = m["sync"]["generated_fields"]
+    for owned in ("name", "type", "grain", "description", "sql", "synonyms"):
+        assert owned in gf
+    assert m["sync"]["generator"] == "agnes-data-semantics-scaffold"
+
+
+def test_fqn_constructed_from_bucket_when_no_bq_fqn():
+    t = _table("orders", "Orders", bucket="sales", source_table="orders_raw")
+    files, _ = _generate(tables=[t])
+    doc = yaml.safe_load(files["engagement/tables/orders.yml"])
+    assert doc["fqn"] == "sales.orders_raw"
+
+
+def test_metric_without_tables_emits_without_coordinate():
+    files, _ = _generate(metrics=[_metric("ratio", type="ratio", grain="day")])
+    m = yaml.safe_load(files["engagement/metrics/ratio.yml"])[0]
+    assert m["name"] == "ratio"
+    assert "coordinate" not in m
+
+
+# --------------------------------------------------------------------------- #
+# _brief.md / _overview.md
+# --------------------------------------------------------------------------- #
+
+
+def test_brief_and_overview_seeded_when_absent():
+    files, report = _generate(tables=[_full_table()], metrics=[_full_metric()])
+    assert "engagement/_brief.md" in files
+    assert "engagement/_overview.md" in files
+    brief = files["engagement/_brief.md"]
+    assert "Engagement" in brief
+    assert "`e1_events`" in brief    # derived tables table
+    assert "`clicks`" in brief       # derived metrics table
+    assert len(report.briefs_seeded) == 2
+
+
+def test_brief_not_overwritten_when_present():
+    files1, _ = _generate(tables=[_full_table()])
+    existing = _reparse(files1)
+    existing["engagement/_brief.md"] = "# Hand-written brief\nDo not touch.\n"
+    files2, report = scaffold_pack(
+        _inputs(_pkg(tables=[_full_table()])), existing=existing, generated_at=FIXED_TS
+    )
+    # seed-if-absent: an existing brief is never re-emitted.
+    assert "engagement/_brief.md" not in files2
+    assert "engagement/_overview.md" not in files2  # also already present
+
+
+# --------------------------------------------------------------------------- #
+# Merge contract
+# --------------------------------------------------------------------------- #
+
+
+def test_hand_authored_item_is_frozen():
+    files1, _ = _generate(metrics=[_full_metric()])
+    existing = _reparse(files1)
+    item = existing["engagement/metrics/clicks.yml"][0]
+    item["sync"]["method"] = "hand-authored"
+    item["display_name"] = "Human Clicks"
+    item["type"] = "frozen"
+    # Source changes, but the human-owned item must not move.
+    changed = _full_metric()
+    changed["display_name"] = "New Auto Name"
+    files2, report = scaffold_pack(
+        _inputs(_pkg(metrics=[changed])), existing=existing, generated_at=FIXED_TS
+    )
+    out = yaml.safe_load(files2["engagement/metrics/clicks.yml"])[0]
+    assert out["display_name"] == "Human Clicks"
+    assert out["type"] == "frozen"
+    assert ("engagement/metrics/clicks.yml", "*", "kept-human") in report.actions
+
+
+def test_human_edit_of_draft_field_wins():
+    files1, _ = _generate(metrics=[_full_metric()])
+    existing = _reparse(files1)
+    existing["engagement/metrics/clicks.yml"][0]["description"] = "HUMAN polished."
+    files2, report = scaffold_pack(
+        _inputs(_pkg(metrics=[_full_metric()])), existing=existing, generated_at=FIXED_TS
+    )
+    out = yaml.safe_load(files2["engagement/metrics/clicks.yml"])[0]
+    assert out["description"] == "HUMAN polished."
+    assert ("engagement/metrics/clicks.yml", "description", "kept-edited") in report.actions
+
+
+def test_untouched_field_regenerates_on_source_change():
+    files1, _ = _generate(metrics=[_full_metric()])
+    existing = _reparse(files1)
+    changed = _full_metric()
+    changed["description"] = "A brand new description."
+    files2, report = scaffold_pack(
+        _inputs(_pkg(metrics=[changed])), existing=existing, generated_at=FIXED_TS
+    )
+    out = yaml.safe_load(files2["engagement/metrics/clicks.yml"])[0]
+    assert out["description"] == "A brand new description."
+    assert ("engagement/metrics/clicks.yml", "description", "regenerated") in report.actions
+
+
+def test_generated_field_removed_when_source_disappears():
+    files1, _ = _generate(metrics=[_full_metric()])
+    existing = _reparse(files1)
+    stripped = _full_metric()
+    stripped.pop("notes")  # source no longer provides notes
+    files2, report = scaffold_pack(
+        _inputs(_pkg(metrics=[stripped])), existing=existing, generated_at=FIXED_TS
+    )
+    out = yaml.safe_load(files2["engagement/metrics/clicks.yml"])[0]
+    assert "notes" not in out
+    assert ("engagement/metrics/clicks.yml", "notes", "removed") in report.actions
+
+
+def test_human_added_field_on_generated_item_is_preserved():
+    files1, _ = _generate(tables=[_full_table()])
+    existing = _reparse(files1)
+    # A field the generator never derives (KEEP).
+    existing["engagement/tables/e1_events.yml"]["approx_rows_per_day"] = "~5M"
+    files2, _ = scaffold_pack(
+        _inputs(_pkg(tables=[_full_table()])), existing=existing, generated_at=FIXED_TS
+    )
+    out = yaml.safe_load(files2["engagement/tables/e1_events.yml"])
+    assert out["approx_rows_per_day"] == "~5M"
+
+
+def test_idempotent_second_run():
+    files1, _ = _generate(tables=[_full_table()], metrics=[_full_metric()])
+    existing = _reparse(files1)
+    _, report = scaffold_pack(
+        _inputs(_pkg(tables=[_full_table()], metrics=[_full_metric()])),
+        existing=existing, generated_at="2099-01-01T00:00:00Z",
+    )
+    counts = report.status_counts()
+    assert counts.get("generated", 0) == 0
+    assert counts.get("regenerated", 0) == 0
+    assert not report.wrote_changes()
+
+
+# --------------------------------------------------------------------------- #
+# --check
+# --------------------------------------------------------------------------- #
+
+
+def test_comparable_view_ignores_timestamp_but_sees_real_changes():
+    a, _ = _generate(metrics=[_full_metric()], ts="2026-01-01T00:00:00Z")
+    b, _ = _generate(metrics=[_full_metric()], ts="2099-09-09T00:00:00Z")
+    assert comparable_view(a) == comparable_view(b)  # only last_synced differs
+    changed = _full_metric()
+    changed["description"] = "Different."
+    c, _ = _generate(metrics=[changed], ts="2026-01-01T00:00:00Z")
+    assert comparable_view(a) != comparable_view(c)
+
+
+# --------------------------------------------------------------------------- #
+# Odd inputs
+# --------------------------------------------------------------------------- #
+
+
+def test_package_without_slug_is_skipped_with_warning():
+    bad = _pkg(slug="", tables=[_full_table()])
+    files, report = scaffold_pack(_inputs(bad), existing={}, generated_at=FIXED_TS)
+    assert files == {}
+    assert any("slug" in w for w in report.warnings)
+
+
+def test_bad_inputs_raise():
+    try:
+        scaffold_pack({"packages": "nope"}, existing={}, generated_at=FIXED_TS)
+    except ScaffoldError:
+        pass
+    else:
+        raise AssertionError("expected ScaffoldError for non-list packages")
+
+
+def test_rendered_yaml_round_trips():
+    files, _ = _generate(tables=[_full_table()], metrics=[_full_metric()])
+    for rel, text in files.items():
+        if rel.endswith(".yml"):
+            assert yaml.safe_load(text) is not None

--- a/tests/test_data_semantics_scaffold.py
+++ b/tests/test_data_semantics_scaffold.py
@@ -159,6 +159,21 @@ def test_metric_without_tables_emits_without_coordinate():
     assert "coordinate" not in m
 
 
+def test_metric_coordinate_unions_tables_and_table_name():
+    # A metric referencing tables[] AND a distinct table_name must list both —
+    # consistent with how the CLI assigns it to a package (Devin #472 finding).
+    m = _metric("ctr", tables=["e1_events"], table_name="s1_sessions",
+                type="ratio", grain="event")
+    doc = yaml.safe_load(_generate(metrics=[m])[0]["engagement/metrics/ctr.yml"])[0]
+    assert doc["coordinate"] == ["e1_events", "s1_sessions"]
+    assert doc["coordinate_fqn"] == ["engagement.e1_events", "engagement.s1_sessions"]
+    # de-dup: a table_name already present in tables is not repeated.
+    m2 = _metric("dup", tables=["e1_events"], table_name="e1_events",
+                 type="count", grain="event")
+    doc2 = yaml.safe_load(_generate(metrics=[m2])[0]["engagement/metrics/dup.yml"])[0]
+    assert doc2["coordinate"] == ["e1_events"]
+
+
 # --------------------------------------------------------------------------- #
 # _brief.md / _overview.md
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

**Gap 1 of #469** — the sibling to the marketplace-metadata scaffolder (Gap 2, cherry-picked into #465). Adds `agnes admin data-semantics generate <dir>`, which emits a *starter* workspace data-semantics pack from data Agnes already holds, so an operator hand-edits know-how instead of authoring the whole tree from a blank page.

## Why

The analyst workspace `data/` knowledge pack (`tables/*.yml`, `metrics/*.yml`, `_brief.md`, `_overview.md` per package) is hand-authored today — expensive to stand up and keep in sync with the catalog. Much of it is derivable: table columns/partition/cluster keys, metric definitions, and the package grouping all live in the system DuckDB.

## What it generates

| Output | Derived from |
|---|---|
| `<slug>/tables/<id>.yml` — id, fqn, partition_by, clustered_by, columns | `table_registry` + `column_metadata` + `bq_metadata_cache` |
| `<slug>/metrics/<name>.yml` — list-form: type/unit/grain/synonyms/dimensions/sql/validation… | `metric_definitions` |
| `<slug>/_brief.md` + `_overview.md` — skeleton (overview + derived tables/metrics summary) | seed-if-absent |
| package → directory grouping | `data_packages` / `data_package_tables` |

## Design — provenance via the pack's native `sync:` block

No bespoke side-car (unlike Gap 2's `_generated`). Each generated item carries `sync.{source, method, last_synced, generated_fields}`; `method` is the ownership switch:

- `method: generated` → 3-way merge per field: regenerate machine-owned fields, keep human edits (content-hash mismatch), preserve human-added keys, and **drop a field whose upstream source disappears** (the Gap-2 audit lesson, built in from the start).
- `method: hand-authored` (or no `sync`) → the whole item is human-owned and never touched.
- `_brief.md` / `_overview.md` are seed-if-absent — never overwritten once they exist.

`--check` re-derives and diffs a timestamp-stripped `comparable_view`, exiting non-zero on drift (CI-enforceable); `--dry-run` / `--json` for inspection.

## Scope (deliberate)

- **Glossary is out of scope** — there's no canonical glossary source in Agnes (no `#399`-style term store), so it can't be derived without inventing stubs.
- `_brief.md` / `_overview.md` generate a *skeleton* only; the query know-how (join contracts, non-negotiable filters, don'ts) stays human-authored.
- Metrics that belong to no data package are **reported, not silently dropped**.
- The engine has no `app.*` dependency (mirrors `src/marketplace_metadata_scaffold.py`); inputs are plain data the CLI assembles from the repositories.

## Test plan

`tests/test_data_semantics_scaffold.py` (18, no DB — pure transformation) + `tests/test_data_semantics_cli.py` (3 end-to-end against a seeded system DuckDB) = **21 passing**. Covers derivation, the `sync`-block merge contract (hand-authored freeze, human-edit-wins, regenerate-on-change, drop-on-source-gone, preserve human-added keys), brief seed-if-absent, `--check`, and the assembly grouping. Read-subsystem repo tests (bq_metadata_cache / data_packages / metrics / table_registry) stay green (113 passed together).

```
uv run pytest tests/test_data_semantics_scaffold.py tests/test_data_semantics_cli.py -q
→ 21 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)