### PR TITLE
fix(infra): startup-script selects compose overlay by persisted backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Fixed
+- **A cloud/DuckDB-backend VM now reboots cleanly instead of hanging on a side-car migration.** The `customer-instance` startup-script baked the Postgres side-car overlay (`docker-compose.postgres.yml` + `…-host-mount.yml`) into the `.env` `COMPOSE_FILE` unconditionally — so a reboot of a `backend: cloud` (or `duckdb`) instance re-engaged the side-car and ran the one-shot `migrate` service against it, which fails (`failed to resolve host 'postgres'`) and blocks `app`/`scheduler` startup via `depends_on`. The startup-script now selects the overlay set from the persisted `instance.yaml` backend — side-car overlay only for `backend=side_car`; `duckdb`/`cloud` run the baseline (cloud reaches managed Postgres via `instance.yaml::database.url`) — mirroring `agnes-state-applier.sh`. Regression test added.
+
 ## [0.63.0] — 2026-06-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.63.1] — 2026-06-03
+
 ### Fixed
 - **A cloud/DuckDB-backend VM now reboots cleanly instead of hanging on a side-car migration.** The `customer-instance` startup-script baked the Postgres side-car overlay (`docker-compose.postgres.yml` + `…-host-mount.yml`) into the `.env` `COMPOSE_FILE` unconditionally — so a reboot of a `backend: cloud` (or `duckdb`) instance re-engaged the side-car and ran the one-shot `migrate` service against it, which fails (`failed to resolve host 'postgres'`) and blocks `app`/`scheduler` startup via `depends_on`. The startup-script now selects the overlay set from the persisted `instance.yaml` backend — side-car overlay only for `backend=side_car`; `duckdb`/`cloud` run the baseline (cloud reaches managed Postgres via `instance.yaml::database.url`) — mirroring `agnes-state-applier.sh`. Regression test added.
 

--- a/infra/modules/customer-instance/startup-script.sh.tpl
+++ b/infra/modules/customer-instance/startup-script.sh.tpl
@@ -273,6 +273,22 @@ if [ -n "$EXISTING_AGNES_TEMP_DIR" ]; then
     AGNES_TEMP_DIR_LINE="AGNES_TEMP_DIR=\"$EXISTING_AGNES_TEMP_DIR\""
 fi
 
+# Select the docker-compose overlay set from the persisted backend state.
+# instance.yaml is written above only when absent, so a VM an operator migrated
+# to side_car / cloud keeps that backend across reboots. The on-VM Postgres
+# side-car overlay is engaged ONLY for backend=side_car; duckdb and cloud run
+# the baseline (cloud reaches managed Postgres via instance.yaml::database.url,
+# not the side-car). Mirrors agnes-state-applier.sh's overlay selection.
+# Without this, a reboot of a cloud/duckdb instance re-engaged the side-car and
+# ran the one-shot `migrate` against it, which fails and blocks app startup via
+# depends_on.
+PERSISTED_BACKEND=$(sed -n 's/^[[:space:]]*backend:[[:space:]]*//p' "$INSTANCE_YAML" 2>/dev/null | tr -d '"' | head -1)
+if [ "$PERSISTED_BACKEND" = "side_car" ]; then
+    COMPOSE_FILE_VALUE="docker-compose.yml:docker-compose.prod.yml:docker-compose.postgres.yml:docker-compose.host-mount.yml:docker-compose.postgres-host-mount.yml"
+else
+    COMPOSE_FILE_VALUE="docker-compose.yml:docker-compose.prod.yml:docker-compose.host-mount.yml"
+fi
+
 cat > "$APP_DIR/.env" <<ENVEOF
 JWT_SECRET_KEY=$JWT_KEY
 DATA_DIR=$DATA_MNT
@@ -295,7 +311,7 @@ ${env_name}=$${${env_name}}
 %{ endfor ~}
 POSTGRES_PASSWORD=$POSTGRES_PASSWORD
 DATABASE_URL=postgresql+psycopg://agnes:$POSTGRES_PASSWORD@postgres:5432/agnes
-COMPOSE_FILE=docker-compose.yml:docker-compose.prod.yml:docker-compose.postgres.yml:docker-compose.host-mount.yml:docker-compose.postgres-host-mount.yml
+COMPOSE_FILE=$COMPOSE_FILE_VALUE
 $CADDY_TLS_LINE
 $AGNES_TEMP_DIR_LINE
 ENVEOF

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.63.0"
+version = "0.63.1"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/tests/test_state_applier_unit_file.py
+++ b/tests/test_state_applier_unit_file.py
@@ -217,6 +217,38 @@ def test_dockerfile_ships_every_startup_installed_ops_unit():
         )
 
 
