### PR TITLE
refactor(web): tokenize hardcoded brand-green via color-mix (#497 §5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Changed
+- Brand-green tints, focus rings, and shadows across the static CSS (`style-custom.css`, `home.css`, `dashboard.css`, `marketplace.css`, `activity_center.css`, `admin_access.css`) now derive from the `--ds-primary` theme token via `color-mix` instead of hardcoded green, so they follow the active theme (light/blue/dark). No visual change in the default theme. (#497)
+
 ## [0.61.0] — 2026-06-03
 
 ### Added
@@ -33,7 +36,6 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   - `docs/initial-workspace-override.md` cross-links to the new contract doc.
 
 ### Changed
-- Brand-green focus ring, button-hover shadows, and badge/flash/grant-row tints now derive from the `--ds-primary` theme token via `color-mix` instead of hardcoded green, so they follow the active theme (light/blue/dark). No visual change in the default theme. (#497)
 - Install-prompt renderer (`app/web/setup_instructions.py`) now sources connector content from the seed manifest + per-skill SKILL.md bodies instead of hardcoded Python strings (A1.2 of the connector-skills refactor).
   - `app/web/connector_prompts.py` retired and deleted. The asana / atlassian / gws prompts moved to `workspace/.claude/skills/connector-*/SKILL.md` inside the seed (operator IWT clone or bundled snapshot fallback). Adding a fourth connector now requires only a new `connector-X/SKILL.md` in the seed — no Agnes code change.
   - `resolve_lines()` / `render_setup_instructions()` accept `connector_manifest: list[ConnectorEntry]` instead of `connector_prompts: dict[str, str]`. `None` triggers a fresh `load_manifest()` call; `[]` intentionally renders no connectors step (was previously rehydrated silently).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   - `docs/initial-workspace-override.md` cross-links to the new contract doc.
 
 ### Changed
+- Brand-green focus ring, button-hover shadows, and badge/flash/grant-row tints now derive from the `--ds-primary` theme token via `color-mix` instead of hardcoded green, so they follow the active theme (light/blue/dark). No visual change in the default theme. (#497)
 - Install-prompt renderer (`app/web/setup_instructions.py`) now sources connector content from the seed manifest + per-skill SKILL.md bodies instead of hardcoded Python strings (A1.2 of the connector-skills refactor).
   - `app/web/connector_prompts.py` retired and deleted. The asana / atlassian / gws prompts moved to `workspace/.claude/skills/connector-*/SKILL.md` inside the seed (operator IWT clone or bundled snapshot fallback). Adding a fourth connector now requires only a new `connector-X/SKILL.md` in the seed — no Agnes code change.
   - `resolve_lines()` / `render_setup_instructions()` accept `connector_manifest: list[ConnectorEntry]` instead of `connector_prompts: dict[str, str]`. `None` triggers a fresh `load_manifest()` call; `[]` intentionally renders no connectors step (was previously rehydrated silently).

--- a/app/web/static/css/activity_center.css
+++ b/app/web/static/css/activity_center.css
@@ -44,8 +44,8 @@
 .obs-live-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--ds-text-disabled); transition: background 0.2s; }
 .obs-live input:checked ~ .obs-live-dot { background: var(--ds-primary); animation: obs-pulse 2s ease-in-out infinite; }
 @keyframes obs-pulse {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(46, 168, 119, 0.6); }
-  50%      { box-shadow: 0 0 0 4px rgba(46, 168, 119, 0); }
+  0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--ds-primary) 60%, transparent); }
+  50%      { box-shadow: 0 0 0 4px color-mix(in srgb, var(--ds-primary) 0%, transparent); }
 }
 
 /* Saved views dropdown -------------------------------------------------- */

