### PR TITLE
fix(db): route remaining MCP-secret + BQ-metadata reads through the repo factory (Postgres)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Fixed
+- **Postgres backend: deleting an MCP source leaked its per-user secrets.**
+  `DELETE /api/admin/mcp-sources/{id}` purged per-user vault rows via a raw
+  `PerUserSecretsRepository(conn)` off the always-DuckDB connection. Per-user
+  secrets were migrated to Postgres (#530), so on a PG instance the rows
+  survived the delete — orphaned encrypted blobs, the exact thing the cleanup
+  was added to prevent. Now routed through `per_user_secrets_repo()`.
+- **Postgres backend: the "this is a VIEW" cost-guard hint never fired.**
+  `query._view_targets_in` (which enriches the `remote_scan_too_large` error
+  with a "LIMIT doesn't push into a view body" note) joined `bq_metadata_cache`
+  against `table_registry` on the always-DuckDB connection — empty on a PG
+  instance, so the hint silently never appeared. Now resolved through
+  `table_registry_repo()` + `bq_metadata_cache_repo()`. Both fixes pinned by
+  both-backends parity tests in `tests/db_pg/`.
+
+### Internal
+- Dropped vestigial `conn` parameters from `app/api/bq_metadata_refresh.py`
+  (`refresh_one`, `_list_remote_bq_rows`, and the three endpoint handlers) — the
+  module is already fully factory-routed, so the `Depends(_get_db)` / passed
+  connection was dead. `bq_metadata_refresh.py` and `query.py` drop out of the
+  backend-split guard's `get_system_db` residual list.
+
 ## [0.65.2] — 2026-06-04
 
 ### Changed

--- a/app/api/admin_mcp.py
+++ b/app/api/admin_mcp.py
@@ -42,13 +42,16 @@ from pydantic import BaseModel, field_validator
 from app.auth.access import require_admin
 from app.auth.dependencies import _get_db
 from app.secrets_vault import (
-    PerUserSecretsRepository,
     SharedSecretsRepository,
     VaultKeyNotConfiguredError,
 )
 from connectors.mcp import classifier as mcp_classifier
 from connectors.mcp import extractor as mcp_extractor
-from src.repositories import mcp_sources_repo, tool_registry_repo
+from src.repositories import (
+    mcp_sources_repo,
+    per_user_secrets_repo,
+    tool_registry_repo,
+)
 from src.repositories.audit import AuditRepository
 from src.repositories.mcp_sources import MCPSourceRepository  # noqa: F401  # kept for type-only imports + tests that monkeypatch the symbol
 from src.repositories.tool_registry import (
@@ -497,7 +500,10 @@ async def delete_mcp_source(
     # Clean up vault secrets so a deleted source leaves no orphaned encrypted
     # blobs — the shared secret plus any per-user rows. (Devin Review on #530.)
     SharedSecretsRepository(conn).delete(source_id)
-    pu_secrets = PerUserSecretsRepository(conn)
+    # Per-user secrets were migrated to Postgres (#530), so they must be dropped
+    # through the factory — a raw PerUserSecretsRepository(conn) deletes from the
+    # always-DuckDB connection and leaves orphaned rows on a PG instance.
+    pu_secrets = per_user_secrets_repo()
     for uid in pu_secrets.list_for_source(source_id):
         pu_secrets.delete(source_id, uid)
     _audit(

--- a/app/api/bq_metadata_refresh.py
+++ b/app/api/bq_metadata_refresh.py
@@ -38,11 +38,10 @@ import time
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 
-import duckdb
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from app.auth.access import require_admin
-from app.auth.dependencies import _get_db, get_current_user
+from app.auth.dependencies import get_current_user
 
 from src.repositories import (
     bq_metadata_cache_repo,
@@ -115,7 +114,7 @@ def compute_freshness(
 # ─── Single-row refresh primitive ──────────────────────────────────────────
 
 
-def refresh_one(conn: duckdb.DuckDBPyConnection, row: dict[str, Any]) -> dict[str, Any]:
+def refresh_one(row: dict[str, Any]) -> dict[str, Any]:
     """Fetch BQ metadata for one row and UPSERT the result.
 
     Synchronous; safe to call from an anyio thread. Returns a small
@@ -176,7 +175,7 @@ def refresh_one(conn: duckdb.DuckDBPyConnection, row: dict[str, Any]) -> dict[st
     }
 
 
-def _list_remote_bq_rows(conn: duckdb.DuckDBPyConnection) -> list[dict[str, Any]]:
+def _list_remote_bq_rows() -> list[dict[str, Any]]:
     rows = table_registry_repo().list_all()
     return [
         r for r in rows
@@ -217,7 +216,6 @@ _refresh_state: dict[str, Any] = {"run_id": None, "started_at": None}
 @router.post("/api/admin/run-bq-metadata-refresh")
 async def run_bq_metadata_refresh(
     user: dict = Depends(require_admin),
-    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
 ):
     """Refresh metadata for every remote BQ row in the registry.
 
@@ -234,8 +232,6 @@ async def run_bq_metadata_refresh(
     many remote tables doesn't fan out to dozens of parallel BQ jobs.
     """
     import uuid
-
-    from src.db import get_system_db
 
     if _refresh_lock.locked():
         # Issue #256: emit 409 instead of doing 2× BQ work.
@@ -255,14 +251,12 @@ async def run_bq_metadata_refresh(
         _refresh_state["run_id"] = run_id
         _refresh_state["started_at"] = started_at
         try:
-            rows = _list_remote_bq_rows(conn)
+            rows = _list_remote_bq_rows()
             sem = asyncio.Semaphore(_refresh_concurrency())
 
             async def _one(row: dict[str, Any]) -> dict[str, Any]:
                 async with sem:
-                    # Each refresh_one call wants its own cursor; the singleton
-                    # connection accessor returns a fresh cursor each call.
-                    return await asyncio.to_thread(refresh_one, get_system_db(), row)
+                    return await asyncio.to_thread(refresh_one, row)
 
             t0 = time.monotonic()
             results = await asyncio.gather(
@@ -304,7 +298,6 @@ async def run_bq_metadata_refresh(
 async def refresh_one_table(
     table: str = Query(..., description="Registry table_id to refresh"),
     user: dict = Depends(require_admin),
-    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
 ):
     """Operator on-demand refresh of one row.
 
@@ -313,8 +306,6 @@ async def refresh_one_table(
     BQ schema change that the operator wants reflected before the next
     scheduled tick.
     """
-    from src.db import get_system_db
-
     row = table_registry_repo().get(table)
     if not row:
         raise HTTPException(status_code=404, detail=f"Unknown table_id: {table}")
@@ -323,13 +314,12 @@ async def refresh_one_table(
             status_code=400,
             detail="Manual metadata refresh is only meaningful for remote BigQuery tables",
         )
-    return await asyncio.to_thread(refresh_one, get_system_db(), row)
+    return await asyncio.to_thread(refresh_one, row)
 
 
 @router.get("/api/v2/metadata-cache/status")
 def metadata_cache_status(
     user: dict = Depends(get_current_user),
-    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
 ):
     """Per-table cache status. Non-admin — analyst tools rely on this to
     decide whether to trust the catalog's ``rows`` / ``size_bytes`` or

--- a/app/api/cache_warmup.py
+++ b/app/api/cache_warmup.py
@@ -167,8 +167,7 @@ def _warm_metadata_sync(row: dict) -> None:
     (the same primitive the scheduler-driven refresh uses).
     """
     from app.api.bq_metadata_refresh import refresh_one
-    from src.db import get_system_db
-    refresh_one(get_system_db(), row)
+    refresh_one(row)
 
 
 def _warm_schema_sync(row: dict) -> None:

--- a/app/api/query.py
+++ b/app/api/query.py
@@ -1282,30 +1282,26 @@ def _view_targets_in(dry_run_set: list) -> list[str]:
     if not dry_run_set:
         return []
     try:
-        from src.db import get_system_db
-        conn = get_system_db()
-        try:
-            pairs = [(b, t) for b, t, _ in dry_run_set]
-            # Build a parameterized OR of (bucket, source_table) pairs.
-            # DuckDB supports row-tuple IN but keeping it explicit OR
-            # avoids any version-specific syntax surprises.
-            where = " OR ".join(
-                "(tr.bucket = ? AND tr.source_table = ?)" for _ in pairs
-            )
-            params: list = []
-            for b, t in pairs:
-                params.extend([b, t])
-            sql_ = (
-                f"SELECT mc.table_id "
-                f"FROM bq_metadata_cache mc "
-                f"JOIN table_registry tr ON tr.id = mc.table_id "
-                f"WHERE mc.entity_type IN ('VIEW', 'MATERIALIZED VIEW') "
-                f"AND ({where})"
-            )
-            rows = conn.execute(sql_, params).fetchall()
-            return [r[0] for r in rows]
-        finally:
-            conn.close()
+        # Route through the repo factory (backend-agnostic): a raw JOIN on the
+        # always-DuckDB system connection comes back empty on a Postgres
+        # instance, so bq_metadata_cache / table_registry would be invisible and
+        # the VIEW hint would silently never fire.
+        from src.repositories import bq_metadata_cache_repo, table_registry_repo
+
+        wanted = {(b, t) for b, t, _ in dry_run_set}
+        target_ids = {
+            r["id"]
+            for r in table_registry_repo().list_all()
+            if (r.get("bucket"), r.get("source_table")) in wanted
+        }
+        if not target_ids:
+            return []
+        view_types = {"VIEW", "MATERIALIZED VIEW"}
+        return [
+            r["table_id"]
+            for r in bq_metadata_cache_repo().list_all()
+            if r.get("table_id") in target_ids and r.get("entity_type") in view_types
+        ]
     except Exception:
         return []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.65.4"
+version = "0.65.5"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/tests/db_pg/conftest.py
+++ b/tests/db_pg/conftest.py
@@ -27,6 +27,14 @@ import sqlalchemy as sa
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 
+# Ensure every SQLAlchemy model is registered on ``src.db_pg.Base.metadata``
+# before any test runs. Tests that call ``Base.metadata.create_all(pg_engine)``
+# (e.g. ``test_db_state_migrator.py``) need the full model set; without this
+# pre-import they fail on a pytest-xdist worker whose test slice doesn't
+# transitively import ``src.models`` before the first such test runs
+# (`relation "users" does not exist` from a half-populated metadata).
+import src.models  # noqa: F401
+
 
 _VALID_BACKENDS = {"container", "embedded", "pgserver"}
 

--- a/tests/db_pg/test_parity_bq_metadata_views.py
+++ b/tests/db_pg/test_parity_bq_metadata_views.py
@@ -1,0 +1,79 @@
+"""Parity test for the BigQuery VIEW-hint lookup across both backends.
+
+``app/api/query._view_targets_in`` enriches the ``remote_scan_too_large`` error
+with "this is a VIEW, LIMIT won't push" by joining ``bq_metadata_cache`` against
+``table_registry``. It previously ran that join on the always-DuckDB system
+connection, so on a Postgres instance both tables came back empty and the hint
+silently never fired. The fix resolves it through the repo factory
+(``table_registry_repo()`` + ``bq_metadata_cache_repo()``).
+
+These tests seed a VIEW and a BASE TABLE through the factory and assert
+``_view_targets_in`` returns only the view's id — on DuckDB AND Postgres.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def _env(state_backend, tmp_path, monkeypatch):
+    """DATA_DIR + (DuckDB) fresh system DB, for either backend."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    for sub in ("extracts", "analytics", "state", "notifications"):
+        (tmp_path / sub).mkdir(exist_ok=True)
+    if state_backend == "duckdb":
+        from src.db import close_system_db, get_system_db
+
+        close_system_db()
+        get_system_db()
+    return state_backend
+
+
+def _seed_remote_bq(table_id: str, bucket: str, source_table: str, entity_type: str):
+    """Register a remote BQ table + its metadata-cache entity_type via factory."""
+    from src.repositories import bq_metadata_cache_repo, table_registry_repo
+
+    table_registry_repo().register(
+        id=table_id,
+        name=table_id,
+        source_type="bigquery",
+        bucket=bucket,
+        source_table=source_table,
+        query_mode="remote",
+    )
+    bq_metadata_cache_repo().upsert_success(
+        table_id,
+        rows=None,
+        size_bytes=None,
+        partition_by=None,
+        clustered_by=None,
+        entity_type=entity_type,
+    )
+
+
+def test_view_targets_in_resolves_views_on_both_backends(_env):
+    from app.api.query import _view_targets_in
+
+    _seed_remote_bq("the_view", "buck", "v_tbl", "VIEW")
+    _seed_remote_bq("the_matview", "buck", "mv_tbl", "MATERIALIZED VIEW")
+    _seed_remote_bq("the_base", "buck", "base_tbl", "BASE TABLE")
+
+    # dry_run_set rows are (bucket, source_table, <ignored>) triples.
+    dry_run_set = [
+        ("buck", "v_tbl", "x"),
+        ("buck", "mv_tbl", "x"),
+        ("buck", "base_tbl", "x"),
+    ]
+    result = set(_view_targets_in(dry_run_set))
+
+    assert result == {"the_view", "the_matview"}, (
+        f"[{_env}] expected only the VIEW / MATERIALIZED VIEW ids; got {result}. "
+        f"On Postgres a raw-conn join would return an empty set."
+    )
+
+
+def test_view_targets_in_empty_when_only_base_tables(_env):
+    from app.api.query import _view_targets_in
+
+    _seed_remote_bq("base_only", "buck", "bt", "BASE TABLE")
+    assert _view_targets_in([("buck", "bt", "x")]) == []

--- a/tests/db_pg/test_parity_mcp_admin.py
+++ b/tests/db_pg/test_parity_mcp_admin.py
@@ -12,6 +12,8 @@ seeded row on BOTH backends; a handler that reads through a raw DuckDB conn
 """
 from __future__ import annotations
 
+import pytest
+
 
 def _auth(seeded_app_both, who="admin"):
     return {"Authorization": f"Bearer {seeded_app_both[f'{who}_token']}"}
@@ -168,4 +170,48 @@ def test_add_mcp_tool_grant_finds_factory_seeded_group(seeded_app_both):
     assert gid in detail.json().get("grants", []), (
         f"[{seeded_app_both['backend']}] grant not reflected in tool detail: "
         f"{detail.json()}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/admin/mcp-sources/{id} — per-user secret cleanup.
+#
+# The delete handler purges the source's vault secrets so no orphaned encrypted
+# blobs survive. Per-user secrets were migrated to Postgres (#530), but the
+# cleanup used a raw ``PerUserSecretsRepository(conn)`` off the always-DuckDB
+# connection — so on a PG instance the per-user rows were NOT deleted and
+# leaked. The fix routes the cleanup through ``per_user_secrets_repo()``.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _vault_key(monkeypatch):
+    """Storing a per-user secret requires a configured Fernet vault key."""
+    from cryptography.fernet import Fernet
+
+    monkeypatch.setenv("AGNES_VAULT_KEY", Fernet.generate_key().decode("ascii"))
+
+
+def test_delete_source_clears_per_user_secret_on_both_backends(
+    seeded_app_both, _vault_key
+):
+    from src.repositories import per_user_secrets_repo
+
+    sid = _seed_source(name="del_cleanup_src")
+    # Seed a per-user secret through the factory (lands in the active backend).
+    per_user_secrets_repo().upsert(sid, "analyst1", "to-be-purged")
+    assert per_user_secrets_repo().has(sid, "analyst1") is True
+
+    r = seeded_app_both["client"].delete(
+        f"/api/admin/mcp-sources/{sid}", headers=_auth(seeded_app_both)
+    )
+    assert r.status_code == 204, (
+        f"[{seeded_app_both['backend']}] DELETE mcp-sources/{{id}} returned "
+        f"{r.status_code}: {r.text}"
+    )
+
+    assert per_user_secrets_repo().has(sid, "analyst1") is False, (
+        f"[{seeded_app_both['backend']}] per-user secret survived source delete "
+        f"— the cleanup deleted off a raw DuckDB conn instead of "
+        f"per_user_secrets_repo(), orphaning the row on Postgres."
     )

--- a/tests/test_backend_split_guard.py
+++ b/tests/test_backend_split_guard.py
@@ -173,11 +173,13 @@ _GRANDFATHERED_DIRECT_INSTANTIATION: dict[str, set[str]] = {
 
 _GRANDFATHERED_GET_SYSTEM_DB: set[str] = {
     "app/api/admin.py",
-    "app/api/bq_metadata_refresh.py",
+    # app/api/bq_metadata_refresh.py — vestigial conn params removed; the file
+    # is fully factory-routed (bq_metadata_cache_repo / table_registry_repo).
     "app/api/cache_warmup.py",
     "app/api/health.py",
     "app/api/mcp_http.py",
-    "app/api/query.py",
+    # app/api/query.py — the bq-metadata VIEW-hint lookup (_view_targets_in)
+    # now routes through the factory; no remaining get_system_db caller.
     "app/api/scripts.py",
     "app/api/sync.py",
     "app/api/upload.py",


### PR DESCRIPTION
## What

Three more Postgres backend-split sites — two real bugs + one cleanup. None were caught by the backend-split guard: the secrets-vault DuckDB class lives outside `src/repositories/` (so the guard's class-pairing can't see it), and the others used raw `get_system_db()` joins the guard tracks only by removal.

### 1. Per-user MCP secrets leaked on source delete (real bug)
`DELETE /api/admin/mcp-sources/{id}` purges a source's vault secrets so no orphaned encrypted blobs survive (Devin review on #530). The per-user cleanup used a raw `PerUserSecretsRepository(conn)` off the always-DuckDB connection — but per-user secrets were migrated to Postgres in #530. So on a PG instance the rows **survived the delete**, the exact orphan the cleanup was meant to prevent. → now `per_user_secrets_repo()`.

### 2. "This is a VIEW" cost-guard hint never fired on PG (real bug)
`query._view_targets_in` enriches the `remote_scan_too_large` error with a "LIMIT doesn't push into a view body, so this still scans the whole table" note. It joined `bq_metadata_cache` against `table_registry` on the always-DuckDB connection — empty on a PG instance, so the hint silently never appeared. → now resolved through `table_registry_repo()` + `bq_metadata_cache_repo()` (no new repo method — uses existing `list_all()` on both backends).

### 3. Vestigial conn params in bq_metadata_refresh.py (cleanup)
`refresh_one`, `_list_remote_bq_rows`, and the three endpoint handlers carried `conn` / `Depends(_get_db)` params although the module was already fully factory-routed (`bq_metadata_cache_repo` / `table_registry_repo`). Dead code removed; the one external caller (`cache_warmup._warm_metadata_sync`) updated.

## Guard

`app/api/bq_metadata_refresh.py` and `app/api/query.py` drop out of the backend-split guard's `get_system_db` residual list (the ratchet shrinks).

## Test

Both behavioural fixes are pinned by new both-backends parity tests:
- `tests/db_pg/test_parity_bq_metadata_views.py` — `_view_targets_in` returns the VIEW / MATERIALIZED VIEW ids on DuckDB **and** Postgres (returns `[]` on `[pg]` before the fix).
- `tests/db_pg/test_parity_mcp_admin.py::test_delete_source_clears_per_user_secret_on_both_backends` — per-user secret is gone after source delete on both backends (survives on `[pg]` before the fix).

Full suite green (6971 passed).

## Stacking

Independent of #532 / #533 — branches off `main` (only depends on merged #527). Can merge in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)