### PR TITLE
fix: fresh customer-instance VMs boot on the Postgres/cloud path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Fixed
+- **Fresh customer-instance VMs on the Postgres/cloud path now boot.** Two gaps broke first-boot for any VM whose startup-script engages the Postgres overlay (existing DuckDB-only fleets were unaffected): (1) the `Dockerfile` never copied `agnes-state-applier-bootstrap.service` into `/opt/agnes-host/`, so the startup-script's `install` of it failed under `set -e` (`install: cannot stat …`); (2) the `migrate` and `data-migrate` services in `docker-compose.postgres.yml` declared only `build: .`, so `docker compose up` tried to build them on the sourceless VM and failed with `failed to read dockerfile`. The Dockerfile now ships the bootstrap unit, and both one-shot services carry an `image:` (the pulled GHCR image) alongside `build` — mirroring the app/scheduler split. Regression tests assert every startup-script-installed ops unit is shipped by the Dockerfile and that the overlay's migrate services carry a prebuilt image.
+
 ## [0.61.5] — 2026-06-03
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN mkdir -p /opt/agnes-host && \
        /app/scripts/ops/agnes-state-applier.sh \
        /app/scripts/ops/agnes-state-applier.service \
        /app/scripts/ops/agnes-state-applier.timer \
+       /app/scripts/ops/agnes-state-applier-bootstrap.service \
        /app/scripts/tls-fetch.sh \
        /opt/agnes-host/ && \
     cp /app/docker-compose.yml /app/docker-compose.prod.yml \
@@ -57,6 +58,7 @@ RUN mkdir -p /opt/agnes-host && \
               /opt/agnes-host/tls-fetch.sh && \
     chmod 0644 /opt/agnes-host/agnes-state-applier.service \
               /opt/agnes-host/agnes-state-applier.timer \
+              /opt/agnes-host/agnes-state-applier-bootstrap.service \
               /opt/agnes-host/docker-compose.yml \
               /opt/agnes-host/docker-compose.prod.yml \
               /opt/agnes-host/docker-compose.host-mount.yml \

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -67,7 +67,13 @@ services:
       - "127.0.0.1:5432:5432"
 
   migrate:
+    # `build` for local dev; `image` for prod, where the VM is sourceless and
+    # `docker compose up` would otherwise fail with "failed to read dockerfile".
+    # Mirrors the app/scheduler build+image pattern (build in base, image in
+    # the prod path) — when the pulled image is present compose uses it instead
+    # of building.
     build: .
+    image: ghcr.io/keboola/agnes-the-ai-analyst:${AGNES_TAG:-stable}
     command: alembic upgrade head
     depends_on:
       postgres:
@@ -92,7 +98,9 @@ services:
   # ``scheduler`` block on this exiting 0 so the runtime never observes a
   # partially-migrated PG.
   data-migrate:
+    # build/image split as for `migrate` above — prod uses the pulled image.
     build: .
+    image: ghcr.io/keboola/agnes-the-ai-analyst:${AGNES_TAG:-stable}
     command: python -m scripts.migrate_duckdb_to_pg --duckdb-path /data/state/system.duckdb
     depends_on:
       postgres:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.62.3"
+version = "0.62.4"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/tests/test_state_applier_unit_file.py
+++ b/tests/test_state_applier_unit_file.py
@@ -183,3 +183,55 @@ def test_startup_script_chowns_env_to_agnes_applier():
         "reviewer's recommendation — don't rely on the bootstrap "
         "unit's later run to fix ownership)."
     )
