### PR TITLE
feat(mcp): per-source env vars for stdio MCP sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Added
+- MCP **sources** can now carry per-source non-secret environment variables (`env`, a `{VAR: value}` map) passed to the spawned **stdio** subprocess — e.g. a base API URL the upstream server needs alongside its `auth_secret_env` secret (which overlays `env`). New optional field on `POST/PUT /api/admin/mcp-sources` and a new nullable `mcp_sources.env` column (DuckDB `_v68_to_v69` + Alembic `0016`). Backward-compatible: existing sources (`env` NULL) behave exactly as before.
+
 ## [0.62.4] — 2026-06-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.63.0] — 2026-06-03
+
 ### Added
 - MCP **sources** can now carry per-source non-secret environment variables (`env`, a `{VAR: value}` map) passed to the spawned **stdio** subprocess — e.g. a base API URL the upstream server needs alongside its `auth_secret_env` secret (which overlays `env`). New optional field on `POST/PUT /api/admin/mcp-sources` and a new nullable `mcp_sources.env` column (DuckDB `_v68_to_v69` + Alembic `0016`). Backward-compatible: existing sources (`env` NULL) behave exactly as before.
 

--- a/app/api/admin_mcp.py
+++ b/app/api/admin_mcp.py
@@ -102,6 +102,7 @@ class CreateMCPSourceRequest(BaseModel):
     transport: str
     command: Optional[str] = None
     args: Optional[List[str]] = None
+    env: Optional[Dict[str, str]] = None
     url: Optional[str] = None
     auth_method: Optional[str] = None
     auth_secret_env: Optional[str] = None
@@ -131,6 +132,7 @@ class UpdateMCPSourceRequest(BaseModel):
     transport: Optional[str] = None
     command: Optional[str] = None
     args: Optional[List[str]] = None
+    env: Optional[Dict[str, str]] = None
     url: Optional[str] = None
     auth_method: Optional[str] = None
     auth_secret_env: Optional[str] = None
@@ -242,6 +244,7 @@ def _serialize_source(row: Dict[str, Any]) -> Dict[str, Any]:
         "transport": row.get("transport"),
         "command": row.get("command"),
         "args": row.get("args") or [],
+        "env": row.get("env") or {},
         "url": row.get("url"),
         "auth_method": row.get("auth_method"),
         "auth_secret_env": row.get("auth_secret_env"),
