### PR TITLE
fix(rbac,memory): atomic DuckDB junction rebuilds (group sync + knowledge domains)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,14 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   Postgres repo which was already atomic via `engine.begin()`. The
   per-`INSERT` `try/except ConstraintException` is replaced with `ON CONFLICT
   (user_id, group_id) DO NOTHING` so an admin/system_seed membership on the
-  same pair survives the refresh without aborting the transaction. Cross-
-  engine contract coverage added in `tests/db_pg/test_rbac_contract.py`.
+  same pair survives the refresh without aborting the transaction. Two
+  concurrent logins for the same user can now collide on the shared DuckDB
+  connection (optimistic concurrency raises `Conflict on tuple deletion!`
+  rather than blocking like Postgres), so the rebuild retries on
+  `TransactionException` instead of letting the fail-soft OAuth caller
+  silently drop a refresh. Cross-engine contract coverage added in
+  `tests/db_pg/test_rbac_contract.py`; DuckDB-specific reader-isolation and
+  retry coverage in `tests/test_group_sync_atomicity.py`.
 
 ## [0.60.0] — 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Fixed
+- **Marketplace transiently drops plugins during Google group sync.** The
+  DuckDB `user_group_members.replace_google_sync_groups` rebuilt a user's
+  synced memberships as a non-transactional `DELETE` + per-group `INSERT` on
+  the shared singleton connection. Between the `DELETE` and the re-`INSERT`s
+  the user briefly had *zero* `google_sync` groups, so any concurrent read of
+  their membership — notably the `/marketplace.git/` endpoint resolving a
+  served plugin set for `agnes refresh-marketplace` — saw a partial group set
+  and dropped every plugin granted via a synced group, self-healing only once
+  the inserts committed. Now wrapped in a single transaction (DuckDB MVCC
+  isolates concurrent readers from the intermediate state), matching the
+  Postgres repo which was already atomic via `engine.begin()`. The
+  per-`INSERT` `try/except ConstraintException` is replaced with `ON CONFLICT
+  (user_id, group_id) DO NOTHING` so an admin/system_seed membership on the
+  same pair survives the refresh without aborting the transaction. Cross-
+  engine contract coverage added in `tests/db_pg/test_rbac_contract.py`.
+
 ## [0.60.0] — 2026-06-02
 
 ### Internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,18 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   silently drop a refresh. Cross-engine contract coverage added in
   `tests/db_pg/test_rbac_contract.py`; DuckDB-specific reader-isolation and
   retry coverage in `tests/test_group_sync_atomicity.py`.
+- **Knowledge-domain junction rewrites were non-atomic (same bug class).** A
+  sweep for the pattern above found two more DuckDB repo methods rewriting the
+  `knowledge_item_domains` junction as DELETE-then-INSERT on the shared
+  singleton connection, where the Postgres siblings were already atomic:
+  `MemoryDomainsRepository.replace_domains_for_item` and the domain-routing
+  path in `KnowledgeRepository.update`. A concurrent reader could see an item
+  momentarily domain-less (breaking domain-scoped RBAC reads), and an unknown
+  slug mid-rewrite left a half-applied edit — in `update` it even committed
+  the scalar column change while failing the domain swap. Both now wrap the
+  rewrite in a transaction (the FTS index rebuild in `update` stays *after*
+  commit — `PRAGMA create_fts_index` is catalog DDL that can't run inside a
+  transaction). Coverage in `tests/test_memory_atomicity.py`.
 
 ## [0.60.0] — 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,18 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   rewrite in a transaction (the FTS index rebuild in `update` stays *after*
   commit — `PRAGMA create_fts_index` is catalog DDL that can't run inside a
   transaction). Coverage in `tests/test_memory_atomicity.py`.
+- **Cascade/reconcile rewrites made atomic (same bug class).** Two more
+  multi-statement DuckDB repo mutations now run in a single transaction to
+  match their already-atomic Postgres siblings:
+  `ToolRegistryRepository.delete` (the `tool_grants` → `tool_registry` cascade,
+  which otherwise leaves a reader observing grants whose parent tool is gone)
+  and `ViewOwnershipRepository.reconcile` (the read + multi-row drop, where a
+  partial mid-loop state could let another source transiently appear to claim
+  a not-yet-released view name). Coverage in
+  `tests/test_repo_cascade_atomicity.py`.
+    (`resource_grants.fanout_system_for_group` was reviewed and left as-is:
+  insert-only / idempotent, and the PG sibling is likewise per-insert — no
+  drop-to-empty window.)
 
 ## [0.60.0] — 2026-06-02
 