--- a/app/web/static/css/admin_access.css
+++ b/app/web/static/css/admin_access.css
@@ -96,7 +96,7 @@
   border-bottom: 1px solid var(--border, #e5e7eb);
   border-left: 4px solid var(--primary);
   background: linear-gradient(to right,
-    rgba(46, 168, 119, 0.10), rgba(46, 168, 119, 0.02));
+    color-mix(in srgb, var(--ds-primary) 10%, transparent), color-mix(in srgb, var(--ds-primary) 2%, transparent));
 }
 .rt-section:nth-child(4n+2) > .rt-section-head {
   border-left-color: #10b981;

--- a/app/web/static/css/dashboard.css
+++ b/app/web/static/css/dashboard.css
@@ -594,7 +594,7 @@
         }
 
         .dashboard-mock .btn-setup-secondary:hover {
-            background: rgba(46, 168, 119, 0.05);
+            background: color-mix(in srgb, var(--ds-primary) 5%, transparent);
         }
 
         .dashboard-mock .btn-setup-secondary.copied {
@@ -853,7 +853,7 @@
         .dashboard-mock .reg-inline .reg-field textarea:focus {
             outline: none;
             border-color: var(--primary);
-            box-shadow: 0 0 0 2px rgba(46, 168, 119, 0.1);
+            box-shadow: 0 0 0 2px color-mix(in srgb, var(--ds-primary) 10%, transparent);
         }
 
         .dashboard-mock .reg-inline .reg-meta {
@@ -869,7 +869,7 @@
             font-family: var(--font-mono);
             font-weight: 600;
             color: var(--primary);
-            background: rgba(46, 168, 119, 0.08);
+            background: color-mix(in srgb, var(--ds-primary) 8%, transparent);
             padding: 2px 8px;
             border-radius: 4px;
         }
@@ -977,7 +977,7 @@
         .dashboard-mock .form-group-v2 textarea:focus {
             outline: none;
             border-color: var(--primary);
-            box-shadow: 0 0 0 2px rgba(46, 168, 119, 0.1);
+            box-shadow: 0 0 0 2px color-mix(in srgb, var(--ds-primary) 10%, transparent);
         }
 
         .dashboard-mock .form-row-v2 {

--- a/app/web/static/css/home.css
+++ b/app/web/static/css/home.css
@@ -245,7 +245,7 @@
 }
 .home-mock a.what-is-item:hover {
     border-color: var(--ds-primary);
-    box-shadow: 0 4px 12px rgba(46, 168, 119, 0.14);
+    box-shadow: 0 4px 12px color-mix(in srgb, var(--ds-primary) 14%, transparent);
     transform: translateY(-1px);
 }
 .home-mock .what-is-item .ico { font-size: 22px; margin-bottom: 8px; display: block; }
@@ -1335,7 +1335,7 @@
     place-items: center;
     font-weight: 700;
     font-size: 16px;
-    box-shadow: 0 2px 6px rgba(46, 168, 119, 0.25);
+    box-shadow: 0 2px 6px color-mix(in srgb, var(--ds-primary) 25%, transparent);
     flex-shrink: 0;
 }
 .home-mock .session-content { min-width: 0; }
