### PR TITLE
fix(db_pg): restore create/update parity with DuckDB repos (title/tagline/requirement/is_required)

### DIFF
--- a/src/repositories/audit_pg.py
+++ b/src/repositories/audit_pg.py
@@ -95,6 +95,7 @@ class AuditPgRepository:
         action_prefix: Optional[str] = None,
         action_in: Optional[List[str]] = None,
         resource: Optional[str] = None,
+        resource_prefix: Optional[str] = None,
         result_pattern: Optional[str] = None,
         correlation_id: Optional[str] = None,
         q: Optional[str] = None,
@@ -129,6 +130,9 @@ class AuditPgRepository:
         if resource is not None:
             where.append("resource = :resource_eq")
             params["resource_eq"] = resource
+        if resource_prefix is not None:
+            where.append("resource LIKE :resource_prefix")
+            params["resource_prefix"] = resource_prefix + "%"
         if result_pattern is not None:
             where.append("result LIKE :result_pattern")
             params["result_pattern"] = result_pattern

--- a/src/repositories/knowledge_pg.py
+++ b/src/repositories/knowledge_pg.py
@@ -110,7 +110,14 @@ class KnowledgePgRepository:
         supersedes: Optional[str] = None,
         sensitivity: str = "internal",
         is_personal: bool = False,
+        is_required: bool = False,
     ) -> None:
+        # NOTE (parity): the DuckDB repo also accepts ``added_by``, used to
+        # attribute the domain link in its knowledge_item_domains join table.
+        # This PG repo stores ``domain`` inline on knowledge_items (no join
+        # table in this path), so there is no separate attribution to record;
+        # ``added_by`` is intentionally not part of this signature. ``is_required``
+        # IS a real column and is wired below.
         now = datetime.now(timezone.utc)
         with self._engine.begin() as conn:
             conn.execute(
@@ -119,14 +126,14 @@ class KnowledgePgRepository:
                         id, title, content, category, source_user, tags, status,
                         confidence, domain, entities, source_type, source_ref,
                         valid_from, valid_until, supersedes, sensitivity, is_personal,
-                        created_at, updated_at
+                        is_required, created_at, updated_at
                     ) VALUES (:id, :title, :content, :category, :su,
                               CAST(:tags AS JSONB), :status,
                               :confidence, :domain,
                               CAST(:entities AS JSONB),
                               :st, :sr,
                               :vf, :vu, :sup, :sens, :ip,
-                              :now, :now)"""
+                              :ireq, :now, :now)"""
                 ),
                 {
                     "id": id, "title": title, "content": content,
@@ -137,7 +144,8 @@ class KnowledgePgRepository:
                     "entities": json.dumps(entities) if entities else None,
                     "st": source_type, "sr": source_ref,
                     "vf": valid_from, "vu": valid_until, "sup": supersedes,
-                    "sens": sensitivity, "ip": is_personal, "now": now,
+                    "sens": sensitivity, "ip": is_personal,
+                    "ireq": is_required, "now": now,
                 },
             )
 

--- a/src/repositories/knowledge_pg.py
+++ b/src/repositories/knowledge_pg.py
@@ -149,6 +149,21 @@ class KnowledgePgRepository:
                 },
             )
 
+    def set_is_required(self, item_id: str, value: bool) -> None:
+        """Toggle the global ``is_required`` flag without touching ``status``
+        (parity with the DuckDB repo). ``status`` stays reserved for lifecycle;
+        the Required tier rides on this boolean.
+        """
+        now = datetime.now(timezone.utc)
+        with self._engine.begin() as conn:
+            conn.execute(
+                sa.text(
+                    "UPDATE knowledge_items SET is_required = :v, updated_at = :now "
+                    "WHERE id = :id"
+                ),
+                {"v": bool(value), "now": now, "id": item_id},
+            )
+
     def update(self, item_id: str, **fields) -> None:
         safe = {k: v for k, v in fields.items() if k in self._UPDATABLE_FIELDS}
         if not safe:
@@ -199,10 +214,13 @@ class KnowledgePgRepository:
         hide_dismissed: bool = False,
         limit: int = 100,
         offset: int = 0,
