### PR TITLE
fix: make system.duckdb resilient to OOM kills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.55.30] — 2026-06-01
+
 ### Fixed
 - **`system.duckdb` could roll back days of admin state (data packages, RBAC grants, group members) after an OOM kill, and the OOM kill itself was self-inflicted.** Three compounding defects in a memory-bounded container (e.g. a 4 GiB cgroup):
   - **Uncapped system connection → OOM loop.** DuckDB enforces `memory_limit` per-connection, not per-process. The analytics + read-only connections were capped (2 GiB each) but the long-lived `system.duckdb` singleton was left uncapped, so a telemetry/audit aggregation on it could grow the process past the cgroup cap and the kernel OOM-killed the worker. `get_system_db()` now applies an explicit budget via a shared `_apply_memory_caps` helper (system 1 GiB, analytics 1.5 GiB, read-only 1 GiB) plus a `temp_directory` so an over-budget query spills to disk instead of growing RSS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Fixed
+- **`system.duckdb` could roll back days of admin state (data packages, RBAC grants, group members) after an OOM kill, and the OOM kill itself was self-inflicted.** Three compounding defects in a memory-bounded container (e.g. a 4 GiB cgroup):
+  - **Uncapped system connection → OOM loop.** DuckDB enforces `memory_limit` per-connection, not per-process. The analytics + read-only connections were capped (2 GiB each) but the long-lived `system.duckdb` singleton was left uncapped, so a telemetry/audit aggregation on it could grow the process past the cgroup cap and the kernel OOM-killed the worker. `get_system_db()` now applies an explicit budget via a shared `_apply_memory_caps` helper (system 1 GiB, analytics 1.5 GiB, read-only 1 GiB) plus a `temp_directory` so an over-budget query spills to disk instead of growing RSS.
+  - **Destructive WAL-replay recovery.** On restart after an unclean kill, an unreplayable WAL (the FTS-index DDL drop-ordering failure below) made `_try_open_system_db` restore the `pre-migrate` snapshot — captured only at migrations, so potentially days stale — discarding the live file's far newer last checkpoint. Recovery now first **discards only the unreplayable WAL and reopens the live file at its last checkpoint** (`_salvage_discard_wal`), losing at most post-checkpoint transactions; the pre-migrate fallback (with the #379 version guard) fires only if the file itself won't open. The discarded WAL is preserved chmod 600 for forensics.
+  - **FTS DDL lingering in the WAL.** `ensure_knowledge_fts_index` rebuilds the `fts_main_knowledge_items` schema on every search; those DROP/CREATE ops sat in the WAL until the next checkpoint and were what DuckDB's replay choked on after a kill. It now `CHECKPOINT`s immediately after (re)creating the index (best-effort) so the FTS DDL never lingers in the WAL.
+
 ## [0.55.29] — 2026-06-01
 
 ### Added

