### PR TITLE
refactor(web): migrate 3 admin pages onto base_page.html (#482 batch 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ### Changed
 - **Removed the four remaining `.container:has(.X-page) { max-width: none }` per-page container opt-outs** (`admin_user_detail`, `admin_group_detail`, `admin_server_config`, `store_upload`). Each inner wrapper is ≤ the canonical 1280px container (`.ud-page`/`.gd-page` 1100px, `.cfg-page` 1260px) or the override was redundant (`store_upload`'s `> main` reset already lives on the canonical `.container`), so rendered width is unchanged — pages now ride the canonical `.container`. This + the guards close the structural-enforcement half of #367; the remaining per-page `<style>` migration onto `base_page.html` is tracked as a follow-up.
+- **Migrated `admin_session_detail`, `admin_store_submissions`, `admin_groups` onto `base_page.html` (#482, batch 1).** Each page declares its hero via top-level `page_hero_*` vars (auto-included by `base_page`) and keeps only component CSS in `{% block head_extra %}`; the redundant `.page-shell` opt-in marker, explicit `_page_hero.html` include, and per-page `_components.html` import are dropped (`base_ds` auto-imports `ds`). Rendered output is unchanged — pages ride the canonical `.container`. First batch of the `base.html` → `base_page.html` migration tail.
 
 ## [0.55.28] — 2026-06-01
 

--- a/app/web/templates/admin_groups.html
+++ b/app/web/templates/admin_groups.html
@@ -1,12 +1,13 @@
-{% extends "base.html" %}
+{% extends "base_page.html" %}
 {% block title %}Groups — {{ config.INSTANCE_NAME }}{% endblock %}
 
-{% block content %}
-{# Design-system component macros — toolbar "+ New group" + 4 modal
-   action buttons render via `ds.button`. JS-generated `.icon-btn` row
-   actions stay page-local. #}
-{% import "_components.html" as ds %}
-<style>  .gp-toolbar {
+{% set page_hero_eyebrow = "Users & Access" %}
+{% set page_hero_title = "Groups" %}
+{% set page_hero_subtitle = "Named groups + members. Resource access lives on the Resource access page." %}
+
+{% block head_extra %}
+<style>
+  .gp-toolbar {
     display: flex; justify-content: space-between; align-items: center;
     gap: 12px; margin-bottom: 18px; flex-wrap: wrap;
   }
@@ -109,15 +110,13 @@
   .toast.success { background: #047857; }
   .toast.error { background: #b91c1c; }
 </style>
+{% endblock %}
 
+{% block page %}
+{# Design-system component macros — toolbar "+ New group" + 4 modal
+   action buttons render via `ds.button` (auto-imported by base_ds).
+   JS-generated `.icon-btn` row actions stay page-local. #}
 <div class="gp-page">
-  {% set page_hero_eyebrow = "Users & Access" %}
-
-  {% set page_hero_title = "Groups" %}
-
-  {% set page_hero_subtitle = "Named groups + members. Resource access lives on the Resource access page." %}
-
-  {% include "_page_hero.html" %}
 
   <div class="gp-toolbar">
     <div>

--- a/app/web/templates/admin_session_detail.html
+++ b/app/web/templates/admin_session_detail.html
@@ -1,47 +1,11 @@
-{% extends "base.html" %}
+{% extends "base_page.html" %}
 {% block title %}Session — {{ username }} / {{ session_file }}{% endblock %}
 
-{% block content %}
-{# Design-system component macros — the 2 header buttons (Next error +
-   Download .jsonl) render via `ds.button`. JS-rendered event cards
-   stay page-local. #}
-{% import "_components.html" as ds %}
-<div class="obs-page page-shell">
+{% set page_hero_eyebrow = "Activity Center" %}
+{% set page_hero_title = "Session transcript" %}
+{% set page_hero_subtitle = "Per-session JSONL viewer." %}
 
-  {% set page_hero_eyebrow = "Activity Center" %}
-
-
-  {% set page_hero_title = "Session transcript" %}
-
-
-  {% set page_hero_subtitle = "Per-session JSONL viewer." %}
-
-
-  {% include "_page_hero.html" %}
-
-
-  <header class="obs-topbar">
-    <div class="obs-topbar-left">
-      <p class="obs-subtitle">
-        <a href="/admin/sessions">← All sessions</a>
-        &nbsp;·&nbsp; <code>{{ username }}/{{ session_file }}</code>
-      </p>
-      <div class="td-meta" id="td-meta"></div>
-    </div>
-    <div class="obs-topbar-right">
-      {{ ds.button('↡ Next error', variant='secondary', size='sm',
-                   type='button', id='td-prev-err', attrs='hidden') }}
-      {{ ds.button('Download .jsonl', variant='secondary', size='sm',
-                   id='td-download',
-                   href='/api/admin/sessions/' ~ username ~ '/' ~ session_file ~ '/download') }}
-    </div>
-  </header>
-
-  <section class="td-events" id="td-events">
-    <div class="obs-empty" id="td-loading">Loading transcript…</div>
-  </section>
-</div>
-
+{% block head_extra %}
 <style>
 .obs-page { font: 14px/1.5 var(--font-sans, system-ui); color: var(--text-primary, #111827); }
 .obs-topbar { display: flex; align-items: flex-start; justify-content: space-between; gap: 24px;
@@ -88,6 +52,35 @@
   color: var(--text-secondary, #6b7280); margin: 0 0 4px; }
 .obs-empty { padding: 40px 16px; text-align: center; color: var(--text-secondary, #6b7280); }
 </style>
+{% endblock %}
+
+{% block page %}
+{# Design-system component macros — the 2 header buttons (Next error +
+   Download .jsonl) render via `ds.button` (auto-imported by base_ds).
+   JS-rendered event cards stay page-local. #}
+<div class="obs-page">
+
+  <header class="obs-topbar">
+    <div class="obs-topbar-left">
+      <p class="obs-subtitle">
+        <a href="/admin/sessions">← All sessions</a>
+        &nbsp;·&nbsp; <code>{{ username }}/{{ session_file }}</code>
+      </p>
+      <div class="td-meta" id="td-meta"></div>
+    </div>
+    <div class="obs-topbar-right">
+      {{ ds.button('↡ Next error', variant='secondary', size='sm',
+                   type='button', id='td-prev-err', attrs='hidden') }}
+      {{ ds.button('Download .jsonl', variant='secondary', size='sm',
+                   id='td-download',
+                   href='/api/admin/sessions/' ~ username ~ '/' ~ session_file ~ '/download') }}
+    </div>
+  </header>
+
+  <section class="td-events" id="td-events">
+    <div class="obs-empty" id="td-loading">Loading transcript…</div>
+  </section>
+</div>
 
 <script>
 (function() {

--- a/app/web/templates/admin_store_submissions.html
+++ b/app/web/templates/admin_store_submissions.html
@@ -1,14 +1,12 @@
-{% extends "base.html" %}
+{% extends "base_page.html" %}
 {% block title %}Store submissions — {{ config.INSTANCE_NAME }}{% endblock %}
 
-{% block content %}
-{# Design-system component macros — form Apply/Reset buttons render via
-   `ds.button`. Status filter chips, status badges, .subs-table stay
-   page-local. #}
-{% import "_components.html" as ds %}
+{% set page_hero_eyebrow = "Agent Experience" %}
+{% set page_hero_title = "Flea Submissions" %}
+{% set page_hero_subtitle = "Plugin / skill / agent submissions awaiting review." %}
+
+{% block head_extra %}
 <style>
-  /* Width + padding come from .page-shell (style-custom.css) — same
-     1280px container as /dashboard, /marketplace, /admin/* peers. */
 
   .subs-form {
     display: grid;
@@ -123,7 +121,12 @@
     color: var(--text-secondary, #6b7280); font-size: 13px;
   }
 </style>
+{% endblock %}
 
+{% block page %}
+{# Design-system component macros — form Apply/Reset buttons render via
+   `ds.button` (auto-imported by base_ds). Status filter chips, status
+   badges, .subs-table stay page-local. #}
 {% set base_qs %}
 {%- if status_filter %}status={{ status_filter }}&{% endif -%}
 {%- if submitter_filter %}submitter={{ submitter_filter }}&{% endif -%}
@@ -160,11 +163,7 @@
   {%- if b is none -%}—{%- elif b < 1024 -%}{{ b }} B{%- elif b < 1048576 -%}{{ "%.1f"|format(b / 1024) }} KB{%- else -%}{{ "%.1f"|format(b / 1048576) }} MB{%- endif -%}
 {%- endmacro %}
 
-<div class="subs-page page-shell">
-  {% set page_hero_eyebrow = "Agent Experience" %}
-  {% set page_hero_title = "Flea Submissions" %}
-  {% set page_hero_subtitle = "Plugin / skill / agent submissions awaiting review." %}
-  {% include "_page_hero.html" %}
+<div class="subs-page">
   <form class="subs-form" method="get" action="/admin/store/submissions">
     {# Preserve status filter when submitting other filters. #}
     {% if status_filter %}<input type="hidden" name="status" value="{{ status_filter }}">{% endif %}


### PR DESCRIPTION
Batch 1 of the **#482** "migration tail" — moving the remaining `base.html` leaf pages onto the `base_page.html` page-shell introduced by #367 / #481.

> **Stacked PR.** Based on `zs/367-design-system-pageshell` (#481), which provides `base_page.html`, so this diff shows **only** batch 1. Retarget to `main` once #481 merges (and rebase).

### Migrated (`base.html` → `base_page.html`)
- `admin_session_detail.html`
- `admin_store_submissions.html`
- `admin_groups.html`

Each page now:
- declares its hero via top-level `page_hero_*` vars (`base_page` auto-includes `_page_hero.html` — the explicit include and double-hero risk are gone);
- keeps only component CSS in `{% block head_extra %}`, with the body + page `<script>` in `{% block page %}` (which still renders **before** `_app_scripts.html`, preserving the existing script/global ordering — e.g. `admin_groups`' own `toast()`);
- drops the redundant `.page-shell` opt-in marker and the per-page `_components.html` import (`base_ds` auto-imports `ds`).

Inert `.subs-page` / `.gp-page` wrappers (and the styled, load-bearing `.obs-page`) are retained to keep the diff minimal and byte-verifiable; CSS/JS bodies are unchanged. Net **−8 lines**.

### Verification
- **Render-check** (real admin auth, all 3 pages): `200`, exactly one `.page-header--hero`, canonical `.container` present, no `.container:has(` opt-out, `page-shell` absent from rendered output.
- **pytest** `test_design_system_contract` + `test_web_ui` + `test_web_home_page` + `test_groups_mapped_email`: **98 passed, 3 skipped**.

### Not in this batch
- The broad `.X-page { max-width }` contract guard stays **deferred** — it's the final step of #482, enabled only after the remaining ~38 pages migrate (some still carry legitimate inner-width wrappers that would false-positive today).

Part of #482.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
