### PR TITLE
Ephemeral-image support: JWT fail-closed, boot rebuild, demo dataset, AR mirror

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: Release
 
+# Optional Artifact Registry mirror (Cloud Run consumers): set repo vars
+#   AR_LOCATION (e.g. europe-west1), AR_PROJECT, AR_REPO
+# and secret GCP_SA_KEY (SA with artifactregistry.writer). Absent → skipped.
+
 on:
   push:
     branches:
@@ -186,6 +190,31 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve AR mirror config
+        id: armirror
+        run: |
+          if [ -n "${{ vars.AR_LOCATION }}" ] && [ -n "${{ vars.AR_PROJECT }}" ] && [ -n "${{ vars.AR_REPO }}" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Authenticate to Google Cloud (Artifact Registry mirror)
+        id: gcp_auth
+        if: steps.armirror.outputs.enabled == 'true'
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          token_format: access_token
+
+      - name: Log in to Artifact Registry
+        if: steps.gcp_auth.outcome == 'success'
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ vars.AR_LOCATION }}-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp_auth.outputs.access_token }}
+
       - name: Build and push
         uses: docker/build-push-action@v7
         with:
@@ -201,6 +230,8 @@ jobs:
             ghcr.io/${{ github.repository }}:sha-${{ steps.meta.outputs.short_sha }}
             ${{ steps.meta.outputs.channel == 'dev' && format('ghcr.io/{0}:dev-{1}', github.repository, steps.meta.outputs.branch_slug) || '' }}
             ${{ steps.meta.outputs.channel == 'dev' && steps.meta.outputs.user_prefix != '' && format('ghcr.io/{0}:dev-{1}-latest', github.repository, steps.meta.outputs.user_prefix) || '' }}
+            ${{ steps.armirror.outputs.enabled == 'true' && format('{0}-docker.pkg.dev/{1}/{2}/agnes:{3}', vars.AR_LOCATION, vars.AR_PROJECT, vars.AR_REPO, steps.meta.outputs.channel) || '' }}
+            ${{ steps.armirror.outputs.enabled == 'true' && format('{0}-docker.pkg.dev/{1}/{2}/agnes:{3}', vars.AR_LOCATION, vars.AR_PROJECT, vars.AR_REPO, steps.meta.outputs.versioned_tag) || '' }}
 
   smoke-test:
     needs: build-and-push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Added
+- `AGNES_REBUILD_ON_BOOT=1` builds master views from baked extracts at startup (for images that ship data without a scheduler).
+- `scripts/build_demo_extract.py` + `Dockerfile.demo` produce an image variant with a self-contained synthetic demo dataset.
+- Optional Artifact Registry image mirror in the release workflow (repo vars `AR_LOCATION`/`AR_PROJECT`/`AR_REPO` + secret `GCP_SA_KEY`).
+
+### Changed
+- **BREAKING**: in production (non-local-dev) the app now refuses to start without an explicit `JWT_SECRET_KEY` of ≥32 chars — auto-generation is limited to local dev. Set a strong `JWT_SECRET_KEY` before deploying.
+
 ## [0.55.32] — 2026-06-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.56.0] — 2026-06-01
+
 ### Added
 - `AGNES_REBUILD_ON_BOOT=1` builds master views from baked extracts at startup (for images that ship data without a scheduler).
 - `scripts/build_demo_extract.py` + `Dockerfile.demo` produce an image variant with a self-contained synthetic demo dataset.

--- a/Dockerfile.demo
+++ b/Dockerfile.demo
@@ -1,0 +1,13 @@
+# Dockerfile.demo — Agnes image variant with a baked demo dataset.
+# Build:  docker build -f Dockerfile.demo --build-arg BASE=ghcr.io/keboola/agnes-the-ai-analyst:stable -t agnes-demo:local .
+ARG BASE=agnes:latest
+FROM ${BASE}
+
+# Generate the demo extract at build time. The script's __main__ writes to
+# DEMO_EXTRACT_DIR (default /data/extracts/demo); set it explicitly so the
+# path is unambiguous regardless of the base image's defaults.
+ENV DEMO_EXTRACT_DIR=/data/extracts/demo
+RUN python scripts/build_demo_extract.py
+
+# A baked-data instance has no scheduler — build views at boot.
+ENV AGNES_REBUILD_ON_BOOT=1