--- a/src/repositories/knowledge.py
+++ b/src/repositories/knowledge.py
@@ -242,34 +242,50 @@ class KnowledgeRepository:
         """
         domain_value = fields.pop("domain", None) if "domain" in fields else _UNSET
         safe = {k: v for k, v in fields.items() if k in self._UPDATABLE_FIELDS}
-        # Scalar-column UPDATE path
-        if safe:
-            now = datetime.now(timezone.utc)
-            set_clause = ", ".join(f"{k} = ?" for k in safe)
-            values = list(safe.values()) + [now, item_id]
-            self.conn.execute(
-                f"UPDATE knowledge_items SET {set_clause}, updated_at = ? WHERE id = ?",
-                values,
-            )
-            # FTS index needs rebuilding only when the indexed text changed —
-            # status / tag / is_required flips don't affect the BM25 token stream.
-            if "title" in safe or "content" in safe:
-                self._refresh_fts_index()
-        # Domain junction path (only if caller passed domain explicitly).
-        if domain_value is not _UNSET:
-            if domain_value is None or domain_value == "":
-                # Clear all junction rows — caller asked to drop the domain.
+        # Scalar UPDATE + domain-junction rewrite run in one transaction so a
+        # concurrent reader never sees a half-applied edit — notably the
+        # domain DELETE+INSERT below, whose empty intermediate would make the
+        # item momentarily domain-less to RBAC reads. The FTS rebuild runs
+        # AFTER commit: `PRAGMA create_fts_index` is catalog DDL and cannot
+        # run inside an explicit transaction.
+        refresh_fts = bool(safe and ("title" in safe or "content" in safe))
+        self.conn.execute("BEGIN")
+        try:
+            # Scalar-column UPDATE path
+            if safe:
+                now = datetime.now(timezone.utc)
+                set_clause = ", ".join(f"{k} = ?" for k in safe)
+                values = list(safe.values()) + [now, item_id]
                 self.conn.execute(
-                    "DELETE FROM knowledge_item_domains WHERE item_id = ?", [item_id]
+                    f"UPDATE knowledge_items SET {set_clause}, updated_at = ? WHERE id = ?",
+                    values,
                 )
-            else:
-                self._set_item_domain_by_slug(item_id, domain_value, added_by="system")
-            # Bump updated_at even if no scalar field changed.
-            if not safe:
-                self.conn.execute(
-                    "UPDATE knowledge_items SET updated_at = ? WHERE id = ?",
-                    [datetime.now(timezone.utc), item_id],
-                )
+            # Domain junction path (only if caller passed domain explicitly).
+            if domain_value is not _UNSET:
+                if domain_value is None or domain_value == "":
+                    # Clear all junction rows — caller asked to drop the domain.
+                    self.conn.execute(
+                        "DELETE FROM knowledge_item_domains WHERE item_id = ?", [item_id]
+                    )
+                else:
+                    self._set_item_domain_by_slug(item_id, domain_value, added_by="system")
+                # Bump updated_at even if no scalar field changed.
+                if not safe:
+                    self.conn.execute(
+                        "UPDATE knowledge_items SET updated_at = ? WHERE id = ?",
+                        [datetime.now(timezone.utc), item_id],
+                    )
+            self.conn.execute("COMMIT")
+        except Exception:
+            try:
+                self.conn.execute("ROLLBACK")
+            except Exception:
+                pass
+            raise
+        # FTS index rebuilds only when the indexed text changed — status / tag
+        # / is_required flips don't affect the BM25 token stream.
+        if refresh_fts:
+            self._refresh_fts_index()
 
     def set_is_required(self, item_id: str, value: bool) -> None:
         """Toggle the global ``is_required`` flag without touching ``status``.