@@ -287,6 +290,7 @@ def _merge_source_patch(
         "transport": data.get("transport", existing.get("transport")),
         "command": data.get("command", existing.get("command")),
         "args": data.get("args", existing.get("args")),
+        "env": data.get("env", existing.get("env")),
         "url": data.get("url", existing.get("url")),
         "auth_method": data.get("auth_method", existing.get("auth_method")),
         "auth_secret_env": data.get(
@@ -358,6 +362,7 @@ async def create_mcp_source(
             transport=payload.transport,
             command=payload.command,
             args=payload.args,
+            env=payload.env,
             url=payload.url,
             auth_method=payload.auth_method,
             auth_secret_env=payload.auth_secret_env,

--- a/connectors/mcp/client.py
+++ b/connectors/mcp/client.py
@@ -197,7 +197,9 @@ async def _open_session(
             except (json.JSONDecodeError, TypeError):
                 args = []
 
-        env_extra: Optional[Dict[str, str]] = None
+        # Per-source non-secret env (e.g. CRM_API_URL) is the base; the
+        # auth_secret_env secret overlays it (takes precedence).
+        env_extra: Dict[str, str] = dict(source.get("env") or {})
         secret_env = source.get("auth_secret_env")
         if secret_env:
             # Vault first, env-var second — same precedence as the HTTP
@@ -208,9 +210,9 @@ async def _open_session(
             # contract stays unchanged.
             token = _lookup_secret_for_source(source, caller_user_id=caller_user_id)
             if token:
-                env_extra = {secret_env: token}
+                env_extra[secret_env] = token
 
-        params = StdioServerParameters(command=command, args=list(args), env=env_extra)
+        params = StdioServerParameters(command=command, args=list(args), env=env_extra or None)
         async with stdio_client(params) as (read, write):
             async with ClientSession(read, write) as session:
                 await session.initialize()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -214,7 +214,7 @@ Files NOT to modify: `connectors/jira/file_lock.py`, `connectors/jira/transform.
 
 ### system.duckdb — `{DATA_DIR}/state/system.duckdb`
 
-Current schema version: **68** (auto-migrated from any earlier version on startup — see `src/db.py`).
+Current schema version: **69** (auto-migrated from any earlier version on startup — see `src/db.py`).
 
 | Table | Purpose |
 |-------|---------|

--- a/migrations/versions/0016_mcp_source_env_v69.py
+++ b/migrations/versions/0016_mcp_source_env_v69.py
@@ -1,0 +1,28 @@
+"""v69: per-source env vars on mcp_sources.
+
+Adds ``mcp_sources.env`` (JSON-as-TEXT, nullable) — non-secret env vars for
+the stdio subprocess. Parity with the DuckDB ``_v68_to_v69`` step.
+
+Revision ID: 0016_mcp_source_env_v69
+Revises: 0015_cloud_chat_v68
+Create Date: 2026-06-03
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0016_mcp_source_env_v69"
+down_revision: Union[str, None] = "0015_cloud_chat_v68"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("mcp_sources", sa.Column("env", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("mcp_sources", "env")

--- a/migrations/versions/0016_mcp_source_env_v69.py
+++ b/migrations/versions/0016_mcp_source_env_v69.py
@@ -1,7 +1,8 @@
 """v69: per-source env vars on mcp_sources.
 
-Adds ``mcp_sources.env`` (JSON-as-TEXT, nullable) — non-secret env vars for
-the stdio subprocess. Parity with the DuckDB ``_v68_to_v69`` step.
+Adds ``mcp_sources.env`` (JSONB, nullable) — non-secret env vars for the
+stdio subprocess. Mirrors the ``args`` column's JSONB type. Parity with the
+DuckDB ``_v68_to_v69`` step.
 
 Revision ID: 0016_mcp_source_env_v69
 Revises: 0015_cloud_chat_v68
@@ -13,6 +14,7 @@ from typing import Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
 
 revision: str = "0016_mcp_source_env_v69"
 down_revision: Union[str, None] = "0015_cloud_chat_v68"
@@ -21,7 +23,7 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.add_column("mcp_sources", sa.Column("env", sa.Text(), nullable=True))
+    op.add_column("mcp_sources", sa.Column("env", JSONB, nullable=True))
 
 
 def downgrade() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.62.4"
+version = "0.63.0"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/src/db.py
+++ b/src/db.py
@@ -47,7 +47,7 @@ from src.duckdb_conn import _open_duckdb  # noqa: F401, E402  (re-export)
 
 _SAFE_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,63}$")
 
-SCHEMA_VERSION = 68
+SCHEMA_VERSION = 69
 
 _SYSTEM_SCHEMA = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -4781,6 +4781,19 @@ def _v67_to_v68(conn: duckdb.DuckDBPyConnection) -> None:
     conn.execute("UPDATE schema_version SET version = 68")
 
 
+def _v68_to_v69(conn: duckdb.DuckDBPyConnection) -> None:
+    """v69: per-source non-secret env vars for stdio MCP sources.
+
+    Adds ``mcp_sources.env`` — a JSON object of ``{VAR: value}`` passed to
+    the spawned stdio subprocess (the ``auth_secret_env`` secret overlays
+    it). NULL on existing rows preserves the prior single-secret behavior.
+    """
+    conn.execute(
+        "ALTER TABLE mcp_sources ADD COLUMN IF NOT EXISTS env VARCHAR"
+    )
+    conn.execute("UPDATE schema_version SET version = 69")
+
+
 def _v57_to_v58(conn: duckdb.DuckDBPyConnection) -> None:
     """v55: ``memory_domain_suggestions`` table — non-admin "Suggest a
     domain" affordance + admin moderation queue.
@@ -5094,6 +5107,9 @@ def _ensure_schema(conn: duckdb.DuckDBPyConnection) -> None:
             # user_workdirs + indexes. _SYSTEM_SCHEMA already creates them on
             # fresh installs via CREATE TABLE/INDEX IF NOT EXISTS (no-op here).
             _v67_to_v68(conn)
+            # v68→v69: mcp_sources.env — per-source non-secret env vars for
+            # the spawned stdio subprocess. ADD COLUMN IF NOT EXISTS (no-op here).
+            _v68_to_v69(conn)
             # Fresh-install seed is handled by the unconditional
             # _seed_core_roles call at the bottom of _ensure_schema —
             # left as a no-op branch here so the migration ladder still
@@ -5283,6 +5299,8 @@ def _ensure_schema(conn: duckdb.DuckDBPyConnection) -> None:
                 _v66_to_v67(conn)
             if current < 68:
                 _v67_to_v68(conn)
+            if current < 69:
+                _v68_to_v69(conn)
             conn.execute(
                 "UPDATE schema_version SET version = ?, applied_at = current_timestamp",
                 [SCHEMA_VERSION],

--- a/src/models/mcp.py
+++ b/src/models/mcp.py
@@ -55,6 +55,7 @@ class MCPSource(Base):
     transport: Mapped[str] = mapped_column(String, nullable=False)
     command: Mapped[str | None] = mapped_column(String, nullable=True)
     args: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+    env: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     url: Mapped[str | None] = mapped_column(String, nullable=True)
     auth_method: Mapped[str | None] = mapped_column(String, nullable=True)
     auth_secret_env: Mapped[str | None] = mapped_column(String, nullable=True)

--- a/src/repositories/mcp_sources.py
+++ b/src/repositories/mcp_sources.py
@@ -17,7 +17,7 @@ class MCPSourceRepository:
         if not row:
             return None
         d = dict(zip(cols, row))
-        for k in ("args",):
+        for k in ("args", "env"):
             if d.get(k) is not None and isinstance(d[k], str):
                 try:
                     d[k] = json.loads(d[k])
@@ -33,6 +33,7 @@ class MCPSourceRepository:
         transport: str,
         command: Optional[str] = None,
         args: Optional[List[str]] = None,
+        env: Optional[Dict[str, str]] = None,
         url: Optional[str] = None,
         auth_method: Optional[str] = None,
         auth_secret_env: Optional[str] = None,
@@ -50,22 +51,24 @@ class MCPSourceRepository:
 
         now = datetime.now(timezone.utc)
         args_json = json.dumps(args) if args is not None else None
+        env_json = json.dumps(env) if env is not None else None
         self.conn.execute(
             """INSERT INTO mcp_sources
-               (id, name, transport, command, args, url, auth_method, auth_secret_env, enabled, scope, created_at, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               (id, name, transport, command, args, env, url, auth_method, auth_secret_env, enabled, scope, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                ON CONFLICT (id) DO UPDATE SET
                    name = excluded.name,
                    transport = excluded.transport,
                    command = excluded.command,
                    args = excluded.args,
+                   env = excluded.env,
                    url = excluded.url,
                    auth_method = excluded.auth_method,
                    auth_secret_env = excluded.auth_secret_env,
                    enabled = excluded.enabled,
                    scope = excluded.scope,
                    updated_at = excluded.updated_at""",
-            [id, name, transport, command, args_json, url, auth_method, auth_secret_env, enabled, scope, now, now],
+            [id, name, transport, command, args_json, env_json, url, auth_method, auth_secret_env, enabled, scope, now, now],
         )
 
     def get(self, source_id: str) -> Optional[Dict[str, Any]]:

--- a/src/repositories/mcp_sources_pg.py
+++ b/src/repositories/mcp_sources_pg.py
@@ -19,7 +19,7 @@ class MCPSourcePgRepository:
     @staticmethod
     def _decode_row(row: Dict[str, Any]) -> Dict[str, Any]:
         d = dict(row)
-        for k in ("args",):
+        for k in ("args", "env"):
             if d.get(k) is not None and isinstance(d[k], str):
                 try:
                     d[k] = json.loads(d[k])
@@ -35,6 +35,7 @@ class MCPSourcePgRepository:
         transport: str,
         command: Optional[str] = None,
         args: Optional[List[str]] = None,
+        env: Optional[Dict[str, str]] = None,
         url: Optional[str] = None,
         auth_method: Optional[str] = None,
         auth_secret_env: Optional[str] = None,
@@ -52,13 +53,14 @@ class MCPSourcePgRepository:
 
         now = datetime.now(timezone.utc)
         args_json = json.dumps(args) if args is not None else None
+        env_json = json.dumps(env) if env is not None else None
         with self._engine.begin() as conn:
             conn.execute(
                 sa.text(
                     """INSERT INTO mcp_sources
-                       (id, name, transport, command, args, url, auth_method,
+                       (id, name, transport, command, args, env, url, auth_method,
                         auth_secret_env, enabled, scope, created_at, updated_at)
-                       VALUES (:id, :name, :transport, :command, :args, :url,
+                       VALUES (:id, :name, :transport, :command, :args, :env, :url,
                                :auth_method, :auth_secret_env, :enabled, :scope,
                                :now, :now)
                        ON CONFLICT (id) DO UPDATE SET
@@ -66,6 +68,7 @@ class MCPSourcePgRepository:
                            transport       = EXCLUDED.transport,
                            command         = EXCLUDED.command,
                            args            = EXCLUDED.args,
+                           env             = EXCLUDED.env,
                            url             = EXCLUDED.url,
                            auth_method     = EXCLUDED.auth_method,
                            auth_secret_env = EXCLUDED.auth_secret_env,
@@ -75,7 +78,7 @@ class MCPSourcePgRepository:
                 ),
                 {
                     "id": id, "name": name, "transport": transport,
-                    "command": command, "args": args_json, "url": url,
+                    "command": command, "args": args_json, "env": env_json, "url": url,
                     "auth_method": auth_method, "auth_secret_env": auth_secret_env,
                     "enabled": enabled, "scope": scope, "now": now,
                 },

--- a/tests/db_pg/test_mcp_sources_contract.py
+++ b/tests/db_pg/test_mcp_sources_contract.py
@@ -92,6 +92,27 @@ def test_upsert_then_get_returns_same_shape(repo):
     assert row["scope"] == "shared"
 
 
+def test_env_round_trips_on_both_backends(repo):
+    """Per-source non-secret env survives upsert→get as a dict on both engines."""
+    repo.upsert(
+        id="s1", name="crm", transport="stdio", command="crm-mcp",
+        env={"CRM_API_URL": "https://x"},
+        auth_secret_env="CRM_TOKEN",
+    )
+    row = repo.get("s1")
+    assert row is not None
+    # env is JSON on the wire but the repo returns a dict on both backends
+    assert row["env"] == {"CRM_API_URL": "https://x"}
+
+
+def test_env_omitted_is_null_for_backward_compat(repo):
+    """Omitting env leaves it NULL/None (existing rows behave as before)."""
+    repo.upsert(id="s1", name="legacy", transport="stdio", command="legacy-mcp")
+    row = repo.get("s1")
+    assert row is not None
+    assert row.get("env") is None
+
+
 def test_upsert_replaces_existing_row(repo):
     repo.upsert(id="s1", name="x", transport="http", url="https://a.example/mcp")
     repo.upsert(id="s1", name="x", transport="http", url="https://b.example/mcp", enabled=False)

--- a/tests/test_mcp_client_transport.py
+++ b/tests/test_mcp_client_transport.py
@@ -146,6 +146,72 @@ def test_http_transport_without_url_raises_value_error():
         asyncio.run(_drive())
 
 
+def test_stdio_env_is_base_secret_overlays(monkeypatch):
+    """Per-source ``env`` is the base; the auth_secret_env secret overlays it."""
+    captured = {}
+
+    def _fake_stdio_params(*, command, args, env):
+        captured["command"] = command
+        captured["args"] = args
+        captured["env"] = env
+        return MagicMock(name="StdioServerParameters")
+
+    fake_stdio = _fake_streams_cm((MagicMock(name="read"), MagicMock(name="write")))
+    ctor, _session = _fake_client_session()
+
+    monkeypatch.setattr(mcp_client, "StdioServerParameters", _fake_stdio_params)
+    monkeypatch.setattr(mcp_client, "stdio_client", fake_stdio)
+    monkeypatch.setattr(mcp_client, "ClientSession", ctor)
+    monkeypatch.setattr(
+        mcp_client, "_lookup_secret_for_source", lambda src, **kw: "tok-123"
+    )
+
+    src = {
+        "transport": "stdio",
+        "command": "crm-mcp",
+        "args": ["--flag"],
+        "env": {"CRM_API_URL": "u"},
+        "auth_secret_env": "CRM_TOKEN",
+    }
+
+    async def _drive():
+        async with mcp_client._open_session(src):
+            pass
+
+    asyncio.run(_drive())
+
+    assert captured["command"] == "crm-mcp"
+    assert captured["args"] == ["--flag"]
+    # base env preserved, secret overlaid under its env-var name
+    assert captured["env"] == {"CRM_API_URL": "u", "CRM_TOKEN": "tok-123"}
+
+
+def test_stdio_no_env_no_secret_passes_none(monkeypatch):
+    """No env and no secret → env=None (prior behavior, unchanged)."""
+    captured = {}
+
+    def _fake_stdio_params(*, command, args, env):
+        captured["env"] = env
+        return MagicMock(name="StdioServerParameters")
+
+    fake_stdio = _fake_streams_cm((MagicMock(name="read"), MagicMock(name="write")))
+    ctor, _session = _fake_client_session()
+
+    monkeypatch.setattr(mcp_client, "StdioServerParameters", _fake_stdio_params)
+    monkeypatch.setattr(mcp_client, "stdio_client", fake_stdio)
+    monkeypatch.setattr(mcp_client, "ClientSession", ctor)
+
+    src = {"transport": "stdio", "command": "plain-mcp"}
+
+    async def _drive():
+        async with mcp_client._open_session(src):
+            pass
+
+    asyncio.run(_drive())
+
+    assert captured["env"] is None
+
+
 def test_unknown_transport_raises_notimplemented():
     src = {"transport": "websocket", "url": "wss://x"}
 


### PR DESCRIPTION
## Why
An MCP **source** registered with `transport=stdio` could only receive a single injected env var — the secret named by `auth_secret_env`. Servers that also need a non-secret var (e.g. a base API URL) alongside their token had no way to get it; the only workaround was wrapping the command in a shell. This adds first-class per-source env support.

## What
New optional `env` field (a `{VAR: value}` map) on an MCP source, persisted and passed to the spawned **stdio** subprocess. The `auth_secret_env` secret **overlays** `env` (takes precedence). Additive and backward-compatible — existing sources (`env` NULL) behave exactly as before; http/sse transports are unaffected.

- **Schema (dual-backend):** new nullable `mcp_sources.env` column — DuckDB `_v68_to_v69` (`ALTER … ADD COLUMN IF NOT EXISTS`, SCHEMA_VERSION 68→69, wired into both fresh-install and incremental ladders) + Alembic `0016_mcp_source_env_v69` (`JSONB`, mirrors `args`). SQLAlchemy model `MCPSource` gains `env` (JSONB), keeping model↔migration↔DuckDB parity.
- **Repos:** both `mcp_sources.py` (DuckDB) and `mcp_sources_pg.py` (PG) decode `env` JSON on read and persist it in `upsert` (INSERT + ON CONFLICT).
- **Admin API:** `env` on the `POST/PUT /api/admin/mcp-sources` request models, serialization, and patch-merge.
- **Spawn (`connectors/mcp/client.py`):** the stdio `env_extra` now starts from `source['env']`; the secret overlays it; `env=env_extra or None` preserves prior behavior.

## Tests
- `tests/db_pg/test_mcp_sources_contract.py`: `env` round-trips on **both** backends + backward-compat (omitted → NULL).
- `tests/test_mcp_client_transport.py`: stdio spawn merges `env` with the secret overlaying; no-env/no-secret → `None`.
- `tests/test_db_schema_version.py` (DuckDB↔Alembic parity gate): green at v69 / migration 0016.

## Reviews
- `agnes-reviewer-architecture`: schema migration + dual-backend parity sound (after adding `env` to the PG model + switching the migration to `JSONB` + bumping the `docs/architecture.md` schema-version reference to 69, all included here).
- `agnes-reviewer-rules`: clean.

## Release
Release-cut **0.63.0** included as the last commit (minor — additive public surface: new API field + column).

## Test suite
`pytest tests/ -n auto` → 6501 passed. Remaining failures are unrelated to this diff: 4× `e2b` (`import e2b` not installed in the local venv — `tests/test_chat_*e2b*`, `tests/test_chat_readiness.py`; CI installs it) and two full-suite-only flakes (`test_stack_resolver_perf.py::test_manifest_generation_perf_smoke`, `test_v2_catalog_invalidation.py::test_invalidate_does_not_touch_persistent_bq_cache`) — both pass in isolation; this diff touches only `mcp_sources.env`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->