### PR TITLE
Dockerfile.demo: pin DATA_DIR=/data so the baked demo extract loads at boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Fixed
+- `Dockerfile.demo` pins `ENV DATA_DIR=/data` so the baked demo extract (written to the absolute `/data/extracts/demo` at build time) is found by the boot-time rebuild. The app default `DATA_DIR=./data` is relative to the `/app` workdir, so without this the demo tables silently never loaded.
+
 ## [0.61.6] — 2026-06-03
 
 ### Fixed

--- a/Dockerfile.demo
+++ b/Dockerfile.demo
@@ -6,6 +6,10 @@ FROM ${BASE}
 # Generate the demo extract at build time. The script's __main__ writes to
 # DEMO_EXTRACT_DIR (default /data/extracts/demo); set it explicitly so the
 # path is unambiguous regardless of the base image's defaults.
+# The app default DATA_DIR is ./data (relative to WORKDIR /app); the demo
+# extract is baked at the ABSOLUTE /data, so pin DATA_DIR=/data or the boot
+# rebuild reads the wrong (empty) dir and the demo tables never appear.
+ENV DATA_DIR=/data
 ENV DEMO_EXTRACT_DIR=/data/extracts/demo
 RUN python scripts/build_demo_extract.py
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.62.2"
+version = "0.62.3"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"


### PR DESCRIPTION
## What
`Dockerfile.demo` writes the baked demo extract to the absolute `/data/extracts/demo` at build time and relies on `AGNES_REBUILD_ON_BOOT=1` to ATTACH it at startup. But the app's default `DATA_DIR` is `./data` (relative to the `/app` WORKDIR → `/app/data`), so the boot rebuild looked in the wrong directory and the demo tables (`orders_demo`, `customers_demo`) silently never loaded — the catalog and any baked-data demo came up empty.

## Fix
Add `ENV DATA_DIR=/data` to `Dockerfile.demo` so the runtime reads from the same absolute path the extract is baked into. One line; the demo image now self-describes its data location regardless of how it's run.

## Verified
Built the image and confirmed `_get_data_dir()` resolves to `/data` and the extract is present; on a live Cloud Run deploy the demo tables (`orders_demo` = 5000 rows, `customers_demo`) now appear and are queryable.

## Notes
Vendor-neutral, single-line change to the demo image only. CHANGELOG bullet under Unreleased/Fixed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/525" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->