--- a/src/repositories/memory_domains.py
+++ b/src/repositories/memory_domains.py
@@ -272,29 +272,44 @@ class MemoryDomainsRepository:
         ``ValueError`` — admin must pre-create domains via the dedicated CRUD
         endpoint. Returns the resolved ``memory_domains.id`` set written.
         """
-        # Resolve all slugs first so we don't half-write on a typo.
-        if not slugs:
+        # Wrapped in one transaction so a concurrent reader never sees the
+        # empty post-DELETE / pre-INSERT window (an item would momentarily
+        # appear domain-less, breaking domain-scoped RBAC reads). Mirrors the
+        # PG sibling's ``self._engine.begin()`` atomicity. The slug resolution
+        # SELECT stays inside the txn; an unknown slug raises and rolls back
+        # so nothing half-writes.
+        self.conn.execute("BEGIN")
+        try:
+            if not slugs:
+                self.conn.execute(
+                    "DELETE FROM knowledge_item_domains WHERE item_id = ?",
+                    [item_id],
+                )
+                self.conn.execute("COMMIT")
+                return []
+            placeholders = ",".join(["?"] * len(slugs))
+            rows = self.conn.execute(
+                f"SELECT slug, id FROM memory_domains WHERE slug IN ({placeholders})",
+                list(slugs),
+            ).fetchall()
+            resolved = {r[0]: r[1] for r in rows}
+            missing = [s for s in slugs if s not in resolved]
+            if missing:
+                raise ValueError(f"Unknown memory domain slug(s): {missing}")
             self.conn.execute(
-                "DELETE FROM knowledge_item_domains WHERE item_id = ?",
-                [item_id],
+                "DELETE FROM knowledge_item_domains WHERE item_id = ?", [item_id]
             )
-            return []
-        placeholders = ",".join(["?"] * len(slugs))
-        rows = self.conn.execute(
-            f"SELECT slug, id FROM memory_domains WHERE slug IN ({placeholders})",
-            list(slugs),
-        ).fetchall()
-        resolved = {r[0]: r[1] for r in rows}
-        missing = [s for s in slugs if s not in resolved]
-        if missing:
-            raise ValueError(f"Unknown memory domain slug(s): {missing}")
-        self.conn.execute(
-            "DELETE FROM knowledge_item_domains WHERE item_id = ?", [item_id]
-        )
-        for slug, did in resolved.items():
-            self.conn.execute(
-                "INSERT INTO knowledge_item_domains(item_id, domain_id, added_by) "
-                "VALUES (?, ?, ?) ON CONFLICT DO NOTHING",
-                [item_id, did, added_by],
-            )
-        return list(resolved.values())
+            for slug, did in resolved.items():
+                self.conn.execute(
+                    "INSERT INTO knowledge_item_domains(item_id, domain_id, added_by) "
+                    "VALUES (?, ?, ?) ON CONFLICT DO NOTHING",
+                    [item_id, did, added_by],
+                )
+            self.conn.execute("COMMIT")
+            return list(resolved.values())
+        except Exception:
+            try:
+                self.conn.execute("ROLLBACK")
+            except Exception:
+                pass
+            raise

--- a/src/repositories/tool_registry.py
+++ b/src/repositories/tool_registry.py
@@ -148,8 +148,21 @@ class ToolRegistryRepository:
         return row is not None
 
     def delete(self, tool_id: str) -> None:
-        self.conn.execute("DELETE FROM tool_grants WHERE tool_id = ?", [tool_id])
-        self.conn.execute("DELETE FROM tool_registry WHERE tool_id = ?", [tool_id])
+        # One transaction so a concurrent reader never sees the orphan window
+        # between the two cascade deletes (tool_grants rows whose parent
+        # tool_registry row is already gone). Matches the PG sibling's single
+        # ``engine.begin()``.
+        self.conn.execute("BEGIN")
+        try:
+            self.conn.execute("DELETE FROM tool_grants WHERE tool_id = ?", [tool_id])
+            self.conn.execute("DELETE FROM tool_registry WHERE tool_id = ?", [tool_id])
+            self.conn.execute("COMMIT")
+        except Exception:
+            try:
+                self.conn.execute("ROLLBACK")
+            except Exception:
+                pass
+            raise
 
     def delete_for_source(self, source_id: str) -> None:
         tool_ids = [r[0] for r in self.conn.execute(

--- a/src/repositories/user_group_members.py
+++ b/src/repositories/user_group_members.py
@@ -122,24 +122,42 @@ class UserGroupMembersRepository:
         INSERTs one row per ``group_ids``. Admin and system_seed rows are
         untouched. Called from the OAuth callback on every login so the
         membership reflects the current Cloud Identity state.
+
+        Wrapped in a single transaction so concurrent readers never observe
+        the post-DELETE / pre-INSERT window where the user has *no*
+        google_sync groups. ``get_system_db()`` hands every caller a cursor
+        on one shared connection, so a non-atomic rebuild leaks an empty
+        intermediate state to anything reading membership mid-refresh — e.g.
+        the marketplace git endpoint resolving a user's served plugin set,
+        which would transiently drop every plugin granted via a google_sync
+        group until the re-INSERTs commit. Mirrors the PG repo's
+        ``self._engine.begin()`` atomicity (cross-engine parity).
         """