--- a/docs/superpowers/specs/2026-06-01-system-duckdb-resilience-design.md
+++ b/docs/superpowers/specs/2026-06-01-system-duckdb-resilience-design.md
@@ -1,0 +1,210 @@
+# system.duckdb resilience — design
+
+**Date:** 2026-06-01
+**Status:** approved (design), pending implementation plan
+**Area:** `src/db.py`, `src/fts.py`
+
+## Problem
+
+On a memory-constrained deployment (e.g. a 4 GiB container), the FastAPI/uvicorn
+process is OOM-killed by the kernel cgroup, restarts, and on restart the
+`system.duckdb` open can fail during WAL replay — which today triggers a
+*destructive* recovery that rolls the database back to a stale snapshot,
+silently losing admin state (data packages, RBAC grants, group members)
+written since that snapshot. Two independent defects combine into a
+data-loss incident:
+
+1. **Unbounded memory → OOM kill (the trigger).** DuckDB sizes
+   `memory_limit` per-connection, not per-process. The analytics
+   connection and the per-request read-only connections are capped (2 GiB
+   each, added in PR #434), but the **`system.duckdb` singleton connection
+   is never capped** — it runs at DuckDB's default (~80% of the cgroup
+   limit). The per-connection budgets do not sum to fit the container:
+   `system (~default) + analytics (2 GiB) + N×readonly (2 GiB each)` can
+   exceed the cgroup cap. A heavy aggregation over the append-only
+   telemetry / audit / usage tables on the uncapped system connection,
+   concurrent with the analytics working set, pushes process RSS past the
+   cap → kernel OOM-kill. (DuckDB 1.5.x *is* cgroup-aware — a fresh
+   connection in a 4 GiB container defaults to ~3.1 GiB — so the fix is
+   explicit conservative per-connection caps that sum under the cap, not
+   reading the cgroup ourselves.)
+
+2. **WAL replay fails on FTS DDL (the corruption path).** The
+   knowledge-item BM25 search rebuilds its FTS index on every `search()`
+   call with `create_fts_index(..., overwrite=1)`, which DROPs+CREATEs the
+   `fts_main_knowledge_items` schema on the **long-lived system
+   connection**. Those DDL operations land in `system.duckdb.wal`. When
+   the process is killed (OOM, or a deploy with a short stop grace) before
+   the next checkpoint, the WAL persists. On restart, DuckDB's WAL replay
+   raises `Failure while replaying WAL … Cannot drop entry
+   "fts_main_knowledge_items" because there are entries that depend on it`
+   — a drop-ordering failure in FTS schema replay.
+
+3. **Recovery is destructive (the amplifier).** `_try_open_system_db`
+   catches the generic WAL-replay error class and restores the
+   `system.duckdb.pre-migrate` snapshot, moving the live file aside to
+   `system.duckdb.broken.<ts>`. The pre-migrate snapshot is only refreshed
+   at migration time, so between migrations it can be days old. The live
+   file's last checkpoint is almost always newer — so the rollback throws
+   away far more data than necessary.
+
+## Goals
+
+- The instance must **survive an unclean kill in a 4 GiB container without
+  rolling back to a stale snapshot** — at most lose transactions written
+  since the last checkpoint, never days of admin state.
+- The instance must **stop OOM-killing itself** under normal dashboard /
+  telemetry / query load in a 4 GiB container.
+- No schema migration. Mirror the existing capped-connection pattern.
+- Vendor-agnostic: no deployment-specific values in code or docs.
+
+## Non-goals
+
+- Reworking the FTS index lifecycle (moving it off `system.duckdb`, or
+  rebuilding only on corpus change) — larger change, deferred.
+- A process-global DuckDB memory budget across connections (DuckDB has no
+  such primitive) — we approximate it with summed per-connection caps +
+  disk spill.
+- Raising the container memory limit — an operator stopgap, not part of
+  this code change. The fix must work within 4 GiB.
+
+## Design
+
+Three focused changes, all in the `system.duckdb` open/use path.
+
+### Change 1 — non-destructive WAL recovery (`src/db.py`, `_try_open_system_db`)
+
+Insert a salvage step before the existing pre-migrate rollback. New
+decision tree on a WAL-replay error:
+
+```
+duckdb.connect(db) raises WAL-replay error class?
+ ├─ no / other error → raise (unchanged)
+ └─ yes:
+     STEP A [new] — discard ONLY the WAL, keep the live file:
+        move <db>.wal → <db>.wal.discarded.<ts> (chmod 600, preserved for forensics)
+        retry duckdb.connect(db)            # opens at the live file's last checkpoint
+        ├─ success → log warning (lost only post-checkpoint txns), return conn
+        └─ failure → the main file itself is unreadable:
+     STEP B [existing] — pre-migrate fallback:
+        _move_to_broken(db, wal)            # wal already moved; move_to_broken skips if absent
+        version-guard (#379) + copy pre-migrate → db + reopen
+```
+
+**Correctness:** the live file's last checkpoint timestamp is always ≥ the
+pre-migrate snapshot timestamp (checkpoints run continuously; pre-migrate
+is captured only at migrations), so discard-WAL loses ≤ the data the
+current rollback loses. It also handles the original mid-migration case:
+if the WAL held an uncommitted migration `ALTER`, discarding it leaves the
+file at the pre-migration schema version and the idempotent migration
+ladder re-runs forward on the same start. The `#379` version-guard stays,
+relevant only on the Step B fallback. Empirically validated: the
+incident's `.broken.<ts>` file opened cleanly read-only *without* its WAL
+and contained the full pre-crash state.
+
+### Change 2 — checkpoint after FTS (re)create (`src/fts.py`, `ensure_knowledge_fts_index`)
+
+After a successful `PRAGMA create_fts_index(...)`, issue a best-effort
+`CHECKPOINT` so the FTS DDL is flushed into the main file and never lingers
+in the WAL to be replayed after an unclean kill. Best-effort: wrap in
+`try/except duckdb.Error`, log at debug, still return `True` (a checkpoint
+failure — e.g. a concurrent write txn — must not break search). Search is
+a low-frequency admin/analyst path over a small corpus, so the checkpoint
+cost is negligible. This removes the unreplayable WAL content *at the
+source*; Change 1 is the safety net if it still occurs.
+
+### Change 3 — cap the system connection + global budget + spill (`src/db.py`)
+
+In `get_system_db()`, after `_try_open_system_db()` and before
+`_ensure_schema()`, apply the same defensive caps the analytics path uses,
+wrapped in `try/except` with a warning on failure:
+
+```python
+SET memory_limit='1GB'              # system DB = metadata + telemetry; 1 GiB is generous
+SET threads=2
+SET preserve_insertion_order=false
+```
+
+Budget so the realistic concurrent sum fits under a 4 GiB cgroup with
+headroom for the host process:
+
+| Connection | cap | rationale |
+|---|---|---|
+| system (singleton) | **1 GiB** | metadata + telemetry aggregations |
+| analytics (singleton) | **1.5 GiB** | lowered from 2 GiB |
+| analytics readonly (per request) | **1 GiB** | lowered from 2 GiB |
+
+Plus a **disk-spill safety net** on each connection so a query exceeding
+its budget spills to disk instead of growing RSS (or surfaces a clean
+DuckDB error) rather than OOM-killing the process:
+
+```python
+SET temp_directory='<state-dir>/duckdb-tmp'
+SET max_temp_directory_size='<bounded, e.g. 10GB>'
+```
+
+The exact numbers are tunable; the invariant is `system + analytics +
+one readonly + host headroom < cgroup cap`, with spill as backstop for
+overshoot. Centralize the cap PRAGMAs for the three `src/db.py`
+connections (system, analytics, readonly) into one helper so the budget
+lives in a single place. The connector/profiler extract-time connections
+(`connectors/keboola/extractor.py`, `connectors/bigquery/access.py`,
+`src/profiler.py`) also hardcode `'2GB'` but are short-lived and
+out-of-process for the app's RSS — unifying them is an optional follow-up,
+out of scope here to keep the diff focused.
+
+## Components & boundaries
+
+- `_try_open_system_db(db_path)` — owns open + recovery. New private
+  helper `_salvage_discard_wal(db_path, wal_path) -> conn | None` keeps the
+  salvage step testable in isolation.
+- `_move_to_broken` — unchanged (already tolerates an absent WAL).
+- `ensure_knowledge_fts_index(conn)` — adds the post-create checkpoint;
+  signature/return contract unchanged.
+- A new `_apply_connection_caps(conn, *, memory, threads=2)` helper (or
+  module constants) centralizes the cap PRAGMAs used by system, analytics,
+  readonly, and the connector/profiler paths.
+
+## Error handling
+
+- Change 1: each branch logged; discarded WAL preserved chmod 600;
+  broken files chmod 600 (unchanged); if Step B also fails, propagate
+  (unchanged — auto-recovery exhausted).
+- Change 2: checkpoint failure → debug log, proceed.
+- Change 3: cap PRAGMA failure → warning log, proceed with default
+  (mirrors the existing analytics path's `except`).
+
+## Testing (TDD)
+
+`_try_open_system_db` (fake `duckdb.connect` via monkeypatch):
+- WAL-replay error → Step A discard-WAL succeeds → returns the live-file
+  connection; pre-migrate snapshot is **not** touched; live file is **not**
+  moved to `.broken`; WAL preserved as `.wal.discarded.<ts>`.
+- WAL-replay error → Step A reopen also fails → falls through to Step B
+  pre-migrate restore with the version-guard (existing behavior preserved).
+- Non-WAL error → raises (unchanged).
+- Real reproduction if it can be made deterministic: build an FTS index,
+  snapshot db+wal mid-flight to simulate a kill, assert the new path opens
+  without data loss.
+
+`ensure_knowledge_fts_index`:
+- After a successful create, a `CHECKPOINT` is issued (spy / assert WAL
+  flushed).
+- A `CHECKPOINT` that raises does not break the function (still `True`).
+
+`get_system_db` caps:
+- After open, `current_setting('memory_limit')` on the system connection
+  reflects the configured cap (not the DuckDB default).
+- Cap-PRAGMA failure is swallowed (connection still returned).
+
+Run the full suite before pushing: `.venv/bin/pytest tests/ --tb=short -n auto -q`.
+
+## Files touched
+
+- `src/db.py` — recovery salvage step; system-connection caps; centralized
+  cap helper.
+- `src/fts.py` — post-create checkpoint.
+- `tests/` — new tests for the above.
+- `CHANGELOG.md` — `Fixed` bullet under `[Unreleased]`.
+
+No schema migration. No config-file changes (caps are code defaults).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.55.29"
+version = "0.55.30"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/src/db.py
+++ b/src/db.py
@@ -1097,6 +1097,36 @@ _analytics_db_lock = threading.Lock()
 _analytics_db_conn: duckdb.DuckDBPyConnection | None = None
 _analytics_db_path: str | None = None
 
+# DuckDB per-connection memory budgets.
+#
+# DuckDB enforces ``memory_limit`` PER CONNECTION, not per process. In a
+# memory-constrained container (e.g. a 4 GiB cgroup) the live connections
+# must sum under the cap or the kernel OOM-kills the whole process. DuckDB
+# 1.5 is cgroup-aware — a fresh connection defaults to ~80% of the cgroup
+# limit — so a single *uncapped* connection can exceed the cap on its own.
+# We give each connection an explicit conservative budget:
+#
+#   system (singleton)             1 GiB    metadata + telemetry aggregations
+#   analytics (singleton)          1.5 GiB  working set over parquet views
+#   analytics readonly (per req)   1 GiB    one analyst's heavy query
+#
+# Steady state — the two singletons plus one in-flight readonly query —
+# is 3.5 GiB, under a 4 GiB cap with host headroom. The readonly path is
+# per-request and unbounded in count (FastAPI threadpool), so a burst of
+# concurrent analyst queries can momentarily exceed the cap; the
+# ``temp_directory`` disk spill below is the backstop — an over-budget
+# query spills to disk (or raises a clean DuckDB OOM) instead of growing
+# process RSS. For very memory-constrained, high-concurrency deployments,
+# tune AGNES_THREADPOOL_SIZE down too. (Bounding readonly connection
+# concurrency directly is a possible follow-up — out of scope here.)
+#
+# See docs/superpowers/specs/2026-06-01-system-duckdb-resilience-design.md.
+_SYSTEM_DB_MEMORY_LIMIT = "1GB"
+_ANALYTICS_DB_MEMORY_LIMIT = "1500MB"
+_ANALYTICS_RO_MEMORY_LIMIT = "1GB"
+_DUCKDB_THREADS = 2
+_DUCKDB_MAX_TEMP_DIR_SIZE = "10GB"
+
 
 def _get_data_dir() -> Path:
     return Path(os.environ.get("DATA_DIR", "./data"))
@@ -1169,14 +1199,34 @@ def _try_open_system_db(db_path: str) -> duckdb.DuckDBPyConnection:
         )
         if not is_wal_replay:
             raise
