### PR TITLE
fix(db): route sync orchestrator + knowledge domain visibility through the repo factory (Postgres)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.65.3] — 2026-06-04
+
 ### Fixed
 - **Postgres backend: the sync pipeline served no data on a PG instance.**
   `SyncOrchestrator.rebuild()` read the table registry, wrote `sync_state`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Fixed
+- **Postgres backend: the sync pipeline served no data on a PG instance.**
+  `SyncOrchestrator.rebuild()` read the table registry, wrote `sync_state`, and
+  read/reconciled `view_ownership` through a raw `get_system_db()` (always
+  DuckDB) — so on a Postgres-backed instance it saw an empty registry, rebuilt
+  zero analytics views, and wrote sync progress to a DuckDB file the
+  factory-backed `/dashboard` never reads. All three now go through the repo
+  factory (`table_registry_repo()` / `sync_state_repo()` / `view_ownership_repo()`),
+  so extract → rebuild → serve works on either backend. (Highest-severity
+  remaining split: without it a PG instance serves no data at all.) The profiler's
+  metric-table map (`profiler.get_table_map`) was the same raw-conn pattern and is
+  now `metric_repo()`-routed too.
+- **Postgres backend: memory visibility for non-admins with domain grants.**
+  `knowledge_pg`'s `list_items` / `_build_filter_clauses` (and `count_by_tag` /
+  `count_by_audience`) resolved `granted_domains` via a stale `domain IN (...)`
+  against an inline column instead of the v49 `knowledge_item_domains` junction
+  (matching the DuckDB sibling), so a non-admin's domain-granted memory items
+  were invisible/miscounted on Postgres.
+
 ## [0.65.2] — 2026-06-04
 
 ### Changed
@@ -32,21 +51,6 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   residual to keep the ratchet honest until they're routed through the factory.
 
 ### Fixed
-- **Postgres backend: the sync pipeline served no data on a PG instance.**
-  `SyncOrchestrator.rebuild()` read the table registry, wrote `sync_state`, and
-  read/reconciled `view_ownership` through a raw `get_system_db()` (always
-  DuckDB) — so on a Postgres-backed instance it saw an empty registry, rebuilt
-  zero analytics views, and wrote sync progress to a DuckDB file the
-  factory-backed `/dashboard` never reads. All three now go through the repo
-  factory (`table_registry_repo()` / `sync_state_repo()` / `view_ownership_repo()`),
-  so extract → rebuild → serve works on either backend. (Highest-severity
-  remaining split: without it a PG instance serves no data at all.)
-- **Postgres backend: memory visibility for non-admins with domain grants.**
-  `knowledge_pg`'s `list_items` / `_build_filter_clauses` (and `count_by_tag` /
-  `count_by_audience`) resolved `granted_domains` via a stale `domain IN (...)`
-  against an inline column instead of the v49 `knowledge_item_domains` junction
-  (matching the DuckDB sibling), so a non-admin's domain-granted memory items
-  were invisible/miscounted on Postgres.
 - **Postgres backend: admin telemetry, the stack resolver, and per-user MCP
   secrets now work on a PG instance.** Three more clusters that read system
   state off a raw DuckDB connection: the `/api/admin/telemetry/*` +

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,21 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   residual to keep the ratchet honest until they're routed through the factory.
 
 ### Fixed
+- **Postgres backend: the sync pipeline served no data on a PG instance.**
+  `SyncOrchestrator.rebuild()` read the table registry, wrote `sync_state`, and
+  read/reconciled `view_ownership` through a raw `get_system_db()` (always
+  DuckDB) — so on a Postgres-backed instance it saw an empty registry, rebuilt
+  zero analytics views, and wrote sync progress to a DuckDB file the
+  factory-backed `/dashboard` never reads. All three now go through the repo
+  factory (`table_registry_repo()` / `sync_state_repo()` / `view_ownership_repo()`),
+  so extract → rebuild → serve works on either backend. (Highest-severity
+  remaining split: without it a PG instance serves no data at all.)
+- **Postgres backend: memory visibility for non-admins with domain grants.**
+  `knowledge_pg`'s `list_items` / `_build_filter_clauses` (and `count_by_tag` /
+  `count_by_audience`) resolved `granted_domains` via a stale `domain IN (...)`
+  against an inline column instead of the v49 `knowledge_item_domains` junction
+  (matching the DuckDB sibling), so a non-admin's domain-granted memory items
+  were invisible/miscounted on Postgres.
 - **Postgres backend: admin telemetry, the stack resolver, and per-user MCP
   secrets now work on a PG instance.** Three more clusters that read system
   state off a raw DuckDB connection: the `/api/admin/telemetry/*` +

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.65.2"
+version = "0.65.3"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -301,12 +301,12 @@ class SyncOrchestrator:
         # rebuild and refuse to silently overwrite a previously-claimed
         # name. The map is kept in system.duckdb (analytics.duckdb is
         # rebuilt fresh each time and would not survive).
