### PR TITLE
Refresh /login feature panel to match product pillars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Changed
+- Refreshed the `/login` feature panel to match the product pillars shown on `/home`: **Data packages**, **Marketplace** (plugins, skills, and agents in one card), **MCP**, **Memory**, and a **Use it anywhere** card for the cloud surfaces (Cowork, web chat, Slack). Replaces the stale, aspirational cards (*Unified Data Access / Instant Automation / Smart Notifications / Performance Intelligence*) with descriptions that reflect what the platform actually does, and adds a `BETA` badge to every capability except the mature Data packages core. The panel subtitle is realigned with the `/home` hero copy, and the cards are tightened so the full set fits without scrolling. Adds a "Made by Keboola" attribution with the Keboola wordmark at the foot of the brand panel.
+
 ## [0.63.0] — 2026-06-03
 
 ### Added

--- a/app/web/static/style-custom.css
+++ b/app/web/static/style-custom.css
@@ -2807,7 +2807,7 @@ a.slack-badge:hover {
 .login-features {
     background: var(--primary);
     color: white;
-    padding: var(--space-8);
+    padding: var(--space-6) var(--space-8);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -2840,7 +2840,7 @@ a.slack-badge:hover {
     font-size: var(--text-md);
     line-height: 1.6;
     opacity: 0.9;
-    margin-bottom: var(--space-6);
+    margin-bottom: var(--space-4);
 }
 
 /* Feature cards */
@@ -2853,7 +2853,7 @@ a.slack-badge:hover {
 .feature-card {
     display: flex;
     gap: var(--space-3);
-    padding: var(--space-4);
+    padding: var(--space-3) var(--space-4);
     background: rgba(255, 255, 255, 0.1);
     border-radius: var(--radius-lg);
     border: 1px solid rgba(255, 255, 255, 0.15);
@@ -2871,14 +2871,6 @@ a.slack-badge:hover {
     color: white;
 }
 
-.feature-icon-data,
-.feature-icon-memory,
-.feature-icon-auto,
-.feature-icon-notif {
-    background: rgba(255, 255, 255, 0.15);
-    color: white;
-}
-
 .feature-text h3 {
     font-size: var(--text-base);
     font-weight: var(--font-semibold);
@@ -2886,11 +2878,47 @@ a.slack-badge:hover {
     color: white;
 }
 
+/* BETA chip on a feature-card heading — translucent-white chip readable
+   on the brand-coloured features panel. Marks every capability that
+   isn't the mature data-package core. */
+.feature-text h3 .feature-beta {
+    display: inline-block;
+    margin-left: var(--space-2);
+    padding: 1px 6px;
+    font-size: 10px;
+    font-weight: var(--font-semibold);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    vertical-align: middle;
+    border-radius: var(--radius-sm);
+    background: rgba(255, 255, 255, 0.2);
+    color: white;
+    border: 1px solid rgba(255, 255, 255, 0.35);
+}
+
 .feature-text p {
     font-size: var(--text-sm);
     line-height: 1.5;
     color: rgba(255, 255, 255, 0.8);
     margin: 0;
+}
+
+/* "Made by Keboola" attribution lockup at the foot of the brand panel.
+   Logo paths use currentColor so the wordmark renders white on the
+   coloured features panel. */
+.login-made-by {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    margin-top: var(--space-5);
+    color: rgba(255, 255, 255, 0.8);
+    font-size: var(--text-sm);
+}
+
+.login-made-by .made-by-logo {
+    height: 26px;
+    width: auto;
+    color: white;
 }
 
 /* Right side: Login card */

--- a/app/web/templates/login.html
+++ b/app/web/templates/login.html
@@ -17,12 +17,18 @@
             <div class="features-content">
                 <h1 class="features-title">{{ config.INSTANCE_NAME }}</h1>
                 <p class="features-subtitle">
-                    Your local AI agent works with centralized data, shared context, and corporate memory that learns from everyone.
+                    One place for your team's curated data, plugins, skills, and shared memory — so your AI agent stops guessing and starts answering.
                 </p>
 
+                {# Feature cards mirror the product pillars surfaced on /home,
+                   with the marketplace's plugins/skills/agents collapsed into
+                   one Marketplace card: Data packages, Marketplace, MCP,
+                   Memory, and the cloud surfaces. Data packages is the mature
+                   core; every other capability is still BETA and carries the
+                   badge. Page-local landing chrome — not data panels. #}
                 <div class="feature-cards">
                     <div class="feature-card">
-                        <div class="feature-icon feature-icon-data">
+                        <div class="feature-icon">
                             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                                 <ellipse cx="12" cy="5" rx="9" ry="3"/>
                                 <path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/>
@@ -30,14 +36,45 @@
                             </svg>
                         </div>
                         <div class="feature-text">
-                            <h3>Unified Data Access</h3>
-                            <p>Synced data from central server with semantic layer, metrics definitions, and full documentation.</p>
+                            <h3>Data packages</h3>
+                            <p>Curated tables, schema, and metric definitions your team registered — documented business rules, synced to your laptop.</p>
                         </div>
                     </div>
 
                     <div class="feature-card">
-                        <div class="feature-icon feature-icon-memory">
-                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <div class="feature-icon">
+                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <rect x="3" y="3" width="7" height="7"/>
+                                <rect x="14" y="3" width="7" height="7"/>
+                                <rect x="14" y="14" width="7" height="7"/>
+                                <rect x="3" y="14" width="7" height="7"/>
+                            </svg>
+                        </div>
+                        <div class="feature-text">
+                            <h3>Marketplace <span class="feature-beta">Beta</span></h3>
+                            <p>One curated, access-filtered catalog of Claude Code plugins, skills, and agents — Asana, Jira, GitHub, reusable workflows for planning and review — plus a flea market to share your own.</p>
+                        </div>
+                    </div>
+
+                    <div class="feature-card">
+                        <div class="feature-icon">
+                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <circle cx="18" cy="5" r="3"/>
+                                <circle cx="6" cy="12" r="3"/>
+                                <circle cx="18" cy="19" r="3"/>
+                                <line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/>
+                                <line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/>
+                            </svg>
+                        </div>
+                        <div class="feature-text">
+                            <h3>MCP <span class="feature-beta">Beta</span></h3>
+                            <p>Connect any MCP server; its tools surface in your workspace — materialized into the catalog or called as live passthrough lookups.</p>
+                        </div>
+                    </div>
+
+                    <div class="feature-card">
+                        <div class="feature-icon">
+                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                                 <path d="M12 2a4 4 0 0 1 4 4c0 1.1-.9 2-2 2h-4c-1.1 0-2-.9-2-2a4 4 0 0 1 4-4z"/>
                                 <path d="M12 8v8"/>
                                 <path d="M8 12h8"/>
@@ -45,51 +82,40 @@
                             </svg>
                         </div>
                         <div class="feature-text">
-                            <h3>Corporate Memory</h3>
-                            <p>Shared context across all users. When someone discovers something, everyone's AI knows it.</p>
+                            <h3>Memory <span class="feature-beta">Beta</span></h3>
+                            <p>Shared analyst knowledge and prior solutions, fed back into Claude's context on demand.</p>
                         </div>
                     </div>
 
                     <div class="feature-card">
-                        <div class="feature-icon feature-icon-auto">
-                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                                <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/>
+                        <div class="feature-icon">
+                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <circle cx="12" cy="12" r="10"/>
+                                <line x1="2" y1="12" x2="22" y2="12"/>
+                                <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
                             </svg>
                         </div>
                         <div class="feature-text">
-                            <h3>Instant Automation</h3>
-                            <p>Turn any analysis into automated scripts. Runs without AI - fast, cheap, and repeatable.</p>
+                            <h3>Use it anywhere <span class="feature-beta">Beta</span></h3>
+                            <p>Beyond your laptop: Cowork on claude.ai, zero-install web chat, and Slack — the same data, plugins, and skills on every surface.</p>
                         </div>
                     </div>
+                </div>
 
-                    <div class="feature-card">
-                        <div class="feature-icon feature-icon-notif">
-                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                                <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/>
-                                <path d="M13.73 21a2 2 0 0 1-3.46 0"/>
-                            </svg>
-                        </div>
-                        <div class="feature-text">
-                            <h3>Smart Notifications</h3>
-                            <p>Your AI agent can set up alerts and deploy them to the cloud. Server monitors 24/7.</p>
-                        </div>
-                    </div>
-
-                    <div class="feature-card">
-                        <div class="feature-icon feature-icon-performance">
-                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                                <path d="M3 3v18h18"/>
-                                <path d="M18 17V9"/>
-                                <path d="M13 17v-6"/>
-                                <path d="M8 17v-3"/>
-                                <polyline points="7 7 12 3 17 6 22 2"/>
-                            </svg>
-                        </div>
-                        <div class="feature-text">
-                            <h3>Performance Intelligence</h3>
-                            <p>Track how data and AI drive measurable business outcomes. Real-time visibility into team maturity, process improvements, and ROI across departments.</p>
-                        </div>
-                    </div>
+                {# Project authorship attribution. Agnes is developed by Keboola,
+                   so the login carries a "Made by Keboola" credit — authorship of
+                   the OSS itself (cf. "Powered by …" on other open-source projects),
+                   not per-deployment customer branding. Intentionally shipped in the
+                   public template. Logo: official Keboola wordmark, drawn in white
+                   via currentColor on the brand panel. #}
+                <div class="login-made-by">
+                    <span>Made by</span>
+                    <svg class="made-by-logo" viewBox="0 0 120 60" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Keboola">
+                        <g transform="translate(-1.8858987)" fill="currentColor">
+                            <path d="m 20.321449,29.499424 c 0.850401,0 1.539739,0.676456 1.539739,1.508817 0,0.834939 -0.689338,1.510105 -1.539739,1.510105 -0.8504,0 -1.53974,-0.675166 -1.53974,-1.510105 0,-0.832361 0.68934,-1.508817 1.53974,-1.508817 z m 4.050998,0 c 0.850402,0 1.53974,0.676456 1.53974,1.508817 0,0.834939 -0.689338,1.510105 -1.53974,1.510105 -0.850401,0 -1.539739,-0.675166 -1.539739,-1.510105 0,-0.832361 0.689338,-1.508817 1.539739,-1.508817 z m -1.879899,5.260886 c 4.777704,0 8.982031,-6.40506 8.982031,-14.517366 0,-8.111016 -3.057576,-9.269365 -8.982031,-9.269365 -5.924457,0 -9.271944,1.158349 -9.271944,9.269365 0,8.112305 4.017498,14.517366 9.271944,14.517366 z m 10.535946,7.403639 c -0.645532,-1.073309 -1.368373,-1.910826 -2.110541,-2.598876 -0.744743,-0.689339 -1.492066,-1.23308 -2.22006,-1.776821 -0.344026,-0.257697 -0.69707,-0.494778 -1.056557,-0.709955 0.359487,-0.215177 0.712531,-0.453547 1.056557,-0.711244 1.662146,-1.240812 3.107827,-2.914556 4.330601,-4.947785 0.431641,-0.717686 0.186829,-1.64282 -0.545031,-2.065442 -0.733147,-0.422623 -1.676319,-0.184253 -2.10925,0.533433 -1.057847,1.76136 -2.261292,3.124578 -3.540758,4.078056 -1.370949,1.016615 -2.719993,1.520413 -4.106403,1.6003 -0.126279,-0.0039 -0.252544,-0.0077 -0.380103,-0.0077 -0.126279,0 -0.253833,0.0039 -0.380105,0.0077 -1.38641,-0.07988 -2.734165,-0.583686 -4.106403,-1.6003 -1.279466,-0.953478 -2.481623,-2.316696 -3.540758,-4.078056 -0.431642,-0.717687 -1.376103,-0.956056 -2.107963,-0.533434 -0.733147,0.422622 -0.97667,1.347756 -0.545028,2.06673 1.222773,2.031942 2.667165,3.705686 4.329311,4.946497 0.344026,0.257697 0.69707,0.496067 1.057846,0.711244 -0.360776,0.215177 -0.71382,0.452258 -1.057846,0.709955 -0.726706,0.543741 -1.475315,1.087483 -2.218773,1.776821 -0.742166,0.688051 -1.466296,1.525568 -2.110538,2.598876 -0.431642,0.717686 -0.188119,1.644107 0.545028,2.06673 0.73186,0.422624 1.676321,0.184254 2.107963,-0.533432 0.496067,-0.823343 1.00502,-1.408315 1.577107,-1.943036 0.570798,-0.532144 1.220195,-1.008884 1.96494,-1.564223 0.363353,-0.269292 0.724129,-0.502509 1.086194,-0.700935 -0.04381,0.07731 -0.08633,0.155906 -0.128847,0.237082 -1.044963,1.963651 -2.120847,4.688798 -2.126002,7.792761 0,0.83236 0.68934,1.507527 1.539741,1.507527 0.8504,0 1.53974,-0.675166 1.53974,-1.507527 -0.0052,-2.396583 0.868439,-4.702973 1.774244,-6.393465 0.275736,-0.515397 0.551473,-0.972808 0.80015,-1.358066 0.262851,0.404585 0.554048,0.889055 0.842669,1.437951 0.891631,1.682761 1.736879,3.953073 1.731725,6.313579 0,0.832361 0.689339,1.507527 1.541029,1.507527 0.8504,0 1.53974,-0.675166 1.53974,-1.507527 -0.0052,-3.103962 -1.082328,-5.829109 -2.126002,-7.79276 -0.04381,-0.08118 -0.08633,-0.159766 -0.128846,-0.237083 0.360776,0.198427 0.722841,0.431644 1.086193,0.700936 0.743456,0.555339 1.392853,1.032079 1.96494,1.564223 0.572088,0.534721 1.079752,1.119693 1.575819,1.941747 0.287332,0.478027 0.801438,0.743456 1.328427,0.743456 0.265429,0 0.534723,-0.06701 0.780822,-0.208735 0.73186,-0.422623 0.976673,-1.349044 0.545031,-2.06673 z"/>
+                            <path d="m 110.04867,33.423349 c 0,1.337363 -1.20425,2.255717 -2.78341,2.255717 -1.1444,0 -2.03283,-0.578894 -2.03283,-1.597275 v -0.03938 c 0,-1.097929 0.90812,-1.757159 2.4479,-1.757159 0.94671,0 1.75637,0.180362 2.36834,0.419796 z m 1.14519,-5.709389 c -0.7309,-0.75847 -1.89499,-1.177478 -3.45446,-1.177478 -1.36257,0 -2.36913,0.239433 -3.35601,0.619062 -0.35521,0.139407 -0.65135,0.518247 -0.65135,0.957734 0,0.559204 0.45445,0.997903 1.00656,0.997903 0.11893,0 0.23707,-0.01969 0.3749,-0.05986 0.65215,-0.259124 1.40195,-0.419008 2.31007,-0.419008 1.67761,0 2.58572,0.798637 2.58572,2.295885 v 0.259123 c -0.80966,-0.259123 -1.63823,-0.438699 -2.8031,-0.438699 -2.54635,0 -4.30351,1.11762 -4.30351,3.393814 v 0.03938 c 0,2.11631 1.73747,3.254407 3.69153,3.254407 1.59885,0 2.68497,-0.67892 3.39539,-1.537416 v 0.399319 c 0,0.538725 0.47336,1.01838 1.16488,1.01838 0.65135,0 1.16409,-0.499345 1.16409,-1.157787 v -5.191142 c 0,-1.376743 -0.35522,-2.49515 -1.12471,-3.253619 z m -10.73828,-5.169877 c -0.671046,0 -1.184568,0.538726 -1.184568,1.197169 v 12.377301 c 0,0.67892 0.533212,1.197955 1.184568,1.197955 0.67104,0 1.20425,-0.519035 1.20425,-1.197955 V 23.741252 c 0,-0.658443 -0.53321,-1.197169 -1.20425,-1.197169 z m -4.954072,9.462354 c 0,1.816231 -1.223947,3.333956 -3.158319,3.333956 -1.855611,0 -3.178009,-1.537416 -3.178009,-3.374124 v -0.04017 c 0,-1.83592 1.223947,-3.353646 3.138628,-3.353646 1.875301,0 3.1977,1.536628 3.1977,3.393814 z m -3.158319,-5.550292 c -3.197699,0 -5.566832,2.495938 -5.566832,5.510124 v 0.04017 c 0,2.993708 2.349443,5.449478 5.527451,5.449478 3.21739,0 5.585735,-2.49515 5.585735,-5.489646 v -0.04017 c 0,-3.014186 -2.348655,-5.469956 -5.546354,-5.469956 z m -8.625912,5.550292 c 0,1.816231 -1.223947,3.333956 -3.158318,3.333956 -1.855611,0 -3.178009,-1.537416 -3.178009,-3.374124 v -0.04017 c 0,-1.83592 1.223947,-3.353646 3.138628,-3.353646 1.875301,0 3.197699,1.536628 3.197699,3.393814 z m -3.158318,-5.550292 c -3.197699,0 -5.566832,2.495938 -5.566832,5.510124 v 0.04017 c 0,2.993708 2.349442,5.449478 5.527451,5.449478 3.21739,0 5.585735,-2.49515 5.585735,-5.489646 v -0.04017 c 0,-3.014186 -2.348655,-5.469956 -5.546354,-5.469956 z m -8.704673,5.510124 c 0,2.076142 -1.342088,3.374124 -2.980319,3.374124 -1.618539,0 -3.040177,-1.35784 -3.040177,-3.374124 v -0.04017 c 0,-2.016283 1.421638,-3.374124 3.040177,-3.374124 1.61854,0 2.980319,1.338151 2.980319,3.374124 z m -2.408513,-5.510124 c -1.697301,0 -2.782629,0.878974 -3.552912,1.976903 v -4.691796 c 0,-0.678921 -0.532425,-1.197169 -1.204256,-1.197169 -0.671045,0 -1.183779,0.518248 -1.183779,1.197169 v 12.377301 c 0,0.658442 0.532425,1.197955 1.183779,1.197955 0.671831,0 1.204256,-0.539513 1.204256,-1.197955 v -0.538726 c 0.730903,0.977425 1.81623,1.856398 3.552912,1.856398 2.467584,0 4.836717,-1.976903 4.836717,-5.469956 v -0.04017 c 0,-3.513531 -2.388823,-5.469956 -4.836717,-5.469956 z M 54.563082,31.2078 c 0.217381,-1.637442 1.243637,-2.774752 2.704655,-2.774752 1.579159,0 2.486487,1.216858 2.644797,2.774752 z m 2.724345,-4.751655 c -2.981106,0 -5.09269,2.475461 -5.09269,5.490434 v 0.03938 c 0,3.254407 2.328965,5.469955 5.348664,5.469955 1.619327,0 2.803106,-0.538725 3.750602,-1.397221 0.178,-0.179575 0.315832,-0.439487 0.315832,-0.738779 0,-0.559203 -0.414284,-0.978212 -0.947496,-0.978212 -0.276451,0 -0.433973,0.08034 -0.611973,0.219743 -0.671045,0.559204 -1.460231,0.918354 -2.466797,0.918354 -1.539779,0 -2.744035,-0.958522 -3.000796,-2.675513 h 6.534017 c 0.611974,0 1.124708,-0.478867 1.124708,-1.157788 0,-2.435292 -1.63823,-5.190354 -4.954071,-5.190353 z m -10.16569,2.934638 4.303505,-4.191664 c 0.275663,-0.259912 0.433973,-0.539514 0.433973,-0.918354 0,-0.599372 -0.454451,-1.138098 -1.125496,-1.138098 -0.433973,0 -0.730115,0.159098 -1.006566,0.459177 l -6.55292,6.667912 v -5.909443 c 0,-0.67892 -0.533213,-1.217646 -1.204257,-1.217646 -0.690735,0 -1.223947,0.538726 -1.223947,1.217646 v 11.737762 c 0,0.67892 0.533212,1.218433 1.223947,1.218433 0.671044,0 1.204257,-0.539513 1.204257,-1.218433 v -2.894469 l 2.250203,-2.195859 4.441336,5.729868 c 0.255974,0.33946 0.552116,0.578893 1.026257,0.578893 0.690735,0 1.223947,-0.519035 1.223947,-1.197955 0,-0.379629 -0.138619,-0.619062 -0.335522,-0.878186 z"/>
+                        </g>
+                    </svg>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## What

Reworks the feature panel on `/login` so it reflects what the platform actually does today.

**Cards** (left brand panel) — replaces the stale, aspirational set (*Unified Data Access / Instant Automation / Smart Notifications / Performance Intelligence*) with the product pillars surfaced on `/home`:

| Card | Beta |
|---|---|
| **Data packages** | — (mature core) |
| **Marketplace** (plugins + skills + agents, curated + flea market) | `BETA` |
| **MCP** (connect MCP servers → materialized / passthrough tools) | `BETA` |
| **Memory** (shared analyst knowledge) | `BETA` |
| **Use it anywhere** (Cowork / web chat / Slack) | `BETA` |

A `BETA` badge marks every capability except the mature Data packages core.

**Copy** — the panel subtitle is realigned with the `/home` hero copy ("…so your AI agent stops guessing and starts answering").

**Layout** — card vertical footprint tightened (padding/subtitle margin) so the full set fits a standard viewport without scrolling. Removed the dead `.feature-icon-*` modifier CSS (base `.feature-icon` already covers it).

**Attribution** — adds a "Made by Keboola" authorship credit + official Keboola wordmark at the foot of the brand panel (authorship of the OSS itself, drawn in white via `currentColor`).

## Verification

- Rendered live from the app (not a mock) and screenshot-verified at 1440×900 — all 5 cards visible, badges and icons correct, attribution renders white on the brand panel.
- Design-system contract test (`tests/test_design_system_contract.py`) + `tests/test_login_form_action.py` pass.
- Jinja template compiles (extends + imports resolve).

## Notes

- **Vendor-content reviewer flag (expected):** the "Made by Keboola" attribution is intentional project-authorship branding shipped in the public template. The vendor-agnostic content guard / `agnes-reviewer-rules` may flag the `Keboola` token — this is a deliberate, accepted deviation.
- **Pre-existing flaky tests (not from this diff):** under `-n auto` the full suite intermittently fails `tests/test_data_package_tools.py::test_repo_add_remove_list_round_trip` and the `test_keboola_extractor_exit_codes` partial-failure cases. Confirmed by running the full suite on a clean tree (changes stashed) — `test_data_package_tools` fails there too, and the failing set varies between runs. This diff is template/CSS/changelog only and cannot affect those code paths.
- Release-cut (version bump) intentionally left for merge time.