+        is_required: Optional[bool] = None,
     ) -> List[Dict[str, Any]]:
         sql_parts = ["SELECT * FROM knowledge_items WHERE 1=1"]
         params: Dict[str, Any] = {"limit": limit, "offset": offset}
 
+        if is_required is not None:
+            sql_parts.append(" AND is_required = :ireq"); params["ireq"] = bool(is_required)
         if statuses:
             keys = []
             for i, s in enumerate(statuses):
@@ -265,6 +283,7 @@ class KnowledgePgRepository:
         hide_dismissed: bool = False,
         limit: int = 100,
         offset: int = 0,
+        is_required: Optional[bool] = None,
     ) -> List[Dict[str, Any]]:
         """FTS via Postgres ``to_tsvector`` + ``plainto_tsquery`` /
         ``ts_rank`` with ILIKE fallback.
@@ -274,6 +293,7 @@ class KnowledgePgRepository:
             source_type=source_type, exclude_personal=exclude_personal,
             user_groups=user_groups, granted_domains=granted_domains,
             dismissed_by_user=dismissed_by_user, hide_dismissed=hide_dismissed,
+            is_required=is_required,
         )
         params: Dict[str, Any] = dict(filter_params)
         params["q"] = query
@@ -323,12 +343,14 @@ class KnowledgePgRepository:
         granted_domains: Optional[List[str]] = None,
         dismissed_by_user: Optional[str] = None,
         hide_dismissed: bool = False,
+        is_required: Optional[bool] = None,
     ) -> int:
         filter_parts, filter_params = self._build_filter_clauses(
             statuses=statuses, category=category, domain=domain,
             source_type=source_type, exclude_personal=exclude_personal,
             user_groups=user_groups, granted_domains=granted_domains,
             dismissed_by_user=dismissed_by_user, hide_dismissed=hide_dismissed,
+            is_required=is_required,
         )
         if not search:
             sql = "SELECT COUNT(*) FROM knowledge_items WHERE 1=1" + "".join(filter_parts)
@@ -370,9 +392,12 @@ class KnowledgePgRepository:
         granted_domains: Optional[List[str]],
         dismissed_by_user: Optional[str],
         hide_dismissed: bool,
+        is_required: Optional[bool] = None,
     ) -> tuple[list[str], Dict[str, Any]]:
         parts: List[str] = []
         params: Dict[str, Any] = {}
+        if is_required is not None:
+            parts.append(" AND is_required = :ireq"); params["ireq"] = bool(is_required)
         if statuses:
             keys = []
             for i, s in enumerate(statuses):

--- a/src/repositories/resource_grants_pg.py
+++ b/src/repositories/resource_grants_pg.py
@@ -130,32 +130,39 @@ class ResourceGrantsPgRepository:
         resource_type: str,
         resource_id: str,
         assigned_by: Optional[str] = None,
+        requirement: Optional[str] = None,
     ) -> str:
+        """Insert a new grant. Returns the assigned id.
+
+        ``requirement`` defaults to the column default (``'available'``) when
+        ``None``. Pass ``'required'`` to create a Required-tier grant in a
+        single round-trip (parity with the DuckDB repo). Rejected if it is
+        anything other than the two enum values.
+        """
+        if requirement is not None and requirement not in ("available", "required"):
+            raise ValueError(
+                f"requirement must be 'available' or 'required', got {requirement!r}"
+            )
         grant_id = str(uuid4())
         per_type_col = _PER_TYPE_COLUMN.get(resource_type)
+
+        cols = ["id", "group_id", "resource_type", "resource_id"]
+        vals = [":id", ":gid", ":rtype", ":rid"]
+        params: Dict[str, Any] = {
+            "id": grant_id, "gid": group_id, "rtype": resource_type,
+            "rid": resource_id, "ab": assigned_by,
+        }
         if per_type_col:
-            sql = sa.text(
-                f"""INSERT INTO resource_grants
-                   (id, group_id, resource_type, resource_id, {per_type_col}, assigned_by)
-                   VALUES (:id, :gid, :rtype, :rid, :rid, :ab)"""
-            )
-        else:
-            sql = sa.text(
-                """INSERT INTO resource_grants
-                   (id, group_id, resource_type, resource_id, assigned_by)
-                   VALUES (:id, :gid, :rtype, :rid, :ab)"""
-            )
+            cols.append(per_type_col); vals.append(":rid")
+        cols.append("assigned_by"); vals.append(":ab")
+        if requirement is not None:
+            cols.append("requirement"); vals.append(":req"); params["req"] = requirement
+
+        sql = sa.text(
+            f"INSERT INTO resource_grants ({', '.join(cols)}) VALUES ({', '.join(vals)})"
+        )
         with self._engine.begin() as conn:
-            conn.execute(
-                sql,
-                {
-                    "id": grant_id,
-                    "gid": group_id,
-                    "rtype": resource_type,
-                    "rid": resource_id,
-                    "ab": assigned_by,
-                },
-            )
+            conn.execute(sql, params)
         return grant_id
 
     def delete(self, grant_id: str) -> bool:

--- a/src/repositories/resource_grants_pg.py
+++ b/src/repositories/resource_grants_pg.py
@@ -165,6 +165,28 @@ class ResourceGrantsPgRepository:
             conn.execute(sql, params)
         return grant_id
 
+    def update_requirement(self, grant_id: str, requirement: str) -> Optional[str]:
+        """Update the ``requirement`` enum on a grant. Returns the prior value
+        (None if the grant is missing) so callers can detect transitions
+        (parity with the DuckDB repo).
+        """
+        if requirement not in ("available", "required"):
+            raise ValueError(
+                f"requirement must be 'available' or 'required', got {requirement!r}"
+            )
+        with self._engine.begin() as conn:
+            before = conn.execute(
+                sa.text("SELECT requirement FROM resource_grants WHERE id = :id"),
+                {"id": grant_id},
+            ).first()
+            if before is None:
+                return None
+            conn.execute(
+                sa.text("UPDATE resource_grants SET requirement = :req WHERE id = :id"),
+                {"req": requirement, "id": grant_id},
+            )
+        return before[0]
+
     def delete(self, grant_id: str) -> bool:
         with self._engine.begin() as conn:
             row = conn.execute(

--- a/src/repositories/store_entities_pg.py
+++ b/src/repositories/store_entities_pg.py
@@ -54,7 +54,20 @@ class StoreEntitiesPgRepository:
         doc_paths: Optional[List[str]] = None,
         file_size: int = 0,
         visibility_status: str = "pending",
+        title: Optional[str] = None,
+        tagline: Optional[str] = None,
+        synthetic_name: Optional[str] = None,
     ) -> Dict[str, Any]:
+        # v49 phase-1 parity with the DuckDB repo: title and synthetic_name fall
+        # back to derived values when the caller doesn't supply them, so the
+        # columns are never NULL for entities created by tests/utilities.
+        # Production (POST /api/store/entities) passes them explicitly.
+        if not title:
+            from src.store_naming import humanize_name
+
+            title = humanize_name(name) or name or "Untitled"
+        if not synthetic_name:
+            synthetic_name = f"{name}-by-{owner_username}"
         now = datetime.now(timezone.utc)
         v1_entry = {
             "n": 1,
@@ -73,10 +86,12 @@ class StoreEntitiesPgRepository:
                          category, version, photo_path, video_url, doc_paths,
                          file_size, install_count, visibility_status,
                          version_no, version_history,
+                         title, tagline, synthetic_name,
                          created_at, updated_at)
                     VALUES (:id, :ou, :un, :t, :n, :d, :c, :v, :pp, :vu,
                             CAST(:dp AS JSONB), :fs, 0, :vs, 1,
-                            CAST(:vh AS JSONB), :now, :now)"""
+                            CAST(:vh AS JSONB), :title, :tagline, :sname,
+                            :now, :now)"""
                 ),
                 {
                     "id": id, "ou": owner_user_id, "un": owner_username,
@@ -85,6 +100,7 @@ class StoreEntitiesPgRepository:
                     "dp": json.dumps(doc_paths or []),
                     "fs": int(file_size), "vs": visibility_status,
                     "vh": json.dumps([v1_entry]),
+                    "title": title, "tagline": tagline, "sname": synthetic_name,
                     "now": now,
                 },
             )
@@ -362,6 +378,9 @@ class StoreEntitiesPgRepository:
         video_url: Optional[str] = None,
         doc_paths: Optional[List[str]] = None,
         file_size: Optional[int] = None,
+        title: Optional[str] = None,
+        tagline: Optional[str] = None,
+        synthetic_name: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         sets: List[str] = []
         params: Dict[str, Any] = {"id": id}
@@ -382,6 +401,14 @@ class StoreEntitiesPgRepository:
             params["doc_paths"] = json.dumps(doc_paths)
         if file_size is not None:
             sets.append("file_size = :file_size"); params["file_size"] = int(file_size)
+        if title is not None:
+            sets.append("title = :title"); params["title"] = title
+        if tagline is not None:
+            # empty string clears tagline (parity with the DuckDB repo)
+            sets.append("tagline = :tagline"); params["tagline"] = tagline or None
+        if synthetic_name is not None:
+            sets.append("synthetic_name = :synthetic_name")
+            params["synthetic_name"] = synthetic_name
         if not sets:
             return self.get(id)
         sets.append("updated_at = :updated_at")

--- a/src/repositories/table_registry_pg.py
+++ b/src/repositories/table_registry_pg.py
@@ -6,6 +6,7 @@ module so behaviour stays bit-identical across backends.
 """
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Union
 