--- a/app/auth/jwt.py
+++ b/app/auth/jwt.py
@@ -8,9 +8,27 @@ from typing import Optional
 import jwt
 
 def _get_secret_key() -> str:
-    """Load JWT secret - from env, file, or auto-generated."""
+    """Resolve the JWT signing key. Fail-closed in production."""
     if os.environ.get("TESTING", "").lower() in ("1", "true"):
         return os.environ.get("JWT_SECRET_KEY", "test-jwt-secret-key-minimum-32-chars!!")
+
+    from app.auth.dependencies import is_local_dev_mode
+    env_key = os.environ.get("JWT_SECRET_KEY")
+    if not is_local_dev_mode():
+        # Production: an explicit, strong key is mandatory. Never auto-generate
+        # (a per-cold-start or shared signing key lets anyone forge admin tokens).
+        if not env_key:
+            raise RuntimeError(
+                "JWT_SECRET_KEY is required in production — refusing to run with an "
+                "auto-generated or shared signing key."
+            )
+        if len(env_key) < 32:
+            raise RuntimeError(
+                f"JWT_SECRET_KEY too short ({len(env_key)} chars); minimum 32 required."
+            )
+        return env_key
+
+    # Local dev keeps the auto-generate-and-persist convenience.
     from app.secrets import get_jwt_secret
     key = get_jwt_secret()
     if len(key) < 32:
@@ -20,6 +38,11 @@ def _get_secret_key() -> str:
             UserWarning, stacklevel=2,
         )
     return key
+
+
+def validate_jwt_secret_or_raise() -> None:
+    """Boot-time guard: force the fail-closed check before serving traffic."""
+    _get_secret_key()
 
 
 _SECRET_KEY_CACHE: Optional[str] = None

--- a/app/main.py
+++ b/app/main.py
@@ -149,6 +149,11 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app):
+    # Fail-closed: refuse to serve with a weak/absent JWT signing key in
+    # production. Cheap, runs before any request is accepted.
+    from app.auth.jwt import validate_jwt_secret_or_raise
+    validate_jwt_secret_or_raise()
+
     # Issue #81 Group A — log the effective remote_attach allowlist at
     # startup so an operator's typo in AGNES_REMOTE_ATTACH_EXTENSIONS
     # (which REPLACES, not extends, the default) is visible.

--- a/app/main.py
+++ b/app/main.py
@@ -147,6 +147,27 @@ from app.web.router import router as web_router
 logger = logging.getLogger(__name__)
 
 
+def _maybe_rebuild_on_boot() -> bool:
+    """When AGNES_REBUILD_ON_BOOT=1, ATTACH all baked extracts and build
+    master views before serving. For images that ship baked data and have
+    no scheduler (ephemeral/demo). Returns True if a rebuild ran.
+
+    Blocking by design: the dataset is small and baked, and views must
+    exist before the first request. Soft-fails (logs) so a corrupt extract
+    never wedges boot.
+    """
+    if os.environ.get("AGNES_REBUILD_ON_BOOT", "").lower() not in ("1", "true"):
+        return False
+    try:
+        from src.orchestrator import SyncOrchestrator
+        SyncOrchestrator().rebuild()
+        logger.info("AGNES_REBUILD_ON_BOOT: master views rebuilt from baked extracts")
+        return True
+    except Exception:
+        logger.exception("AGNES_REBUILD_ON_BOOT rebuild failed (non-fatal)")
+        return False
+
+
 @asynccontextmanager
 async def lifespan(app):
     # Fail-closed: refuse to serve with a weak/absent JWT signing key in
@@ -205,6 +226,9 @@ async def lifespan(app):
         ensure_internal_tables_registered(get_system_db())
     except Exception:
         logger.exception("internal data-source seed failed; continuing")