+        wal_path = Path(db_path + ".wal")
+
+        # STEP A — salvage the live file. Its last checkpoint is almost
+        # always newer than any pre-migrate snapshot (checkpoints run
+        # continuously; the snapshot is captured only at migrations).
+        # Discard ONLY the unreplayable WAL — DuckDB couldn't apply it
+        # anyway — and reopen the file at its last checkpoint. This loses
+        # at most the transactions written since that checkpoint, never
+        # the days of admin state a stale-snapshot rollback would drop.
+        # It also subsumes the mid-migration case: an uncommitted ALTER
+        # lives in the discarded WAL, so the file is at the pre-migration
+        # version and the idempotent ladder re-runs forward on this start.
+        salvaged = _salvage_discard_wal(db_path, wal_path, original_error=e)
+        if salvaged is not None:
+            return salvaged
+
+        # STEP B — the live file itself won't open. Fall back to the
+        # pre-migrate snapshot (with the #379 version guard below). The
+        # WAL was already moved aside by Step A, so _move_to_broken here
+        # just relocates the unreadable DB file.
         snapshot = Path(db_path).parent / "system.duckdb.pre-migrate"
         if not snapshot.exists():
             logger.error(
-                "WAL replay failed and no pre-migrate snapshot at %s — manual recovery required.",
+                "WAL replay failed, live file unreadable, and no pre-migrate "
+                "snapshot at %s — manual recovery required.",
                 snapshot,
             )
             raise
-        wal_path = Path(db_path + ".wal")
 
         # #379: refuse auto-recovery if the snapshot version doesn't
         # match SCHEMA_VERSION exactly. The migration ladder is
@@ -1241,6 +1291,49 @@ def _try_open_system_db(db_path: str) -> duckdb.DuckDBPyConnection:
         return duckdb.connect(db_path)
 
 