@@ -48,6 +49,7 @@ class TableRegistryPgRepository:
         partition_by: Optional[str] = None,
         partition_granularity: Optional[str] = None,
         initial_load_chunk_days: Optional[int] = None,
+        bq_fqn: Optional[str] = None,
     ) -> None:
         ts = registered_at or datetime.now(timezone.utc)
         encoded_pk = _encode_primary_key(primary_key)
@@ -62,12 +64,12 @@ class TableRegistryPgRepository:
                           sync_schedule, profile_after_sync,
                           incremental_window_days, max_history_days, incremental_column,
                           where_filters, partition_by, partition_granularity,
-                          initial_load_chunk_days)
+                          initial_load_chunk_days, bq_fqn)
                        VALUES (:id, :name, :folder, :strategy, :pk, :description,
                                :registered_by, :registered_at,
                                :source_type, :bucket, :source_table, :source_query, :query_mode,
                                :sync_schedule, :profile_after_sync,
-                               :iwd, :mhd, :icol, :wf, :pby, :pgr, :ilcd)
+                               :iwd, :mhd, :icol, :wf, :pby, :pgr, :ilcd, :bq_fqn)
                        ON CONFLICT (id) DO UPDATE SET
                          name = EXCLUDED.name,
                          folder = EXCLUDED.folder,