+
+
+def test_dockerfile_ships_every_startup_installed_ops_unit():
+    """Regression: the customer-instance startup-script ``install``s ops units
+    from ``$APP_DIR`` — which is populated by ``docker cp`` of the image's
+    ``/opt/agnes-host/``. Every unit the startup-script installs MUST therefore
+    be shipped by the Dockerfile into ``/opt/agnes-host/``, or a fresh VM boot
+    dies under ``set -e`` with ``install: cannot stat '.../<unit>'``.
+
+    Caught in the wild: ``agnes-state-applier-bootstrap.service`` was added
+    both as a committed unit and to the startup-script's install list, but
+    never added to the Dockerfile COPY list — so it shipped in no image and
+    every fresh postgres-path VM failed to boot."""
+    import re
+    from pathlib import Path
+
+    tpl = Path("infra/modules/customer-instance/startup-script.sh.tpl").read_text()
+    dockerfile = Path("Dockerfile").read_text()
+    installed = set(re.findall(
+        r'install[^\n]*"\$APP_DIR/(agnes-state-applier[^"]+)"', tpl,
+    ))
+    # Sanity for the test itself — the bootstrap unit is the known case.
+    assert "agnes-state-applier-bootstrap.service" in installed, (
+        "expected the startup-script to install the bootstrap unit from "
+        "$APP_DIR; did the install path change?"
+    )
+    for unit in sorted(installed):
+        assert f"scripts/ops/{unit}" in dockerfile, (
+            f"Dockerfile must COPY scripts/ops/{unit} into /opt/agnes-host/ — "
+            f"the startup-script installs it from $APP_DIR, so an image that "
+            f"doesn't ship it breaks every fresh VM boot."
+        )
+
+
+def test_compose_postgres_migrate_services_carry_prebuilt_image():
+    """Regression: the ``migrate`` and ``data-migrate`` services in the
+    postgres overlay must declare an ``image:`` (the pulled GHCR image), not
+    only ``build: .``. Production VMs are sourceless — a build-only service
+    makes ``docker compose up`` fail with ``failed to read dockerfile`` and
+    breaks the side-car/cloud boot path. Mirrors the app/scheduler
+    build+image split."""
+    import yaml
+    from pathlib import Path
+
+    compose = yaml.safe_load(Path("docker-compose.postgres.yml").read_text())
+    for svc in ("migrate", "data-migrate"):
+        spec = compose["services"][svc]
+        assert "image" in spec and "agnes-the-ai-analyst" in spec["image"], (
+            f"{svc} must declare a prebuilt image: so sourceless prod VMs use "
+            f"the pulled image instead of attempting a build (got "
+            f"image={spec.get('image')!r})"
+        )


### PR DESCRIPTION
## Problem

A freshly-provisioned `customer-instance` VM whose startup-script engages the Postgres overlay fails to boot. Two independent gaps, both latent (existing DuckDB-only deployments are unaffected — they predate the Postgres-overlay startup path):

1. **Bootstrap unit not shipped.** `scripts/ops/agnes-state-applier-bootstrap.service` is a committed unit and the startup-script `install`s it from `$APP_DIR` — but the `Dockerfile` never copied it into `/opt/agnes-host/` (the `docker cp` contract dir). So it shipped in no image and the startup-script aborts under `set -e`:
   ```
   install: cannot stat '/opt/agnes/agnes-state-applier-bootstrap.service': No such file or directory
   ```
2. **Build-only migrate services.** `migrate` and `data-migrate` in `docker-compose.postgres.yml` declared only `build: .`. Production VMs are sourceless, so `docker compose up` tries to build them and fails:
   ```
   target data-migrate: failed to solve: failed to read dockerfile: open Dockerfile: no such file or directory
   ```

## Fix

- `Dockerfile`: add `agnes-state-applier-bootstrap.service` to the `/opt/agnes-host/` COPY + `chmod 0644` lists.
- `docker-compose.postgres.yml`: give `migrate` and `data-migrate` an `image: ghcr.io/keboola/agnes-the-ai-analyst:${AGNES_TAG:-stable}` alongside `build: .` — the same build+image split the `app`/`scheduler` services already use, so local dev still builds while sourceless prod VMs use the pulled image. (Putting the override here, not in `docker-compose.prod.yml`, avoids introducing image-only phantom services when the prod overlay is used without the Postgres overlay.)

## Tests

Two regression tests in `tests/test_state_applier_unit_file.py`:
- every ops unit the startup-script installs from `$APP_DIR` must be shipped by the Dockerfile to `/opt/agnes-host/` (would have caught bug #1);
- the overlay's `migrate`/`data-migrate` services must carry a prebuilt `image:` (bug #2).

Full suite green locally: `6489 passed, 68 skipped`.

## Notes

- CHANGELOG bullet added under `[Unreleased]` (Fixed).
- Release-cut + merge intentionally left for the maintainer.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->