+def _salvage_discard_wal(
+    db_path: str, wal_path: Path, *, original_error: Exception
+) -> duckdb.DuckDBPyConnection | None:
+    """Discard an unreplayable WAL and reopen the DB at its last checkpoint.
+
+    Returns the open connection on success, or ``None`` if the database
+    file itself won't open (the caller then falls back to the pre-migrate
+    snapshot). The discarded WAL is moved to ``<db>.wal.discarded.<ts>``
+    (chmod ``0o600`` — it can hold uncommitted password/PAT writes) and
+    preserved for forensics: its content is exactly what DuckDB failed to
+    replay.
+    """
+    if wal_path.exists():
+        discarded = Path(str(db_path) + f".wal.discarded.{int(time.time())}")
+        try:
+            shutil.move(str(wal_path), str(discarded))
+            try:
+                os.chmod(discarded, 0o600)
+            except OSError:
+                pass  # best-effort; preservation matters more than mode
+        except OSError as move_err:
+            logger.error(
+                "WAL salvage: could not move WAL aside (%s); cannot reopen",
+                move_err,
+            )
+            return None
+    try:
+        conn = duckdb.connect(db_path)
+    except duckdb.Error as reopen_err:
+        logger.warning(
+            "WAL salvage reopen failed (%s); falling back to pre-migrate snapshot",
+            reopen_err,
+        )
+        return None
+    logger.warning(
+        "WAL replay failed (%s) — discarded the unreplayable WAL and reopened "
+        "system.duckdb at its last checkpoint. Transactions written since that "
+        "checkpoint are lost; admin state up to the checkpoint is intact.",
+        str(original_error).split("\n", 1)[0][:200],
+    )
+    return conn
+
+
 def _move_to_broken(db_path: str, wal_path: Path) -> Path:
     """Move the broken DB (+ WAL if present) aside to ``.broken.<ts>``.
 
@@ -1270,6 +1363,38 @@ def _move_to_broken(db_path: str, wal_path: Path) -> Path:
     return broken
 
 
+def _apply_memory_caps(
+    conn: duckdb.DuckDBPyConnection, memory_limit: str, *, label: str
+) -> None:
+    """Apply defensive memory caps + disk-spill settings to *conn*.
+
+    DuckDB ``memory_limit`` is per-connection; this keeps any single
+    connection from growing the process past the container cgroup cap
+    (see the ``_*_MEMORY_LIMIT`` constants). Best-effort: a failing PRAGMA
+    (read-only DB, in-memory DB, older DuckDB) is logged and skipped so
+    the connection stays usable on defaults. The essential caps
+    (memory_limit/threads) are applied in their own try so an optional
+    temp-spill failure can't undo them.
+    """
+    try:
+        conn.execute(f"SET memory_limit='{memory_limit}'")
+        conn.execute(f"SET threads={_DUCKDB_THREADS}")
+        conn.execute("SET preserve_insertion_order=false")
+    except Exception as e:
+        logger.warning(
+            "%s: SET memory/threads failed (%s); defaults remain", label, e
+        )
+    # Disk spill: a query that exceeds its memory budget spills to disk
+    # (or raises a clean DuckDB error) instead of OOM-killing the process.
+    try:
+        tmp = _get_state_dir() / "duckdb-tmp"
+        tmp.mkdir(parents=True, exist_ok=True)
+        conn.execute(f"SET temp_directory='{tmp}'")
+        conn.execute(f"SET max_temp_directory_size='{_DUCKDB_MAX_TEMP_DIR_SIZE}'")
+    except Exception as e:
+        logger.debug("%s: temp_directory spill setup failed (%s)", label, e)
+
+
 def get_system_db() -> duckdb.DuckDBPyConnection:
     """Get a connection to the system state database.
 
@@ -1290,6 +1415,14 @@ def get_system_db() -> duckdb.DuckDBPyConnection:
                     pass
             Path(db_path).parent.mkdir(parents=True, exist_ok=True)
             _system_db_conn = _try_open_system_db(db_path)
+            # Cap BEFORE _ensure_schema so migrations + the on-demand FTS
+            # index rebuild (src/fts.py) run under the budget too. The
+            # system DB was missed by the analytics-only cap in PR #434 —
+            # an uncapped singleton was the dominant allocator behind the
+            # 4 GiB-cgroup OOM loop.
+            _apply_memory_caps(
+                _system_db_conn, _SYSTEM_DB_MEMORY_LIMIT, label="get_system_db"
+            )
             _system_db_path = db_path
             _ensure_schema(_system_db_conn)
         return _maybe_instrument(_system_db_conn.cursor(), "system")
@@ -1322,27 +1455,16 @@ def get_analytics_db() -> duckdb.DuckDBPyConnection:
                     pass
             Path(db_path).parent.mkdir(parents=True, exist_ok=True)
             _analytics_db_conn = duckdb.connect(db_path)
-            # Defensive memory cap. Default ``memory_limit`` is 80% of
-            # system RAM, which on a 4 GiB cgroup container resolves to
-            # ~3.2 GiB — leaves no headroom for the host process + the
-            # short-lived consolidation / profiler connections that
-            # share the container. 2 GiB matches the cap applied in
-            # ``connectors/{keboola,bigquery}/extractor.py`` and
-            # ``src/profiler.py``. Analyst-facing queries that hit
-            # the cap surface a clear DuckDB OOM exception which
-            # the caller can present (vs. a silent process-wide
-            # OOM-kill). preserve_insertion_order=false matches the
-            # other capped paths.
-            try:
-                _analytics_db_conn.execute("SET memory_limit='2GB'")
-                _analytics_db_conn.execute("SET threads=2")
-                _analytics_db_conn.execute("SET preserve_insertion_order=false")
-            except Exception as e:
-                logger.warning(
-                    "get_analytics_db: SET memory/threads failed (%s); "
-                    "extension defaults remain in place",
-                    e,
-                )
+            # Defensive memory cap (budgeted with the system + readonly
+            # connections to sum under a 4 GiB cgroup — see the
+            # ``_*_MEMORY_LIMIT`` constants). Analyst-facing queries that
+            # hit the cap spill to disk or surface a clear DuckDB OOM
+            # exception, rather than a silent process-wide OOM-kill.
+            _apply_memory_caps(
+                _analytics_db_conn,
+                _ANALYTICS_DB_MEMORY_LIMIT,
+                label="get_analytics_db",
+            )
             _analytics_db_path = db_path
         return _maybe_instrument(_analytics_db_conn.cursor(), "analytics")
 
@@ -1511,13 +1633,8 @@ def get_analytics_db_readonly() -> duckdb.DuckDBPyConnection:
             conn.execute("SET enable_external_access = false")
         except Exception:
             pass
-        # Memory cap — see get_analytics_db above for rationale.
-        try:
-            conn.execute("SET memory_limit='2GB'")
-            conn.execute("SET threads=2")
-            conn.execute("SET preserve_insertion_order=false")
-        except Exception:
-            pass
+        # Memory cap — see get_analytics_db / the _*_MEMORY_LIMIT constants.
+        _apply_memory_caps(conn, _ANALYTICS_RO_MEMORY_LIMIT, label="analytics_ro")
         return _maybe_instrument(conn, "analytics_ro")
     conn = duckdb.connect(str(db_path), read_only=True)
     # Memory cap (see get_analytics_db rationale). Read-only conns can