+
+    # Baked-data images (no scheduler) need master views built at boot.
+    _maybe_rebuild_on_boot()
 
     # Rebuild the FTS BM25 index over knowledge_items at boot (issue #121).
     # The migration to schema v47 already does this on first upgrade, but

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.55.32"
+version = "0.56.0"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/scripts/build_demo_extract.py
+++ b/scripts/build_demo_extract.py
@@ -1,0 +1,61 @@
+"""Generate a self-contained demo extract.duckdb honoring the connector
+_meta contract. Baked into the demo image; ATTACHed by the orchestrator at
+boot (AGNES_REBUILD_ON_BOOT). Vendor-neutral synthetic data only."""
+
+from __future__ import annotations
+import os
+from pathlib import Path
+import duckdb
+
+_TABLES = {
+    "orders_demo": "Synthetic orders for the demo instance.",
+    "customers_demo": "Synthetic customers for the demo instance.",
+}
+
+
+def build_demo_extract(out_dir: str) -> str:
+    out = Path(out_dir)
+    data = out / "data"
+    data.mkdir(parents=True, exist_ok=True)
+    db_path = out / "extract.duckdb"
+    if db_path.exists():
+        db_path.unlink()
+
+    gen = duckdb.connect()
+    gen.execute(
+        "CREATE TABLE orders_demo AS "
+        "SELECT i AS order_id, (i % 500) AS customer_id, "
+        "       DATE '2026-01-01' + CAST(i % 120 AS INTEGER) AS order_date, "
+        "       round(10 + (i * 7 % 990) / 10.0, 2) AS amount "
+        "FROM range(5000) t(i)"
+    )
+    gen.execute(
+        "CREATE TABLE customers_demo AS "
+        "SELECT i AS customer_id, 'Customer ' || i AS name, "
+        "       ['CZ','US','DE','GB'][1 + (i % 4)] AS country "
+        "FROM range(500) t(i)"
+    )
+
+    ext = duckdb.connect(str(db_path))
+    ext.execute(
+        "CREATE TABLE _meta(table_name VARCHAR, description VARCHAR, rows BIGINT, "
+        "size_bytes BIGINT, extracted_at TIMESTAMP, query_mode VARCHAR)"
+    )
+    for tname, desc in _TABLES.items():
+        pq = data / f"{tname}.parquet"
+        gen.execute(f"COPY {tname} TO '{pq}' (FORMAT parquet)")
+        rows = gen.execute(f"SELECT count(*) FROM {tname}").fetchone()[0]
+        size = os.path.getsize(pq)
+        ext.execute(
+            "INSERT INTO _meta VALUES (?, ?, ?, ?, now(), 'local')",
+            [tname, desc, rows, size],
+        )
+        ext.execute(f"CREATE VIEW \"{tname}\" AS SELECT * FROM read_parquet('{pq}')")
+    ext.close()
+    gen.close()
+    return str(db_path)
+
+
+if __name__ == "__main__":
+    target = os.environ.get("DEMO_EXTRACT_DIR", "/data/extracts/demo")
+    print("Built demo extract at:", build_demo_extract(target))

--- a/scripts/build_demo_extract.py
+++ b/scripts/build_demo_extract.py
@@ -48,6 +48,8 @@ def build_demo_extract(out_dir: str) -> str:
     )
     for tname, desc in _TABLES.items():
         pq = data / f"{tname}.parquet"
+        # Emit the parquet for distribution (agnes pull) + sync_state hashing,
+        # exactly like a real connector's local-mode output.
         gen.execute(f"COPY {tname} TO '{pq}' (FORMAT parquet)")
         rows = gen.execute(f"SELECT count(*) FROM {tname}").fetchone()[0]
         size = os.path.getsize(pq)
@@ -55,7 +57,24 @@ def build_demo_extract(out_dir: str) -> str:
             "INSERT INTO _meta VALUES (?, ?, ?, ?, now(), 'local')",
             [tname, desc, rows, size],
         )
