### PR TITLE
Render configured instance logo on the login page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.61.5] — 2026-06-03
+
 ### Added
 - The configured instance logo (`AGNES_INSTANCE_LOGO_SVG` env > `instance.logo_svg` YAML) now renders on the `/login` Sign In card, above the heading — previously the logo only surfaced in the app header. Empty default keeps the OSS vendor-neutral: no logo renders unless an operator sets one.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Added
+- The configured instance logo (`AGNES_INSTANCE_LOGO_SVG` env > `instance.logo_svg` YAML) now renders on the `/login` Sign In card, above the heading — previously the logo only surfaced in the app header. Empty default keeps the OSS vendor-neutral: no logo renders unless an operator sets one.
+
 ## [0.61.0] — 2026-06-03
 
 ### Added

--- a/app/web/static/style-custom.css
+++ b/app/web/static/style-custom.css
@@ -632,6 +632,24 @@ code {
     border: 1px solid var(--border);
 }
 
+/* Operator brand lockup above the Sign In heading. The card has a light
+   `--card-bg`, so a colored wordmark SVG (the typical operator logo) reads
+   well here. Constrain height and let width scale so any aspect ratio fits;
+   `svg { display: block }` drops the inline-baseline gap under the lockup. */
+.login-card-logo {
+    margin-bottom: 24px;
+    display: flex;
+    justify-content: center;
+}
+
+.login-card-logo svg,
+.login-card-logo img {
+    display: block;
+    height: 36px;
+    width: auto;
+    max-width: 100%;
+}
+
 .login-card h2 {
     margin-bottom: 12px;
     font-size: 1.75rem;

--- a/app/web/templates/login.html
+++ b/app/web/templates/login.html
@@ -97,6 +97,14 @@
         <!-- Right: Login Card -->
         <div class="login-card-wrapper">
             <div class="login-card">
+                {# Operator brand lockup. Renders the configured instance logo
+                   (AGNES_INSTANCE_LOGO_SVG env > instance.logo_svg YAML) above
+                   the Sign In heading — same `config.LOGO_SVG` slot the app
+                   header uses. Empty default keeps the OSS vendor-neutral:
+                   no logo renders unless an operator sets one. #}
+                {% if config.LOGO_SVG %}
+                <div class="login-card-logo">{{ config.LOGO_SVG | safe }}</div>
+                {% endif %}
                 <h2>Sign In</h2>
                 <p class="login-description">
                     Access your AI data analysis workspace

--- a/config/instance.yaml.example
+++ b/config/instance.yaml.example
@@ -28,9 +28,9 @@ instance:
                                      # "FoundryAI"). Set explicitly only if you want a folder
                                      # name that differs from the auto-derivation. Env override:
                                      # AGNES_WORKSPACE_DIR_NAME.
-  # logo_svg: |                      # Inline <svg> element rendered into the header brand slot.
+  # logo_svg: |                      # Inline <svg> element rendered into the header brand slot
   #   <svg width="120" height="30" viewBox="0 0 100 30" xmlns="http://www.w3.org/2000/svg">
-  #     <text y="22" font-size="24" fill="#333">Logo</text>
+  #     <text y="22" font-size="24" fill="#333">Logo</text>     # and above the Sign In card on /login.
   #   </svg>
   #                                  # When set, the SVG replaces the text brand in the header.
   #                                  # `name` above still drives browser <title> text and page

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.61.4"
+version = "0.61.5"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/tests/test_web_ui.py
+++ b/tests/test_web_ui.py
@@ -66,6 +66,25 @@ class TestWebUISmoke:
         resp = web_client.get("/login")
         assert resp.status_code == 200
 
+    def test_login_page_has_no_logo_by_default(self, web_client):
+        # Vendor-neutral default: no operator logo configured → the login card
+        # renders no brand lockup, just the text heading.
+        resp = web_client.get("/login")
+        assert resp.status_code == 200
+        assert "login-card-logo" not in resp.text
+
+    def test_login_page_renders_configured_logo(self, web_client, monkeypatch):
+        # When an operator sets AGNES_INSTANCE_LOGO_SVG, the login card renders
+        # it inline above the Sign In heading (same slot the app header uses).
+        monkeypatch.setenv(
+            "AGNES_INSTANCE_LOGO_SVG",
+            '<svg id="brand-mark" xmlns="http://www.w3.org/2000/svg"></svg>',
+        )
+        resp = web_client.get("/login")
+        assert resp.status_code == 200
+        assert "login-card-logo" in resp.text
+        assert 'id="brand-mark"' in resp.text
+
     def test_dashboard(self, web_client, admin_cookie):
         resp = web_client.get("/dashboard", cookies=admin_cookie)
         assert resp.status_code in (200, 302)


### PR DESCRIPTION
## What

The configurable instance logo (`AGNES_INSTANCE_LOGO_SVG` env > `instance.logo_svg` YAML) already renders in the app header via `config.LOGO_SVG`, but the `/login` Sign In page never used it. This wires the same slot into the login card, above the **Sign In** heading.

## Why

Operators who set a brand logo expect it on the first screen users see — the login page — not only after sign-in. This closes that gap with zero new config surface (reuses the existing `config.LOGO_SVG`).

## Vendor-neutral by default

No brand is hardcoded. `get_instance_logo_svg()` defaults to `""`, so out of the box the login card renders exactly as before (text heading, no logo). A logo appears **only** when an operator sets `AGNES_INSTANCE_LOGO_SVG` / `instance.logo_svg` — the same opt-in mechanism the header already uses. The OSS distribution stays white-label.

## Changes

- `app/web/templates/login.html` — render `config.LOGO_SVG` in a `.login-card-logo` slot above the heading, guarded by `{% if config.LOGO_SVG %}`.
- `app/web/static/style-custom.css` — `.login-card-logo` styling (centered, 36px height, width auto). The card's light `--card-bg` reads colored wordmarks well.
- `config/instance.yaml.example` — note that `logo_svg` now also shows on `/login`.
- `tests/test_web_ui.py` — positive (logo present when env set) + negative (no `.login-card-logo` by default) render tests.
- `CHANGELOG.md` — Unreleased bullet.

## Testing

- `tests/test_web_ui.py` login render tests + `test_design_system_contract.py` pass.
- Full suite: 6444 passed. The 5 `-n auto` failures (`test_chat_auto_title`, `test_mcp_http`, `test_cache_warmup`) are pre-existing xdist parallelism flakes (DuckDB lock contention) — they pass serially on a clean `origin/main` and are unrelated to this template/CSS diff.