@@ -88,7 +90,8 @@ class TableRegistryPgRepository:
                          where_filters = EXCLUDED.where_filters,
                          partition_by = EXCLUDED.partition_by,
                          partition_granularity = EXCLUDED.partition_granularity,
-                         initial_load_chunk_days = EXCLUDED.initial_load_chunk_days"""
+                         initial_load_chunk_days = EXCLUDED.initial_load_chunk_days,
+                         bq_fqn = EXCLUDED.bq_fqn"""
                 ),
                 {
                     "id": id,
@@ -113,6 +116,7 @@ class TableRegistryPgRepository:
                     "pby": partition_by,
                     "pgr": partition_granularity,
                     "ilcd": initial_load_chunk_days,
+                    "bq_fqn": bq_fqn,
                 },
             )
 
@@ -123,6 +127,66 @@ class TableRegistryPgRepository:
         if "where_filters" in row_dict:
             row_dict["where_filters"] = _decode_where_filters(row_dict["where_filters"])
         return row_dict
+
+    def update_docs(
+        self,
+        table_id: str,
+        *,
+        # v52 docs surface
+        sample_questions: Optional[List[str]] = None,
+        things_to_know: Optional[str] = None,
+        pairs_well_with: Optional[List[str]] = None,
+        clear_sample_questions: bool = False,
+        clear_things_to_know: bool = False,
+        clear_pairs_well_with: bool = False,
+        # v56 structured docs
+        grain: Optional[str] = None,
+        platforms: Optional[List[str]] = None,
+        partition_col: Optional[str] = None,
+        history: Optional[str] = None,
+        gotchas: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        """Parity with the DuckDB repo: partial write of per-table docs fields
+        shown on /catalog/t/<id> and the package-detail page. Optional-is-no-op;
+        pass an explicit ``clear_*`` flag to actively NULL a v52 field.
+
+        Column types in the PG model: ``sample_questions`` / ``pairs_well_with``
+        are JSONB; ``platforms`` / ``gotchas`` are text columns that store the
+        JSON-serialized value (mirrors the DuckDB repo); the rest are plain text.
+        """
+        fields: List[str] = []
+        params: Dict[str, Any] = {"id": table_id}
+        if clear_sample_questions:
+            fields.append("sample_questions = NULL")
+        elif sample_questions is not None:
+            fields.append("sample_questions = CAST(:sq AS JSONB)")
+            params["sq"] = json.dumps(sample_questions)
+        if clear_things_to_know:
+            fields.append("things_to_know = NULL")
+        elif things_to_know is not None:
+            fields.append("things_to_know = :ttk"); params["ttk"] = things_to_know
+        if clear_pairs_well_with:
+            fields.append("pairs_well_with = NULL")
+        elif pairs_well_with is not None:
+            fields.append("pairs_well_with = CAST(:pww AS JSONB)")
+            params["pww"] = json.dumps(pairs_well_with)
+        if grain is not None:
+            fields.append("grain = :grain"); params["grain"] = grain
+        if platforms is not None:
+            fields.append("platforms = :plat"); params["plat"] = json.dumps(platforms)
+        if partition_col is not None:
+            fields.append("partition_col = :pcol"); params["pcol"] = partition_col
+        if history is not None:
+            fields.append("history = :hist"); params["hist"] = history
+        if gotchas is not None:
+            fields.append("gotchas = :got"); params["got"] = json.dumps(gotchas)
+        if not fields:
+            return
+        with self._engine.begin() as conn:
+            conn.execute(
+                sa.text(f"UPDATE table_registry SET {', '.join(fields)} WHERE id = :id"),
+                params,
+            )
 
     def unregister(self, table_id: str) -> None:
         with self._engine.begin() as conn:


### PR DESCRIPTION
## Problem
On a Postgres-backed instance, uploading a store entity (skill) 500s:
```
TypeError: StoreEntitiesPgRepository.create() got an unexpected keyword argument 'title'
```
The `*_pg.py` repos drifted behind their DuckDB siblings on newer columns, so calls that work on DuckDB raise `TypeError` on Postgres. `app/api/store.py::create_entity` passes `title=`/`tagline=`, which the DuckDB repo accepts but the PG repo doesn't.

## Audit
AST-compared every `src/repositories/<name>_pg.py` `create`/`update` signature against its DuckDB sibling. Gaps found:

| PG repo method | missing kwargs | caller | status |
|---|---|---|---|
| `store_entities_pg.create()` / `update()` | `title`, `tagline`, `synthetic_name` | `store.py:1562` | **live crash** |
| `resource_grants_pg.create()` | `requirement` | `access.py:711` | **live crash** |
| `knowledge_pg.create()` | `is_required`, `added_by` | none | latent |

## Fix
Repo-method-only (schemas already have the columns — `models/store.py` v50+, `models/rbac.py` v50+, `models/knowledge.py`; **no migration**). Mirrors the DuckDB repos' behaviour:
- **store_entities** create+update: add `title`/`tagline`/`synthetic_name`; title→`humanize_name(name)` fallback, synthetic_name→`{name}-by-{owner_username}` fallback, tagline empty-string clears.
- **resource_grants** create: add `requirement` (validated against `{available, required}`, omitted from INSERT when `None` to keep the column default).
- **knowledge** create: add `is_required` (wired to the column). `added_by` intentionally **not** added — the DuckDB repo uses it to attribute a `knowledge_item_domains` join-table row, but this PG repo stores `domain` inline (no join table in this path) and no caller passes it to `create()`. Documented inline.

## Verification
- AST parity audit re-run: clean except the documented `knowledge added_by` divergence.
- `py_compile` clean.
- **Live INSERT** of the new `store_entities` shape (title/tagline/synthetic_name) against a real Cloud SQL Postgres schema succeeds and round-trips, then cleans up.

Found while rolling a fleet of instances onto Postgres — this is the class of DuckDB→PG repo drift that only surfaces once the PG backend is active.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->