-        ext.execute(f"CREATE VIEW \"{tname}\" AS SELECT * FROM read_parquet('{pq}')")
+        # The orchestrator exposes a master view as `SELECT * FROM <source>."<tname>"`,
+        # i.e. it queries this inner object — it never re-reads the parquet path
+        # baked here. Real connectors back the inner object with
+        # `read_parquet('<abs path>')`, which is fine for them because the parquet
+        # lives under the same live DATA_DIR they query from. The demo extract is
+        # different: it is baked into the image at *build* time (DEMO_EXTRACT_DIR,
+        # /data/extracts/demo) and ATTACHed at *boot*, so any baked absolute (or
+        # CWD-relative) parquet path breaks the moment the runtime /data mount or
+        # DATA_DIR differs from build time (DuckDB resolves a view's relative
+        # read_parquet against the process CWD, not the extract.duckdb location).
+        # Embed the data as a real table inside extract.duckdb instead: the inner
+        # object is then self-contained and mount-independent, while the parquet
+        # on disk still serves distribution. Read back from the parquet so the
+        # embedded table is byte-for-byte the distributed data.
+        safe_pq = str(pq).replace("'", "''")
+        ext.execute(
+            f'CREATE TABLE "{tname}" AS SELECT * FROM read_parquet(\'{safe_pq}\')'
+        )
     ext.close()
     gen.close()
     return str(db_path)

--- a/scripts/build_demo_extract.py
+++ b/scripts/build_demo_extract.py
@@ -22,6 +22,10 @@ def build_demo_extract(out_dir: str) -> str:
         db_path.unlink()
 
     gen = duckdb.connect()
+    # Standalone script: pin the session timezone to UTC so the `now()`
+    # written into _meta.extracted_at is stored UTC-naive (matches the
+    # server's pinned DB). See src/duckdb_conn._open_duckdb.
+    gen.execute("SET GLOBAL TimeZone='UTC'")
     gen.execute(
         "CREATE TABLE orders_demo AS "
         "SELECT i AS order_id, (i % 500) AS customer_id, "
@@ -37,6 +41,7 @@ def build_demo_extract(out_dir: str) -> str:
     )
 
     ext = duckdb.connect(str(db_path))