-        from src.db import get_system_db
-        from src.repositories.view_ownership import ViewOwnershipRepository
-        sys_conn_for_views = get_system_db()
+        # Backend-aware: view ownership lives in system state (Postgres on a
+        # PG instance) — use the factory, not a raw DuckDB conn.
+        from src.repositories import view_ownership_repo
         view_repo = None
         try:
-            view_repo = ViewOwnershipRepository(sys_conn_for_views)
+            view_repo = view_ownership_repo()
             # Pre-scan every connector's _meta so we can run the reconcile
             # pass BEFORE claims are evaluated. This makes "owner stopped
             # publishing → name freed → another source can claim" work in
@@ -335,11 +335,6 @@ class SyncOrchestrator:
             )
             existing_owners = {}
             view_repo = None
-            try:
-                sys_conn_for_views.close()
-            except Exception:
-                pass
-            sys_conn_for_views = None
 
         # Track every (source, view) pair this rebuild successfully claims.
         claimed_pairs: List[tuple] = []
@@ -381,7 +376,7 @@ class SyncOrchestrator:
                     conn, ext_dir.name, str(db_file),
                     existing_owners=existing_owners,
                     claimed_pairs=claimed_pairs,
-                    view_repo=view_repo if sys_conn_for_views else None,
+                    view_repo=view_repo,
                 )
                 if tables:
                     result[ext_dir.name] = tables
@@ -399,11 +394,6 @@ class SyncOrchestrator:
         finally:
             conn.execute("CHECKPOINT")
             conn.close()
-            if sys_conn_for_views is not None:
-                try:
-                    sys_conn_for_views.close()
-                except Exception:
-                    pass
 
         # Atomic swap: replace analytics.duckdb with new version
         _atomic_swap_db(tmp_path, self._db_path)
@@ -560,30 +550,23 @@ class SyncOrchestrator:
                     # parquet_in_extracts` pins this contract.
                     registered_ids: Optional[set] = None
                     try:
-                        from src.db import get_system_db
-                        from src.repositories.table_registry import (
-                            TableRegistryRepository,
-                        )
-                        sys_conn = get_system_db()
-                        try:
-                            rows = TableRegistryRepository(sys_conn).list_all()
-                            # Match parquet stems against registry rows for
-                            # THIS source where query_mode='materialized'.
-                            # The parquet filename is keyed by registry
-                            # `name` (per `_run_materialized_pass` /
-                            # `materialize_query` convention).
-                            registered_ids = {
-                                str(r.get("name"))
-                                for r in rows
-                                if (r.get("source_type") or "") == source_name
-                                and (r.get("query_mode") or "") == "materialized"
-                                and r.get("name")
-                            }
-                        finally:
-                            try:
-                                sys_conn.close()
-                            except Exception:
-                                pass
+                        # Backend-aware: read the registry through the factory
+                        # (Postgres on a PG instance) — a raw DuckDB conn would
+                        # see an empty registry and skip materialized parquets.
+                        from src.repositories import table_registry_repo
+                        rows = table_registry_repo().list_all()
+                        # Match parquet stems against registry rows for
+                        # THIS source where query_mode='materialized'.
+                        # The parquet filename is keyed by registry
+                        # `name` (per `_run_materialized_pass` /
+                        # `materialize_query` convention).
+                        registered_ids = {
+                            str(r.get("name"))
+                            for r in rows
+                            if (r.get("source_type") or "") == source_name
+                            and (r.get("query_mode") or "") == "materialized"
+                            and r.get("name")
+                        }
                     except Exception as e:
                         # No registry access (test fixture, transient DB
                         # error) — skip the fallback rather than risk
