### PR TITLE
fix(ci): e2e-nightly + docker-e2e write JWT_SECRET_KEY (closes #487)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,15 @@ jobs:
 
       - name: Start services
         run: |
-          touch .env
+          # docker-compose.yml declares `env_file: .env` as required; CI
+          # ships no .env. Generate a random per-run JWT_SECRET_KEY so the
+          # app's v0.56.0 fail-closed guard (refuses to start in production
+          # without an explicit ≥32-char key; see app/auth/jwt.py and
+          # PR #483) is satisfied. Random rather than hard-coded so the
+          # value can't be mistaken for a real key in logs or screenshots.
+          # All other runtime values are still provided by the compose
+          # `environment:` block.
+          echo "JWT_SECRET_KEY=$(openssl rand -hex 32)" > .env
           docker compose up -d --wait --wait-timeout 60
 
       - name: Run Docker E2E tests

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -56,9 +56,15 @@ jobs:
         if: env.SKIP_MATRIX != '1'
         run: |
           # docker-compose.yml declares `env_file: .env` as required; CI
-          # ships no .env, so create an empty one. Runtime values are
-          # already in the compose `environment:` block.
-          touch .env
+          # ships no .env. Generate a random per-run JWT_SECRET_KEY so the
+          # app's v0.56.0 fail-closed guard (refuses to start in production
+          # without an explicit ≥32-char key; see app/auth/jwt.py and
+          # PR #483) is satisfied. Random rather than hard-coded so the
+          # value can't be mistaken for a real key in logs or screenshots,
+          # and so two parallel runs never share the same minted token.
+          # All other runtime values are still provided by the compose
+          # `environment:` block (DATA_DIR, AGNES_TEMP_DIR, …).
+          echo "JWT_SECRET_KEY=$(openssl rand -hex 32)" > .env
           # --wait + healthcheck (defined in docker-compose.yml, hits
           # /api/health) is the same pattern as ci.yml; cleaner than
           # the prior hand-rolled curl loop, which polled the wrong

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.58.1] — 2026-06-02
+
+### Fixed
+- **`e2e-nightly.yml` + `ci.yml` docker-e2e workflows no longer fail at container start after v0.56.0's BREAKING JWT fail-closed (#483).** Both workflows created an empty `.env` (`touch .env`) and relied on docker-compose's `environment:` block for runtime values; with `JWT_SECRET_KEY` absent, the app refused to start in production mode and the `Container agnes-the-ai-analyst-app-1 is unhealthy` failure auto-filed issue #487 against the first v0.58.0 nightly run. Both workflows now write a random 64-hex `JWT_SECRET_KEY` (per run, via `openssl rand -hex 32`) to `.env` before `docker compose up` so the safety guard is satisfied without committing a secret to the repo. `release.yml` smoke-test was unaffected — it already mounts `docker-compose.ci.yml` overlay which sets `JWT_SECRET_KEY` for the built-image path.
+
 ## [0.58.0] — 2026-06-02
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.58.0"
+version = "0.58.1"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"


### PR DESCRIPTION
## Why

Issue #487 — nightly agent-browser smoke against the v0.58.0 merge commit failed at `Container agnes-the-ai-analyst-app-1 is unhealthy` with:

```
RuntimeError: JWT_SECRET_KEY is required in production —
refusing to run with an auto-generated or shared signing key.
```

Cause: v0.56.0 (PR #483) made the JWT bootstrap fail-closed in production — the app now refuses to start without an explicit ≥32-char `JWT_SECRET_KEY` (auto-generation is gated behind `LOCAL_DEV_MODE=1`). `release.yml`'s smoke-test was unaffected because it mounts `docker-compose.ci.yml` overlay which sets the key. But `e2e-nightly.yml` and `ci.yml`'s docker-e2e job were both still on the pre-v0.56.0 pattern: `touch .env` and rely on docker-compose's `environment:` block for runtime values. With `JWT_SECRET_KEY` absent, both workflows hard-fail at container start.

## Fix

Both workflows now write a random per-run `JWT_SECRET_KEY` (via `openssl rand -hex 32`) to `.env` before `docker compose up`. Random rather than hard-coded so the value can't be mistaken for a real key in CI logs or screenshots, and so two parallel runs never share the same minted token. All other runtime values stay provided by the compose `environment:` block.

## Release-cut

0.58.1 (patch — CI infra fix tightening release-pipeline reliability, no user-visible behavior change).

## Closes

#487

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->