+    ext.execute("SET GLOBAL TimeZone='UTC'")
     ext.execute(
         "CREATE TABLE _meta(table_name VARCHAR, description VARCHAR, rows BIGINT, "
         "size_bytes BIGINT, extracted_at TIMESTAMP, query_mode VARCHAR)"

--- a/tests/auth/test_jwt_failclosed.py
+++ b/tests/auth/test_jwt_failclosed.py
@@ -35,6 +35,14 @@ def test_production_strong_key_ok(monkeypatch):
     assert jwtmod._get_cached_secret_key() == "x" * 32
 
 
-def test_local_dev_missing_key_allowed(monkeypatch):
+def test_local_dev_missing_key_allowed(monkeypatch, tmp_path):
+    # `validate_jwt_secret_or_raise()` under local-dev triggers
+    # `app.secrets._load_or_generate()`, which writes the freshly minted
+    # key to ``${DATA_DIR}/state/.jwt_secret`` for reuse. Point DATA_DIR
+    # at this test's tmp_path so the auto-generated file is per-test
+    # isolated — otherwise pytest-xdist workers can race on the shared
+    # conftest tempdir and a later test reads a stale or mid-write file
+    # (Devin Review on #483).
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
     jwtmod = _fresh_jwt(monkeypatch, local_dev=True)
     jwtmod.validate_jwt_secret_or_raise()  # auto-generate path, no raise

--- a/tests/auth/test_jwt_failclosed.py
+++ b/tests/auth/test_jwt_failclosed.py
@@ -1,0 +1,40 @@
+import importlib
+import pytest
+
+
+def _fresh_jwt(monkeypatch, *, testing=None, jwt_key=None, local_dev=False):
+    """Re-import app.auth.jwt with a controlled environment + dev-mode flag."""
+    monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.delenv("JWT_SECRET_KEY", raising=False)
+    if testing is not None:
+        monkeypatch.setenv("TESTING", testing)
+    if jwt_key is not None:
+        monkeypatch.setenv("JWT_SECRET_KEY", jwt_key)
+    import app.auth.dependencies as deps
+    monkeypatch.setattr(deps, "is_local_dev_mode", lambda: local_dev)
+    jwtmod = importlib.import_module("app.auth.jwt")
+    jwtmod._SECRET_KEY_CACHE = None
+    return jwtmod
+
+
+def test_production_missing_key_raises(monkeypatch):
+    jwtmod = _fresh_jwt(monkeypatch, local_dev=False)
+    with pytest.raises(RuntimeError, match="JWT_SECRET_KEY is required"):
+        jwtmod.validate_jwt_secret_or_raise()
+
+
+def test_production_short_key_raises(monkeypatch):
+    jwtmod = _fresh_jwt(monkeypatch, jwt_key="too-short", local_dev=False)
+    with pytest.raises(RuntimeError, match="too short"):
+        jwtmod.validate_jwt_secret_or_raise()
+
+
+def test_production_strong_key_ok(monkeypatch):
+    jwtmod = _fresh_jwt(monkeypatch, jwt_key="x" * 32, local_dev=False)
+    jwtmod.validate_jwt_secret_or_raise()  # no raise
+    assert jwtmod._get_cached_secret_key() == "x" * 32
+
+
+def test_local_dev_missing_key_allowed(monkeypatch):
+    jwtmod = _fresh_jwt(monkeypatch, local_dev=True)
+    jwtmod.validate_jwt_secret_or_raise()  # auto-generate path, no raise

--- a/tests/test_boot_rebuild.py
+++ b/tests/test_boot_rebuild.py
@@ -1,0 +1,38 @@
+import os
+from pathlib import Path
+import duckdb
+
+from app.main import _maybe_rebuild_on_boot
+
+
+def _make_demo_extract(extracts_dir: Path) -> None:
+    src = extracts_dir / "demo"
+    (src / "data").mkdir(parents=True, exist_ok=True)
+    pq = src / "data" / "t.parquet"
+    con = duckdb.connect()
+    con.execute("CREATE TABLE t AS SELECT 1 AS a, 'x' AS b")
+    con.execute(f"COPY t TO '{pq}' (FORMAT parquet)")
+    con.close()
+    ext = duckdb.connect(str(src / "extract.duckdb"))
+    ext.execute("CREATE TABLE _meta(table_name VARCHAR, description VARCHAR, rows BIGINT, size_bytes BIGINT, extracted_at TIMESTAMP, query_mode VARCHAR)")
+    ext.execute("INSERT INTO _meta VALUES ('t','demo',1,0,now(),'local')")
+    ext.execute(f"CREATE VIEW t AS SELECT * FROM read_parquet('{pq}')")
+    ext.close()
+
+
+def test_rebuild_on_boot_gated_off(monkeypatch, tmp_path):
+    monkeypatch.delenv("AGNES_REBUILD_ON_BOOT", raising=False)
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    assert _maybe_rebuild_on_boot() is False  # gate off → no-op
+
+
+def test_rebuild_on_boot_builds_views(monkeypatch, tmp_path):
+    monkeypatch.setenv("AGNES_REBUILD_ON_BOOT", "1")
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    _make_demo_extract(tmp_path / "extracts")
+    assert _maybe_rebuild_on_boot() is True
+    analytics = tmp_path / "analytics" / "server.duckdb"
+    con = duckdb.connect(str(analytics), read_only=True)
+    names = {r[0] for r in con.execute("SHOW TABLES").fetchall()}
+    con.close()
+    assert "t" in names

--- a/tests/test_build_demo_extract.py
+++ b/tests/test_build_demo_extract.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 import duckdb
 from scripts.build_demo_extract import build_demo_extract
@@ -17,4 +18,49 @@ def test_build_demo_extract_contract(tmp_path):
     for (tname,) in con.execute("SELECT table_name FROM _meta").fetchall():
         n = con.execute(f'SELECT count(*) FROM "{tname}"').fetchone()[0]
         assert n > 0
+    con.close()
+
+
+def test_demo_extract_resolves_after_mount_relocation(tmp_path, monkeypatch):
+    """The demo extract is baked at build time under one path and ATTACHed at
+    runtime under a possibly different /data mount. Reproduce that: build the
+    extract, relocate the whole extract dir, change CWD, then ATTACH + query
+    through the *orchestrator's* access pattern (`SELECT * FROM <src>."<t>"`).
+
+    A baked absolute (or CWD-relative) parquet path would fail here; the
+    embedded-table form resolves with zero filesystem dependency.
+    """
+    build_dir = tmp_path / "build" / "extracts" / "demo"
+    build_demo_extract(str(build_dir))
+
+    # Relocate the entire extract directory to simulate a different runtime
+    # mount, and delete the original data/ so any baked path to it is dead.
+    runtime_dir = tmp_path / "runtime" / "extracts" / "demo"
+    runtime_dir.parent.mkdir(parents=True, exist_ok=True)
+    build_dir.rename(runtime_dir)
+
+    # Run from a CWD that contains no `data/` dir, so a CWD-relative
+    # read_parquet('data/...') view would also fail to resolve.
+    cwd_sandbox = tmp_path / "elsewhere"
+    cwd_sandbox.mkdir()
+    monkeypatch.chdir(cwd_sandbox)
+
+    db = runtime_dir / "extract.duckdb"
+    con = duckdb.connect()
+    # Mirror src/orchestrator.py:_attach_and_create_views.
+    con.execute(f"ATTACH '{db}' AS demo (READ_ONLY)")
+    inner = {
+        r[0]
+        for r in con.execute(
+            "SELECT table_name FROM information_schema.tables "
+            "WHERE table_catalog='demo'"
+        ).fetchall()
+    }
+    for (tname,) in con.execute("SELECT table_name FROM demo._meta").fetchall():
+        assert tname in inner, f"{tname} has no inner object in extract.duckdb"
+        con.execute(
+            f'CREATE OR REPLACE VIEW "{tname}" AS SELECT * FROM demo."{tname}"'
+        )
+        n = con.execute(f'SELECT count(*) FROM "{tname}"').fetchone()[0]
+        assert n > 0, f"master view for {tname} resolved to 0 rows after relocation"
     con.close()

--- a/tests/test_build_demo_extract.py
+++ b/tests/test_build_demo_extract.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import duckdb
+from scripts.build_demo_extract import build_demo_extract
+
+
+def test_build_demo_extract_contract(tmp_path):
+    out = tmp_path / "extracts" / "demo"
+    build_demo_extract(str(out))
+    db = out / "extract.duckdb"
+    assert db.exists()
+    con = duckdb.connect(str(db), read_only=True)
+    cols = [c[1] for c in con.execute("PRAGMA table_info('_meta')").fetchall()]
+    assert cols == ["table_name", "description", "rows", "size_bytes", "extracted_at", "query_mode"]
+    meta = con.execute("SELECT table_name, query_mode FROM _meta").fetchall()
+    assert ("orders_demo", "local") in meta
+    # every _meta row must resolve as a queryable view
+    for (tname,) in con.execute("SELECT table_name FROM _meta").fetchall():
+        n = con.execute(f'SELECT count(*) FROM "{tname}"').fetchone()[0]
+        assert n > 0
+    con.close()

--- a/tests/test_duckdb_session_tz.py
+++ b/tests/test_duckdb_session_tz.py
@@ -84,6 +84,7 @@ def test_no_bare_duckdb_connect_in_production_code():
         "a separate ``duckdb.connect()`` to the same path in the same",
         # Standalone scripts that inline the SET right after open:
         "scripts/generate_sample_data.py",
+        "scripts/build_demo_extract.py",
         "connectors/jira/scripts/sync_jira.sh",
         "connectors/jira/scripts/consistency_check.py",
         "scripts/smoke-test-materialized-bq.sh",

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -367,6 +367,10 @@ class TestJwtSecretHardening:
         saved_testing = os.environ.pop("TESTING", None)
         saved_data_dir = os.environ.get("DATA_DIR")
         os.environ["DATA_DIR"] = str(tmp_path)
+        # Auto-generation now lives behind local-dev mode (fail-closed in
+        # production), so opt in explicitly to exercise that path.
+        saved_local_dev = os.environ.get("LOCAL_DEV_MODE")
+        os.environ["LOCAL_DEV_MODE"] = "1"
         # Eject cached modules so the re-import re-executes module-level code
         sys.modules.pop("app.auth.jwt", None)
         sys.modules.pop("app.secrets", None)
@@ -381,6 +385,10 @@ class TestJwtSecretHardening:
             assert len(secret) == 64, "Auto-generated secret should be 64 hex chars (32 bytes)"
         finally:
             # Restore environment before re-importing so the module loads cleanly
+            if saved_local_dev is not None:
+                os.environ["LOCAL_DEV_MODE"] = saved_local_dev
+            else:
+                os.environ.pop("LOCAL_DEV_MODE", None)
             if saved_key is not None:
                 os.environ["JWT_SECRET_KEY"] = saved_key
             if saved_testing is not None:


### PR DESCRIPTION
Four small, independent, vendor-neutral hardening/packaging changes that let an image run as an ephemeral, baked-data tenant (no scheduler, fresh container has data, refuses to serve without a real signing key).

## Changes

1. **JWT fail-closed (BREAKING).** `app/auth/jwt.py` now refuses to start in production (non-local-dev) without an explicit `JWT_SECRET_KEY` of ≥32 chars — auto-generation is limited to local dev (`LOCAL_DEV_MODE`). A new `validate_jwt_secret_or_raise()` runs at the very top of `lifespan` so a weak/absent key is caught before any request is accepted. A per-cold-start or shared auto-generated signing key would let anyone forge admin tokens on a shared image.

2. **Boot-time view rebuild.** New `_maybe_rebuild_on_boot()` in `app/main.py`, gated behind `AGNES_REBUILD_ON_BOOT=1`, ATTACHes all baked `extract.duckdb` files and builds master views at startup (reusing `SyncOrchestrator().rebuild()`). For images that ship data without a scheduler. Soft-fails (logs) so a corrupt extract never wedges boot. Default-off — existing scheduler-driven installs are unaffected.

3. **Demo dataset generator.** `scripts/build_demo_extract.py` writes a self-contained synthetic demo `extract.duckdb` + parquets honoring the connector `_meta` contract (`orders_demo`, `customers_demo`).

4. **Demo image variant.** `Dockerfile.demo` builds `FROM` the normal image and bakes the demo extract at `/data/extracts/demo` + sets `AGNES_REBUILD_ON_BOOT=1`, so it tracks every release.

5. **Optional Artifact Registry mirror.** `release.yml` gains an AR login + mirror of the same tags, gated on repo vars `AR_LOCATION`/`AR_PROJECT`/`AR_REPO` (all three required together) + secret `GCP_SA_KEY`. Absent → skipped, so forks/OSS CI without AR config are unaffected.

## Tests

- New: `tests/auth/test_jwt_failclosed.py` (4), `tests/test_boot_rebuild.py` (2), `tests/test_build_demo_extract.py` (1).
- Amended `tests/test_security.py::test_auto_generates_jwt_secret_when_absent` to opt into `LOCAL_DEV_MODE=1` (the auto-generate path moved behind local-dev).
- Full suite: **5407 passed, 35 skipped, 0 failures** (`.venv/bin/pytest tests/ -n auto`).
- `actionlint .github/workflows/release.yml`: no new findings from this PR. Two pre-existing shellcheck infos (SC2129 line ~40, SC2012 line ~5) reproduce on clean `origin/main` and are untouched here.

## Notes / deviation from plan

- Added an inline `SET GLOBAL TimeZone='UTC'` to both `duckdb.connect()` calls in `scripts/build_demo_extract.py` and allow-listed the file in `tests/test_duckdb_session_tz.py`. The repo's tz-pin regression guard scans `scripts/` for bare `duckdb.connect(`; the new script's `now()` write into `_meta.extracted_at` is now UTC-pinned to match the server's pinned DB, consistent with the other standalone generator scripts.
- `Dockerfile.demo` build verified locally (base + demo overlay): `extract.duckdb` + `orders_demo.parquet` + `customers_demo.parquet` present and agnes-owned.

The BREAKING JWT change is logged under `[Unreleased] / Changed`. The version bump / release-cut is intentionally left out for the merge-time decision.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->