### PR TITLE
refactor(web): migrate 4 admin pages onto base_page.html (#482 batch 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ### Changed
 - **Removed the four remaining `.container:has(.X-page) { max-width: none }` per-page container opt-outs** (`admin_user_detail`, `admin_group_detail`, `admin_server_config`, `store_upload`). Each inner wrapper is ≤ the canonical 1280px container (`.ud-page`/`.gd-page` 1100px, `.cfg-page` 1260px) or the override was redundant (`store_upload`'s `> main` reset already lives on the canonical `.container`), so rendered width is unchanged — pages now ride the canonical `.container`. This + the guards close the structural-enforcement half of #367; the remaining per-page `<style>` migration onto `base_page.html` is tracked as a follow-up.
+- **Migrated `admin_sessions`, `admin_usage` (Telemetry), `admin_welcome` (Init Prompt), `admin_workspace_prompt` onto `base_page.html` (#482, batch 2).** Same treatment as batch 1: hero via top-level `page_hero_*` vars, component CSS — plus the CodeMirror `<link>`/`<script>` assets on the two editor pages — moved into `{% block head_extra %}`, body + page `<script>` in `{% block page %}`, and the redundant `.page-shell` marker + per-page `_components.html` import dropped. Rendered output unchanged — all four ride the canonical `.container`.
 
 ## [0.55.28] — 2026-06-01
 

--- a/app/web/templates/admin_sessions.html
+++ b/app/web/templates/admin_sessions.html
@@ -1,23 +1,81 @@
-{% extends "base.html" %}
+{% extends "base_page.html" %}
 {% block title %}Sessions — Admin{% endblock %}
 
-{% block content %}
+{% set page_hero_eyebrow = "Activity Center" %}
+{% set page_hero_title = "Sessions" %}
+{% set page_hero_subtitle = "Every collected JSONL across users plus a transcript viewer with next-error navigation." %}
+
+{% block head_extra %}
+<style>
+.obs-page { font: 14px/1.5 var(--font-sans, system-ui); color: var(--text-primary, #111827); }
+.obs-topbar { display: flex; align-items: flex-start; justify-content: space-between; gap: 24px;
+  padding: 12px 0 20px; border-bottom: 1px solid var(--border, #e5e7eb); margin-bottom: 16px; }
+.obs-topbar-left { flex: 1; min-width: 0; }
+.obs-subtitle { margin: 0 0 10px; color: var(--text-secondary, #6b7280); font-size: 13px; max-width: 720px; }
+.obs-subtitle b { color: var(--text-primary, #111827); }
+.obs-narrative { font-size: 16px; line-height: 1.45; }
+.obs-narrative b { font-weight: 600; }
+.obs-topbar-right { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+.obs-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.4px;
+  color: var(--text-secondary, #6b7280); display: block; margin-bottom: 2px; }
+.obs-window select { padding: 6px 8px; border: 1px solid var(--border, #e5e7eb); border-radius: 6px;
+  background: var(--surface, #fff); font: inherit; }
+/* `.obs-btn` rules deleted — buttons render via `ds.button(variant=
+   'secondary', size='sm')` carrying canonical .btn family. */
+.obs-kpis { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-bottom: 16px; }
+.obs-kpi { text-align: left; padding: 14px 16px; border: 1px solid var(--border, #e5e7eb);
+  border-radius: 8px; background: var(--surface, #fff); cursor: pointer;
+  display: flex; flex-direction: column; gap: 4px; }
+.obs-kpi:hover { border-color: #2563eb; background: var(--border-light, #f3f4f6); }
+.obs-kpi-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.4px;
+  color: var(--text-secondary, #6b7280); }
+.obs-kpi-value { font-size: 22px; font-weight: 600; font-variant-numeric: tabular-nums; }
+.obs-kpi-sub { font-size: 12px; color: var(--text-secondary, #6b7280); font-variant-numeric: tabular-nums; }
+.obs-filters { display: flex; gap: 12px; align-items: flex-end; flex-wrap: wrap;
+  padding: 12px 14px; background: var(--border-light, #f3f4f6); border-radius: 8px; margin-bottom: 12px; }
+.obs-filter { display: flex; flex-direction: column; gap: 4px; min-width: 140px; }
+.obs-filter-grow { flex: 1; min-width: 200px; }
+.obs-filter label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.4px;
+  color: var(--text-secondary, #6b7280); }
+.obs-select, .obs-filter input[type=search] { padding: 6px 8px;
+  border: 1px solid var(--border, #e5e7eb); border-radius: 6px;
+  background: var(--surface, #fff); font: inherit; }
+.obs-checkbox { display: flex; align-items: center; gap: 6px;
+  text-transform: none; letter-spacing: 0; font-size: 13px;
+  color: var(--text-primary, #111827); cursor: pointer; padding-top: 14px; }
+.obs-filter-actions { display: flex; align-items: flex-end; }
+.obs-table-wrap { border: 1px solid var(--border, #e5e7eb); border-radius: 8px;
+  overflow: hidden; background: var(--surface, #fff); }
+.obs-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.obs-table thead th { text-align: left; padding: 10px 12px; background: var(--border-light, #f3f4f6);
+  border-bottom: 1px solid var(--border, #e5e7eb); font-weight: 600;
+  color: var(--text-secondary, #6b7280); font-size: 11px;
+  text-transform: uppercase; letter-spacing: 0.4px; white-space: nowrap; }
+.obs-table thead th button { background: none; border: 0; padding: 0; font: inherit; color: inherit;
+  cursor: pointer; display: inline-flex; gap: 4px; text-transform: inherit; letter-spacing: inherit; }
+.obs-table thead th[aria-sort="ascending"] .obs-sort-arrow::before { content: "▲"; }
+.obs-table thead th[aria-sort="descending"] .obs-sort-arrow::before { content: "▼"; }
+.obs-sort-arrow { font-size: 9px; color: var(--text-secondary, #6b7280); }
+.obs-table tbody td { padding: 8px 12px; border-bottom: 1px solid var(--border-light, #f3f4f6); vertical-align: top; }
+.obs-table tbody tr { cursor: pointer; }
+.obs-table tbody tr:hover { background: var(--border-light, #f3f4f6); }
+.obs-table tbody tr.has-errors { background: #fff7f7; }
+.obs-table tbody tr.has-errors:hover { background: #ffebeb; }
+.obs-num { text-align: right; font-variant-numeric: tabular-nums; }
+.obs-empty { padding: 40px 16px; text-align: center; color: var(--text-secondary, #6b7280); font-size: 13px; }
+.obs-table-footer { display: flex; justify-content: space-between; align-items: center;
+  padding: 10px 14px; border-top: 1px solid var(--border, #e5e7eb); background: var(--border-light, #f3f4f6); }
+.obs-row-count { color: var(--text-secondary, #6b7280); font-size: 12px; }
+.obs-err-chip { display: inline-block; padding: 1px 6px; border-radius: 4px; background: #fee2e2;
+  color: #991b1b; font-size: 11px; font-weight: 500; }
+</style>
+{% endblock %}
+
+{% block page %}
 {# Design-system component macros — Reset + Prev/Next paginator render
-   via `ds.button`. .obs-kpi cards + .obs-table page-local enhancements
-   stay as-is per system.md. #}
-{% import "_components.html" as ds %}
-<div class="obs-page page-shell">
-
-  {% set page_hero_eyebrow = "Activity Center" %}
-
-
-  {% set page_hero_title = "Sessions" %}
-
-
-  {% set page_hero_subtitle = "Every collected JSONL across users plus a transcript viewer with next-error navigation." %}
-
-
-  {% include "_page_hero.html" %}
+   via `ds.button` (auto-imported by base_ds). .obs-kpi cards + .obs-table
+   page-local enhancements stay as-is per system.md. #}
+<div class="obs-page">
 
 
   <header class="obs-topbar">
@@ -103,70 +161,6 @@
     </div>
   </section>
 </div>
-
-<style>
-.obs-page { font: 14px/1.5 var(--font-sans, system-ui); color: var(--text-primary, #111827); }
-.obs-topbar { display: flex; align-items: flex-start; justify-content: space-between; gap: 24px;
-  padding: 12px 0 20px; border-bottom: 1px solid var(--border, #e5e7eb); margin-bottom: 16px; }
-.obs-topbar-left { flex: 1; min-width: 0; }
-.obs-subtitle { margin: 0 0 10px; color: var(--text-secondary, #6b7280); font-size: 13px; max-width: 720px; }
-.obs-subtitle b { color: var(--text-primary, #111827); }
-.obs-narrative { font-size: 16px; line-height: 1.45; }
-.obs-narrative b { font-weight: 600; }
-.obs-topbar-right { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
-.obs-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.4px;
-  color: var(--text-secondary, #6b7280); display: block; margin-bottom: 2px; }
-.obs-window select { padding: 6px 8px; border: 1px solid var(--border, #e5e7eb); border-radius: 6px;
-  background: var(--surface, #fff); font: inherit; }
-/* `.obs-btn` rules deleted — buttons render via `ds.button(variant=
-   'secondary', size='sm')` carrying canonical .btn family. */
-.obs-kpis { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-bottom: 16px; }
-.obs-kpi { text-align: left; padding: 14px 16px; border: 1px solid var(--border, #e5e7eb);
-  border-radius: 8px; background: var(--surface, #fff); cursor: pointer;
-  display: flex; flex-direction: column; gap: 4px; }
-.obs-kpi:hover { border-color: #2563eb; background: var(--border-light, #f3f4f6); }
-.obs-kpi-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.4px;
-  color: var(--text-secondary, #6b7280); }
-.obs-kpi-value { font-size: 22px; font-weight: 600; font-variant-numeric: tabular-nums; }
-.obs-kpi-sub { font-size: 12px; color: var(--text-secondary, #6b7280); font-variant-numeric: tabular-nums; }
-.obs-filters { display: flex; gap: 12px; align-items: flex-end; flex-wrap: wrap;
-  padding: 12px 14px; background: var(--border-light, #f3f4f6); border-radius: 8px; margin-bottom: 12px; }
-.obs-filter { display: flex; flex-direction: column; gap: 4px; min-width: 140px; }
-.obs-filter-grow { flex: 1; min-width: 200px; }
-.obs-filter label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.4px;
-  color: var(--text-secondary, #6b7280); }
-.obs-select, .obs-filter input[type=search] { padding: 6px 8px;
-  border: 1px solid var(--border, #e5e7eb); border-radius: 6px;
-  background: var(--surface, #fff); font: inherit; }
-.obs-checkbox { display: flex; align-items: center; gap: 6px;
-  text-transform: none; letter-spacing: 0; font-size: 13px;
-  color: var(--text-primary, #111827); cursor: pointer; padding-top: 14px; }
-.obs-filter-actions { display: flex; align-items: flex-end; }
-.obs-table-wrap { border: 1px solid var(--border, #e5e7eb); border-radius: 8px;
-  overflow: hidden; background: var(--surface, #fff); }
-.obs-table { width: 100%; border-collapse: collapse; font-size: 13px; }
-.obs-table thead th { text-align: left; padding: 10px 12px; background: var(--border-light, #f3f4f6);
-  border-bottom: 1px solid var(--border, #e5e7eb); font-weight: 600;
-  color: var(--text-secondary, #6b7280); font-size: 11px;
-  text-transform: uppercase; letter-spacing: 0.4px; white-space: nowrap; }
-.obs-table thead th button { background: none; border: 0; padding: 0; font: inherit; color: inherit;
-  cursor: pointer; display: inline-flex; gap: 4px; text-transform: inherit; letter-spacing: inherit; }
-.obs-table thead th[aria-sort="ascending"] .obs-sort-arrow::before { content: "▲"; }
-.obs-table thead th[aria-sort="descending"] .obs-sort-arrow::before { content: "▼"; }
-.obs-sort-arrow { font-size: 9px; color: var(--text-secondary, #6b7280); }
-.obs-table tbody td { padding: 8px 12px; border-bottom: 1px solid var(--border-light, #f3f4f6); vertical-align: top; }
-.obs-table tbody tr { cursor: pointer; }
-.obs-table tbody tr:hover { background: var(--border-light, #f3f4f6); }
-.obs-table tbody tr.has-errors { background: #fff7f7; }
-.obs-table tbody tr.has-errors:hover { background: #ffebeb; }
-.obs-num { text-align: right; font-variant-numeric: tabular-nums; }
-.obs-empty { padding: 40px 16px; text-align: center; color: var(--text-secondary, #6b7280); font-size: 13px; }
-.obs-table-footer { display: flex; justify-content: space-between; align-items: center;
-  padding: 10px 14px; border-top: 1px solid var(--border, #e5e7eb); background: var(--border-light, #f3f4f6); }
-.obs-row-count { color: var(--text-secondary, #6b7280); font-size: 12px; }
-.obs-err-chip { display: inline-block; padding: 1px 6px; border-radius: 4px; background: #fee2e2;
-  color: #991b1b; font-size: 11px; font-weight: 500; }
-</style>
 
 <script>
 (function() {

--- a/app/web/templates/admin_usage.html
+++ b/app/web/templates/admin_usage.html
@@ -1,23 +1,88 @@
-{% extends "base.html" %}
+{% extends "base_page.html" %}
 {% block title %}Telemetry — Admin{% endblock %}
 
-{% block content %}
+{% set page_hero_eyebrow = "Activity Center" %}
+{% set page_hero_title = "Telemetry" %}
+{% set page_hero_subtitle = "Claude Code tool / skill / agent / slash-command invocations across users." %}
+
+{% block head_extra %}
+{# The /admin/activity page already ships the .obs-* styles via
+   activity_center.html. We re-include them here so /admin/usage renders
+   identically without depending on the user having visited /admin/activity
+   first (browser CSS cache miss is the common case for admins clicking the
+   nav link cold). #}
+<style>
+.obs-page { font: 14px/1.5 var(--font-sans, system-ui); color: var(--text-primary, #111827); }
+.obs-topbar { display: flex; align-items: flex-start; justify-content: space-between; gap: 24px;
+  padding: 12px 0 20px; border-bottom: 1px solid var(--border, #e5e7eb); margin-bottom: 16px; }
+.obs-topbar-left { flex: 1; min-width: 0; }
+.obs-subtitle { margin: 0 0 10px; color: var(--text-secondary, #6b7280); font-size: 13px; max-width: 720px; }
+.obs-subtitle a { color: #2563eb; text-decoration: none; border-bottom: 1px dashed currentColor; }
+.obs-subtitle a:hover { border-bottom-style: solid; }
+.obs-narrative { font-size: 16px; line-height: 1.45; }
+.obs-narrative b { font-weight: 600; }
+.obs-topbar-right { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+.obs-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.4px;
+  color: var(--text-secondary, #6b7280); display: block; margin-bottom: 2px; }
+.obs-window select { padding: 6px 8px; border: 1px solid var(--border, #e5e7eb); border-radius: 6px;
+  background: var(--surface, #fff); font: inherit; }
+/* `.obs-btn` rules deleted — buttons render via `ds.button(variant=
+   'secondary', size='sm')` carrying canonical .btn family. */
+.obs-kpis { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-bottom: 16px; }
+.obs-kpi { text-align: left; padding: 14px 16px; border: 1px solid var(--border, #e5e7eb);
+  border-radius: 8px; background: var(--surface, #fff); cursor: pointer;
+  transition: border-color 0.15s, background 0.15s; display: flex; flex-direction: column; gap: 4px; }
+.obs-kpi:hover { border-color: #2563eb; background: var(--border-light, #f3f4f6); }
+.obs-kpi-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.4px;
+  color: var(--text-secondary, #6b7280); }
+.obs-kpi-value { font-size: 22px; font-weight: 600; font-variant-numeric: tabular-nums; }
+.obs-kpi-sub { font-size: 12px; color: var(--text-secondary, #6b7280); font-variant-numeric: tabular-nums; }
+.obs-filters { display: flex; gap: 12px; align-items: flex-end; flex-wrap: wrap;
+  padding: 12px 14px; background: var(--border-light, #f3f4f6); border-radius: 8px; margin-bottom: 12px; }
+.obs-filter { display: flex; flex-direction: column; gap: 4px; min-width: 140px; }
+.obs-filter-grow { flex: 1; min-width: 200px; }
+.obs-filter label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.4px;
+  color: var(--text-secondary, #6b7280); }
+.obs-select, .obs-filter input { padding: 6px 8px; border: 1px solid var(--border, #e5e7eb);
+  border-radius: 6px; background: var(--surface, #fff); font: inherit; }
+.obs-filter input { min-width: 200px; }
+.obs-filter-actions { display: flex; align-items: flex-end; }
+.obs-table-wrap { border: 1px solid var(--border, #e5e7eb); border-radius: 8px;
+  overflow: hidden; background: var(--surface, #fff); }
+.obs-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.obs-table thead th { text-align: left; padding: 10px 12px; background: var(--border-light, #f3f4f6);
+  border-bottom: 1px solid var(--border, #e5e7eb); font-weight: 600;
+  color: var(--text-secondary, #6b7280); font-size: 11px;
+  text-transform: uppercase; letter-spacing: 0.4px; white-space: nowrap; }
+.obs-table thead th button { background: none; border: 0; padding: 0; font: inherit; color: inherit;
+  cursor: pointer; display: inline-flex; align-items: center; gap: 4px;
+  text-transform: inherit; letter-spacing: inherit; }
+.obs-table thead th[aria-sort="ascending"] .obs-sort-arrow::before { content: "▲"; }
+.obs-table thead th[aria-sort="descending"] .obs-sort-arrow::before { content: "▼"; }
+.obs-sort-arrow { font-size: 9px; color: var(--text-secondary, #6b7280); }
+.obs-table tbody td { padding: 8px 12px; border-bottom: 1px solid var(--border-light, #f3f4f6); vertical-align: top; }
+.obs-table tbody tr:last-child td { border-bottom: none; }
+.obs-table tbody tr:hover { background: var(--border-light, #f3f4f6); }
+.obs-num { text-align: right; font-variant-numeric: tabular-nums; }
+.obs-empty { padding: 40px 16px; text-align: center; color: var(--text-secondary, #6b7280); font-size: 13px; }
+.obs-table-footer { display: flex; justify-content: space-between; align-items: center;
+  padding: 10px 14px; border-top: 1px solid var(--border, #e5e7eb); background: var(--border-light, #f3f4f6); }
+.obs-row-count { color: var(--text-secondary, #6b7280); font-size: 12px; }
+.obs-source-pill { display: inline-block; padding: 2px 6px; border-radius: 4px; font-size: 11px;
+  text-transform: lowercase; background: var(--border-light, #f3f4f6); color: var(--text-secondary, #6b7280); }
+.obs-source-pill.is-curated { background: #ede9fe; color: #5b21b6; }
+.obs-source-pill.is-flea    { background: #fef3c7; color: #92400e; }
+.obs-source-pill.is-builtin { background: #dcfce7; color: #166534; }
+.obs-bar-fill { display: inline-block; height: 8px; background: #2563eb; border-radius: 2px;
+  vertical-align: middle; margin-left: 6px; min-width: 2px; }
+</style>
+{% endblock %}
+
+{% block page %}
 {# Design-system component macros — Reset + Prev/Next paginator render
-   via `ds.button`. .obs-kpi cards + .obs-table page-local enhancements
-   stay as-is per system.md. #}
-{% import "_components.html" as ds %}
-<div class="obs-page page-shell">
-
-  {% set page_hero_eyebrow = "Activity Center" %}
-
-
-  {% set page_hero_title = "Telemetry" %}
-
-
-  {% set page_hero_subtitle = "Claude Code tool / skill / agent / slash-command invocations across users." %}
-
-
-  {% include "_page_hero.html" %}
+   via `ds.button` (auto-imported by base_ds). .obs-kpi cards + .obs-table
+   page-local enhancements stay as-is per system.md. #}
+<div class="obs-page">
 
 
   <header class="obs-topbar">
@@ -116,77 +181,6 @@
   </section>
 
 </div>
-
-{# The /admin/activity page already ships the .obs-* styles via
-   activity_center.html. We re-include them here so /admin/usage renders
-   identically without depending on the user having visited /admin/activity
-   first (browser CSS cache miss is the common case for admins clicking the
-   nav link cold). #}
-<style>
-.obs-page { font: 14px/1.5 var(--font-sans, system-ui); color: var(--text-primary, #111827); }
-.obs-topbar { display: flex; align-items: flex-start; justify-content: space-between; gap: 24px;
-  padding: 12px 0 20px; border-bottom: 1px solid var(--border, #e5e7eb); margin-bottom: 16px; }
-.obs-topbar-left { flex: 1; min-width: 0; }
-.obs-subtitle { margin: 0 0 10px; color: var(--text-secondary, #6b7280); font-size: 13px; max-width: 720px; }
-.obs-subtitle a { color: #2563eb; text-decoration: none; border-bottom: 1px dashed currentColor; }
-.obs-subtitle a:hover { border-bottom-style: solid; }
-.obs-narrative { font-size: 16px; line-height: 1.45; }
-.obs-narrative b { font-weight: 600; }
-.obs-topbar-right { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
-.obs-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.4px;
-  color: var(--text-secondary, #6b7280); display: block; margin-bottom: 2px; }
-.obs-window select { padding: 6px 8px; border: 1px solid var(--border, #e5e7eb); border-radius: 6px;
-  background: var(--surface, #fff); font: inherit; }
-/* `.obs-btn` rules deleted — buttons render via `ds.button(variant=
-   'secondary', size='sm')` carrying canonical .btn family. */
-.obs-kpis { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-bottom: 16px; }
-.obs-kpi { text-align: left; padding: 14px 16px; border: 1px solid var(--border, #e5e7eb);
-  border-radius: 8px; background: var(--surface, #fff); cursor: pointer;
-  transition: border-color 0.15s, background 0.15s; display: flex; flex-direction: column; gap: 4px; }
-.obs-kpi:hover { border-color: #2563eb; background: var(--border-light, #f3f4f6); }
-.obs-kpi-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.4px;
-  color: var(--text-secondary, #6b7280); }
-.obs-kpi-value { font-size: 22px; font-weight: 600; font-variant-numeric: tabular-nums; }
-.obs-kpi-sub { font-size: 12px; color: var(--text-secondary, #6b7280); font-variant-numeric: tabular-nums; }
-.obs-filters { display: flex; gap: 12px; align-items: flex-end; flex-wrap: wrap;
-  padding: 12px 14px; background: var(--border-light, #f3f4f6); border-radius: 8px; margin-bottom: 12px; }
-.obs-filter { display: flex; flex-direction: column; gap: 4px; min-width: 140px; }
-.obs-filter-grow { flex: 1; min-width: 200px; }
-.obs-filter label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.4px;
-  color: var(--text-secondary, #6b7280); }
-.obs-select, .obs-filter input { padding: 6px 8px; border: 1px solid var(--border, #e5e7eb);
-  border-radius: 6px; background: var(--surface, #fff); font: inherit; }
-.obs-filter input { min-width: 200px; }
-.obs-filter-actions { display: flex; align-items: flex-end; }
-.obs-table-wrap { border: 1px solid var(--border, #e5e7eb); border-radius: 8px;
-  overflow: hidden; background: var(--surface, #fff); }
-.obs-table { width: 100%; border-collapse: collapse; font-size: 13px; }
-.obs-table thead th { text-align: left; padding: 10px 12px; background: var(--border-light, #f3f4f6);
-  border-bottom: 1px solid var(--border, #e5e7eb); font-weight: 600;
-  color: var(--text-secondary, #6b7280); font-size: 11px;
-  text-transform: uppercase; letter-spacing: 0.4px; white-space: nowrap; }
-.obs-table thead th button { background: none; border: 0; padding: 0; font: inherit; color: inherit;
-  cursor: pointer; display: inline-flex; align-items: center; gap: 4px;
-  text-transform: inherit; letter-spacing: inherit; }
-.obs-table thead th[aria-sort="ascending"] .obs-sort-arrow::before { content: "▲"; }
-.obs-table thead th[aria-sort="descending"] .obs-sort-arrow::before { content: "▼"; }
-.obs-sort-arrow { font-size: 9px; color: var(--text-secondary, #6b7280); }
-.obs-table tbody td { padding: 8px 12px; border-bottom: 1px solid var(--border-light, #f3f4f6); vertical-align: top; }
-.obs-table tbody tr:last-child td { border-bottom: none; }
-.obs-table tbody tr:hover { background: var(--border-light, #f3f4f6); }
-.obs-num { text-align: right; font-variant-numeric: tabular-nums; }
-.obs-empty { padding: 40px 16px; text-align: center; color: var(--text-secondary, #6b7280); font-size: 13px; }
-.obs-table-footer { display: flex; justify-content: space-between; align-items: center;
-  padding: 10px 14px; border-top: 1px solid var(--border, #e5e7eb); background: var(--border-light, #f3f4f6); }
-.obs-row-count { color: var(--text-secondary, #6b7280); font-size: 12px; }
-.obs-source-pill { display: inline-block; padding: 2px 6px; border-radius: 4px; font-size: 11px;
-  text-transform: lowercase; background: var(--border-light, #f3f4f6); color: var(--text-secondary, #6b7280); }
-.obs-source-pill.is-curated { background: #ede9fe; color: #5b21b6; }
-.obs-source-pill.is-flea    { background: #fef3c7; color: #92400e; }
-.obs-source-pill.is-builtin { background: #dcfce7; color: #166534; }
-.obs-bar-fill { display: inline-block; height: 8px; background: #2563eb; border-radius: 2px;
-  vertical-align: middle; margin-left: 6px; min-width: 2px; }
-</style>
 
 <script>
 (function() {

--- a/app/web/templates/admin_welcome.html
+++ b/app/web/templates/admin_welcome.html
@@ -1,11 +1,11 @@
-{% extends "base.html" %}
+{% extends "base_page.html" %}
 {% block title %}Init Prompt — {{ config.INSTANCE_NAME }}{% endblock %}
 
-{% block content %}
-{# Design-system component macros — editor Reset/Save + modal Cancel/
-   Reset render via `ds.button`. `.btn-copy` (page-local Catppuccin
-   dark-surface pill) stays page-local per system.md. #}
-{% import "_components.html" as ds %}
+{% set page_hero_eyebrow = "Agent Experience" %}
+{% set page_hero_title = "Init Prompt" %}
+{% set page_hero_subtitle = "Welcome shown to analysts at <code style=&quot;color:#fff;background:rgba(255,255,255,0.15);border:none;padding:1px 6px;border-radius:4px&quot;>agnes init</code>. Overrides the OSS default." %}
+
+{% block head_extra %}
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.css"
       integrity="sha512-uf06llspW44/LZpHzHT6qBOIVODjWtv4MxCricRxkzvopAlSWnTf6hpZTFxuuZcuNE9CBQhqE0Seu1CoRk84nQ=="
       crossorigin="anonymous">
@@ -194,15 +194,13 @@
   .toast.success { background: #047857; }
   .toast.error { background: #b91c1c; }
 </style>
+{% endblock %}
 
+{% block page %}
+{# Design-system component macros — editor Reset/Save + modal Cancel/
+   Reset render via `ds.button` (auto-imported by base_ds). `.btn-copy`
+   (page-local Catppuccin dark-surface pill) stays page-local per system.md. #}
 <div class="welcome-page">
-  {% set page_hero_eyebrow = "Agent Experience" %}
-
-  {% set page_hero_title = "Init Prompt" %}
-
-  {% set page_hero_subtitle = "Welcome shown to analysts at <code style=&quot;color:#fff;background:rgba(255,255,255,0.15);border:none;padding:1px 6px;border-radius:4px&quot;>agnes init</code>. Overrides the OSS default." %}
-
-  {% include "_page_hero.html" %}
 
   <div class="welcome-toolbar">
     <div>

--- a/app/web/templates/admin_workspace_prompt.html
+++ b/app/web/templates/admin_workspace_prompt.html
@@ -1,11 +1,11 @@
-{% extends "base.html" %}
+{% extends "base_page.html" %}
 {% block title %}Workspace Prompt — {{ config.INSTANCE_NAME }}{% endblock %}
 
-{% block content %}
-{# Design-system component macros — editor Reset/Save + modal Cancel/
-   Reset render via `ds.button`. `.btn-copy` (page-local Catppuccin
-   dark-surface pill) stays page-local per system.md. #}
-{% import "_components.html" as ds %}
+{% set page_hero_eyebrow = "Agent Experience" %}
+{% set page_hero_title = "Workspace Prompt" %}
+{% set page_hero_subtitle = "CLAUDE.md template injected into each analyst workspace. Overrides the OSS default." %}
+
+{% block head_extra %}
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.css"
       integrity="sha512-uf06llspW44/LZpHzHT6qBOIVODjWtv4MxCricRxkzvopAlSWnTf6hpZTFxuuZcuNE9CBQhqE0Seu1CoRk84nQ=="
       crossorigin="anonymous">
@@ -194,15 +194,13 @@
   .toast.success { background: #047857; }
   .toast.error { background: #b91c1c; }
 </style>
+{% endblock %}
 
+{% block page %}
+{# Design-system component macros — editor Reset/Save + modal Cancel/
+   Reset render via `ds.button` (auto-imported by base_ds). `.btn-copy`
+   (page-local Catppuccin dark-surface pill) stays page-local per system.md. #}
 <div class="welcome-page">
-  {% set page_hero_eyebrow = "Agent Experience" %}
-
-  {% set page_hero_title = "Workspace Prompt" %}
-
-  {% set page_hero_subtitle = "CLAUDE.md template injected into each analyst workspace. Overrides the OSS default." %}
-
-  {% include "_page_hero.html" %}
 
   <div class="welcome-toolbar">
     <div>


### PR DESCRIPTION
Batch 2 of the **#482** "migration tail" — moving more `base.html` leaf pages onto the `base_page.html` page-shell (#367 / #481).

> **Stacked PR.** Based on `zs/367-design-system-pageshell` (#481), so this diff shows **only** batch 2. Retarget to `main` once #481 merges (and rebase). Sibling of #484 (batch 1).

### Migrated (`base.html` → `base_page.html`)
- `admin_sessions.html` — `/admin/sessions`
- `admin_usage.html` — `/admin/telemetry` (the Telemetry page; `/admin/usage` 308-redirects here)
- `admin_welcome.html` — `/admin/agent-prompt` (Init Prompt)
- `admin_workspace_prompt.html` — `/admin/workspace-prompt`

Each page now declares its hero via top-level `page_hero_*` vars (`base_page` auto-includes `_page_hero.html`), keeps component CSS in `{% block head_extra %}` with body + page `<script>` in `{% block page %}`, and drops the redundant `.page-shell` marker + per-page `_components.html` import (`base_ds` auto-imports `ds`).

**Editor pages (`admin_welcome`, `admin_workspace_prompt`):** the CodeMirror CDN `<link>`/`<script>` assets moved into `{% block head_extra %}` with their **SRI integrity hashes byte-for-byte intact**; the inline editor scripts stay in `{% block page %}` (before `_app_scripts.html`) because they define globals (`toast()` / `openModal()`) whose load order must be preserved. Styled, load-bearing `.obs-page` / `.welcome-page` wrappers retained.

### Verification
- **Render-check** (real admin auth, all 4 pages): `200`, exactly one `.page-header--hero`, canonical `.container`, no `.container:has(` opt-out, `page-shell` absent from output, CodeMirror `<link>` present in `<head>`.
- **pytest** `test_design_system_contract` + `test_web_ui` + `test_web_home_page`: **78 passed, 3 skipped**.

### Not in this batch
- The broad `.X-page { max-width }` contract guard stays **deferred** — final step of #482. ~34 pages remain.

Part of #482.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
