### PR TITLE
fix(marketplace): My Stack 500 on Postgres — PG list_for_user missing enriched columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   stale DuckDB row, leaving the setup panel visible forever regardless of
   reloads or cache. `/home` now reads `onboarded` through `users_repo()` so
   the read and write share the active backend.
+- Marketplace **My Stack** tab returned HTTP 500 on the Postgres state backend — the `user_store_installs` PG repo's `list_for_user` omitted `title` / `tagline` / `synthetic_name` from its SELECT, which the flea-card builder (`_flea_to_item`) reads directly (`entity["synthetic_name"]` → `KeyError`). Brought the PG projection to parity with the DuckDB repo and added a cross-engine contract test.
 
 ## [0.61.5] — 2026-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.61.6] — 2026-06-03
+
 ### Fixed
 - `/home` "Mark me as onboarded" (and `agnes init`) now takes effect on a
   Postgres-backed instance. The route read `users.onboarded` with a raw
@@ -18,8 +20,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   SIDE_CAR instance the flag was written to Postgres but read back from the
   stale DuckDB row, leaving the setup panel visible forever regardless of
   reloads or cache. `/home` now reads `onboarded` through `users_repo()` so
-  the read and write share the active backend.
-- Marketplace **My Stack** tab returned HTTP 500 on the Postgres state backend — the `user_store_installs` PG repo's `list_for_user` omitted `title` / `tagline` / `synthetic_name` from its SELECT, which the flea-card builder (`_flea_to_item`) reads directly (`entity["synthetic_name"]` → `KeyError`). Brought the PG projection to parity with the DuckDB repo and added a cross-engine contract test.
+  the read and write share the active backend. (#518)
+- Marketplace **My Stack** tab returned HTTP 500 on the Postgres state backend — the `user_store_installs` PG repo's `list_for_user` omitted `title` / `tagline` / `synthetic_name` from its SELECT, which the flea-card builder (`_flea_to_item`) reads directly (`entity["synthetic_name"]` → `KeyError`). Brought the PG projection to parity with the DuckDB repo and added a cross-engine contract test. (#517)
 
 ## [0.61.5] — 2026-06-03
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.61.5"
+version = "0.61.6"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/src/repositories/user_store_installs_pg.py
+++ b/src/repositories/user_store_installs_pg.py
@@ -48,6 +48,7 @@ class UserStoreInstallsPgRepository:
                            se.photo_path, se.video_url, se.file_size,
                            se.install_count, se.created_at, se.updated_at,
                            se.visibility_status,
+                           se.title, se.tagline, se.synthetic_name,
                            usi.installed_at
                        FROM user_store_installs usi
                        JOIN store_entities se ON se.id = usi.entity_id

--- a/tests/db_pg/test_store_contract.py
+++ b/tests/db_pg/test_store_contract.py
@@ -182,6 +182,21 @@ def test_uninstall_removes_row(store_repos):
     assert removed2 is False
 
 
+def test_list_for_user_returns_enriched_columns(store_repos):
+    """list_for_user must surface title/tagline/synthetic_name on BOTH
+    backends — _flea_to_item reads entity['synthetic_name'] directly
+    (KeyError → marketplace My Stack 500 otherwise)."""
+    repos, _, _ = store_repos
+    repos["users"].create(id="user-1", email="alice@x.com", name="Alice")
+    _make_entity(repos["entities"], visibility_status="approved")
+    repos["installs"].install("user-1", "entity-1")
+
+    rows = repos["installs"].list_for_user("user-1")
+    assert len(rows) == 1
+    for key in ("synthetic_name", "title", "tagline"):
+        assert key in rows[0], f"missing {key}"
+
+
 def test_submission_lifecycle_pending_to_approved(store_repos):
     """create → status='pending_llm' → update_status to 'approved' → get reflects it."""
     repos, _, _ = store_repos


### PR DESCRIPTION
## Problem

On Postgres state-backend deploys (`use_pg() == True`), the Marketplace **My Stack** tab (`/marketplace?tab=my`) renders no cards — the category facet chips show non-zero counts, but the grid is empty and the tab badge reads `0`.

Root cause, confirmed empirically on a live PG deploy:

- `GET /api/marketplace/items?tab=my` returns **HTTP 500**. The frontend `fetchOne()` swallows it (`catch → {items:[], total:0}`), so the grid falls to its empty state and the badge shows 0.
- Traceback:
  ```
  app/api/marketplace.py:1180  list_items → _flea_to_item(...)
  app/api/marketplace.py:826   invocation = entity["synthetic_name"]
  KeyError: 'synthetic_name'
  ```

The DuckDB repo `src/repositories/user_store_installs.py:list_for_user` selects `se.title, se.tagline, se.synthetic_name`; the Postgres sibling `user_store_installs_pg.py:list_for_user` **omitted all three**. `_flea_to_item` reads `entity["synthetic_name"]` directly (intentional — the column is NOT NULL), so on PG it raised `KeyError`. `title`/`tagline` are read with `.get()` and so degraded silently (missing My Stack card display name / tagline on PG). The `categories?tab=my` endpoint survived because it reads the same rows via `.get()` only.

This is the dual-backend parity drift class CLAUDE.md warns about; mirrors the #474 PG-parity fixes.

## Change

- **`src/repositories/user_store_installs_pg.py`** — add `se.title, se.tagline, se.synthetic_name` to the `list_for_user` SELECT, bringing the PG projection to parity with DuckDB.
- **`tests/db_pg/test_store_contract.py`** — new `test_list_for_user_returns_enriched_columns`, parametrized over `[duckdb, pg]`, asserting the enriched columns surface on both backends (would have caught this drift).
- **`CHANGELOG.md`** — `Fixed` bullet under `[Unreleased]`.

## Verification

- Fixed SELECT validated directly against a live Postgres deploy: returns `synthetic_name` (`xlsx-by-c-marustamyan`), `title`, `tagline` — the exact rows that were crashing — with no error.
- ⚠️ Full local test suite **not run** in this environment (no `.venv` / `sqlalchemy` available locally); the contract test runs in CI against the PG fixture. Please confirm CI green before merge.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->