+def test_startup_script_selects_compose_overlay_by_backend():
+    """Regression (bug #3): the startup-script must pick the docker-compose
+    overlay set from the persisted ``instance.yaml`` backend, NOT bake the
+    Postgres side-car overlay into the ``.env`` ``COMPOSE_FILE`` line
+    unconditionally.
+
+    Caught in the wild: on a `backend: cloud` VM, a reboot re-engaged the
+    side-car overlay and ran the one-shot ``migrate`` service against the
+    side-car Postgres, which failed (`failed to resolve host 'postgres'`) and
+    blocked ``app``/``scheduler`` startup via ``depends_on``. The startup-script
+    must mirror agnes-state-applier.sh: side-car overlay only for
+    ``backend=side_car``; duckdb and cloud run the baseline."""
+    from pathlib import Path
+
+    tpl = Path("infra/modules/customer-instance/startup-script.sh.tpl").read_text()
+    assert "COMPOSE_FILE=$COMPOSE_FILE_VALUE" in tpl, (
+        "startup-script must write COMPOSE_FILE from the computed per-backend "
+        "value, not a hardcoded overlay list"
+    )
+    assert "PERSISTED_BACKEND" in tpl and '= "side_car"' in tpl, (
+        "startup-script must read the persisted backend and gate the side-car "
+        "overlay on backend=side_car"
+    )
+    assert (
+        "COMPOSE_FILE=docker-compose.yml:docker-compose.prod.yml:docker-compose.postgres.yml"
+        not in tpl
+    ), (
+        "the Postgres side-car overlay must not be baked into the COMPOSE_FILE "
+        ".env line unconditionally — it belongs only in the side_car branch"
+    )
+
+
 def test_compose_postgres_migrate_services_carry_prebuilt_image():
     """Regression: the ``migrate`` and ``data-migrate`` services in the
     postgres overlay must declare an ``image:`` (the pulled GHCR image), not


### PR DESCRIPTION
## Problem

A `customer-instance` VM on the **cloud** (or **duckdb**) backend does not reboot cleanly. The startup-script baked the Postgres side-car overlay into the `.env` `COMPOSE_FILE` **unconditionally**:

```
COMPOSE_FILE=docker-compose.yml:docker-compose.prod.yml:docker-compose.postgres.yml:docker-compose.host-mount.yml:docker-compose.postgres-host-mount.yml
```

So on reboot of a `backend: cloud` instance, `docker compose up` re-engages the side-car and runs the one-shot `migrate` service against it. That service fails:

```
migrate | sqlalchemy ... psycopg.OperationalError: failed to resolve host 'postgres'
agnes-migrate-1 Error: service "migrate" didn't complete successfully: exit 1
```

and because `app`/`scheduler` `depends_on: { data-migrate: service_completed_successfully }`, the whole stack fails to start — the app is left down after a reboot. (Surfaced only after the boot-blocking bugs in #524 were fixed; this is the next layer.)

## Fix

Select the overlay set from the **persisted `instance.yaml` backend**, mirroring `agnes-state-applier.sh`:

- `backend=side_car` → baseline + `docker-compose.postgres.yml` + `…-host-mount.yml`
- `backend=duckdb` / `cloud` (or unset) → baseline only (`docker-compose.yml` + `prod.yml` + `host-mount.yml`)

`instance.yaml` is written by the startup-script only when absent, so an operator-migrated backend survives reboots. A cloud instance reaches managed Postgres via `instance.yaml::database.url`; it never needs the side-car. This also protects existing DuckDB fleets from accidentally engaging the side-car on their next reboot.

## Tests

Regression test in `tests/test_state_applier_unit_file.py`: the startup-script must write `COMPOSE_FILE` from the computed per-backend value, gate the side-car overlay on `backend=side_car`, and never bake the overlay into the `.env` line unconditionally.

## Test suite note

The full `-n auto` suite shows **pre-existing non-deterministic flakiness unrelated to this diff**: a branch run failed 16 tests (all in `test_keboola_extractor_exit_codes.py`), while a clean-`main` baseline run failed a *different* single test (`test_mcp_http.py::test_exactly_six_server_side_tools`) with the keboola tests green. Failures vary run-to-run and all pass in isolation — classic xdist test-ordering pollution. This diff is a Terraform template + CHANGELOG + an additive file-reading test, with no causal path to those modules. (Worth a separate test-isolation pass.)

## Notes

- CHANGELOG bullet under `[Unreleased]` (Fixed).
- **Release-cut to `0.63.1` included** as the last commit (per CLAUDE.md — this PR lands the only `[Unreleased]` content). Merge + post-merge `v0.63.1` tag/GitHub Release + cutting `infra-v1.13.0` (this changes the `customer-instance` module) left to the maintainer.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->