### PR TITLE
feat(tables): LLM auto-documentation of table descriptions (#399)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Added
+- **`agnes admin autodoc-tables` — LLM-generate descriptions for undescribed tables (#399).** Most registered tables ship with no `description`, weakening `agnes catalog` for AI agents. The command reads each undescribed table's stored profile (columns + sample rows) and asks the configured LLM (Haiku by default, via `connectors.llm`) for a short factual description, then saves it via `TableRegistryRepository.set_description`. Only empty descriptions are filled — an existing one is never overwritten — and only already-profiled tables are touched. `--table` to target one, `--dry-run` to preview, `--limit N` to cap. Pure prompt/parse core in `src/table_autodoc.py` (no `app.`/DB/network deps). Uses `ANTHROPIC_API_KEY` / `LLM_API_KEY` (or the instance `ai:` block).
+
 ## [0.55.28] — 2026-06-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.55.29] — 2026-06-01
+
 ### Added
 - **`agnes admin autodoc-tables` — LLM-generate descriptions for undescribed tables (#399).** Most registered tables ship with no `description`, weakening `agnes catalog` for AI agents. The command reads each undescribed table's stored profile (columns + sample rows) and asks the configured LLM (Haiku by default, via `connectors.llm`) for a short factual description, then saves it via `TableRegistryRepository.set_description`. Only empty descriptions are filled — an existing one is never overwritten — and only already-profiled tables are touched. `--table` to target one, `--dry-run` to preview, `--limit N` to cap. Pure prompt/parse core in `src/table_autodoc.py` (no `app.`/DB/network deps). Uses `ANTHROPIC_API_KEY` / `LLM_API_KEY` (or the instance `ai:` block).
 

--- a/cli/commands/admin.py
+++ b/cli/commands/admin.py
@@ -7,6 +7,7 @@ import typer
 from cli.client import api_get, api_post, api_delete, api_patch, api_put
 from cli.commands.admin_activity import activity_app
 from cli.commands.admin_ask import app as admin_ask_app
+from cli.commands.admin_autodoc import autodoc_tables
 from cli.commands.admin_data_package import admin_data_package_app
 from cli.commands.admin_memory_domain import admin_memory_domain_app
 from cli.commands.admin_metrics import admin_metrics_app
@@ -32,6 +33,9 @@ admin_app.add_typer(admin_usage_app, name="telemetry", help="Telemetry export an
 admin_app.add_typer(admin_usage_app, name="usage", help="(deprecated alias of `telemetry`)")
 admin_app.add_typer(admin_data_package_app, name="data-package", help="Data Package CRUD (v49)")
 admin_app.add_typer(admin_memory_domain_app, name="memory-domain", help="Memory Domain CRUD (v49)")
+# Single direct command (mirrors `register-table` / `discover-and-register`):
+# LLM-generate descriptions for undescribed tables (#399).
+admin_app.command("autodoc-tables")(autodoc_tables)
 
 
 @admin_app.command("add-user")

--- a/cli/commands/admin_autodoc.py
+++ b/cli/commands/admin_autodoc.py
@@ -18,14 +18,31 @@ import typer
 def _build_extractor():
     """Construct the configured StructuredExtractor.
 
-    Uses the instance ``ai:`` block when present, else ``ANTHROPIC_API_KEY`` /
-    ``LLM_API_KEY`` from the environment (the Agnes server context). Raises
+    Reads the instance ``ai:`` block via the overlay-aware
+    ``app.instance_config.load_instance_config`` (so an ``ai:`` block written
+    to ``${DATA_DIR}/state/instance.yaml`` is honoured), and falls back to
+    ``ANTHROPIC_API_KEY`` / ``LLM_API_KEY`` from the environment. Raises
     ``ValueError`` with an actionable message when no LLM is configured.
-    Isolated as a module-level seam so tests can substitute a fake extractor.
-    """
-    from connectors.llm.factory import create_extractor_from_env_or_config
 
-    return create_extractor_from_env_or_config(None)
+    Mirrors the resolution in ``services/corporate_memory/collector.py`` and
+    ``services/session_processors/verification.py``. Isolated as a module-level
+    seam so tests can substitute a fake extractor.
+    """
+    from connectors.llm import create_extractor_from_env_or_config
+
+    ai_config = None
+    try:
+        from app.instance_config import load_instance_config
+
+        try:
+            instance_config = load_instance_config()
+        except (ValueError, FileNotFoundError):
+            instance_config = {}
+        ai_config = instance_config.get("ai") if instance_config else None
+    except Exception:
+        ai_config = None
+
+    return create_extractor_from_env_or_config(ai_config)
 
 
 def autodoc_tables(

--- a/cli/commands/admin_autodoc.py
+++ b/cli/commands/admin_autodoc.py
@@ -1,0 +1,118 @@
+"""`agnes admin autodoc-tables` — LLM-generate descriptions for tables that
+have none (#399).
+
+Reads each undescribed registered table's stored profile (columns + sample
+rows) and asks the configured LLM (Haiku by default) for a short factual
+description, then saves it. Never overwrites a description that already exists.
+The pure prompt/parse logic lives in :mod:`src.table_autodoc`; this command
+just wires the repositories + extractor to it.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import typer
+
+
+def _build_extractor():
+    """Construct the configured StructuredExtractor.
+
+    Uses the instance ``ai:`` block when present, else ``ANTHROPIC_API_KEY`` /
+    ``LLM_API_KEY`` from the environment (the Agnes server context). Raises
+    ``ValueError`` with an actionable message when no LLM is configured.
+    Isolated as a module-level seam so tests can substitute a fake extractor.
+    """
+    from connectors.llm.factory import create_extractor_from_env_or_config
+
+    return create_extractor_from_env_or_config(None)
+
+
+def autodoc_tables(
+    table: Optional[str] = typer.Option(
+        None, "--table", help="Only document this one table id."
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Print the generated descriptions; save nothing."
+    ),
+    limit: int = typer.Option(
+        0, "--limit", min=0, help="Max tables to process (0 = no limit)."
+    ),
+):
+    """Generate descriptions for undescribed tables from their sample data.
+
+    Only tables whose ``description`` is empty are touched, and only those that
+    have already been profiled (so sample rows exist). Re-run any time; an
+    existing description is never clobbered.
+    """
+    from connectors.llm.exceptions import LLMError
+    from src.db import get_system_db
+    from src.repositories.profiles import ProfileRepository
+    from src.repositories.table_registry import TableRegistryRepository
+    from src.table_autodoc import generate_description
+
+    conn = get_system_db()
+    try:
+        reg = TableRegistryRepository(conn)
+        profiles = ProfileRepository(conn)
+
+        rows = reg.list_all()
+        if table:
+            rows = [r for r in rows if r.get("id") == table]
+            if not rows:
+                typer.echo(f"No registered table with id {table!r}.", err=True)
+                raise typer.Exit(1)
+
+        targets = [r for r in rows if not (r.get("description") or "").strip()]
+        if not targets:
+            typer.echo("All matching tables already have descriptions. Nothing to do.")
+            return
+        if limit:
+            targets = targets[:limit]
+
+        try:
+            extractor = _build_extractor()
+        except ValueError as e:
+            typer.echo(f"Error: {e}", err=True)
+            raise typer.Exit(1)
+
+        described = 0
+        skipped = 0
+        for r in targets:
+            tid = r["id"]
+            profile = profiles.get(tid)
+            if not profile or not (profile.get("sample_rows") or profile.get("columns")):
+                typer.echo(
+                    f"  skip {tid}: no profile/sample data yet (sync + profile first)",
+                    err=True,
+                )
+                skipped += 1
+                continue
+            try:
+                desc = generate_description(
+                    extractor,
+                    r.get("name") or tid,
+                    profile.get("columns"),
+                    profile.get("sample_rows"),
+                    source=r.get("source_type"),
+                )
+            except LLMError as e:
+                typer.echo(f"  skip {tid}: LLM error: {e}", err=True)
+                skipped += 1
+                continue
+            if not desc:
+                typer.echo(f"  skip {tid}: model returned an empty description", err=True)
+                skipped += 1
+                continue
+
+            if dry_run:
+                typer.echo(f"\n[{tid}] (dry-run, not saved)\n  {desc}")
+            else:
+                reg.set_description(tid, desc)
+                typer.echo(f"  ✓ {tid}: {desc}")
+            described += 1
+
+        verb = "would describe" if dry_run else "described"
+        typer.echo(f"\n{verb} {described} table(s); skipped {skipped}.")
+    finally:
+        conn.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.55.28"
+version = "0.55.29"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/src/repositories/table_registry.py
+++ b/src/repositories/table_registry.py
@@ -276,6 +276,16 @@ class TableRegistryRepository:
     def unregister(self, table_id: str) -> None:
         self.conn.execute("DELETE FROM table_registry WHERE id = ?", [table_id])
 
+    def set_description(self, table_id: str, description: str) -> None:
+        """Set only the ``description`` column, leaving every other field
+        untouched (unlike ``register()``'s full upsert). Used by the LLM
+        auto-doc tool (#399) to backfill descriptions without disturbing
+        sync-strategy / partition / docs columns."""
+        self.conn.execute(
+            "UPDATE table_registry SET description = ? WHERE id = ?",
+            [description, table_id],
+        )
+
     def get(self, table_id: str) -> Optional[Dict[str, Any]]:
         result = self.conn.execute(
             "SELECT * FROM table_registry WHERE id = ?", [table_id]

--- a/src/table_autodoc.py
+++ b/src/table_autodoc.py
@@ -1,0 +1,119 @@
+"""LLM auto-documentation of table descriptions (#399).
+
+Most registered tables ship with no ``description``, which makes ``agnes
+catalog`` weaker for AI agents. This module turns a table's columns + a few
+sample rows into a short, factual description using the existing
+``connectors.llm`` ``StructuredExtractor`` (Haiku by default).
+
+It is deliberately a *pure* helper: the caller (``agnes admin autodoc-tables``)
+supplies the extractor and the already-sampled data, and this module only
+builds the prompt and parses the structured result. That keeps it free of any
+``app.``/DB/network dependency and unit-testable with a fake extractor — no
+live LLM call required.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+# Descriptions are short; cap the response budget tightly.
+MAX_TOKENS = 400
+
+# How many sample rows to show the model. More rarely helps the description
+# and just costs tokens.
+SAMPLE_ROWS = 5
+
+DESCRIPTION_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "description": {
+            "type": "string",
+            "description": (
+                "One or two factual sentences: what the table contains and its "
+                "grain (one row per what). No marketing tone."
+            ),
+        }
+    },
+    "required": ["description"],
+    "additionalProperties": False,
+}
+
+
+def _format_columns(columns: Optional[List[Dict[str, Any]]]) -> str:
+    lines: List[str] = []
+    for c in columns or []:
+        if not isinstance(c, dict):
+            continue
+        name = c.get("name") or c.get("column_name")
+        if not name:
+            continue
+        typ = c.get("type") or c.get("basetype") or c.get("dtype") or "?"
+        lines.append(f"- {name} ({typ})")
+    return "\n".join(lines) or "(no column metadata)"
+
+
+def _format_sample_rows(
+    sample_rows: Optional[List[Dict[str, Any]]], limit: int = SAMPLE_ROWS
+) -> str:
+    rows = [r for r in (sample_rows or []) if isinstance(r, dict)][:limit]
+    if not rows:
+        return "(no sample rows)"
+    return json.dumps(rows, ensure_ascii=False, default=str, indent=2)
+
+
+def build_prompt(
+    table_name: str,
+    columns: Optional[List[Dict[str, Any]]],
+    sample_rows: Optional[List[Dict[str, Any]]],
+    *,
+    source: Optional[str] = None,
+) -> str:
+    """Compose the extraction prompt from a table's columns + sample rows."""
+    src = f" (source: {source})" if source else ""
+    return (
+        "You are documenting a data-warehouse table for an analytics catalog.\n"
+        f"Table: {table_name}{src}\n\n"
+        f"Columns:\n{_format_columns(columns)}\n\n"
+        f"Sample rows (up to {SAMPLE_ROWS}):\n{_format_sample_rows(sample_rows)}\n\n"
+        "Write a concise, factual description (1-2 sentences, <= 240 characters) "
+        "of what this table contains and its grain (one row per what). Base it only "
+        "on the column names and sample values shown — do not invent columns or "
+        "business meaning that isn't evident. No marketing tone."
+    )
+
+
+def generate_description(
+    extractor: Any,
+    table_name: str,
+    columns: Optional[List[Dict[str, Any]]],
+    sample_rows: Optional[List[Dict[str, Any]]],
+    *,
+    source: Optional[str] = None,
+    max_tokens: int = MAX_TOKENS,
+) -> str:
+    """Ask the model for a one/two-sentence description; return it stripped.
+
+    ``extractor`` is any :class:`connectors.llm.base.StructuredExtractor`.
+    Raises whatever the extractor raises (``LLMError`` subclasses) — the caller
+    decides whether to skip or fail. Returns ``""`` if the model produced no
+    usable string.
+    """
+    prompt = build_prompt(table_name, columns, sample_rows, source=source)
+    result = extractor.extract_json(
+        prompt=prompt,
+        max_tokens=max_tokens,
+        json_schema=DESCRIPTION_SCHEMA,
+        schema_name="table_description",
+    )
+    desc = (result or {}).get("description", "")
+    return desc.strip() if isinstance(desc, str) else ""
+
+
+__all__ = [
+    "MAX_TOKENS",
+    "SAMPLE_ROWS",
+    "DESCRIPTION_SCHEMA",
+    "build_prompt",
+    "generate_description",
+]

--- a/tests/test_table_autodoc.py
+++ b/tests/test_table_autodoc.py
@@ -1,0 +1,165 @@
+"""Tests for LLM table auto-documentation (#399).
+
+The pure core (`src.table_autodoc`) is exercised with a fake extractor — no
+live LLM. The CLI command is exercised end-to-end against a seeded system
+DuckDB with the extractor monkeypatched, proving the repo + profile wiring.
+"""
+
+from __future__ import annotations
+
+import typer
+import pytest
+from typer.testing import CliRunner
+
+from src.table_autodoc import build_prompt, generate_description
+
+
+class _FakeExtractor:
+    """Stands in for connectors.llm StructuredExtractor."""
+
+    def __init__(self, description="Synthetic test description.", error=None):
+        self.description = description
+        self.error = error
+        self.calls = []
+
+    def extract_json(self, *, prompt, max_tokens, json_schema, schema_name):
+        self.calls.append({"prompt": prompt, "schema_name": schema_name,
+                           "max_tokens": max_tokens})
+        if self.error:
+            raise self.error
+        return {"description": self.description}
+
+
+# --------------------------------------------------------------------------- #
+# Pure core
+# --------------------------------------------------------------------------- #
+
+
+def test_build_prompt_includes_table_columns_and_samples():
+    p = build_prompt(
+        "orders",
+        [{"name": "id", "type": "STRING"}, {"name": "amount", "type": "NUMERIC"}],
+        [{"id": "a1", "amount": "9.99"}],
+        source="bigquery",
+    )
+    assert "orders" in p and "bigquery" in p
+    assert "id (STRING)" in p and "amount (NUMERIC)" in p
+    assert "9.99" in p  # sample value surfaced
+
+
+def test_build_prompt_tolerates_missing_metadata():
+    p = build_prompt("t", None, None)
+    assert "(no column metadata)" in p and "(no sample rows)" in p
+
+
+def test_generate_description_returns_model_text():
+    fx = _FakeExtractor("One row per order.")
+    out = generate_description(fx, "orders", [{"name": "id", "type": "STRING"}], [{"id": "x"}])
+    assert out == "One row per order."
+    assert fx.calls and fx.calls[0]["schema_name"] == "table_description"
+
+
+def test_generate_description_strips_and_handles_empty():
+    assert generate_description(_FakeExtractor("  padded.  "), "t", [], []) == "padded."
+    assert generate_description(_FakeExtractor(""), "t", [], []) == ""
+
+
+def test_generate_description_propagates_llm_error():
+    from connectors.llm.exceptions import LLMError
+
+    with pytest.raises(LLMError):
+        generate_description(_FakeExtractor(error=LLMError("boom")), "t", [], [])
+
+
+# --------------------------------------------------------------------------- #
+# CLI — agnes admin autodoc-tables
+# --------------------------------------------------------------------------- #
+
+
+def _cli_app():
+    """Throwaway Typer hosting just the command (callback prevents Typer from
+    hoisting the single command and dropping the verb)."""
+    app = typer.Typer()
+
+    @app.callback()
+    def _cb() -> None:
+        pass
+
+    from cli.commands.admin_autodoc import autodoc_tables
+
+    app.command("autodoc-tables")(autodoc_tables)
+    return app
+
+
+@pytest.fixture
+def seeded(monkeypatch, tmp_path):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    from src.db import get_system_db
+    from src.repositories.profiles import ProfileRepository
+    from src.repositories.table_registry import TableRegistryRepository
+
+    conn = get_system_db()
+    reg = TableRegistryRepository(conn)
+    prof = ProfileRepository(conn)
+
+    # A: empty description + profile -> a target.
+    reg.register(id="orders", name="Orders", source_type="bigquery")
+    prof.save("orders", {
+        "columns": [{"name": "id", "type": "STRING"}, {"name": "amount", "type": "NUMERIC"}],
+        "sample_rows": [{"id": "a1", "amount": "9.99"}],
+    })
+    # B: already described + profile -> must be left untouched.
+    reg.register(id="users", name="Users", source_type="bigquery",
+                 description="Already described.")
+    prof.save("users", {"columns": [{"name": "uid", "type": "STRING"}],
+                        "sample_rows": [{"uid": "u1"}]})
+    # C: empty description, NO profile -> skipped.
+    reg.register(id="events", name="Events", source_type="bigquery")
+    return tmp_path
+
+
+def _reg():
+    from src.db import get_system_db
+    from src.repositories.table_registry import TableRegistryRepository
+
+    return TableRegistryRepository(get_system_db())
+
+
+def test_cli_fills_empty_description_and_respects_existing(seeded, monkeypatch):
+    import cli.commands.admin_autodoc as m
+
+    monkeypatch.setattr(m, "_build_extractor", lambda: _FakeExtractor("One row per order."))
+    r = CliRunner().invoke(_cli_app(), ["autodoc-tables"])
+    assert r.exit_code == 0, r.output
+
+    reg = _reg()
+    assert reg.get("orders")["description"] == "One row per order."   # filled
+    assert reg.get("users")["description"] == "Already described."     # not clobbered
+    assert (reg.get("events")["description"] or "") == ""              # skipped (no profile)
+
+
+def test_cli_dry_run_saves_nothing(seeded, monkeypatch):
+    import cli.commands.admin_autodoc as m
+
+    monkeypatch.setattr(m, "_build_extractor", lambda: _FakeExtractor("Would be saved."))
+    r = CliRunner().invoke(_cli_app(), ["autodoc-tables", "--dry-run"])
+    assert r.exit_code == 0, r.output
+    assert "Would be saved." in r.output
+    assert (_reg().get("orders")["description"] or "") == ""  # nothing persisted
+
+
+def test_cli_table_filter_targets_one(seeded, monkeypatch):
+    import cli.commands.admin_autodoc as m
+
+    monkeypatch.setattr(m, "_build_extractor", lambda: _FakeExtractor("Just orders."))
+    r = CliRunner().invoke(_cli_app(), ["autodoc-tables", "--table", "orders"])
+    assert r.exit_code == 0, r.output
+    assert _reg().get("orders")["description"] == "Just orders."
+
+
+def test_cli_unknown_table_errors(seeded, monkeypatch):
+    import cli.commands.admin_autodoc as m
+
+    monkeypatch.setattr(m, "_build_extractor", lambda: _FakeExtractor())
+    r = CliRunner().invoke(_cli_app(), ["autodoc-tables", "--table", "nope"])
+    assert r.exit_code == 1


### PR DESCRIPTION
## Summary

Closes the documentation gap behind #399: most registered tables ship with **no `description`**, which makes `agnes catalog` weaker for AI agents. Adds `agnes admin autodoc-tables`, which backfills descriptions for undescribed tables from data Agnes already holds — reusing the existing `connectors.llm` infrastructure (Haiku by default).

This is a building block for #469 Gap 1 (the workspace data-semantics generator, #472): once descriptions are filled here, that generator emits richer `tables/*.yml` automatically.

## What it does

`agnes admin autodoc-tables [--table <id>] [--dry-run] [--limit N]`

For each registered table whose `description` is empty **and** that has already been profiled, it reads the stored profile's columns + sample rows, asks the configured LLM for a short factual description, and saves it. Guarantees:

- **Never overwrites** an existing description (only empty ones are filled).
- **Only already-profiled tables** are touched (sample data must exist — sync/profile first).
- `--dry-run` previews without saving; `--table` targets one; `--limit` caps the batch.
- Metrics-style failure isolation: a per-table LLM error or empty result is skipped with a note, not fatal.

## Design

- **`src/table_autodoc.py`** — pure prompt/parse core (`build_prompt` + `generate_description` over a `connectors.llm` `StructuredExtractor`). No `app.` / DB / network dependency, so it's unit-testable with a fake extractor and reusable later for an automatic at-sync hook.
- **`cli/commands/admin_autodoc.py`** — the command, registered as a direct `admin_app` command (mirrors `register-table`). Sample data via `ProfileRepository`; LLM via `create_extractor_from_env_or_config` (`ANTHROPIC_API_KEY` / `LLM_API_KEY` / the `ai:` block).
- **`TableRegistryRepository.set_description`** — targeted `UPDATE` of just the `description` column (unlike `register()`'s full upsert, which would risk resetting sync/partition/docs fields).

## Trigger choice

This v1 is an **explicit admin command** (backfill on demand) rather than an automatic at-registration/at-sync hook. Rationale: no LLM call in the sync hot path (cost/latency), far easier to test, lower blast radius. The pure core is trivially promotable into a post-profile hook as a follow-up — the issue's "or on first sync" path — without touching the prompt/parse logic.

## Scope / notes

- Descriptions are short (1–2 sentences, `max_tokens=400`); the prompt forbids inventing columns/meaning not evident from the sample.
- No automatic hook, no schema change, no new endpoint — read-mostly + a single-column UPDATE.

## Test plan

`tests/test_table_autodoc.py`: 5 core (prompt content, model-text return, strip/empty handling, `LLMError` propagation) + 4 end-to-end against a **seeded system DuckDB** with the extractor monkeypatched (fills empty description, leaves an existing one untouched, skips an unprofiled table, `--dry-run` saves nothing, `--table` filter, unknown-table errors). **9 passing**; the `table_registry` repo suite stays green (28 together). No live LLM call in tests.

```
uv run pytest tests/test_table_autodoc.py -q
→ 9 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)