@@ -804,30 +787,27 @@ class SyncOrchestrator:
         path while their on-disk content was unrelated.
         """
         try:
-            from src.db import get_system_db
-            from src.repositories.sync_state import SyncStateRepository
+            # Backend-aware: write sync_state through the factory (Postgres on
+            # a PG instance) so /dashboard's factory-backed reads see it.
+            from src.repositories import sync_state_repo
 
             extracts_dir = _get_extracts_dir()
-            sys_conn = get_system_db()
-            try:
-                repo = SyncStateRepository(sys_conn)
-                for table_name, rows, size_bytes, query_mode in meta_rows:
-                    pq_path = extracts_dir / source_name / "data" / f"{table_name}.parquet"
-                    file_hash = ""
-                    if pq_path.exists():
-                        h = hashlib.md5()
-                        with open(pq_path, "rb") as f:
-                            for chunk in iter(lambda: f.read(8192), b""):
-                                h.update(chunk)
-                        file_hash = h.hexdigest()
+            repo = sync_state_repo()
+            for table_name, rows, size_bytes, query_mode in meta_rows:
+                pq_path = extracts_dir / source_name / "data" / f"{table_name}.parquet"
+                file_hash = ""
+                if pq_path.exists():
+                    h = hashlib.md5()
+                    with open(pq_path, "rb") as f:
+                        for chunk in iter(lambda: f.read(8192), b""):
+                            h.update(chunk)
+                    file_hash = h.hexdigest()
 
-                    repo.update_sync(
-                        table_id=table_name,
-                        rows=rows or 0,
-                        file_size_bytes=size_bytes or 0,
-                        hash=file_hash,
-                    )
-            finally:
-                sys_conn.close()
+                repo.update_sync(
+                    table_id=table_name,
+                    rows=rows or 0,
+                    file_size_bytes=size_bytes or 0,
+                    hash=file_hash,
+                )
         except Exception as e:
             logger.warning("Could not update sync_state: %s", e)

--- a/src/profiler.py
+++ b/src/profiler.py
@@ -96,14 +96,11 @@ DATA_DESCRIPTION_PATH = DOCS_DIR / "data_description.md"
 def _load_metrics_from_db() -> Dict[str, List[str]]:
     """Load metrics table map from DuckDB. Returns empty dict on failure."""
     try:
-        from src.db import get_system_db
-        from src.repositories.metrics import MetricRepository
+        # Backend-aware: metric definitions live in the active backend
+        # (Postgres on a PG instance) — use the factory, not a raw DuckDB conn.
+        from src.repositories import metric_repo
 
-        conn = get_system_db()
-        repo = MetricRepository(conn)
-        table_map = repo.get_table_map()
-        conn.close()
-        return table_map
+        return metric_repo().get_table_map()
     except Exception as exc:
         logger.debug("Could not load metrics from DuckDB: %s", exc)
         return {}

--- a/src/repositories/knowledge_pg.py
+++ b/src/repositories/knowledge_pg.py
@@ -251,7 +251,11 @@ class KnowledgePgRepository:
                 keys = []
                 for i, d in enumerate(granted_domains):
                     k = f"gd_{i}"; keys.append(f":{k}"); params[k] = d
-                visibility.append(f"domain IN ({','.join(keys)})")
+                visibility.append(
+                    "EXISTS (SELECT 1 FROM knowledge_item_domains kid "
+                    "WHERE kid.item_id = knowledge_items.id "
+                    f"AND kid.domain_id IN ({','.join(keys)}))"
+                )
             sql_parts.append(" AND (" + " OR ".join(visibility) + ")")
         if hide_dismissed and dismissed_by_user:
             sql_parts.append(
@@ -422,7 +426,11 @@ class KnowledgePgRepository:
                 keys = []
                 for i, d in enumerate(granted_domains):
                     k = f"gd_{i}"; keys.append(f":{k}"); params[k] = d
-                vis.append(f"domain IN ({','.join(keys)})")
+                vis.append(
+                    "EXISTS (SELECT 1 FROM knowledge_item_domains kid "
+                    "WHERE kid.item_id = knowledge_items.id "
+                    f"AND kid.domain_id IN ({','.join(keys)}))"
+                )
             parts.append(" AND (" + " OR ".join(vis) + ")")
         if hide_dismissed and dismissed_by_user:
             parts.append(

--- a/tests/test_backend_split_guard.py
+++ b/tests/test_backend_split_guard.py
@@ -164,9 +164,8 @@ _GRANDFATHERED_DIRECT_INSTANTIATION: dict[str, set[str]] = {
     "src/catalog_export.py": {"TableRegistryRepository"},
     "src/claude_md.py": {"ClaudeMdTemplateRepository"},
     # src/orchestrator.py — rebuild/sync_state/view_ownership migrated to the
-    # factory (view_ownership_repo / table_registry_repo / sync_state_repo) so
-    # the sync pipeline reads/writes the active backend; entry removed.
-    "src/profiler.py": {"MetricRepository"},
+    # factory; entry removed.
+    # src/profiler.py — get_table_map migrated to metric_repo(); entry removed.
     "src/store_guardrails/purge.py": {"StoreEntitiesRepository", "StoreSubmissionsRepository"},
     "src/store_guardrails/reaper.py": {"AuditRepository"},
     "src/store_guardrails/runner.py": {"AuditRepository", "StoreEntitiesRepository", "StoreSubmissionsRepository"},
@@ -203,7 +202,6 @@ _GRANDFATHERED_GET_SYSTEM_DB: set[str] = {
     "cli/commands/admin_metrics.py",
     "services/verification_detector/__main__.py",
     "src/catalog_export.py",
-    "src/profiler.py",
     "src/rbac.py",
 }
 

--- a/tests/test_backend_split_guard.py
+++ b/tests/test_backend_split_guard.py
@@ -163,7 +163,9 @@ _GRANDFATHERED_DIRECT_INSTANTIATION: dict[str, set[str]] = {
     "services/slack_bot/events.py": {"UserRepository"},
     "src/catalog_export.py": {"TableRegistryRepository"},
     "src/claude_md.py": {"ClaudeMdTemplateRepository"},
-    "src/orchestrator.py": {"SyncStateRepository", "TableRegistryRepository", "ViewOwnershipRepository"},
+    # src/orchestrator.py — rebuild/sync_state/view_ownership migrated to the
+    # factory (view_ownership_repo / table_registry_repo / sync_state_repo) so
+    # the sync pipeline reads/writes the active backend; entry removed.
     "src/profiler.py": {"MetricRepository"},
     "src/store_guardrails/purge.py": {"StoreEntitiesRepository", "StoreSubmissionsRepository"},
     "src/store_guardrails/reaper.py": {"AuditRepository"},
@@ -201,7 +203,6 @@ _GRANDFATHERED_GET_SYSTEM_DB: set[str] = {
     "cli/commands/admin_metrics.py",
     "services/verification_detector/__main__.py",
     "src/catalog_export.py",
-    "src/orchestrator.py",
     "src/profiler.py",
     "src/rbac.py",
 }

--- a/tests/test_orchestrator_sync_state_hash.py
+++ b/tests/test_orchestrator_sync_state_hash.py
@@ -52,7 +52,11 @@ def _run_update(system_db_path, meta_rows, data_dir):
     def fake_get_system_db():
         return duckdb.connect(str(system_db_path))
 
+    # The orchestrator now writes sync_state through the repo factory, which
+    # binds get_system_db at src.repositories import time — patch both the
+    # source and the factory's binding so the redirect takes effect.
     with patch("src.db.get_system_db", side_effect=fake_get_system_db), \
+         patch("src.repositories.get_system_db", side_effect=fake_get_system_db), \
          patch("src.orchestrator._get_extracts_dir", return_value=data_dir / "extracts"):
         orch = SyncOrchestrator.__new__(SyncOrchestrator)
         orch._update_sync_state(meta_rows=meta_rows, source_name="keboola")


### PR DESCRIPTION
## Follow-up to #527 — further "running on Postgres" hardening

> **Stacks on #527** (uses the parity harness + backend-split guard added there). Merge #527 first; this branch's diff collapses to just the two fixes below once rebased onto main.

Continuing the systematic audit of what breaks when Agnes runs on a Postgres state backend — beyond the request-endpoint layer (#527) into the background/sync pipeline.

### Fixed

- **The sync pipeline served NO data on a PG instance (highest-severity remaining split).** `SyncOrchestrator.rebuild()` read the table registry, wrote `sync_state`, and read/reconciled `view_ownership` through a raw `get_system_db()` (always DuckDB). On a Postgres-backed instance it therefore saw an *empty* registry → rebuilt zero analytics views → served nothing, and wrote sync progress to a DuckDB file the factory-backed `/dashboard` never reads. All three now route through `table_registry_repo()` / `sync_state_repo()` / `view_ownership_repo()`, so extract → rebuild → serve works on either backend.
- **Memory visibility for non-admins with domain grants on PG.** `knowledge_pg`'s `list_items` / `_build_filter_clauses` resolved `granted_domains` via a stale `domain IN (...)` (inline column) instead of the v49 `knowledge_item_domains` junction (matching the DuckDB sibling + the `count_by_tag`/`count_by_audience`/`stats_breakdown` already on this base). A non-admin's domain-granted items were invisible/miscounted on Postgres.

### Tests
- Backend-split guard allow-lists shrank: `src/orchestrator.py` removed from both the direct-instantiation and `get_system_db` lists.
- `test_orchestrator_sync_state_hash` updated to patch the factory's `get_system_db` binding.
- Verified: orchestrator suite (74 passed), `tests/db_pg` knowledge/memory parity, guard (6/6), ruff F-clean.

Found by continuing the deterministic `get_system_db()` residual sweep into the background/ops layer.
