### PR TITLE
Revert "feat(web): rename AI Tools page to Cowork + move into Admin dropdown" (#491)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,21 +10,6 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
-### Added
-
-### Changed
-
-### Fixed
-
-### Removed
-
-### Internal
-
-## [0.59.0] — 2026-06-02
-
-### Changed
-- **Cowork page renamed and relocated in the header.** The `/me/mcp` page (added in 0.58.0 as "AI Tools" in the primary nav) is now titled **"Cowork"** and reached from the **Admin → Agent Experience** dropdown instead of the top-level navigation. Page `<h1>` and browser `<title>` updated to match. Note: the Admin dropdown is admin-only, so the page is no longer linked from the header for non-admins (the route itself remains accessible to any authenticated user).
-
 ## [0.58.1] — 2026-06-02
 
 ### Fixed

--- a/app/web/templates/_app_header.html
+++ b/app/web/templates/_app_header.html
@@ -31,6 +31,7 @@
            authenticated users. The admin review queue is separate:
            /admin/corporate-memory, in the Admin dropdown below. #}
         <a class="app-nav-link {% if _path == '/corporate-memory' %}is-active{% endif %}" href="/corporate-memory">Memory</a>
+        <a class="app-nav-link {% if _path.startswith('/me/mcp') %}is-active{% endif %}" href="/me/mcp">AI Tools</a>
 
         {# Admin menu: admin-only. Backend gates the routes via
            require_admin (see app/web/router.py for /admin/*, including
@@ -38,7 +39,7 @@
            visibility tidy-up — non-admins who deep-link still get a 403
            from the route handler. #}
         {% if session.user.is_admin %}
-        {% set _admin_active = _path.startswith('/admin/tables') or _path.startswith('/admin/tokens') or _path.startswith('/admin/users') or _path.startswith('/admin/groups') or _path.startswith('/admin/access') or _path.startswith('/admin/server-config') or _path.startswith('/admin/agent-prompt') or _path.startswith('/admin/workspace-prompt') or _path.startswith('/admin/marketplaces') or _path.startswith('/admin/mcp-sources') or _path.startswith('/admin/mcp-tools') or _path.startswith('/admin/store') or _path.startswith('/admin/scheduler-runs') or _path.startswith('/admin/activity') or _path.startswith('/admin/telemetry') or _path.startswith('/admin/usage') or _path.startswith('/admin/sessions') or _path.startswith('/admin/corporate-memory') or _path.startswith('/admin/sync') or _path.startswith('/me/mcp') %}
+        {% set _admin_active = _path.startswith('/admin/tables') or _path.startswith('/admin/tokens') or _path.startswith('/admin/users') or _path.startswith('/admin/groups') or _path.startswith('/admin/access') or _path.startswith('/admin/server-config') or _path.startswith('/admin/agent-prompt') or _path.startswith('/admin/workspace-prompt') or _path.startswith('/admin/marketplaces') or _path.startswith('/admin/mcp-sources') or _path.startswith('/admin/mcp-tools') or _path.startswith('/admin/store') or _path.startswith('/admin/scheduler-runs') or _path.startswith('/admin/activity') or _path.startswith('/admin/telemetry') or _path.startswith('/admin/usage') or _path.startswith('/admin/sessions') or _path.startswith('/admin/corporate-memory') or _path.startswith('/admin/sync') %}
         <div class="app-nav-menu" id="adminNavMenu">
             <button type="button"
                     class="app-nav-link app-nav-menu-trigger {% if _admin_active %}is-active{% endif %}"
@@ -88,7 +89,6 @@
                    for what an analyst's AI agent sees / can do. #}
                 <details class="app-nav-menu-group" data-section="agent-experience" open>
                     <summary class="app-nav-menu-section">Agent Experience</summary>
-                    <a class="app-nav-menu-item {% if _path.startswith('/me/mcp') %}is-active{% endif %}" role="menuitem" href="/me/mcp">Cowork</a>
                     <a class="app-nav-menu-item {% if _path.startswith('/admin/marketplaces') %}is-active{% endif %}" role="menuitem" href="/admin/marketplaces">Curated Marketplaces</a>
                     <a class="app-nav-menu-item {% if _path.startswith('/admin/corporate-memory') %}is-active{% endif %}" role="menuitem" href="/admin/corporate-memory">Curated memory reviews</a>
                     <a class="app-nav-menu-item {% if _path.startswith('/admin/store/submissions') %}is-active{% endif %}" role="menuitem" href="/admin/store/submissions">Flea Submissions</a>

--- a/app/web/templates/me_mcp.html
+++ b/app/web/templates/me_mcp.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Cowork — {{ instance_brand }}{% endblock %}
+{% block title %}AI Tools — {{ instance_brand }}{% endblock %}
 
 {% block layout %}
 <main class="main">{{ self.content() }}</main>
@@ -132,7 +132,7 @@
 <div class="mcp-page">
 
   <div class="mcp-page-header">
-    <h1>Cowork</h1>
+    <h1>AI Tools</h1>
     <p>Tools and skills Claude can use when connected to this Agnes instance via MCP.</p>
   </div>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.59.0"
+version = "0.58.1"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"


### PR DESCRIPTION
Reverts PR #491 (Cowork page rename + move into Admin dropdown). Reverting the merge commit `e5dc0b8e` restores the previous header ("AI Tools" in the primary nav) and rolls `pyproject.toml` back to 0.58.1. The change will be re-introduced in a fresh PR for re-review. The `v0.59.0` tag + GitHub Release have been deleted.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->