### PR TITLE
fix(web): /home reads onboarded via repo factory (works on Postgres backend)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Fixed
+- `/home` "Mark me as onboarded" (and `agnes init`) now takes effect on a
+  Postgres-backed instance. The route read `users.onboarded` with a raw
+  `conn.execute` against DuckDB while `POST /api/me/onboarded` writes through
+  the backend-aware `users_repo()` — so on a `db-state-machine` CLOUD /
+  SIDE_CAR instance the flag was written to Postgres but read back from the
+  stale DuckDB row, leaving the setup panel visible forever regardless of
+  reloads or cache. `/home` now reads `onboarded` through `users_repo()` so
+  the read and write share the active backend.
+
 ## [0.61.5] — 2026-06-03
 
 ### Added

--- a/app/web/router.py
+++ b/app/web/router.py
@@ -764,10 +764,16 @@ async def home_page(
 
     See origin: docs/brainstorms/home-page-requirements.md.
     """
-    row = conn.execute(
-        "SELECT onboarded FROM users WHERE id = ?", [user["id"]]
-    ).fetchone()
-    onboarded = bool(row[0]) if row else False
+    # Read onboarded through the backend-aware repo factory, NOT the raw
+    # `conn` (which is always DuckDB via `_get_db`). On a Postgres-backed
+    # instance the source of truth is Postgres: POST /api/me/onboarded
+    # writes there via `users_repo()`, but a raw DuckDB read here returns the
+    # stale pre-migration value — so the "Mark me as onboarded" button (and
+    # `agnes init`) would flip the flag in Postgres yet /home keeps rendering
+    # the setup view forever. Routing the read through `users_repo()` keeps
+    # write and read on the same backend.
+    urow = users_repo().get_by_id(user["id"])
+    onboarded = bool(urow.get("onboarded")) if urow else False
 
     # Pull the latest published news intro for the bottom-of-page section.
     # Template renders the section only when intro is non-empty, so an

--- a/tests/test_web_home_page.py
+++ b/tests/test_web_home_page.py
@@ -290,6 +290,48 @@ def test_home_no_auto_transition_after_post_until_reload(fresh_db):
     assert 'class="install-block"' not in post.text
 
 
+def test_home_reads_onboarded_through_repo_factory_not_raw_duckdb(fresh_db, monkeypatch):
+    """/home must read `onboarded` through `users_repo()`, not a raw
+    `conn.execute` against DuckDB.
+
+    Regression: on a Postgres-backed instance (db-state-machine CLOUD /
+    SIDE_CAR state) POST /api/me/onboarded writes the flag to Postgres via
+    `users_repo()`, but /home was reading it back with a raw DuckDB query
+    on the request `conn`. The DuckDB row stays frozen at its pre-migration
+    value, so the "Mark me as onboarded" button flips Postgres yet /home
+    renders the setup view forever — independent of any browser cache.
+
+    Simulate the split without a live Postgres: the DuckDB row says
+    onboarded=FALSE, but the repo factory reports TRUE (the real backend).
+    /home must honor the repo (show the nav hub), proving it no longer
+    reads the stale raw-DuckDB value."""
+    from src.db import get_system_db, close_system_db
+
+    conn = get_system_db()
+    try:
+        uid, sess = _make_user_and_session(conn, onboarded=False)
+    finally:
+        conn.close()
+        close_system_db()
+
+    import app.web.router as router
+
+    class _FakeUsersRepo:
+        def get_by_id(self, user_id):
+            # Mirrors the active (e.g. Postgres) backend's truth, which
+            # diverges from the stale DuckDB row.
+            return {"id": user_id, "email": "u@example.com", "onboarded": True}
+
+    monkeypatch.setattr(router, "users_repo", lambda: _FakeUsersRepo())
+
+    resp = _client().get("/home", cookies={"access_token": sess})
+    assert resp.status_code == 200
+    # Honors the repo (onboarded=True) → nav-hub view, not the stale
+    # DuckDB FALSE → setup view.
+    assert_element(resp.text, "div", class_="offboard-strip")
+    assert 'class="install-block"' not in resp.text
+
+
 # ── GWS Email-admin button render tests (admin_email knob coverage) ────────
 
 


### PR DESCRIPTION
## Problem

On a Postgres-backed instance, `/home`'s "Mark me as onboarded" button (and the hero X-close, and `agnes init`) appears to do nothing: the page reloads but the setup panel never hides — regardless of reload, hard refresh, or cache state.

## Root cause

Backend split between the write and the read:

- `POST /api/me/onboarded` writes `users.onboarded` through the **backend-aware** `users_repo()` factory.
- `app/web/router.py::home_page` read it back with a **raw `conn.execute("SELECT onboarded …")`** against `conn = Depends(_get_db)` — which is **always DuckDB**.

On a `db-state-machine` **CLOUD / SIDE_CAR (Postgres)** instance (`use_pg() == True`), the write lands in Postgres but `/home` reads the stale pre-migration DuckDB row. The flag flips in Postgres while `/home` renders the setup view forever. On a plain DuckDB instance both sides hit the same DB, so it works — which is why it reproduced on a deployed Postgres box but not on a local dev server.

### Verified on the live instance

On the affected box (`use_pg()=True`, backend = CLOUD Postgres):
- `users_repo().get_by_email(...)` → `onboarded=True`, `updated_at` = today (the button POSTs **were** persisting, to Postgres).
- The DuckDB `users` row → `onboarded=False`, `updated_at` months stale.

Not a frontend bug (the link and the X + confirm-modal paths both hide the panel correctly in a browser) and not a cache bug (hard refresh doesn't help — the server genuinely returns the stale DuckDB value).

## Fix

`/home` reads `onboarded` through `users_repo().get_by_id(...)`, so the read and the write share the active backend.

## Test

`test_home_reads_onboarded_through_repo_factory_not_raw_duckdb` simulates the split without a live Postgres: the DuckDB row says `onboarded=False` while the repo factory reports `True` (the real backend); `/home` must honor the repo and render the nav hub. Fails before the fix, passes after. `tests/test_web_home_page.py`: 18 passed.

## Follow-up (out of scope here)

`home_page` still passes the raw DuckDB `conn` to `is_user_admin(...)` and `compute_home_stats(...)`, and other web routes use `Depends(_get_db)` directly for system-table reads. These are similarly backend-unaware and likely misbehave on Postgres-backed instances. Worth a broader audit of raw-`conn` system reads vs. the repo factory.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->