### PR TITLE
fix(mcp): close 3 Devin follow-ups from #474 + cross-engine contract tests (release 0.61.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.61.1] — 2026-06-03
+
+### Fixed
+- **`app/api/mcp_http.py:_BASE` no longer reuses `AGNES_BASE_URL` for self-calls.** The MCP HTTP server makes server-side self-calls into Agnes for `catalog` / `schema` / `describe` / `query` / `skills`. Reusing the public-facing `AGNES_BASE_URL` made every tool round-trip through the reverse proxy (added TLS + DNS + proxy latency, broke when the external URL wasn't resolvable from inside the container). The base URL is now read from a dedicated `AGNES_MCP_INTERNAL_URL` env var (default `http://localhost:8000`). Operators running Agnes split across multiple pods can point the var at the in-cluster service URL. (Devin Review on #474.)
+- **`app/api/admin_mcp.py` adopts the `mcp_sources_repo()` / `tool_registry_repo()` factory functions across all 15 handler sites.** Direct `MCPSourceRepository(conn)` / `ToolRegistryRepository(conn)` instantiations skipped the dual-backend factory, so a Postgres-backed (side-car / cloud) deploy was reading MCP source / tool data from the wrong place. The `audit_log` path keeps the conn dependency intact since it's a per-router helper; only the MCP repository constructions were swapped. (Devin Review on #474.)
+
+### Internal
+- **Cross-engine contract tests for the MCP repository pairs.** New `tests/db_pg/test_mcp_sources_contract.py` (11 tests) + `tests/db_pg/test_tool_registry_contract.py` (8 tests) parametrise over `[duckdb, pg]` (sister of `test_data_packages_contract.py`) so DuckDB and Postgres implementations of `mcp_sources` + `tool_registry` upsert / get / get_by_name / list / delete + their validators are exercised against the same call sites. Closes the third Devin Review follow-up on #474 (cross-engine contract tests for the 3 new repository pairs landed by Cowork + MCP); the `setup_tokens` pair (the third) has narrower API surface and is exercised end-to-end through the existing Cowork bundle setup tests.
+
 ## [0.61.0] — 2026-06-03
 
 ### Added

--- a/app/api/admin_mcp.py
+++ b/app/api/admin_mcp.py
@@ -44,12 +44,13 @@ from app.auth.dependencies import _get_db
 from app.secrets_vault import SharedSecretsRepository
 from connectors.mcp import classifier as mcp_classifier
 from connectors.mcp import extractor as mcp_extractor
+from src.repositories import mcp_sources_repo, tool_registry_repo
 from src.repositories.audit import AuditRepository
-from src.repositories.mcp_sources import MCPSourceRepository
+from src.repositories.mcp_sources import MCPSourceRepository  # noqa: F401  # kept for type-only imports + tests that monkeypatch the symbol
 from src.repositories.tool_registry import (
     MATERIALIZE,
     PASSTHROUGH,
-    ToolRegistryRepository,
+    ToolRegistryRepository,  # noqa: F401  # kept for type-only imports + tests that monkeypatch the symbol
 )
 
 logger = logging.getLogger(__name__)
@@ -346,7 +347,7 @@ async def create_mcp_source(
     name = (payload.name or "").strip()
     if not name:
         raise HTTPException(status_code=400, detail="name is required")
-    repo = MCPSourceRepository(conn)
+    repo = mcp_sources_repo()
     if repo.get_by_name(name) is not None:
         raise HTTPException(status_code=409, detail="name_exists")
     source_id = str(uuid.uuid4())
@@ -384,7 +385,7 @@ async def list_mcp_sources(
     user: dict = Depends(require_admin),
     conn: duckdb.DuckDBPyConnection = Depends(_get_db),
 ):
-    repo = MCPSourceRepository(conn)
+    repo = mcp_sources_repo()
     rows = repo.list_all(enabled_only=enabled_only)
     return [_serialize_source(r) for r in rows]
 
@@ -396,11 +397,11 @@ async def get_mcp_source(
     conn: duckdb.DuckDBPyConnection = Depends(_get_db),
 ):
     """Detail view — includes the list of tools registered against this source."""
-    repo = MCPSourceRepository(conn)
+    repo = mcp_sources_repo()
     src = repo.get(source_id)
     if not src:
         raise HTTPException(status_code=404, detail="mcp_source_not_found")
-    tools_repo = ToolRegistryRepository(conn)
+    tools_repo = tool_registry_repo()
     tools = tools_repo.list_for_source(source_id)
     out = _serialize_source(src)
     out["tools"] = [_serialize_tool(t) for t in tools]
@@ -415,7 +416,7 @@ async def update_mcp_source(
     conn: duckdb.DuckDBPyConnection = Depends(_get_db),
 ):
     """Partial update. Audit row carries before/after for the changed fields."""
-    repo = MCPSourceRepository(conn)
+    repo = mcp_sources_repo()
     existing = repo.get(source_id)
     if not existing:
         raise HTTPException(status_code=404, detail="mcp_source_not_found")
@@ -457,11 +458,11 @@ async def delete_mcp_source(
     """Hard delete — cascades to ``tool_registry`` + ``tool_grants`` for this
     source via :py:meth:`ToolRegistryRepository.delete_for_source` (which
     deletes grants per tool before the registry row)."""
-    src_repo = MCPSourceRepository(conn)
+    src_repo = mcp_sources_repo()
     existing = src_repo.get(source_id)
     if not existing:
         raise HTTPException(status_code=404, detail="mcp_source_not_found")
-    tool_repo = ToolRegistryRepository(conn)
+    tool_repo = tool_registry_repo()
     tool_count = len(tool_repo.list_for_source(source_id))
     tool_repo.delete_for_source(source_id)
     src_repo.delete(source_id)
@@ -498,7 +499,7 @@ async def set_mcp_source_secret(
     ``auth_secret_env`` lookup if the vault has no row, so an operator
     can roll out the vault without a flag-day rewrite of source rows.
     """
-    src_repo = MCPSourceRepository(conn)
+    src_repo = mcp_sources_repo()
     if not src_repo.get(source_id):
         raise HTTPException(status_code=404, detail="mcp_source_not_found")
     if not body.value:
@@ -518,7 +519,7 @@ async def delete_mcp_source_secret(
 ):
     """Drop the vault row for ``source_id``. Source then falls back to
     its ``auth_secret_env`` env-var, or to anonymous if neither is set."""
-    src_repo = MCPSourceRepository(conn)
+    src_repo = mcp_sources_repo()
     if not src_repo.get(source_id):
         raise HTTPException(status_code=404, detail="mcp_source_not_found")
     SharedSecretsRepository(conn).delete(source_id)
@@ -540,7 +541,7 @@ async def introspect_mcp_source(
     conn: duckdb.DuckDBPyConnection = Depends(_get_db),
 ):
     """Live-connect to the source and list its tools verbatim."""
-    src_repo = MCPSourceRepository(conn)
+    src_repo = mcp_sources_repo()
     src = src_repo.get(source_id)
     if not src:
         raise HTTPException(status_code=404, detail="mcp_source_not_found")
@@ -570,7 +571,7 @@ async def classify_mcp_source(
     conn: duckdb.DuckDBPyConnection = Depends(_get_db),
 ):
     """Introspect + run heuristic classifier; return per-tool proposals."""
-    src_repo = MCPSourceRepository(conn)
+    src_repo = mcp_sources_repo()
     src = src_repo.get(source_id)
     if not src:
         raise HTTPException(status_code=404, detail="mcp_source_not_found")
@@ -612,7 +613,7 @@ async def test_mcp_source(
 ):
     """Lightweight connectivity probe. Returns ``{ok, tool_count, error}``;
     HTTP 200 even on connect failure so the UI can render the diagnostic."""
-    src_repo = MCPSourceRepository(conn)
+    src_repo = mcp_sources_repo()
     src = src_repo.get(source_id)
     if not src:
         raise HTTPException(status_code=404, detail="mcp_source_not_found")
@@ -644,7 +645,7 @@ async def materialize_mcp_source(
     Returns the extractor's summary dict (source_name, extract_duckdb path,
     tables, errors). Use the SyncOrchestrator's next rebuild to attach.
     """
-    src_repo = MCPSourceRepository(conn)
+    src_repo = mcp_sources_repo()
     src = src_repo.get(source_id)
     if not src:
         raise HTTPException(status_code=404, detail="mcp_source_not_found")
@@ -697,11 +698,11 @@ async def create_mcp_tool(
     The repo enforces mode-specific rules (e.g. materialize requires
     ``schedule``); we surface those as 400s.
     """
-    src_repo = MCPSourceRepository(conn)
+    src_repo = mcp_sources_repo()
     if not src_repo.get(payload.source_id):
         raise HTTPException(status_code=404, detail="mcp_source_not_found")
     tool_id = payload.tool_id or str(uuid.uuid4())
-    repo = ToolRegistryRepository(conn)
+    repo = tool_registry_repo()
     if repo.get(tool_id) is not None:
         raise HTTPException(status_code=409, detail="tool_id_exists")
     try:
@@ -745,7 +746,7 @@ async def list_mcp_tools(
     conn: duckdb.DuckDBPyConnection = Depends(_get_db),
 ):
     """List all tools, optionally restricted to one source."""
-    repo = ToolRegistryRepository(conn)
+    repo = tool_registry_repo()
     rows = repo.list_for_source(source_id) if source_id else repo.list_all()
     return [_serialize_tool(r) for r in rows]
 
@@ -757,7 +758,7 @@ async def get_mcp_tool(
     conn: duckdb.DuckDBPyConnection = Depends(_get_db),
 ):
     """Detail view — includes the list of group_ids granted access."""
-    repo = ToolRegistryRepository(conn)
+    repo = tool_registry_repo()
     row = repo.get(tool_id)
     if not row:
         raise HTTPException(status_code=404, detail="mcp_tool_not_found")
@@ -774,14 +775,14 @@ async def update_mcp_tool(
     conn: duckdb.DuckDBPyConnection = Depends(_get_db),
 ):
     """Partial update. Audit row carries before/after for changed fields."""
-    repo = ToolRegistryRepository(conn)
+    repo = tool_registry_repo()
     existing = repo.get(tool_id)
     if not existing:
         raise HTTPException(status_code=404, detail="mcp_tool_not_found")
 
     # If source_id is being changed, validate the new source exists.
     if payload.source_id and payload.source_id != existing.get("source_id"):
-        if not MCPSourceRepository(conn).get(payload.source_id):
+        if not mcp_sources_repo().get(payload.source_id):
             raise HTTPException(status_code=404, detail="mcp_source_not_found")
 
     merged = _merge_tool_patch(existing, payload)
@@ -818,7 +819,7 @@ async def delete_mcp_tool(
     conn: duckdb.DuckDBPyConnection = Depends(_get_db),
 ):
     """Hard delete — cascades grants via the repo."""
-    repo = ToolRegistryRepository(conn)
+    repo = tool_registry_repo()
     existing = repo.get(tool_id)
     if not existing:
         raise HTTPException(status_code=404, detail="mcp_tool_not_found")
@@ -850,7 +851,7 @@ async def add_mcp_tool_grant(
     conn: duckdb.DuckDBPyConnection = Depends(_get_db),
 ):
     """Grant a user group access to the tool. Idempotent (ON CONFLICT DO NOTHING)."""
-    repo = ToolRegistryRepository(conn)
+    repo = tool_registry_repo()
     if not repo.get(tool_id):
         raise HTTPException(status_code=404, detail="mcp_tool_not_found")
     group_id = (payload.group_id or "").strip()
@@ -884,7 +885,7 @@ async def remove_mcp_tool_grant(
     conn: duckdb.DuckDBPyConnection = Depends(_get_db),
 ):
     """Revoke a group grant. Idempotent (DELETE missing row is a no-op)."""
-    repo = ToolRegistryRepository(conn)
+    repo = tool_registry_repo()
     if not repo.get(tool_id):
         raise HTTPException(status_code=404, detail="mcp_tool_not_found")
     repo.remove_grant(tool_id, group_id)

--- a/app/api/mcp_http.py
+++ b/app/api/mcp_http.py
@@ -38,7 +38,20 @@ _current_token: contextvars.ContextVar[str] = contextvars.ContextVar(
 
 # Internal base URL for self-calls. Stays on HTTP/localhost since the MCP
 # server runs inside the same process/container as Agnes.
-_BASE = os.environ.get("AGNES_BASE_URL", "http://localhost:8000").rstrip("/")
+#
+# Devin Review on #474 flagged that reusing ``AGNES_BASE_URL`` (the
+# public-facing hostname operators set so Cowork VMs can reach Agnes)
+# made every self-call here round-trip through the public proxy
+# (TLS + reverse-proxy + DNS), adding latency and breaking when the
+# external URL isn't resolvable from inside the container (e.g. when
+# the reverse proxy is air-gapped from internal traffic). Use a
+# dedicated ``AGNES_MCP_INTERNAL_URL`` instead, defaulting to
+# ``http://localhost:8000`` — the right shape for self-calls in the
+# single-container deploy. Operators running Agnes split across
+# multiple pods can point this at the in-cluster service URL.
+_BASE = os.environ.get(
+    "AGNES_MCP_INTERNAL_URL", "http://localhost:8000"
+).rstrip("/")
 
 mcp = FastMCP(
     "Agnes",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.61.0"
+version = "0.61.1"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/tests/db_pg/test_mcp_sources_contract.py
+++ b/tests/db_pg/test_mcp_sources_contract.py
@@ -1,0 +1,167 @@
+"""Cross-engine contract tests for the ``mcp_sources`` repository.
+
+Parametrises over [DuckDB impl, Postgres impl]. The same calls go to
+both; the same return shapes must come back. Any divergence is a bug in
+whichever side is wrong.
+
+Follows the pattern established in ``test_data_packages_contract.py``.
+Closes the Devin Review follow-up on PR #474 (cross-engine contract
+tests missing for the 3 new repository pairs landed by Cowork + MCP).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# repo construction helpers — one per backend
+# ---------------------------------------------------------------------------
+
+def _make_duckdb_repo(tmp_path):
+    # Route through `_open_duckdb` (rather than bare `duckdb.connect`) so
+    # the session timezone is pinned to UTC — keeps `tests/db_pg/`'s
+    # `test_no_bare_duckdb_connect_in_production_code` regression guard
+    # green on new files. (The guard's allowlist intentionally only
+    # covers tests that predate the `_open_duckdb` rollout; new ones
+    # must funnel through the helper.)
+    from src.db import _ensure_schema
+    from src.duckdb_conn import _open_duckdb
+    from src.repositories.mcp_sources import MCPSourceRepository
+
+    conn = _open_duckdb(str(tmp_path / "duck.duckdb"))
+    _ensure_schema(conn)
+    return MCPSourceRepository(conn), conn
+
+
+def _make_pg_repo(pg_engine, monkeypatch):
+    """Run migrations on the per-test PG engine, then return a PG repo."""
+    from alembic import command
+    from alembic.config import Config
+
+    cfg = Config(str(REPO_ROOT / "alembic.ini"))
+    cfg.set_main_option("script_location", str(REPO_ROOT / "migrations"))
+    cfg.attributes["sqlalchemy.url"] = str(pg_engine.url)
+    command.upgrade(cfg, "head")
+
+    monkeypatch.setenv("AGNES_DB_URL", str(pg_engine.url))
+    import src.db_pg as db_pg
+    db_pg.dispose()
+    db_pg.get_engine()
+
+    from src.repositories.mcp_sources_pg import MCPSourcePgRepository
+    return MCPSourcePgRepository(db_pg.get_engine()), None
+
+
+@pytest.fixture(params=["duckdb", "pg"])
+def repo(request, tmp_path, pg_engine, monkeypatch):
+    """Yields an ``mcp_sources`` repo bound to either DuckDB or PG."""
+    backend = request.param
+    if backend == "duckdb":
+        repo, conn = _make_duckdb_repo(tmp_path)
+        yield repo
+        if conn is not None:
+            conn.close()
+    else:
+        repo, _ = _make_pg_repo(pg_engine, monkeypatch)
+        yield repo
+
+
+# ---------------------------------------------------------------------------
+# contract tests — same calls, same answers from both engines
+# ---------------------------------------------------------------------------
+
+def test_upsert_then_get_returns_same_shape(repo):
+    repo.upsert(
+        id="s1", name="filesystem", transport="stdio",
+        command="npx", args=["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+        enabled=True,
+    )
+    row = repo.get("s1")
+    assert row is not None
+    assert row["id"] == "s1"
+    assert row["name"] == "filesystem"
+    assert row["transport"] == "stdio"
+    assert row["command"] == "npx"
+    # args is JSON on the wire but the repo returns a list on both backends
+    assert row["args"] == ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+    assert row["enabled"] is True
+    assert row["scope"] == "shared"
+
+
+def test_upsert_replaces_existing_row(repo):
+    repo.upsert(id="s1", name="x", transport="http", url="https://a.example/mcp")
+    repo.upsert(id="s1", name="x", transport="http", url="https://b.example/mcp", enabled=False)
+    row = repo.get("s1")
+    assert row is not None
+    assert row["url"] == "https://b.example/mcp"
+    assert row["enabled"] is False
+
+
+def test_get_returns_none_for_missing_id(repo):
+    assert repo.get("not-here") is None
+
+
+def test_get_by_name_resolves_and_returns_none_when_missing(repo):
+    repo.upsert(id="s1", name="weather", transport="stdio", command="weather-mcp")
+    found = repo.get_by_name("weather")
+    assert found is not None
+    assert found["id"] == "s1"
+    assert repo.get_by_name("does-not-exist") is None
+
+
+def test_list_all_orders_and_filters_enabled_only(repo):
+    repo.upsert(id="s1", name="a", transport="stdio", command="a-mcp", enabled=True)
+    repo.upsert(id="s2", name="b", transport="stdio", command="b-mcp", enabled=False)
+    repo.upsert(id="s3", name="c", transport="stdio", command="c-mcp", enabled=True)
+
+    # Both backends must return the same set when enabled_only=False
+    all_ids = {r["id"] for r in repo.list_all(enabled_only=False)}
+    assert all_ids == {"s1", "s2", "s3"}
+
+    # And the same filtered set when enabled_only=True
+    enabled_ids = {r["id"] for r in repo.list_all(enabled_only=True)}
+    assert enabled_ids == {"s1", "s3"}
+
+
+def test_delete_removes_row(repo):
+    repo.upsert(id="s1", name="x", transport="stdio", command="x-mcp")
+    assert repo.get("s1") is not None
+    repo.delete("s1")
+    assert repo.get("s1") is None
+
+
+def test_delete_missing_id_is_idempotent(repo):
+    """Both backends must treat delete-of-nonexistent as a no-op (no raise)."""
+    repo.delete("never-existed")
+    # And a real row alongside it still works
+    repo.upsert(id="s1", name="x", transport="stdio", command="x-mcp")
+    repo.delete("s1")
+    assert repo.get("s1") is None
+
+
+def test_transport_validation_is_consistent(repo):
+    """Both backends must reject bad transport with the same shape (ValueError)."""
+    with pytest.raises(ValueError):
+        repo.upsert(id="s1", name="x", transport="grpc", command="x")
+
+
+def test_scope_validation_is_consistent(repo):
+    with pytest.raises(ValueError):
+        repo.upsert(
+            id="s1", name="x", transport="stdio", command="x",
+            scope="weird-scope",  # type: ignore[arg-type]
+        )
+
+
+def test_stdio_without_command_rejected(repo):
+    with pytest.raises(ValueError):
+        repo.upsert(id="s1", name="x", transport="stdio")
+
+
+def test_http_without_url_rejected(repo):
+    with pytest.raises(ValueError):
+        repo.upsert(id="s1", name="x", transport="http")

--- a/tests/db_pg/test_tool_registry_contract.py
+++ b/tests/db_pg/test_tool_registry_contract.py
@@ -1,0 +1,197 @@
+"""Cross-engine contract tests for the ``tool_registry`` repository.
+
+Parametrises over [DuckDB impl, Postgres impl]. The same calls go to
+both; the same return shapes must come back.
+
+Sister of ``test_mcp_sources_contract.py`` — closes the second half of
+the Devin Review follow-up on PR #474 (cross-engine contract tests for
+the MCP repository pairs).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# repo construction helpers — one per backend
+# ---------------------------------------------------------------------------
+
+def _seed_source_duckdb(conn) -> None:
+    from src.repositories.mcp_sources import MCPSourceRepository
+    src_repo = MCPSourceRepository(conn)
+    src_repo.upsert(
+        id="src1", name="filesystem", transport="stdio", command="fs-mcp",
+    )
+
+
+def _seed_source_pg(engine) -> None:
+    from src.repositories.mcp_sources_pg import MCPSourcePgRepository
+    src_repo = MCPSourcePgRepository(engine)
+    src_repo.upsert(
+        id="src1", name="filesystem", transport="stdio", command="fs-mcp",
+    )
+
+
+def _make_duckdb_repo(tmp_path):
+    # Route through `_open_duckdb` (rather than bare `duckdb.connect`)
+    # so the session timezone is pinned to UTC — same rationale as in
+    # `test_mcp_sources_contract.py::_make_duckdb_repo`.
+    from src.db import _ensure_schema
+    from src.duckdb_conn import _open_duckdb
+    from src.repositories.tool_registry import ToolRegistryRepository
+
+    conn = _open_duckdb(str(tmp_path / "duck.duckdb"))
+    _ensure_schema(conn)
+    _seed_source_duckdb(conn)
+    return ToolRegistryRepository(conn), conn
+
+
+def _make_pg_repo(pg_engine, monkeypatch):
+    from alembic import command
+    from alembic.config import Config
+
+    cfg = Config(str(REPO_ROOT / "alembic.ini"))
+    cfg.set_main_option("script_location", str(REPO_ROOT / "migrations"))
+    cfg.attributes["sqlalchemy.url"] = str(pg_engine.url)
+    command.upgrade(cfg, "head")
+
+    monkeypatch.setenv("AGNES_DB_URL", str(pg_engine.url))
+    import src.db_pg as db_pg
+    db_pg.dispose()
+    db_pg.get_engine()
+
+    _seed_source_pg(db_pg.get_engine())
+
+    from src.repositories.tool_registry_pg import ToolRegistryPgRepository
+    return ToolRegistryPgRepository(db_pg.get_engine()), None
+
+
+@pytest.fixture(params=["duckdb", "pg"])
+def repo(request, tmp_path, pg_engine, monkeypatch):
+    """Yields a ``tool_registry`` repo bound to either DuckDB or PG."""
+    backend = request.param
+    if backend == "duckdb":
+        repo, conn = _make_duckdb_repo(tmp_path)
+        yield repo
+        if conn is not None:
+            conn.close()
+    else:
+        repo, _ = _make_pg_repo(pg_engine, monkeypatch)
+        yield repo
+
+
+# ---------------------------------------------------------------------------
+# contract tests — same calls, same answers from both engines
+# ---------------------------------------------------------------------------
+
+def test_upsert_then_get_returns_same_shape(repo):
+    from src.repositories.tool_registry import PASSTHROUGH
+
+    repo.upsert(
+        tool_id="t1", source_id="src1",
+        original_name="read_file", exposed_name="filesystem__read_file",
+        mode=PASSTHROUGH,
+        input_schema={"type": "object", "properties": {"path": {"type": "string"}}, "required": ["path"]},
+        description="Read a file from the configured root.",
+        enabled=True,
+    )
+    row = repo.get("t1")
+    assert row is not None
+    assert row["tool_id"] == "t1"
+    assert row["source_id"] == "src1"
+    assert row["original_name"] == "read_file"
+    assert row["exposed_name"] == "filesystem__read_file"
+    assert row["mode"] == PASSTHROUGH
+    # JSON-on-wire / dict-in-app contract must hold on both backends
+    assert row["input_schema"]["required"] == ["path"]
+    assert row["enabled"] is True
+
+
+def test_upsert_replaces_existing_row(repo):
+    from src.repositories.tool_registry import PASSTHROUGH
+
+    repo.upsert(
+        tool_id="t1", source_id="src1",
+        original_name="read_file", exposed_name="orig_name",
+        mode=PASSTHROUGH,
+    )
+    repo.upsert(
+        tool_id="t1", source_id="src1",
+        original_name="read_file", exposed_name="new_name",
+        mode=PASSTHROUGH,
+        description="updated",
+    )
+    row = repo.get("t1")
+    assert row is not None
+    assert row["exposed_name"] == "new_name"
+    assert row["description"] == "updated"
+
+
+def test_get_returns_none_for_missing_id(repo):
+    assert repo.get("not-here") is None
+
+
+def test_list_for_source_filters_and_excludes_other_sources(repo):
+    from src.repositories.mcp_sources import MCPSourceRepository
+    from src.repositories.tool_registry import PASSTHROUGH
+
+    # Seed a second source on whichever backend the parametrized repo is bound to.
+    # The two impls use different private attrs (`conn` for DuckDB,
+    # `_engine` for PG); branch on which one is present rather than
+    # name-mangling either.
+    if hasattr(repo, "conn"):
+        # DuckDB path
+        MCPSourceRepository(repo.conn).upsert(
+            id="src2", name="other", transport="stdio", command="other-mcp",
+        )
+    else:
+        # PG path — pull the engine off the private attr
+        from src.repositories.mcp_sources_pg import MCPSourcePgRepository
+        MCPSourcePgRepository(repo._engine).upsert(
+            id="src2", name="other", transport="stdio", command="other-mcp",
+        )
+
+    repo.upsert(tool_id="t1", source_id="src1", original_name="a", exposed_name="a", mode=PASSTHROUGH)
+    repo.upsert(tool_id="t2", source_id="src1", original_name="b", exposed_name="b", mode=PASSTHROUGH)
+    repo.upsert(tool_id="t3", source_id="src2", original_name="c", exposed_name="c", mode=PASSTHROUGH)
+
+    src1_ids = {r["tool_id"] for r in repo.list_for_source("src1")}
+    src2_ids = {r["tool_id"] for r in repo.list_for_source("src2")}
+    assert src1_ids == {"t1", "t2"}
+    assert src2_ids == {"t3"}
+
+
+def test_delete_removes_row(repo):
+    from src.repositories.tool_registry import PASSTHROUGH
+
+    repo.upsert(tool_id="t1", source_id="src1", original_name="x", exposed_name="x", mode=PASSTHROUGH)
+    assert repo.get("t1") is not None
+    repo.delete("t1")
+    assert repo.get("t1") is None
+
+
+def test_delete_missing_id_is_idempotent(repo):
+    """Both backends must treat delete-of-nonexistent as a no-op (no raise)."""
+    repo.delete("never-existed")
+
+
+def test_mode_validation_is_consistent(repo):
+    with pytest.raises(ValueError):
+        repo.upsert(
+            tool_id="t1", source_id="src1",
+            original_name="x", exposed_name="x", mode="unknown_mode",
+        )
+
+
+def test_materialize_without_schedule_rejected(repo):
+    from src.repositories.tool_registry import MATERIALIZE
+    with pytest.raises(ValueError):
+        repo.upsert(
+            tool_id="t1", source_id="src1",
+            original_name="x", exposed_name="x", mode=MATERIALIZE,
+            # missing schedule
+        )


### PR DESCRIPTION
## Why

PR #474 (Cowork + Universal MCP, v0.58.0) left three Devin 🚩 findings open. I noted them as "tracked for 0.58.1" in the merge commit body and then never returned — v0.58.1 cut something else (e2e-nightly JWT, closes #487). This PR finally lands them.

## Findings closed

### 1. `app/api/mcp_http.py:41` — `_BASE` self-call loops through public proxy

The MCP HTTP server's tools (`server_info`, `catalog`, `schema`, `describe`, `query`, `skills`) make server-side self-calls back into Agnes. They read `_BASE` from `AGNES_BASE_URL` — but that env var is the operator's public-facing hostname (set so Cowork VMs can reach Agnes). Every tool call round-tripped through the reverse proxy: TLS handshake + DNS + reverse-proxy + back. Plus broke entirely on deployments where the external URL isn't resolvable from inside the container.

`_BASE` now reads a dedicated `AGNES_MCP_INTERNAL_URL` env var, default `http://localhost:8000` (the right shape for single-container deploys). Operators running Agnes split across multiple pods can point this at the in-cluster service URL.

### 2. `app/api/admin_mcp.py` — 15 sites of DuckDB-only repo instantiation

Every `MCPSourceRepository(conn)` / `ToolRegistryRepository(conn)` direct constructor skipped the `mcp_sources_repo()` / `tool_registry_repo()` factory functions. On a Postgres-backed (side-car / cloud) deploy, the admin endpoints were reading MCP source / tool data from the wrong place. 15 sites swapped to factory calls. `_audit(conn, …)` keeps its conn dependency since that's a per-router helper.

### 3. Cross-engine contract tests for the MCP repository pairs (CLAUDE.md dual-backend rule)

New `tests/db_pg/test_mcp_sources_contract.py` (11 tests) + `tests/db_pg/test_tool_registry_contract.py` (8 tests), sister of the existing `test_data_packages_contract.py`. Parametrise over `[duckdb, pg]`, exercising upsert / get / get_by_name / list / delete + their validators against both backends. 19 contract tests in total.

The `setup_tokens` pair (the third new repository pair from #474) has a narrower API and is already exercised end-to-end through the existing Cowork bundle setup tests, so it's not in this batch.

## Release-cut

0.61.1 (patch). No behaviour change in default Docker single-container deployments; no API surface change. Operators who explicitly set `AGNES_BASE_URL` and depended on the MCP HTTP server using that for self-calls will need to switch to the new `AGNES_MCP_INTERNAL_URL` env var — but that path was buggy anyway (the loopback Devin flagged).

## Tests

31 admin_mcp + mcp_http + passthrough tests pass locally. 19 new contract tests pass on DuckDB path (PG path runs in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->