### PR TITLE
refactor(web): migrate the 7 remaining base.html leaf pages onto base_ds (#482 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.61.4] — 2026-06-03
+
 ### Changed
 - **Migrated the 7 remaining `base.html` leaf pages onto the design-system base (`base_ds`).** `admin_tables`, `admin_database`, `admin_sync`, `admin_mcp_sources`, `admin_mcp_source_detail`, `admin_mcp_tool_grants`, `cowork_help` — pages added on `main` *after* the #481 batch (Cowork + Universal MCP #474, db-state #455). Each is an extends-swap onto `base_ds` with its per-page component CSS moved into `{% block head_extra %}` and the redundant `_components.html` import dropped (`base_ds` auto-imports `ds`); every hero is kept in place (faithful — no visual change, render-verified). Only the 7 intentionally-bespoke templates (the catalog/marketplace `*_detail` card-heroes, the dead `admin_scheduler_runs` redirect, and the `_message` partial) now remain on `base.html`. Migration-tail follow-up to #482.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Changed
+- **Migrated the 7 remaining `base.html` leaf pages onto the design-system base (`base_ds`).** `admin_tables`, `admin_database`, `admin_sync`, `admin_mcp_sources`, `admin_mcp_source_detail`, `admin_mcp_tool_grants`, `cowork_help` — pages added on `main` *after* the #481 batch (Cowork + Universal MCP #474, db-state #455). Each is an extends-swap onto `base_ds` with its per-page component CSS moved into `{% block head_extra %}` and the redundant `_components.html` import dropped (`base_ds` auto-imports `ds`); every hero is kept in place (faithful — no visual change, render-verified). Only the 7 intentionally-bespoke templates (the catalog/marketplace `*_detail` card-heroes, the dead `admin_scheduler_runs` redirect, and the `_message` partial) now remain on `base.html`. Migration-tail follow-up to #482.
+
 ## [0.61.3] — 2026-06-03
 
 ### Changed

--- a/app/web/templates/admin_database.html
+++ b/app/web/templates/admin_database.html
@@ -1,8 +1,7 @@
-{% extends "base.html" %}
+{% extends "base_ds.html" %}
 {% block title %}Database backend — {{ config.INSTANCE_NAME }}{% endblock %}
 
-{% block content %}
-{% import "_components.html" as ds %}
+{% block head_extra %}
 <style>
   /* /admin/database — DB backend state machine. Mirrors the
      /admin/tokens hero pattern (gradient header + chip-style summary
@@ -166,7 +165,9 @@
     font-size: 12px;
   }
 </style>
+{% endblock %}
 
+{% block content %}
 <div class="db-page container">
   <section class="page-header page-header--hero db-hero" aria-labelledby="db-title">
     <div class="page-header__main">

--- a/app/web/templates/admin_mcp_source_detail.html
+++ b/app/web/templates/admin_mcp_source_detail.html
@@ -1,8 +1,7 @@
-{% extends "base.html" %}
+{% extends "base_ds.html" %}
 {% block title %}MCP source detail — {{ config.INSTANCE_NAME }}{% endblock %}
 
-{% block content %}
-{% import "_components.html" as ds %}
+{% block head_extra %}
 <style>
   .src-toolbar {
     display: flex; justify-content: space-between; align-items: center;
@@ -169,7 +168,9 @@
   .toast.success { background: #047857; }
   .toast.error { background: #b91c1c; }
 </style>
+{% endblock %}
 
+{% block content %}
 <div class="mcp-detail-page">
   <a class="src-back" href="/admin/mcp-sources">&larr; All MCP sources</a>
 

--- a/app/web/templates/admin_mcp_sources.html
+++ b/app/web/templates/admin_mcp_sources.html
@@ -1,11 +1,10 @@
-{% extends "base.html" %}
+{% extends "base_ds.html" %}
 {% block title %}MCP Sources — {{ config.INSTANCE_NAME }}{% endblock %}
 
-{% block content %}
+{% block head_extra %}
 {# Design-system component macros — toolbar "+ Add MCP source" + modal
    buttons render via `ds.button`. JS-generated per-row `.icon-btn`
    actions stay page-local, mirroring admin_marketplaces.html. #}
-{% import "_components.html" as ds %}
 <style>
   .mcp-toolbar {
     display: flex; justify-content: space-between; align-items: center;
@@ -117,7 +116,9 @@
   .toast.success { background: #047857; }
   .toast.error { background: #b91c1c; }
 </style>
+{% endblock %}
 
+{% block content %}
 <div class="mcp-sources-page">
   {% set page_hero_eyebrow = "Agent Experience" %}
   {% set page_hero_title = "MCP Sources" %}

--- a/app/web/templates/admin_mcp_tool_grants.html
+++ b/app/web/templates/admin_mcp_tool_grants.html
@@ -1,8 +1,7 @@
-{% extends "base.html" %}
+{% extends "base_ds.html" %}
 {% block title %}MCP tool grants — {{ config.INSTANCE_NAME }}{% endblock %}
 
-{% block content %}
-{% import "_components.html" as ds %}
+{% block head_extra %}
 <style>
   .gr-back { font-size: 12px; color: var(--text-secondary, #6b7280); text-decoration: none; margin-bottom: 8px; display: inline-block; }
   .gr-back:hover { color: var(--ds-primary); }
@@ -95,7 +94,9 @@
   .toast.success { background: #047857; }
   .toast.error { background: #b91c1c; }
 </style>
+{% endblock %}
 
+{% block content %}
 <div class="mcp-grants-page">
   <a class="gr-back" id="gr-back-link" href="/admin/mcp-sources">&larr; Back to MCP sources</a>
 

--- a/app/web/templates/admin_sync.html
+++ b/app/web/templates/admin_sync.html
@@ -1,8 +1,7 @@
-{% extends "base.html" %}
+{% extends "base_ds.html" %}
 {% block title %}Sync — {{ config.INSTANCE_NAME }}{% endblock %}
 
-{% block content %}
-{% import "_components.html" as ds %}
+{% block head_extra %}
 <style>
   .sync-toolbar {
     display: flex; align-items: center; gap: 12px; margin-bottom: 20px; flex-wrap: wrap;
@@ -59,7 +58,9 @@
   .toast.success { background: #047857; }
   .toast.error   { background: #b91c1c; }
 </style>
+{% endblock %}
 
+{% block content %}
 <div>
   {% set page_hero_eyebrow = "Data Pipeline" %}
   {% set page_hero_title = "Sync" %}

--- a/app/web/templates/admin_tables.html
+++ b/app/web/templates/admin_tables.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "base_ds.html" %}
 
 {% block title %}Table Management - {{ config.INSTANCE_NAME }}{% endblock %}
 

--- a/app/web/templates/cowork_help.html
+++ b/app/web/templates/cowork_help.html
@@ -1,7 +1,7 @@
-{% extends "base.html" %}
+{% extends "base_ds.html" %}
 {% block title %}Connect Claude Code — {{ config.INSTANCE_NAME }}{% endblock %}
 
-{% block content %}
+{% block head_extra %}
 <style>
   .cowork-help {
     max-width: 680px;
@@ -190,7 +190,9 @@
   }
   .ch-faq .faq-body a { color: var(--ds-primary); }
 </style>
+{% endblock %}
 
+{% block content %}
 <div class="cowork-help">
   <a href="/me/cowork" class="back">
     <svg width="14" height="14" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.61.3"
+version = "0.61.4"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"


### PR DESCRIPTION
Migration-tail follow-up to #482 (closed) / #481 (merged). Migrates the **7 `base.html` leaf pages that landed on `main` *after* #481's batch** onto the design-system base, so the whole dashboard rides the page shell.

## Pages (all → `base_ds`)

| Page | Arrived via | Note |
|---|---|---|
| `admin_tables` | pre-existing | 1-line extends-swap (`<style>` was already in `head_extra`) |
| `admin_database` | #455 (db-state) | bespoke `.db-hero` kept in `content` |
| `admin_sync` | #474 (Cowork+MCP) | hero via `page_hero_*` + `_page_hero`, kept in `content` |
| `admin_mcp_sources` | #474 | ″ |
| `admin_mcp_source_detail` | #474 | ″ |
| `admin_mcp_tool_grants` | #474 | ″ |
| `cowork_help` | #474 | no hero |

Each page: `{% extends "base.html" %}` → `base_ds.html`; per-page component CSS → `{% block head_extra %}`; the redundant `{% import "_components.html" as ds %}` dropped (`base_ds` auto-imports `ds`); the hero is **kept in place** so the rendered output is unchanged. `me_mcp` is intentionally **not** here — it was superseded by `me_cowork` (already on `base_ds`) in #494.

After this, **only the 7 intentionally-bespoke templates remain on `base.html`**: the catalog/marketplace `*_detail` card-hero pages, the dead `admin_scheduler_runs` redirect, and the `_message` partial.

## Verification
- **compile-check**: all 7 templates compile (no block-structure errors).
- **render-check** (TestClient): `/admin/tables`, `/admin/sync`, `/admin/database`, `/admin/mcp-sources`, `/help/cowork` → `200`, exactly one hero each (0 for `cowork_help`), no `.container:has(` opt-out, no `page-shell` class. The two detail routes (`/admin/mcp-sources/{id}`, `/admin/mcp-tools/{id}/grants`) also render `200` with their hero.
- **pytest**: `test_design_system_contract` (scans the migrated templates) + `test_web_ui` + `test_web_home_page` + `test_custom_scripts_render` + the `admin_tables` UI tests + `test_web_nav_cowork` — **109 passed**.

Followed the build recipe documented in `docs/architecture.md` → *Extending the Platform → New Web Page* (added in #481).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