@@ -1525,12 +1642,7 @@ def get_analytics_db_readonly() -> duckdb.DuckDBPyConnection:
     # ``CREATE TEMP TABLE`` over read_parquet — capping keeps a single
     # analyst's heavy query from process-wide OOM-killing all other
     # in-flight requests.
-    try:
-        conn.execute("SET memory_limit='2GB'")
-        conn.execute("SET threads=2")
-        conn.execute("SET preserve_insertion_order=false")
-    except Exception:
-        pass
+    _apply_memory_caps(conn, _ANALYTICS_RO_MEMORY_LIMIT, label="analytics_ro")
     # ATTACH extract.duckdb files FIRST so views referencing them work
     extracts_dir = _get_data_dir() / "extracts"
     if extracts_dir.exists():

--- a/src/fts.py
+++ b/src/fts.py
@@ -69,6 +69,23 @@ def ensure_knowledge_fts_index(conn: duckdb.DuckDBPyConnection) -> bool:
             "'main.knowledge_items', 'id', 'title', 'content', "
             "strip_accents=1, lower=1, overwrite=1)"
         )
+        # Flush the FTS DDL into the main DB file immediately. create_fts_index
+        # DROPs + CREATEs the multi-table ``fts_main_knowledge_items`` schema,
+        # and those ops sit in ``system.duckdb.wal`` until the next checkpoint.
+        # If the process is killed (OOM, short deploy grace) before then, the
+        # WAL persists and DuckDB's replay fails on the FTS-schema drop
+        # ordering ("Cannot drop entry fts_main_knowledge_items ... depends on
+        # it"), forcing a destructive recovery. Checkpointing here keeps that
+        # DDL out of the WAL. Best-effort: a concurrent write txn or read-only
+        # handle can make CHECKPOINT raise — that must not break search (the
+        # WAL-discard recovery in src/db.py is the safety net).
+        try:
+            conn.execute("CHECKPOINT")
+        except duckdb.Error as ckpt_err:
+            logger.debug(
+                "FTS index created but CHECKPOINT failed (%s); WAL flush deferred",
+                ckpt_err,
+            )
         return True
     except duckdb.Error as e:
         logger.warning(

--- a/tests/test_db_memory_caps.py
+++ b/tests/test_db_memory_caps.py
@@ -1,0 +1,66 @@
+"""Per-connection DuckDB memory caps (system.duckdb resilience).
+
+DuckDB enforces ``memory_limit`` per-connection, not per process. The
+``system.duckdb`` singleton was previously uncapped — in a memory-bounded
+container it could grow the process past the cgroup cap on its own and the
+kernel OOM-killed everything. ``get_system_db`` must now apply an explicit
+budget (mirroring the analytics path) so the connections sum under the cap.
+"""
+from __future__ import annotations
+
+import duckdb
+
+
+def _fresh_system_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    import src.db as db_module
+
+    db_module._system_db_conn = None
+    db_module._system_db_path = None
+    return db_module, db_module.get_system_db()
+
+
+def test_system_connection_has_memory_cap(tmp_path, monkeypatch):
+    """The system connection reports the configured cap, not DuckDB's
+    cgroup/host default. Compared against a control connection so the
+    assertion is independent of how DuckDB formats the limit string."""
+    db_module, conn = _fresh_system_db(tmp_path, monkeypatch)
+
+    sys_limit = conn.execute("SELECT current_setting('memory_limit')").fetchone()[0]
+
+    control = duckdb.connect()
+    control.execute(f"SET memory_limit='{db_module._SYSTEM_DB_MEMORY_LIMIT}'")
+    expected = control.execute("SELECT current_setting('memory_limit')").fetchone()[0]
+    control.close()
+
+    assert sys_limit == expected
+    threads = conn.execute("SELECT current_setting('threads')").fetchone()[0]
+    assert int(threads) == db_module._DUCKDB_THREADS
+
+
+def test_apply_memory_caps_swallows_pragma_failure(tmp_path, monkeypatch):
+    """A connection whose SET PRAGMAs raise must not blow up the helper —
+    the connection stays usable on its defaults."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    import src.db as db_module
+
+    class _BadConn:
+        def execute(self, *args, **kwargs):
+            raise duckdb.Error("boom")
+
+    # Must return normally (no exception escapes).
+    db_module._apply_memory_caps(_BadConn(), "1GB", label="test")
+
+
+def test_apply_memory_caps_sets_temp_directory(tmp_path, monkeypatch):
+    """The spill directory is configured so an over-budget query spills to
+    disk instead of growing process RSS."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    import src.db as db_module
+
+    conn = duckdb.connect()
+    db_module._apply_memory_caps(conn, "1GB", label="test")
+    temp_dir = conn.execute("SELECT current_setting('temp_directory')").fetchone()[0]
+    conn.close()
+    assert temp_dir, "temp_directory should be set for disk spill"
+    assert "duckdb-tmp" in temp_dir

--- a/tests/test_db_wal_recovery.py
+++ b/tests/test_db_wal_recovery.py
@@ -9,20 +9,25 @@ default database set`` and the system database becomes unrecoverable
 from the running binary — the operator has to restore from the
 pre-migrate snapshot by hand.
 
-The fix is two-pronged:
+The recovery is layered:
   1. ``_ensure_schema`` runs ``CHECKPOINT`` immediately after the
      migration ladder so a fresh ALTER doesn't sit in the WAL beyond
      the migration window. Tested implicitly by every migration test
      that survives a process restart between fixture runs (covered by
      the existing v25→v26→v27 tests).
-  2. ``_try_open_system_db`` catches the WAL-replay error class and
-     falls back to ``system.duckdb.pre-migrate``. That's the path
-     this file exercises.
+  2. STEP A — ``_try_open_system_db`` catches the WAL-replay error class
+     and first tries to SALVAGE the live file: discard only the
+     unreplayable WAL (``_salvage_discard_wal``) and reopen at the last
+     checkpoint. This preserves everything up to the checkpoint — far
+     more than a snapshot rollback — and is the common path.
+  3. STEP B — only if the live file itself won't reopen does it fall
+     back to ``system.duckdb.pre-migrate`` (with the #379 version guard).
 
-Additional coverage (issue #379): schema-version-aware refusal —
-auto-recovery proceeds when the pre-migrate snapshot is at HEAD, but
-raises RuntimeError when the snapshot is stale (older than
-SCHEMA_VERSION) or unreadable.
+Issue #379 coverage: schema-version-aware refusal — the Step B fallback
+proceeds when the pre-migrate snapshot is at HEAD, but raises
+RuntimeError when the snapshot is stale (older than SCHEMA_VERSION) or
+unreadable. The Step B tests force Step A to fail (``fail_times=2``) so
+the snapshot path is reached.
 """
 from __future__ import annotations
 
@@ -61,17 +66,24 @@ def make_wal_error():
     ``_try_open_system_db`` specifically handles) and subsequent calls
     delegate to the real ``duckdb.connect``.
 
+    ``fail_times`` controls how many opens of ``db_path`` raise the
+    WAL-replay error before delegating to the real connect. Use the
+    default (1) to exercise the Step A salvage (initial open fails, the
+    post-WAL-discard reopen succeeds). Use 2 to force Step A to fail too
+    (initial open + salvage reopen both fail) so the test reaches the
+    Step B pre-migrate fallback.
+
     Usage inside a test::
 
         def test_foo(tmp_path, make_wal_error):
             db_path = tmp_path / "system.duckdb"
             ...
-            with make_wal_error(db_path):
+            with make_wal_error(db_path, fail_times=2):
                 conn = db_module._try_open_system_db(str(db_path))
     """
     real_connect = duckdb.connect
 
-    def _factory(db_path: Path):
+    def _factory(db_path: Path, fail_times: int = 1):
         call_count = {"n": 0}
         fake_error = duckdb.Error(
             "INTERNAL Error: Failure while replaying WAL file: "
@@ -80,7 +92,7 @@ def make_wal_error():
         )
 
         def flaky_connect(path, *args, **kwargs):
-            if str(path) == str(db_path) and call_count["n"] == 0:
+            if str(path) == str(db_path) and call_count["n"] < fail_times:
                 call_count["n"] += 1
                 raise fake_error
             return real_connect(path, *args, **kwargs)
@@ -178,8 +190,12 @@ def test_recovery_restores_pre_migrate_snapshot_on_wal_replay_error(
         "database set"
     )
 
+    # Fail the initial open AND the Step A salvage reopen, so recovery
+    # falls through to the Step B pre-migrate restore (the path this test
+    # asserts). The third connect — after the snapshot is copied in —
+    # succeeds.
     def flaky_connect(path, *args, **kwargs):
-        if str(path) == str(db_path) and call_count["n"] == 0:
+        if str(path) == str(db_path) and call_count["n"] < 2:
             call_count["n"] += 1
             raise fake_error
         return real_connect(path, *args, **kwargs)
@@ -197,16 +213,17 @@ def test_recovery_restores_pre_migrate_snapshot_on_wal_replay_error(
         f"({SCHEMA_VERSION}); got {ver[0]}"
     )
 
-    # 5. Broken DB and broken WAL were moved aside (kept for forensics).
-    all_broken = sorted(state_dir.glob("system.duckdb.broken.*"))
-    broken_dbs = [p for p in all_broken if not p.name.endswith(".wal")]
-    broken_wals = [p for p in all_broken if p.name.endswith(".wal")]
-    assert len(broken_dbs) == 1, all_broken
-    assert len(broken_wals) == 1, all_broken
+    # 5. The unreadable DB was moved aside to .broken.<ts> (Step B), and
+    #    the unreplayable WAL was preserved aside to .wal.discarded.<ts>
+    #    (Step A) — both kept for forensics.
+    broken_dbs = sorted(state_dir.glob("system.duckdb.broken.*"))
+    discarded_wals = sorted(state_dir.glob("system.duckdb.wal.discarded.*"))
+    assert len(broken_dbs) == 1, broken_dbs
+    assert len(discarded_wals) == 1, discarded_wals
 
-    # 6. The current main DB exists and the (broken) WAL beside it does
-    #    NOT — the recovery path must drop the unflushed WAL or the
-    #    next start would replay the same broken op.
+    # 6. The current main DB exists (restored from snapshot) and the
+    #    broken WAL beside it does NOT — recovery must drop the unflushed
+    #    WAL or the next start would replay the same broken op.
     assert db_path.exists()
     assert not (state_dir / "system.duckdb.wal").exists()
 
@@ -315,7 +332,7 @@ def test_recovery_proceeds_when_snapshot_is_at_head(tmp_path, make_wal_error):
     _make_db_with_schema_version(snapshot_path, db_module.SCHEMA_VERSION)
     _corrupt_wal_so_replay_fails(db_path)
 
-    with make_wal_error(db_path):
+    with make_wal_error(db_path, fail_times=2):
         conn = db_module._try_open_system_db(str(db_path))
     try:
         # The recovered DB carries the snapshot's schema_version row.
@@ -327,11 +344,10 @@ def test_recovery_proceeds_when_snapshot_is_at_head(tmp_path, make_wal_error):
         conn.close()
 
     # Both the broken DB and the broken WAL must be preserved.
-    all_broken = sorted(tmp_path.glob("system.duckdb.broken.*"))
-    broken_dbs = [p for p in all_broken if not p.name.endswith(".wal")]
-    broken_wals = [p for p in all_broken if p.name.endswith(".wal")]
-    assert len(broken_dbs) == 1, all_broken
-    assert len(broken_wals) == 1, all_broken
+    broken_dbs = sorted(tmp_path.glob("system.duckdb.broken.*"))
+    discarded_wals = sorted(tmp_path.glob("system.duckdb.wal.discarded.*"))
+    assert len(broken_dbs) == 1, broken_dbs
+    assert len(discarded_wals) == 1, discarded_wals
     # Snapshot was copied into the main DB path.
     assert db_path.exists()
     # Snapshot file itself was left in place (not consumed).
@@ -351,7 +367,7 @@ def test_recovery_refuses_when_snapshot_is_stale(tmp_path, make_wal_error):
     _make_db_with_schema_version(snapshot_path, db_module.SCHEMA_VERSION - 1)
     _corrupt_wal_so_replay_fails(db_path)
 
-    with make_wal_error(db_path):
+    with make_wal_error(db_path, fail_times=2):
         with pytest.raises(RuntimeError) as excinfo:
             db_module._try_open_system_db(str(db_path))
 
@@ -362,11 +378,10 @@ def test_recovery_refuses_when_snapshot_is_stale(tmp_path, make_wal_error):
 
     # Both broken files preserved (DB + WAL split — same pattern as
     # the pre-existing test_recovery_restores_... test).
-    all_broken = sorted(tmp_path.glob("system.duckdb.broken.*"))
-    broken_dbs = [p for p in all_broken if not p.name.endswith(".wal")]
-    broken_wals = [p for p in all_broken if p.name.endswith(".wal")]
-    assert len(broken_dbs) == 1, all_broken
-    assert len(broken_wals) == 1, all_broken
+    broken_dbs = sorted(tmp_path.glob("system.duckdb.broken.*"))
+    discarded_wals = sorted(tmp_path.glob("system.duckdb.wal.discarded.*"))
+    assert len(broken_dbs) == 1, broken_dbs
+    assert len(discarded_wals) == 1, discarded_wals
 
     # Snapshot was not consumed.
     assert snapshot_path.exists()
@@ -390,7 +405,7 @@ def test_recovery_refuses_when_snapshot_has_no_schema_version_table(
     _make_db_no_schema_version_table(snapshot_path)
     _corrupt_wal_so_replay_fails(db_path)
 
-    with make_wal_error(db_path):
+    with make_wal_error(db_path, fail_times=2):
         with pytest.raises(RuntimeError) as excinfo:
             db_module._try_open_system_db(str(db_path))
 
@@ -423,7 +438,7 @@ def test_recovery_refuses_when_snapshot_is_from_future_version(
     _make_db_with_schema_version(snapshot_path, db_module.SCHEMA_VERSION + 1)
     _corrupt_wal_so_replay_fails(db_path)
 
-    with make_wal_error(db_path):
+    with make_wal_error(db_path, fail_times=2):
         with pytest.raises(RuntimeError) as excinfo:
             db_module._try_open_system_db(str(db_path))
 
@@ -453,12 +468,17 @@ def test_recovery_broken_files_are_chmod_0600(tmp_path, make_wal_error):
     _make_db_with_schema_version(snapshot_path, db_module.SCHEMA_VERSION - 1)
     _corrupt_wal_so_replay_fails(db_path)
 
-    with make_wal_error(db_path):
+    with make_wal_error(db_path, fail_times=2):
         with pytest.raises(RuntimeError):
             db_module._try_open_system_db(str(db_path))
 
-    broken = list(tmp_path.glob("system.duckdb.broken.*"))
+    broken = list(tmp_path.glob("system.duckdb.broken.*")) + list(
+        tmp_path.glob("system.duckdb.wal.discarded.*")
+    )
     assert broken, "no broken-aside files were created"
+    # Both the broken DB (Step B) and the discarded WAL (Step A) hold
+    # potentially-sensitive bytes and must be owner-only.
+    assert any(".wal.discarded." in p.name for p in broken), broken
     for path in broken:
         mode = stat.S_IMODE(path.stat().st_mode)
         # 0o600 owner-only RW. We accept any subset that's ≤ 0o600 in
@@ -467,3 +487,70 @@ def test_recovery_broken_files_are_chmod_0600(tmp_path, make_wal_error):
         assert mode & 0o077 == 0, (
             f"{path.name}: mode {oct(mode)} has group/other bits set"
         )
+
+
+# ---------------------------------------------------------------------------
+# Step A — salvage the live file by discarding the unreplayable WAL.
+# ---------------------------------------------------------------------------
+
+def test_salvage_reopens_live_file_without_snapshot_restore(
+    tmp_path, make_wal_error
+):
+    """The common case: WAL replay fails but the live file opens cleanly
+    once the WAL is discarded. Recovery must return the LIVE-file
+    connection, never touch the pre-migrate snapshot, keep the DB in
+    place (not moved to .broken), and preserve the discarded WAL."""
+    from src import db as db_module
+
+    db_path = tmp_path / "system.duckdb"
+    snapshot_path = tmp_path / "system.duckdb.pre-migrate"
+    _make_db_with_schema_version(db_path, db_module.SCHEMA_VERSION)
+    # A DELIBERATELY different snapshot version: if recovery wrongly fell
+    # back to the snapshot, the returned version would change (and the
+    # #379 guard would fire). Step A must make the snapshot irrelevant.
+    _make_db_with_schema_version(snapshot_path, db_module.SCHEMA_VERSION - 5)
+    _corrupt_wal_so_replay_fails(db_path)
+
+    with make_wal_error(db_path, fail_times=1):
+        conn = db_module._try_open_system_db(str(db_path))
+    try:
+        version = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()[0]
+        assert version == db_module.SCHEMA_VERSION, "returned the live file, not the snapshot"
+    finally:
+        conn.close()
+
+    # Live DB kept in place — NOT moved to .broken.
+    assert db_path.exists()
+    assert not list(tmp_path.glob("system.duckdb.broken.*"))
+    # Snapshot untouched (still the stale version, not consumed).
+    assert snapshot_path.exists()
+    assert db_module._peek_schema_version(snapshot_path) == db_module.SCHEMA_VERSION - 5
+    # Unreplayable WAL discarded aside, not left in place to replay again.
+    assert not (tmp_path / "system.duckdb.wal").exists()
+    assert len(list(tmp_path.glob("system.duckdb.wal.discarded.*"))) == 1
+
+
+def test_salvage_preserves_checkpointed_rows(tmp_path, make_wal_error):
+    """Salvage keeps every row up to the last checkpoint — the whole
+    point of preferring the live file over a stale snapshot. No
+    pre-migrate snapshot exists here, so only Step A can recover."""
+    from src import db as db_module
+
+    db_path = tmp_path / "system.duckdb"
+    seed = duckdb.connect(str(db_path))
+    seed.execute("CREATE TABLE keep (id INTEGER)")
+    seed.execute("INSERT INTO keep VALUES (1), (2), (3)")
+    seed.execute("CHECKPOINT")
+    seed.close()
+    _corrupt_wal_so_replay_fails(db_path)
+
+    with make_wal_error(db_path, fail_times=1):
+        conn = db_module._try_open_system_db(str(db_path))
+    try:
+        assert conn.execute("SELECT count(*) FROM keep").fetchone()[0] == 3
+    finally:
+        conn.close()
+
+    # No snapshot was needed or created; data recovered from the file itself.
+    assert not (tmp_path / "system.duckdb.pre-migrate").exists()
+    assert not list(tmp_path.glob("system.duckdb.broken.*"))

--- a/tests/test_knowledge_fts_search.py
+++ b/tests/test_knowledge_fts_search.py
@@ -258,3 +258,56 @@ class TestCzechDiacritics:
         # Accent-stripped query must still hit the diacritic-bearing doc.
         results = repo.search("cesky")
         assert [r["id"] for r in results] == ["cs"]
+
+
+class _RecordingConn:
+    """Wraps a real DuckDB connection, records executed SQL, and can be
+    told to fail CHECKPOINT — used to assert the FTS-index flush behaviour
+    without patching methods on the C-extension connection object."""
+
+    def __init__(self, real):
+        self._real = real
+        self.calls: list[str] = []
+        self.fail_checkpoint = False
+
+    def execute(self, sql, *args, **kwargs):
+        self.calls.append(sql)
+        if self.fail_checkpoint and sql.strip().upper() == "CHECKPOINT":
+            raise duckdb.Error("Cannot CHECKPOINT: an active transaction exists")
+        return self._real.execute(sql, *args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+class TestFtsIndexCheckpoint:
+    """Change: ``ensure_knowledge_fts_index`` CHECKPOINTs after (re)create
+    so the FTS DDL is flushed out of ``system.duckdb.wal`` and an unclean
+    kill can't leave an unreplayable WAL."""
+
+    def test_checkpoint_issued_after_index_create(self, tmp_path, monkeypatch):
+        real = _fresh_db(tmp_path, monkeypatch)
+        from src.fts import ensure_fts_loaded, ensure_knowledge_fts_index
+
+        if not ensure_fts_loaded(real):
+            pytest.skip("fts extension not loadable in this environment")
+
+        rec = _RecordingConn(real)
+        assert ensure_knowledge_fts_index(rec) is True
+        assert any(c.strip().upper() == "CHECKPOINT" for c in rec.calls), rec.calls
+        # CHECKPOINT must come AFTER the index DDL, not before.
+        ddl_i = next(i for i, c in enumerate(rec.calls) if "create_fts_index" in c)
+        ckpt_i = next(i for i, c in enumerate(rec.calls) if c.strip().upper() == "CHECKPOINT")
+        assert ckpt_i > ddl_i
+
+    def test_checkpoint_failure_does_not_break_index(self, tmp_path, monkeypatch):
+        real = _fresh_db(tmp_path, monkeypatch)
+        from src.fts import ensure_fts_loaded, ensure_knowledge_fts_index
+
+        if not ensure_fts_loaded(real):
+            pytest.skip("fts extension not loadable in this environment")
+
+        rec = _RecordingConn(real)
+        rec.fail_checkpoint = True
+        # A raising CHECKPOINT must be swallowed — search keeps working.
+        assert ensure_knowledge_fts_index(rec) is True


### PR DESCRIPTION
## Problem

In a memory-bounded container (e.g. a 4 GiB cgroup), three compounding defects turned a routine OOM kill into silent loss of admin state (data packages, RBAC grants, group members):

1. **Uncapped system connection → OOM loop.** DuckDB enforces `memory_limit` *per connection*, not per process. The analytics and read-only connections were capped (2 GiB each), but the long-lived `system.duckdb` singleton was left uncapped — a telemetry/audit aggregation on it could grow the worker past the cgroup cap, and the kernel OOM-killed it. DuckDB 1.5 is cgroup-aware (a fresh connection defaults to ~80% of the cgroup limit), so an uncapped connection alone can exceed the cap.
2. **Destructive WAL-replay recovery.** On the restart after an unclean kill, an unreplayable WAL made `_try_open_system_db` restore the `pre-migrate` snapshot — captured only at migrations, so potentially days stale — and move the live file (with its far newer last checkpoint) aside to `.broken.<ts>`. The rollback discarded far more than necessary.
3. **FTS DDL lingering in the WAL.** `ensure_knowledge_fts_index` rebuilds the `fts_main_knowledge_items` schema on every search (`create_fts_index(overwrite=1)`); those DROP/CREATE ops sit in the WAL until the next checkpoint, and the FTS-schema drop-ordering is exactly what DuckDB's WAL replay chokes on after a kill.

## Fix

- **`get_system_db`** now applies an explicit memory budget via a shared `_apply_memory_caps` helper (system 1 GiB, analytics 1.5 GiB, read-only 1 GiB) plus a `temp_directory` so an over-budget query spills to disk instead of growing RSS. Steady state (two singletons + one in-flight readonly = 3.5 GiB) sits under a 4 GiB cap; disk spill is the backstop for burst concurrency.
- **`_try_open_system_db`** recovery now first **discards only the unreplayable WAL and reopens the live file at its last checkpoint** (`_salvage_discard_wal`) — losing at most post-checkpoint transactions, never days of state. The pre-migrate fallback (with the #379 version guard) fires only if the file itself won't open. The discarded WAL is preserved chmod 600 for forensics.
- **`ensure_knowledge_fts_index`** issues a best-effort `CHECKPOINT` after (re)creating the index so the FTS DDL never lingers in the WAL.

No schema migration. No config-file changes (caps are code defaults).

## Design

`docs/superpowers/specs/2026-06-01-system-duckdb-resilience-design.md`.

## Testing

- New/updated tests: `tests/test_db_wal_recovery.py` (salvage path + the existing pre-migrate fallback updated for the new decision tree), `tests/test_knowledge_fts_search.py` (post-create CHECKPOINT + failure tolerance), `tests/test_db_memory_caps.py` (system cap applied; helper swallows PRAGMA failure; temp_directory set).
- Full suite: **5351 passed, 34 skipped**. The 39 errors are all in `tests/test_e2e_corporate_memory.py` (`fixture 'page' not found` — `pytest-playwright` is not installed in this environment); confirmed pre-existing — they reproduce identically with this branch's changes stashed.

## Reviewers

Architecture + rules reviewers run: no blockers. One should-fix (budget comment overstated the concurrency guarantee) addressed by clarifying the comment.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->