### PR TITLE
Remove redundant Database backend card from /admin/server-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ### Removed
 
+- Redundant "Database backend" pointer card at the bottom of `/admin/server-config`. The backend state machine has its own `/admin/database` page, already linked from the Admin menu, so the card was a duplicate signpost that looked out of place in the instance-config form.
+
 ### Internal
 
 ## [0.59.1] - 2026-06-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ### Removed
 
+### Internal
+
+## [0.59.2] — 2026-06-02
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
 - Redundant "Database backend" pointer card at the bottom of `/admin/server-config`. The backend state machine has its own `/admin/database` page, already linked from the Admin menu, so the card was a duplicate signpost that looked out of place in the instance-config form.
 
 ### Internal

--- a/app/web/templates/admin_server_config.html
+++ b/app/web/templates/admin_server_config.html
@@ -1690,24 +1690,4 @@ async function iwDelete() {
 document.getElementById("iw-modal-save").addEventListener("click", iwSave);
 iwLoad();
 </script>
-
-<!-- ==== Database backend (state machine) ==== -->
-<!--
-  The state-machine UI moved to its own page at /admin/database — the
-  section that used to live here looked out of place in the
-  instance-config form (it doesn't share the section-by-section save
-  pattern) and the operator workflow benefits from being one click
-  from the admin menu, not buried at the bottom of this scroll.
--->
-{% import "_components.html" as ds %}
-<section id="db-backend-section">
-  {% call ds.panel(href='/admin/database', klass='quick-card') %}
-    <h2>Database backend</h2>
-    <p>
-      Switch app-state DB between DuckDB, side-car Postgres, and a managed
-      cloud Postgres. Now on a dedicated admin page —
-      <a href="/admin/database">open <strong>/admin/database</strong> →</a>
-    </p>
-  {% endcall %}
-</section>
 {% endblock %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.59.1"
+version = "0.59.2"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"


### PR DESCRIPTION
## What

Removes the leftover **"Database backend"** pointer card at the bottom of `/admin/server-config`.

## Why

The backend state-machine UI moved to its own dedicated page at `/admin/database`, which is already linked from the **Admin** menu (`_app_header.html`). The card on the instance-config page was therefore a duplicate signpost — and it looked out of place there, since it didn't follow the section-by-section save pattern the rest of that form uses.

## Changes

- Delete the `#db-backend-section` block (the comment + redundant `{% import "_components.html" as ds %}` + the `ds.panel` quick-card) from `app/web/templates/admin_server_config.html`. `ds` is still imported at the top of the file and `ds.button` usage elsewhere is unaffected.
- CHANGELOG bullet under **Removed**.

No route changes; `/admin/database` and its nav link are untouched.

## Testing

- Full suite: `6120 passed, 36 skipped`.
- No test asserted the presence of the card on `/admin/server-config`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/498" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->