-        self.conn.execute(
-            "DELETE FROM user_group_members WHERE user_id = ? AND source = 'google_sync'",
-            [user_id],
-        )
-        for group_id in group_ids:
-            try:
+        self.conn.execute("BEGIN")
+        try:
+            self.conn.execute(
+                "DELETE FROM user_group_members "
+                "WHERE user_id = ? AND source = 'google_sync'",
+                [user_id],
+            )
+            for group_id in group_ids:
+                # ON CONFLICT DO NOTHING: an Admin / system_seed row may
+                # already own this (user_id, group_id) pair — the user is
+                # a member through a higher-priority source, leave it. Using
+                # the conflict clause instead of catching ConstraintException
+                # keeps the surrounding transaction alive (a raised
+                # constraint error would otherwise abort it). Matches PG.
                 self.conn.execute(
                     """INSERT INTO user_group_members
                        (user_id, group_id, source, added_by)
-                       VALUES (?, ?, 'google_sync', ?)""",
+                       VALUES (?, ?, 'google_sync', ?)
+                       ON CONFLICT (user_id, group_id) DO NOTHING""",
                     [user_id, group_id, added_by],
                 )
-            except duckdb.ConstraintException:
-                # Admin or system_seed row already present for this pair —
-                # leave it alone, the user is already a member through a
-                # higher-priority source.
-                pass
+            self.conn.execute("COMMIT")
+        except Exception:
+            self.conn.execute("ROLLBACK")
+            raise
 
     def remove_user_from_all_groups(self, user_id: str) -> int:
         """Hard delete every membership for a user. Used on user deletion.

--- a/src/repositories/user_group_members.py
+++ b/src/repositories/user_group_members.py
@@ -20,9 +20,21 @@ the OAuth callback; ``add_member`` / ``remove_member`` cover admin actions.
 
 from __future__ import annotations
 
+import time
 from typing import Any, Dict, List, Optional
 
 import duckdb
+
+# Same-user concurrent logins both rewrite the user's google_sync rows. The
+# shared singleton connection (get_system_db) gives each request its own
+# cursor with an independent transaction, but DuckDB uses optimistic
+# concurrency: two transactions deleting the same (user_id, source) tuples
+# don't block — the loser raises a TransactionException ("Conflict on tuple
+# deletion!"). Retry a few times so a racing login isn't silently dropped by
+# the fail-soft OAuth caller. Postgres serializes these via row locks, so its
+# sibling needs no retry.
+_SYNC_CONFLICT_RETRIES = 3
+_SYNC_CONFLICT_BACKOFF_S = 0.05
 
 
 class UserGroupMembersRepository:
@@ -132,32 +144,55 @@ class UserGroupMembersRepository:
         which would transiently drop every plugin granted via a google_sync
         group until the re-INSERTs commit. Mirrors the PG repo's
         ``self._engine.begin()`` atomicity (cross-engine parity).
+
+        Retries on a DuckDB write-write conflict (see ``_SYNC_CONFLICT_*``)
+        so two concurrent logins for the same user don't lose a refresh.
         """
-        self.conn.execute("BEGIN")
-        try:
-            self.conn.execute(
-                "DELETE FROM user_group_members "
-                "WHERE user_id = ? AND source = 'google_sync'",
-                [user_id],
-            )
-            for group_id in group_ids:
-                # ON CONFLICT DO NOTHING: an Admin / system_seed row may
-                # already own this (user_id, group_id) pair — the user is
-                # a member through a higher-priority source, leave it. Using
-                # the conflict clause instead of catching ConstraintException
-                # keeps the surrounding transaction alive (a raised
-                # constraint error would otherwise abort it). Matches PG.
+        last_err: Optional[duckdb.Error] = None
+        for attempt in range(_SYNC_CONFLICT_RETRIES):
+            try:
+                self.conn.execute("BEGIN")
                 self.conn.execute(
-                    """INSERT INTO user_group_members
-                       (user_id, group_id, source, added_by)
-                       VALUES (?, ?, 'google_sync', ?)
-                       ON CONFLICT (user_id, group_id) DO NOTHING""",
-                    [user_id, group_id, added_by],
+                    "DELETE FROM user_group_members "
+                    "WHERE user_id = ? AND source = 'google_sync'",
+                    [user_id],
                 )
-            self.conn.execute("COMMIT")
-        except Exception:
+                for group_id in group_ids:
+                    # ON CONFLICT DO NOTHING: an Admin / system_seed row may
+                    # already own this (user_id, group_id) pair — the user is
+                    # a member through a higher-priority source, leave it.
+                    # Using the conflict clause instead of catching
+                    # ConstraintException keeps the surrounding transaction
+                    # alive (a raised constraint error would otherwise abort
+                    # it). Matches PG.
+                    self.conn.execute(
+                        """INSERT INTO user_group_members
+                           (user_id, group_id, source, added_by)
+                           VALUES (?, ?, 'google_sync', ?)
+                           ON CONFLICT (user_id, group_id) DO NOTHING""",
+                        [user_id, group_id, added_by],
+                    )
+                self.conn.execute("COMMIT")
+                return
+            except duckdb.TransactionException as e:
+                # Lost an optimistic-concurrency race with a concurrent
+                # same-user login. Roll back (best-effort — the txn may
+                # already be aborted) and retry with a short backoff.
+                self._safe_rollback()
+                last_err = e
+                time.sleep(_SYNC_CONFLICT_BACKOFF_S * (attempt + 1))
+            except Exception:
+                self._safe_rollback()
+                raise
+        # Exhausted retries — surface the last conflict to the caller.
+        if last_err is not None:
+            raise last_err
+
+    def _safe_rollback(self) -> None:
+        try:
             self.conn.execute("ROLLBACK")
-            raise
+        except Exception:
+            pass
 
     def remove_user_from_all_groups(self, user_id: str) -> int:
         """Hard delete every membership for a user. Used on user deletion.

--- a/src/repositories/view_ownership.py
+++ b/src/repositories/view_ownership.py
@@ -84,19 +84,33 @@ class ViewOwnershipRepository:
         let a different source claim it without operator intervention.
         """
         live = set(current_pairs)
-        all_rows = self.conn.execute(
-            "SELECT source_name, view_name FROM view_ownership"
-        ).fetchall()
-        dropped = [
-            (src, view) for src, view in all_rows
-            if (src, view) not in live
-        ]
-        for src, view in dropped:
-            self.conn.execute(
-                "DELETE FROM view_ownership "
-                "WHERE source_name = ? AND view_name = ?",
-                [src, view],
-            )
+        # One transaction over the read + the multi-row drop so a concurrent
+        # reader sees the full ownership set or the fully-reconciled set, never
+        # a partial mid-loop state (a half-dropped set could let another source
+        # transiently appear to claim a not-yet-released name). Matches the PG
+        # sibling's single ``engine.begin()``.
+        self.conn.execute("BEGIN")
+        try:
+            all_rows = self.conn.execute(
+                "SELECT source_name, view_name FROM view_ownership"
+            ).fetchall()
+            dropped = [
+                (src, view) for src, view in all_rows
+                if (src, view) not in live
+            ]
+            for src, view in dropped:
+                self.conn.execute(
+                    "DELETE FROM view_ownership "
+                    "WHERE source_name = ? AND view_name = ?",
+                    [src, view],
+                )
+            self.conn.execute("COMMIT")
+        except Exception:
+            try:
+                self.conn.execute("ROLLBACK")
+            except Exception:
+                pass
+            raise
         return dropped
 
     def list_for_source(self, source_name: str) -> List[str]:

--- a/tests/db_pg/test_rbac_contract.py
+++ b/tests/db_pg/test_rbac_contract.py
@@ -208,6 +208,55 @@ def test_list_groups_for_user_returns_joined_groups(rbac_repos):
     assert set(group_ids) == {g1["id"], g2["id"]}
 
 
+def test_replace_google_sync_groups_sets_final_membership(rbac_repos):
+    """google_sync refresh is authoritative for that source on both engines."""
+    repos, _, _ = rbac_repos
+    users = repos["users"]
+    groups = repos["groups"]
+    members = repos["members"]
+
+    users.create(id="gs1", email="erin@example.com", name="Erin")
+    g1 = groups.create(name="gs-finance", created_by="admin@x.com")
+    g2 = groups.create(name="gs-curator", created_by="admin@x.com")
+    g3 = groups.create(name="gs-legal", created_by="admin@x.com")
+
+    members.replace_google_sync_groups("gs1", [g1["id"], g2["id"]])
+    assert set(members.list_groups_for_user("gs1")) == {g1["id"], g2["id"]}
+
+    # Re-running is authoritative: drops g1, keeps g2, adds g3 — never an
+    # empty intermediate (the rebuild is wrapped in one transaction so a
+    # concurrent reader can't observe the post-DELETE / pre-INSERT gap).
+    members.replace_google_sync_groups("gs1", [g2["id"], g3["id"]])
+    assert set(members.list_groups_for_user("gs1")) == {g2["id"], g3["id"]}
+
+
+def test_replace_google_sync_preserves_higher_priority_source(rbac_repos):
+    """An admin/system_seed membership on the same (user, group) pair must
+    survive a google_sync refresh — ON CONFLICT DO NOTHING keeps the existing
+    higher-priority row instead of erroring or downgrading it."""
+    repos, _, _ = rbac_repos
+    users = repos["users"]
+    groups = repos["groups"]
+    members = repos["members"]
+
+    users.create(id="gs2", email="frank@example.com", name="Frank")
+    admin_grp = groups.create(name="gs-admin-pin", created_by="admin@x.com")
+    sync_grp = groups.create(name="gs-sync-only", created_by="admin@x.com")
+
+    members.add_member("gs2", admin_grp["id"], source="admin", added_by="admin@x.com")
+
+    # google_sync also reports the admin-pinned group → must not error or
+    # duplicate; the admin row stays. The sync-only group is added.
+    members.replace_google_sync_groups("gs2", [admin_grp["id"], sync_grp["id"]])
+    assert set(members.list_groups_for_user("gs2")) == {admin_grp["id"], sync_grp["id"]}
+
+    # A later refresh that no longer lists the admin-pinned group must NOT
+    # remove it — it's owned by source='admin', not 'google_sync'.
+    members.replace_google_sync_groups("gs2", [sync_grp["id"]])
+    assert members.has_membership("gs2", admin_grp["id"])
+    assert set(members.list_groups_for_user("gs2")) == {admin_grp["id"], sync_grp["id"]}
+
+
 def test_system_group_rename_raises(rbac_repos):
     """Both engines must protect system groups from rename."""
     repos, _, _ = rbac_repos

--- a/tests/test_group_sync_atomicity.py
+++ b/tests/test_group_sync_atomicity.py
@@ -1,0 +1,128 @@
+"""DuckDB-specific concurrency guarantees for google_sync group rebuild.
+
+The cross-engine *functional* contract lives in
+``tests/db_pg/test_rbac_contract.py``; these tests pin the DuckDB-only
+concurrency behavior that the contract harness can't express:
+
+  1. The rebuild is transaction-isolated — a concurrent reader on a separate
+     ``get_system_db()`` cursor never observes the empty post-DELETE /
+     pre-INSERT window (the marketplace-drop bug this fix targets).
+  2. A DuckDB write-write conflict (two concurrent same-user logins) is
+     retried instead of being silently swallowed by the fail-soft OAuth
+     caller.
+"""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from src.db import get_system_db
+from src.repositories.user_group_members import UserGroupMembersRepository
+from src.repositories.user_groups import UserGroupsRepository
+from src.repositories.users import UserRepository
+
+
+@pytest.fixture()
+def fresh_system_db(tmp_path, monkeypatch):
+    """Point get_system_db() at an isolated DATA_DIR for this test."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    # Reset the module-level singleton so the new DATA_DIR takes effect.
+    import src.db as db
+
+    monkeypatch.setattr(db, "_system_db_conn", None, raising=False)
+    monkeypatch.setattr(db, "_system_db_path", None, raising=False)
+    return get_system_db()
+
+
+def _seed(conn):
+    UserRepository(conn).create(id="u1", email="e@x.com", name="E")
+    groups = UserGroupsRepository(conn)
+    g1 = groups.create(name="finance", created_by="a")
+    g2 = groups.create(name="legal", created_by="a")
+    return g1["id"], g2["id"]
+
+
+def test_reader_never_sees_empty_intermediate(fresh_system_db):
+    """While the rebuild's transaction is open with the DELETE applied, a
+    separate cursor still sees the previously-committed group set — not the
+    empty window that dropped marketplace plugins."""
+    g1, g2 = _seed(fresh_system_db)
+    UserGroupMembersRepository(get_system_db()).replace_google_sync_groups("u1", [g1, g2])
+
+    writer = get_system_db()
+    reader = get_system_db()
+
+    # Manually drive the same DELETE the rebuild does, leaving the txn open.
+    writer.execute("BEGIN")
+    writer.execute(
+        "DELETE FROM user_group_members WHERE user_id = ? AND source = 'google_sync'",
+        ["u1"],
+    )
+    try:
+        # Reader is isolated from the uncommitted delete.
+        during = set(UserGroupMembersRepository(reader).list_groups_for_user("u1"))
+        assert during == {g1, g2}, f"reader saw empty intermediate: {during}"
+    finally:
+        writer.execute("ROLLBACK")
+
+    after = set(UserGroupMembersRepository(get_system_db()).list_groups_for_user("u1"))
+    assert after == {g1, g2}
+
+
+def test_transaction_conflict_is_retried(fresh_system_db):
+    """A TransactionException on the first attempt is retried, not surfaced
+    to the fail-soft caller — the refresh still lands."""
+    g1, g2 = _seed(fresh_system_db)
+    base = get_system_db()
+
+    class FlakyConn:
+        """Raises a conflict on the first DELETE, then delegates."""
+
+        def __init__(self, inner):
+            self._inner = inner
+            self._delete_calls = 0
+
+        def execute(self, sql, *args, **kwargs):
+            if sql.strip().upper().startswith("DELETE FROM USER_GROUP_MEMBERS"):
+                self._delete_calls += 1
+                if self._delete_calls == 1:
+                    # Mimic DuckDB's "Conflict on tuple deletion!" — the txn
+                    # opened by the preceding BEGIN must be unwound first so
+                    # the retry's BEGIN doesn't nest.
+                    self._inner.execute("ROLLBACK")
+                    raise duckdb.TransactionException("Conflict on tuple deletion!")
+            return self._inner.execute(sql, *args, **kwargs)
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+    repo = UserGroupMembersRepository(FlakyConn(base))
+    repo.replace_google_sync_groups("u1", [g1, g2])  # must not raise
+
+    final = set(UserGroupMembersRepository(get_system_db()).list_groups_for_user("u1"))
+    assert final == {g1, g2}
+
+
+def test_conflict_exhaustion_raises(fresh_system_db):
+    """If every attempt conflicts, the last exception escapes (so the caller
+    can log it) rather than silently reporting success."""
+    g1, _ = _seed(fresh_system_db)
+    base = get_system_db()
+
+    class AlwaysConflict:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def execute(self, sql, *args, **kwargs):
+            if sql.strip().upper().startswith("DELETE FROM USER_GROUP_MEMBERS"):
+                self._inner.execute("ROLLBACK")
+                raise duckdb.TransactionException("Conflict on tuple deletion!")
+            return self._inner.execute(sql, *args, **kwargs)
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+    repo = UserGroupMembersRepository(AlwaysConflict(base))
+    with pytest.raises(duckdb.TransactionException):
+        repo.replace_google_sync_groups("u1", [g1])

--- a/tests/test_memory_atomicity.py
+++ b/tests/test_memory_atomicity.py
@@ -1,0 +1,99 @@
+"""Atomicity of the knowledge-domain junction rewrites (DuckDB).
+
+``MemoryDomainsRepository.replace_domains_for_item`` and
+``KnowledgeRepository.update`` both rewrite the ``knowledge_item_domains``
+junction as DELETE-then-INSERT on the shared singleton connection. These
+tests pin that the rewrite is transaction-wrapped:
+
+  * a concurrent reader never sees the empty post-DELETE / pre-INSERT window
+    (an item would momentarily read as domain-less, breaking domain-scoped
+    RBAC), and
+  * a bad slug rolls the whole operation back — including the scalar column
+    update in ``KnowledgeRepository.update`` — instead of half-writing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.db import get_system_db
+from src.repositories.knowledge import KnowledgeRepository
+from src.repositories.memory_domains import MemoryDomainsRepository
+
+
+@pytest.fixture()
+def repos(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    import src.db as db
+
+    monkeypatch.setattr(db, "_system_db_conn", None, raising=False)
+    monkeypatch.setattr(db, "_system_db_path", None, raising=False)
+    conn = get_system_db()
+    kr = KnowledgeRepository(conn)
+    dr = MemoryDomainsRepository(conn)
+    dr.create(slug="zfin", name="ZFin", description="", icon="", color="", created_by="a")
+    dr.create(slug="zleg", name="ZLeg", description="", icon="", color="", created_by="a")
+    kr.create(
+        id="i1", title="A", content="C", category="x",
+        source_type="manual", added_by="a",
+    )
+    return conn, kr, dr
+
+
+def _domains(conn, item_id="i1"):
+    rows = conn.execute(
+        "SELECT md.slug FROM knowledge_item_domains kid "
+        "JOIN memory_domains md ON md.id = kid.domain_id "
+        "WHERE kid.item_id = ?",
+        [item_id],
+    ).fetchall()
+    return {r[0] for r in rows}
+
+
+def test_replace_domains_rolls_back_on_unknown_slug(repos):
+    conn, _, dr = repos
+    dr.replace_domains_for_item("i1", ["zfin", "zleg"], added_by="a")
+    assert _domains(conn) == {"zfin", "zleg"}
+
+    # A typo in the middle of the set must not half-write — the prior
+    # membership stays intact.
+    with pytest.raises(ValueError):
+        dr.replace_domains_for_item("i1", ["zfin", "bogus"], added_by="a")
+    assert _domains(conn) == {"zfin", "zleg"}
+
+
+def test_replace_domains_reader_isolation(repos):
+    conn, _, dr = repos
+    dr.replace_domains_for_item("i1", ["zfin", "zleg"], added_by="a")
+
+    writer = get_system_db()
+    reader = get_system_db()
+    writer.execute("BEGIN")
+    writer.execute("DELETE FROM knowledge_item_domains WHERE item_id = ?", ["i1"])
+    try:
+        assert _domains(reader) == {"zfin", "zleg"}, "reader saw empty intermediate"
+    finally:
+        writer.execute("ROLLBACK")
+
+
+def test_update_rolls_back_scalar_and_domain_on_bad_slug(repos):
+    conn, kr, _ = repos
+    kr.update("i1", title="T2", domain="zfin")
+    assert _domains(conn) == {"zfin"}
+    assert conn.execute("SELECT title FROM knowledge_items WHERE id='i1'").fetchone()[0] == "T2"
+
+    # A bad domain slug must roll back the scalar title change too — the whole
+    # update is one transaction, not a half-applied edit.
+    with pytest.raises(ValueError):
+        kr.update("i1", title="T3", domain="bogus")
+    assert conn.execute("SELECT title FROM knowledge_items WHERE id='i1'").fetchone()[0] == "T2"
+    assert _domains(conn) == {"zfin"}
+
+
+def test_update_domain_swap_is_atomic(repos):
+    conn, kr, _ = repos
+    kr.update("i1", domain="zfin")
+    assert _domains(conn) == {"zfin"}
+    # Swapping the domain replaces cleanly (single-domain helper semantics).
+    kr.update("i1", domain="zleg")
+    assert _domains(conn) == {"zleg"}

--- a/tests/test_repo_cascade_atomicity.py
+++ b/tests/test_repo_cascade_atomicity.py
@@ -1,0 +1,89 @@
+"""Transaction atomicity for multi-statement DuckDB repo mutations.
+
+Mirrors the Postgres siblings' single-``engine.begin()`` wrapping:
+
+  * ``ToolRegistryRepository.delete`` — the two cascade deletes (grants then
+    registry row) must be one transaction so a reader never sees a grant whose
+    parent tool is already gone, and a mid-cascade failure rolls both back.
+  * ``ViewOwnershipRepository.reconcile`` — the read + multi-row drop is one
+    transaction; a reader sees the full set or the reconciled set, never a
+    partial mid-loop state.
+"""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from src.db import get_system_db
+from src.repositories.tool_registry import ToolRegistryRepository
+from src.repositories.view_ownership import ViewOwnershipRepository
+
+
+@pytest.fixture()
+def conn(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    import src.db as db
+
+    monkeypatch.setattr(db, "_system_db_conn", None, raising=False)
+    monkeypatch.setattr(db, "_system_db_path", None, raising=False)
+    return get_system_db()
+
+
+def _seed_tool(conn, tool_id="t1"):
+    conn.execute(
+        "INSERT INTO tool_registry (tool_id, source_id, original_name, exposed_name, mode) "
+        "VALUES (?, ?, ?, ?, ?)",
+        [tool_id, "src1", "mytool", "mytool", "read"],
+    )
+    conn.execute("INSERT INTO tool_grants (tool_id, group_id) VALUES (?, ?)", [tool_id, "g1"])
+
+
+def test_tool_delete_removes_both_tables(conn):
+    _seed_tool(conn)
+    ToolRegistryRepository(conn).delete("t1")
+    assert conn.execute("SELECT COUNT(*) FROM tool_registry WHERE tool_id='t1'").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM tool_grants WHERE tool_id='t1'").fetchone()[0] == 0
+
+
+def test_tool_delete_rolls_back_on_failure(conn):
+    """A failure after the first cascade delete must leave BOTH rows intact —
+    no orphaned half-delete."""
+    _seed_tool(conn)
+
+    class Boom(Exception):
+        pass
+
+    class Flaky:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def execute(self, sql, *a, **k):
+            # Fail on the second delete (the registry row) after the grants
+            # delete has already run inside the transaction.
+            if sql.strip().upper().startswith("DELETE FROM TOOL_REGISTRY"):
+                raise Boom()
+            return self._inner.execute(sql, *a, **k)
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+    with pytest.raises(Boom):
+        ToolRegistryRepository(Flaky(conn)).delete("t1")
+
+    # Both rows survive — the grants delete was rolled back with the failure.
+    assert conn.execute("SELECT COUNT(*) FROM tool_registry WHERE tool_id='t1'").fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM tool_grants WHERE tool_id='t1'").fetchone()[0] == 1
+
+
+def test_view_ownership_reconcile_drops_only_stale(conn):
+    for s, v in [("srcA", "v1"), ("srcA", "v2"), ("srcB", "v3")]:
+        conn.execute(
+            "INSERT INTO view_ownership(source_name, view_name) VALUES (?, ?) "
+            "ON CONFLICT DO NOTHING",
+            [s, v],
+        )
+    dropped = ViewOwnershipRepository(conn).reconcile([("srcA", "v1")])
+    assert set(dropped) == {("srcA", "v2"), ("srcB", "v3")}
+    left = {tuple(r) for r in conn.execute("SELECT source_name, view_name FROM view_ownership").fetchall()}
+    assert left == {("srcA", "v1")}


### PR DESCRIPTION
## Problem

Investigating a report that `agnes refresh-marketplace` intermittently served a partial plugin set (only `groupon-marketplace` plugins survived; `legal-common` and others vanished and "self-healed ~30 min later"), I traced it to a **race in Google group sync**, not the marketplace serving layer (verified correct end-to-end on the dev instance).

`user_group_members.replace_google_sync_groups` (DuckDB) — called from the Google OAuth callback on **every login** — rebuilt synced memberships non-atomically on the process-wide shared singleton connection:

```
DELETE ... WHERE source='google_sync'   # autocommits immediately
for gid: INSERT ...                       # each autocommits, one at a time
```

Between the `DELETE` and the last `INSERT`, the user briefly has **zero** `google_sync` groups. A concurrent read in that window — `/marketplace.git/` → `resolve_user_marketplace` → `resolve_allowed_plugins` → `_user_group_ids` — sees a partial group set and drops every plugin granted via a synced group. Self-heals once the inserts commit. The **Postgres** sibling was already atomic (`engine.begin()`) — DuckDB↔PG parity drift.

## Fixes

1. **`replace_google_sync_groups`** — wrap the rebuild in one transaction (DuckDB MVCC isolates concurrent readers from the empty intermediate); `ON CONFLICT (user_id, group_id) DO NOTHING` replaces the txn-poisoning `try/except` so an admin/system_seed row on the same pair survives.
2. **Conflict retry** (from the Codex adversarial review) — two concurrent same-user logins both DELETE the same tuples; DuckDB's optimistic concurrency raises `Conflict on tuple deletion!` (Postgres blocks instead), which the fail-soft OAuth caller would swallow → silent lost refresh. Now retried with bounded backoff.
3. **Same-class sweep → 2 more** — `MemoryDomainsRepository.replace_domains_for_item` and the domain path in `KnowledgeRepository.update` had the identical non-atomic DELETE-then-INSERT on `knowledge_item_domains` (PG siblings already atomic). A reader could see an item momentarily domain-less (breaks domain-scoped RBAC); a bad slug left a half-applied edit (`update` even committed the scalar column while failing the domain swap). Both wrapped in a transaction; the FTS rebuild in `update` stays **after** commit (`PRAGMA create_fts_index` is catalog DDL, can't run in a txn).

## Tests

- `tests/db_pg/test_rbac_contract.py` — cross-engine (DuckDB + PG) authoritative-replace + higher-priority-source preserve.
- `tests/test_group_sync_atomicity.py` — DuckDB reader isolation, conflict retry, conflict exhaustion.
- `tests/test_memory_atomicity.py` — rollback on bad slug (incl. scalar+domain in `update`), reader isolation, clean domain swap.

> The full local suite couldn't run in this environment (missing optional deps `mcp`, `pixeltable_pgserver`); the new DuckDB tests pass locally and CI runs the full parametrized suite on both backends.