### PR TITLE
release: 0.61.0 — seed-driven connector framework + 4 Dependabot bumps

### DIFF
--- a/.github/workflows/e2e-e2b.yml
+++ b/.github/workflows/e2e-e2b.yml
@@ -47,10 +47,10 @@ jobs:
           echo "::error::ANTHROPIC_API_KEY and E2B_API_KEY must be set as GitHub secrets"
           exit 1
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,7 +202,7 @@ jobs:
       - name: Authenticate to Google Cloud (Artifact Registry mirror)
         id: gcp_auth
         if: steps.armirror.outputs.enabled == 'true'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
           token_format: access_token

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.61.0] — 2026-06-03
+
 ### Added
 - Seed-driven connector framework foundation (A1.1 of the connector-skills refactor).
   - `src/_bundled_seed/` snapshot of the OSS workspace seed ships inside the wheel and serves as the fallback when no Initial Workspace Template is configured. Resolution chain: operator IWT clone first, bundled snapshot second.
@@ -98,6 +100,11 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
     (`resource_grants.fanout_system_for_group` was reviewed and left as-is:
   insert-only / idempotent, and the PG sibling is likewise per-insert — no
   drop-to-empty window.)
+- **Dependency bumps (4 Dependabot PRs consolidated):**
+  - `actions/checkout` v4 → v6 (Node 24 runtime, no behaviour change for our usage). Supersedes #500.
+  - `actions/setup-python` v5 → v6 (Node 24 runtime; requires GHA runner ≥ v2.327.1 — GitHub-hosted `ubuntu-latest` is well past). Supersedes #502.
+  - `google-github-actions/auth` v2 → v3 (used in `release.yml` for the Artifact Registry mirror auth step). Supersedes #501.
+  - `e2b` Python lib upper-bound widened from `<2.0.0` to `<3.0.0` (lets the resolver pick up the v2 line as the e2b SDK ships it; runtime API surface that `app/chat/e2b_provider.py` uses is unchanged). Supersedes #503.
 
 ## [0.60.0] — 2026-06-02
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.60.0"
+version = "0.61.0"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"
@@ -67,7 +67,7 @@ dependencies = [
     # microVM (`AsyncSandbox`); `app/chat/e2b_provider.py` adapts the SDK's
     # background-command + filesystem APIs to our `SandboxProvider`
     # Protocol. See `docs/cloud-chat.md` for operator setup.
-    "e2b>=1.0.0,<2.0.0",
+    "e2b>=1.0.0,<3.0.0",
     # Per-IP rate limiting on auth endpoints (#45). In-process counters by
     # default — fine for single-replica deploys. Multi-replica rollouts can
     # swap the storage backend via slowapi's `storage_uri` (Redis, Memcached).


### PR DESCRIPTION
## Why minor + consolidated

`origin/main` was sitting at `pyproject.toml: 0.60.0` while `[Unreleased]` already carried the full body of @cvrysanek's seed-driven connector framework (PR #462: A1.1+A1.2+A1.3 — new `/api/connectors/manifest` + `/api/connectors/params` endpoints, BREAKING-for-behaviour markers on Atlassian / GWS operator-baked values, new `docs/seed-repo-contract.md`, atomic-merge sweep fixes). PR #462 was merged without a release-cut commit, so the next release-cut needs to take ownership of that block — minor (0.61.0) is the correct level per the CHANGELOG header rule.

At the same time, four Dependabot PRs landed today (#500–#503). Rather than four sequential release cycles, this PR consolidates them into the same minor cut as Internal entries. None of the four changes runtime behaviour:

- `actions/checkout` v4 → v6 — Node 24 runtime; `e2e-e2b.yml` updated. (closes #500)
- `actions/setup-python` v5 → v6 — Node 24 runtime; requires GHA runner ≥ v2.327.1 (GitHub-hosted `ubuntu-latest` is well past); `e2e-e2b.yml` updated. (closes #502)
- `google-github-actions/auth` v2 → v3 — `release.yml` Artifact Registry mirror auth step. (closes #501)
- `e2b` Python lib upper bound widened from `<2.0.0` to `<3.0.0` — `pyproject.toml`. Runtime API surface that `app/chat/e2b_provider.py` uses is unchanged. (closes #503)

## Release-cut

`pyproject.toml` 0.60.0 → 0.61.0, `[Unreleased]` content (already on main from #462) renamed to `[0.61.0]` section with the four dependency bumps appended under its existing Internal subsection.

Closes #500, #501, #502, #503.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->