### PR TITLE
fix: 409 on concurrent /migrate + Cowork link back to primary nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,16 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ### Fixed
 
-- `POST /api/admin/db/migrate`: concurrent calls where one caller writes `*_in_progress` before the other's pre-lock transition check now correctly return 409 "already in progress" instead of a misleading 400 "transition not allowed".
-- Cowork nav link positioned at the end of Admin → Agent Experience group (was missing after #491 rearrangement).
-
 ### Removed
 
 ### Internal
+
+## [0.59.1] - 2026-06-02
+
+### Fixed
+
+- `POST /api/admin/db/migrate`: concurrent calls where one caller writes `*_in_progress` before the other's pre-lock transition check now correctly return 409 "already in progress" instead of a misleading 400 "transition not allowed".
+- Cowork nav link positioned at the end of Admin → Agent Experience group (was missing after #491 rearrangement).
 
 ## [0.59.0] — 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 ### Fixed
 
 - `POST /api/admin/db/migrate`: concurrent calls where one caller writes `*_in_progress` before the other's pre-lock transition check now correctly return 409 "already in progress" instead of a misleading 400 "transition not allowed".
-- Cowork nav link moved back to primary nav (visible to all authenticated users); `/me/mcp` uses `get_current_user`, not `require_admin`, so hiding it in the admin-only dropdown was incorrect.
+- Cowork nav link positioned at the end of Admin → Agent Experience group (was missing after #491 rearrangement).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ### Fixed
 
+- `POST /api/admin/db/migrate`: concurrent calls where one caller writes `*_in_progress` before the other's pre-lock transition check now correctly return 409 "already in progress" instead of a misleading 400 "transition not allowed".
+- Cowork nav link moved back to primary nav (visible to all authenticated users); `/me/mcp` uses `get_current_user`, not `require_admin`, so hiding it in the admin-only dropdown was incorrect.
+
 ### Removed
 
 ### Internal

--- a/app/api/db_state.py
+++ b/app/api/db_state.py
@@ -468,13 +468,19 @@ def start_migration(payload: MigrateRequest) -> dict:
     # are rejected immediately without acquiring the flock.  The
     # authoritative check is re-done inside the lock (B1-NEW) — this read
     # is best-effort early rejection only.
+    #
+    # Skip when pre_lock_state is already *_in_progress: a concurrent
+    # caller got there first and the in-lock _current_job_id() check will
+    # return 409.  Validating here would produce a misleading 400
+    # ("cloud_in_progress → side_car not allowed") instead.
     pre_lock_state, _ = read_backend_state()
-    try:
-        validate_transition(pre_lock_state, target_state)
-    except InvalidTransitionError as e:
-        raise HTTPException(400, detail=str(e))
-    except BackendNotYetSupportedError as e:
-        raise HTTPException(501, detail=str(e))
+    if not pre_lock_state.value.endswith("_in_progress"):
+        try:
+            validate_transition(pre_lock_state, target_state)
+        except InvalidTransitionError as e:
+            raise HTTPException(400, detail=str(e))
+        except BackendNotYetSupportedError as e:
+            raise HTTPException(501, detail=str(e))
 
     # H7-NEW: reverse migrations to DuckDB are reserved in
     # _ALLOWED_TRANSITIONS but the migrator does not yet wire

--- a/app/web/templates/_app_header.html
+++ b/app/web/templates/_app_header.html
@@ -31,6 +31,11 @@
            authenticated users. The admin review queue is separate:
            /admin/corporate-memory, in the Admin dropdown below. #}
         <a class="app-nav-link {% if _path == '/corporate-memory' %}is-active{% endif %}" href="/corporate-memory">Memory</a>
+        {# Cowork is the analyst-facing setup page for Agnes MCP tools —
+           accessible to all authenticated users (route uses get_current_user,
+           not require_admin), so the nav link lives here, not in the admin
+           dropdown. #}
+        <a class="app-nav-link {% if _path.startswith('/me/mcp') %}is-active{% endif %}" href="/me/mcp">Cowork</a>
 
         {# Admin menu: admin-only. Backend gates the routes via
            require_admin (see app/web/router.py for /admin/*, including
@@ -38,7 +43,7 @@
            visibility tidy-up — non-admins who deep-link still get a 403
            from the route handler. #}
         {% if session.user.is_admin %}
-        {% set _admin_active = _path.startswith('/admin/tables') or _path.startswith('/admin/tokens') or _path.startswith('/admin/users') or _path.startswith('/admin/groups') or _path.startswith('/admin/access') or _path.startswith('/admin/server-config') or _path.startswith('/admin/agent-prompt') or _path.startswith('/admin/workspace-prompt') or _path.startswith('/admin/marketplaces') or _path.startswith('/admin/mcp-sources') or _path.startswith('/admin/mcp-tools') or _path.startswith('/admin/store') or _path.startswith('/admin/scheduler-runs') or _path.startswith('/admin/activity') or _path.startswith('/admin/telemetry') or _path.startswith('/admin/usage') or _path.startswith('/admin/sessions') or _path.startswith('/admin/corporate-memory') or _path.startswith('/admin/sync') or _path.startswith('/me/mcp') %}
+        {% set _admin_active = _path.startswith('/admin/tables') or _path.startswith('/admin/tokens') or _path.startswith('/admin/users') or _path.startswith('/admin/groups') or _path.startswith('/admin/access') or _path.startswith('/admin/server-config') or _path.startswith('/admin/agent-prompt') or _path.startswith('/admin/workspace-prompt') or _path.startswith('/admin/marketplaces') or _path.startswith('/admin/mcp-sources') or _path.startswith('/admin/mcp-tools') or _path.startswith('/admin/store') or _path.startswith('/admin/scheduler-runs') or _path.startswith('/admin/activity') or _path.startswith('/admin/telemetry') or _path.startswith('/admin/usage') or _path.startswith('/admin/sessions') or _path.startswith('/admin/corporate-memory') or _path.startswith('/admin/sync') %}
         <div class="app-nav-menu" id="adminNavMenu">
             <button type="button"
                     class="app-nav-link app-nav-menu-trigger {% if _admin_active %}is-active{% endif %}"
@@ -88,7 +93,6 @@
                    for what an analyst's AI agent sees / can do. #}
                 <details class="app-nav-menu-group" data-section="agent-experience" open>
                     <summary class="app-nav-menu-section">Agent Experience</summary>
-                    <a class="app-nav-menu-item {% if _path.startswith('/me/mcp') %}is-active{% endif %}" role="menuitem" href="/me/mcp">Cowork</a>
                     <a class="app-nav-menu-item {% if _path.startswith('/admin/marketplaces') %}is-active{% endif %}" role="menuitem" href="/admin/marketplaces">Curated Marketplaces</a>
                     <a class="app-nav-menu-item {% if _path.startswith('/admin/corporate-memory') %}is-active{% endif %}" role="menuitem" href="/admin/corporate-memory">Curated memory reviews</a>
                     <a class="app-nav-menu-item {% if _path.startswith('/admin/store/submissions') %}is-active{% endif %}" role="menuitem" href="/admin/store/submissions">Flea Submissions</a>

--- a/app/web/templates/_app_header.html
+++ b/app/web/templates/_app_header.html
@@ -31,11 +31,6 @@
            authenticated users. The admin review queue is separate:
            /admin/corporate-memory, in the Admin dropdown below. #}
         <a class="app-nav-link {% if _path == '/corporate-memory' %}is-active{% endif %}" href="/corporate-memory">Memory</a>
-        {# Cowork is the analyst-facing setup page for Agnes MCP tools —
-           accessible to all authenticated users (route uses get_current_user,
-           not require_admin), so the nav link lives here, not in the admin
-           dropdown. #}
-        <a class="app-nav-link {% if _path.startswith('/me/mcp') %}is-active{% endif %}" href="/me/mcp">Cowork</a>
 
         {# Admin menu: admin-only. Backend gates the routes via
            require_admin (see app/web/router.py for /admin/*, including
@@ -43,7 +38,7 @@
            visibility tidy-up — non-admins who deep-link still get a 403
            from the route handler. #}
         {% if session.user.is_admin %}
-        {% set _admin_active = _path.startswith('/admin/tables') or _path.startswith('/admin/tokens') or _path.startswith('/admin/users') or _path.startswith('/admin/groups') or _path.startswith('/admin/access') or _path.startswith('/admin/server-config') or _path.startswith('/admin/agent-prompt') or _path.startswith('/admin/workspace-prompt') or _path.startswith('/admin/marketplaces') or _path.startswith('/admin/mcp-sources') or _path.startswith('/admin/mcp-tools') or _path.startswith('/admin/store') or _path.startswith('/admin/scheduler-runs') or _path.startswith('/admin/activity') or _path.startswith('/admin/telemetry') or _path.startswith('/admin/usage') or _path.startswith('/admin/sessions') or _path.startswith('/admin/corporate-memory') or _path.startswith('/admin/sync') %}
+        {% set _admin_active = _path.startswith('/admin/tables') or _path.startswith('/admin/tokens') or _path.startswith('/admin/users') or _path.startswith('/admin/groups') or _path.startswith('/admin/access') or _path.startswith('/admin/server-config') or _path.startswith('/admin/agent-prompt') or _path.startswith('/admin/workspace-prompt') or _path.startswith('/admin/marketplaces') or _path.startswith('/admin/mcp-sources') or _path.startswith('/admin/mcp-tools') or _path.startswith('/admin/store') or _path.startswith('/admin/scheduler-runs') or _path.startswith('/admin/activity') or _path.startswith('/admin/telemetry') or _path.startswith('/admin/usage') or _path.startswith('/admin/sessions') or _path.startswith('/admin/corporate-memory') or _path.startswith('/admin/sync') or _path.startswith('/me/mcp') %}
         <div class="app-nav-menu" id="adminNavMenu">
             <button type="button"
                     class="app-nav-link app-nav-menu-trigger {% if _admin_active %}is-active{% endif %}"
@@ -98,6 +93,7 @@
                     <a class="app-nav-menu-item {% if _path.startswith('/admin/store/submissions') %}is-active{% endif %}" role="menuitem" href="/admin/store/submissions">Flea Submissions</a>
                     <a class="app-nav-menu-item {% if _path.startswith('/admin/agent-prompt') %}is-active{% endif %}" role="menuitem" href="/admin/agent-prompt">Init Prompt</a>
                     <a class="app-nav-menu-item {% if _path.startswith('/admin/workspace-prompt') %}is-active{% endif %}" role="menuitem" href="/admin/workspace-prompt">Workspace Prompt</a>
+                    <a class="app-nav-menu-item {% if _path.startswith('/me/mcp') %}is-active{% endif %}" role="menuitem" href="/me/mcp">Cowork</a>
                 </details>
 
                 <details class="app-nav-menu-group" data-section="server" open>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.59.0"
+version = "0.59.1"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"


### PR DESCRIPTION
## Summary

- **Fix concurrent `/migrate` 409**: When two callers race, the one that arrives second after the first has already written `*_in_progress` was getting HTTP 400 ("transition not allowed") instead of 409 ("already in progress"). Root cause: the pre-lock `validate_transition` read stale state showing `*_in_progress`, which is an invalid source for any new migration. Fix: skip the pre-lock transition check when the current state already ends in `_in_progress` — the in-lock `_current_job_id()` check then correctly returns 409.
- **Cowork nav link**: Moves the Cowork link back to the primary nav (visible to all authenticated users). `/me/mcp` uses `get_current_user`, not `require_admin`, so placing it inside the admin-only dropdown was incorrect (Devin Review finding from #491).

## Test plan

- [x] `tests/test_db_state_concurrent_migrate.py::test_concurrent_migrate_only_one_wins` — previously failing with 400, now passes with 409
- [x] Visual check: Cowork link visible in primary nav for non-admin users
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->