@@ -1547,7 +1547,7 @@
 .home-mock .surface-card .what code {
     background: var(--ds-primary-light);
     color: var(--ds-primary-dark);
-    border: 1px solid rgba(46, 168, 119, 0.30);
+    border: 1px solid color-mix(in srgb, var(--ds-primary) 30%, transparent);
     padding: 1px 6px;
     border-radius: 4px;
     font-family: var(--ds-font-mono);
@@ -1674,7 +1674,7 @@
 .home-mock .surface-card .steps code {
     background: var(--ds-primary-light);
     color: var(--ds-primary-dark);
-    border: 1px solid rgba(46, 168, 119, 0.30);
+    border: 1px solid color-mix(in srgb, var(--ds-primary) 30%, transparent);
     padding: 1px 5px;
     border-radius: 4px;
     font-family: var(--ds-font-mono);
@@ -1950,7 +1950,7 @@
 .home-mock .install-hero a {
     color: var(--ds-primary);
     text-decoration: underline;
-    text-decoration-color: rgba(46, 168, 119, 0.4);
+    text-decoration-color: color-mix(in srgb, var(--ds-primary) 40%, transparent);
 }
 .home-mock .install-hero a:hover,
 .home-mock .install-hero a:focus {
@@ -1963,7 +1963,7 @@
 .home-mock .install-note > code {
     background: var(--ds-primary-light);
     color: var(--ds-primary-dark);
-    border-color: rgba(46, 168, 119, 0.30);
+    border-color: color-mix(in srgb, var(--ds-primary) 30%, transparent);
 }
 /* Setup-meta chips on light bg — primary chip uses brand-light pill,
    secondary chips lose the white-on-dark treatment for ink-muted. */
@@ -2032,7 +2032,7 @@
 .home-mock .install-block .step-lede code {
     background: var(--ds-primary-light);
     color: var(--ds-primary-dark);
-    border: 1px solid rgba(46, 168, 119, 0.30);
+    border: 1px solid color-mix(in srgb, var(--ds-primary) 30%, transparent);
     padding: 1px 6px;
     border-radius: 4px;
     font-family: var(--ds-font-mono);
@@ -2231,11 +2231,11 @@
 .home-mock .auto-detect-badge {
     background: var(--ds-primary-light);
     color: var(--ds-primary-dark);
-    border: 1px solid rgba(46, 168, 119, 0.30);
+    border: 1px solid color-mix(in srgb, var(--ds-primary) 30%, transparent);
 }
 .home-mock .auto-detect-badge .pulse { background: var(--ds-primary); }
 .home-mock .auto-detect-badge code {
-    background: rgba(46, 168, 119, 0.18);
+    background: color-mix(in srgb, var(--ds-primary) 18%, transparent);
     color: var(--ds-primary-dark);
 }
 /* Terminal-howto disclosure — blue info-hint box matching the design's

--- a/app/web/static/css/marketplace.css
+++ b/app/web/static/css/marketplace.css
@@ -8,7 +8,7 @@
 
   .mp-page {
     --surface: #ffffff;
-    --primary-light: rgba(46, 168, 119, 0.12);
+    --primary-light: color-mix(in srgb, var(--ds-primary) 12%, transparent);
     --border-light: #eceff1;
     --text-primary: #202124;
     --text-secondary: #5f6368;
@@ -265,7 +265,7 @@
   }
   .mp-card:hover {
     border-color: var(--primary);
-    box-shadow: 0 6px 20px rgba(46, 168, 119, 0.12);
+    box-shadow: 0 6px 20px color-mix(in srgb, var(--ds-primary) 12%, transparent);
     transform: translateY(-2px);
   }
   .mp-card .photo {
@@ -303,7 +303,7 @@
     font-size: 10px; font-weight: var(--font-semibold);
     text-transform: uppercase; letter-spacing: 0.5px;
   }
-  .mp-card .type-badge[data-type="plugin"] { background: rgba(46, 168, 119, 0.12); color: #0056A3; }
+  .mp-card .type-badge[data-type="plugin"] { background: color-mix(in srgb, var(--ds-primary) 12%, transparent); color: #0056A3; }
   .mp-card .type-badge[data-type="skill"]  { background: rgba(16, 183, 127, 0.14); color: #0e9b6a; }
   .mp-card .type-badge[data-type="agent"]  { background: rgba(124, 58, 237, 0.14); color: #6d28d9; }
   .mp-card .cat-badge {

--- a/app/web/static/style-custom.css
+++ b/app/web/static/style-custom.css
@@ -91,8 +91,10 @@
     --shadow-card: 0 1px 3px 0 rgba(15, 27, 58, 0.06), 0 1px 2px -1px rgba(15, 27, 58, 0.05);
     --shadow-elevated: 0 8px 24px rgba(15, 27, 58, 0.14);
 
-    /* Focus + interaction */
-    --focus-ring: 0 0 0 3px rgba(46, 168, 119, 0.25);
+    /* Focus + interaction — alpha brand-green below uses color-mix on
+       var(--ds-primary) so it follows the active theme (light/blue/dark);
+       these were hardcoded brand-green rgba() literals (#497 §5). */
+    --focus-ring: 0 0 0 3px color-mix(in srgb, var(--ds-primary) 25%, transparent);
     --transition-fast: 120ms ease;
     --transition-base: 200ms ease;
     --transition-slow: 320ms ease;
@@ -255,7 +257,7 @@ nav {
 
 .btn-primary:hover {
     background-color: var(--ds-primary-dark);
-    box-shadow: 0 2px 8px rgba(46, 168, 119, 0.3);
+    box-shadow: 0 2px 8px color-mix(in srgb, var(--ds-primary) 30%, transparent);
 }
 
 .btn-primary:active {
@@ -1641,7 +1643,7 @@ footer {
 }
 
 .badge-admin-v2 {
-    background: rgba(46, 168, 119, 0.1);
+    background: color-mix(in srgb, var(--ds-primary) 10%, transparent);
     color: var(--primary);
 }
 
@@ -1807,7 +1809,7 @@ footer {
 .flash-info-v2 {
     background: var(--primary-light);
     color: var(--primary);
-    border: 1px solid rgba(46, 168, 119, 0.3);
+    border: 1px solid color-mix(in srgb, var(--ds-primary) 30%, transparent);
 }
 
 /* Footer */
@@ -1945,10 +1947,10 @@ footer {
 
 .category-tag.finance { background: rgba(16, 183, 127, 0.1); color: #0d9668; }
 .category-tag.hr { background: rgba(139, 92, 246, 0.1); color: #7c3aed; }
-.category-tag.sales { background: rgba(46, 168, 119, 0.1); color: var(--primary); }
+.category-tag.sales { background: color-mix(in srgb, var(--ds-primary) 10%, transparent); color: var(--primary); }
 .category-tag.telemetry { background: rgba(245, 159, 10, 0.1); color: #b45309; }
 .category-tag.support { background: rgba(234, 88, 12, 0.1); color: #EA580C; }
-.category-tag.revenue { background: rgba(46, 168, 119, 0.1); color: var(--primary); }
+.category-tag.revenue { background: color-mix(in srgb, var(--ds-primary) 10%, transparent); color: var(--primary); }
 .category-tag.customers { background: rgba(139, 92, 246, 0.1); color: #7c3aed; }
 .category-tag.marketing { background: rgba(245, 159, 10, 0.1); color: #b45309; }
 
@@ -3899,7 +3901,7 @@ a.news-cta:hover { background: #0056A3; }
 .modal-btn.primary:hover {
     background-color: var(--ds-primary-dark);
     border-color: var(--ds-primary-dark);
-    box-shadow: 0 2px 8px rgba(46, 168, 119, 0.3);
+    box-shadow: 0 2px 8px color-mix(in srgb, var(--ds-primary) 30%, transparent);
 }
 
 .btn-secondary {
@@ -4984,9 +4986,9 @@ details.section-card > summary {
     font-family: var(--font-mono);
     font-size: var(--text-sm);
     font-weight: 600;
-    background: rgba(46, 168, 119, 0.10);
+    background: color-mix(in srgb, var(--ds-primary) 10%, transparent);
     color: var(--primary);
-    border: 1px solid rgba(46, 168, 119, 0.25);
+    border: 1px solid color-mix(in srgb, var(--ds-primary) 25%, transparent);
 }
 .role-chip.is-core { background: rgba(16, 185, 129, 0.10); color: #047857; border-color: rgba(16, 185, 129, 0.25); }
 .grant-list, .group-roles-list {
@@ -5024,7 +5026,7 @@ details.section-card > summary {
     color: var(--text-secondary);
     font-weight: 600;
 }
-.grant-row .grant-source.source-direct { background: rgba(46, 168, 119, 0.12); color: var(--primary); }
+.grant-row .grant-source.source-direct { background: color-mix(in srgb, var(--ds-primary) 12%, transparent); color: var(--primary); }
 .grant-row .grant-source.source-auto { background: rgba(245, 158, 11, 0.12); color: #b45309; }
 .grant-row .grant-meta {
     font-size: var(--text-sm);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.61.2"
+version = "0.61.3"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"


### PR DESCRIPTION
Addresses **§5 of #497** — hardcoded brand-green that bypasses the theme tokens.

The brand green (`--ds-primary` = `#2ea877`) was hardcoded as `rgba(46, 168, 119, α)` in **30 spots across 6 static CSS files**, so it didn't follow the `light`/`blue`/`dark` theme switch (each overrides `--ds-primary`).

## Change

Replaced all 30 with `color-mix(in srgb, var(--ds-primary) X%, transparent)`:

| File | instances |
|---|---|
| `style-custom.css` | 10 (focus-ring, btn + modal hover shadows, badge/flash, category-tag, grant-row) |
| `home.css` | 9 |
| `dashboard.css` | 4 |
| `marketplace.css` | 3 (incl. the local `--primary-light` token def) |
| `activity_center.css` | 2 (pulse keyframe) |
| `admin_access.css` | 2 (a two-stop gradient) |

**Why `color-mix`, not an `--ds-primary-rgb` token:** no `-rgb`/`color-mix` precedent existed, and the `blue` theme sets `--ds-primary: var(--primary)` — a literal rgb companion can't express that. `color-mix` keeps one source of truth and follows every theme. It's identical to the old `rgba(...)` in the default theme → **no visual change there**; the win is that dark/blue themes now get themed rings/shadows.

**Edge cases (both keep the green hue):** the `admin_access` two-stop gradient (10%→2%) and the `activity_center` pulse ring (60%→0%). ⚠️ The pulse's `0%` endpoint computes to transparent, so its fade interpolates toward transparent-*black* rather than transparent-green — a subtle theoretical darkening on an expanding shadow ring. Worth a quick visual glance, but I judged it negligible.

**Left intact** (intentional semantic colors, not brand-green bypasses): `--success` (`#10B77F`), `#22c55e` indicators, the `.group-chip.is-google_sync` chip, and the `design-tokens.css` token *definitions* themselves.

**Out of scope / follow-up:** template inline-style greens (`style="…rgba(46,168,119)…"`, dozens of them) — a messier, separate sweep, often entangled with the §2 chrome work.

`color-mix()` is baseline since 2023 (Chrome 111 / FF 113 / Safari 16.2) — fine for an internal admin tool. Draft pending review + CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
