### PR TITLE
fix(db): seed system groups into the active backend so RBAC bootstraps on Postgres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
-<<<<<<< HEAD
+## [0.65.7] — 2026-06-04
+
 ### Fixed
 - **Postgres backend: a fresh instance had no `Admin` / `Everyone` system
   groups, so admin access and Everyone-scoped grants never worked.** The system
@@ -21,8 +22,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   admin access. Startup now seeds the system groups through the factory
   (`user_groups_repo().ensure_system`, idempotent on either backend) and the
   seed-admin step resolves group ids + writes membership through the factory.
-  Pinned by both-backends parity tests (`tests/db_pg/test_parity_seed_admin_groups.py`).
-=======
+  Pinned by both-backends parity tests (`tests/db_pg/test_parity_seed_admin_groups.py`). (#536)
+
 ## [0.65.6] — 2026-06-04
 
 ### Fixed
@@ -34,7 +35,6 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   which dispatches on `use_pg()` (Postgres via the engine, DuckDB via the system
   connection) while keeping the same RBAC row filter. Pinned by a both-backends
   parity test (`tests/db_pg/test_parity_internal_sample.py`).
->>>>>>> origin/main
 
 ## [0.65.5] — 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Fixed
+- **Postgres backend: a fresh instance had no `Admin` / `Everyone` system
+  groups, so admin access and Everyone-scoped grants never worked.** The system
+  groups are seeded by `src.db._seed_system_groups`, which runs only on a DuckDB
+  connect — nothing seeded them on Postgres. The lifespan seed-admin step then
+  looked the `Admin` group up off a raw DuckDB connection, so the membership it
+  wrote referenced a DuckDB-only group id absent from Postgres and granted no
+  admin access. Startup now seeds the system groups through the factory
+  (`user_groups_repo().ensure_system`, idempotent on either backend) and the
+  seed-admin step resolves group ids + writes membership through the factory.
+  Pinned by both-backends parity tests (`tests/db_pg/test_parity_seed_admin_groups.py`).
+
 ## [0.65.5] — 2026-06-04
 
 ### Fixed

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@
 import warnings as _warnings
 from src.repositories import (
     user_group_members_repo,
+    user_groups_repo,
     users_repo,
 )
 try:
@@ -441,7 +442,6 @@ async def lifespan(app):
     # backend.
     try:
         from src.db import _SYSTEM_GROUPS_SEED
-        from src.repositories import user_groups_repo
         _ug_repo = user_groups_repo()
         for _grp_name, _grp_desc in _SYSTEM_GROUPS_SEED:
             _ug_repo.ensure_system(_grp_name, _grp_desc)

--- a/app/main.py
+++ b/app/main.py
@@ -431,12 +431,31 @@ async def lifespan(app):
     except Exception:
         logger.exception("BQ startup config validation crashed (non-fatal)")
 
+    # Seed the Admin/Everyone system groups into the ACTIVE state backend.
+    # On DuckDB this duplicates src.db._seed_system_groups (idempotent), but
+    # that runs ONLY on a DuckDB connect — nothing seeds these groups on a
+    # Postgres instance, so without this a fresh PG deploy has no Admin group
+    # (require_admin can never pass) and no Everyone group (Everyone-scoped
+    # grants like Required onboarding never surface). ensure_system is
+    # idempotent and routes through the factory, so it is correct on either
+    # backend.
+    try:
+        from src.db import _SYSTEM_GROUPS_SEED
+        from src.repositories import user_groups_repo
+        _ug_repo = user_groups_repo()
+        for _grp_name, _grp_desc in _SYSTEM_GROUPS_SEED:
+            _ug_repo.ensure_system(_grp_name, _grp_desc)
+    except Exception as e:
+        logger.warning("Could not seed system groups: %s", e)
+
     # Seed admin user (SEED_ADMIN_EMAIL) and add them to the Admin user_group.
     # Optional SEED_ADMIN_PASSWORD lets the seeded user sign in immediately
     # without going through bootstrap; never overwritten if already set.
-    # The Admin/Everyone user_groups themselves are seeded inside
-    # _ensure_schema (src.db._seed_system_groups), so this hook only has to
-    # handle membership for the seed admin.
+    # The Admin/Everyone user_groups were ensured just above (factory →
+    # active backend), so this hook only has to handle membership for the
+    # seed admin — looking the groups up through the factory too, so it gets
+    # the active backend's group ids (a raw DuckDB read returned a DuckDB-only
+    # group id that does not exist on a Postgres instance).
     # Lives in lifespan (worker-only), NOT create_app(): the latter runs
     # in the uvicorn --reload master too, and duckdb >=1.5 holds an
     # exclusive per-process file lock on system.duckdb that would then
@@ -445,9 +464,10 @@ async def lifespan(app):
     seed_email = os.environ.get("SEED_ADMIN_EMAIL") or (get_local_dev_email() if is_local_dev_mode() else None)
     if seed_email:
         try:
-            from src.db import SYSTEM_ADMIN_GROUP, get_system_db
-            conn = get_system_db()
+            from src.db import SYSTEM_ADMIN_GROUP, SYSTEM_EVERYONE_GROUP
             repo = users_repo()
+            groups_repo = user_groups_repo()
+            members_repo = user_group_members_repo()
             seed_password = os.environ.get("SEED_ADMIN_PASSWORD") or None
             password_hash = None
             if seed_password:
@@ -470,15 +490,14 @@ async def lifespan(app):
                     repo.update(id=user_id, password_hash=password_hash)
                     logger.info("Set password on existing seed admin: %s", seed_email)
             # Make sure the seed admin is actually in the Admin group — this
-            # is what gives them admin access in v12. Idempotent.
-            from src.db import SYSTEM_EVERYONE_GROUP
-            admin_group = conn.execute(
-                "SELECT id FROM user_groups WHERE name = ?", [SYSTEM_ADMIN_GROUP],
-            ).fetchone()
+            # is what gives them admin access in v12. Idempotent. Look the
+            # group up through the factory so we get the ACTIVE backend's id
+            # (raw DuckDB read returned a DuckDB group id absent from Postgres).
+            admin_group = groups_repo.get_by_name(SYSTEM_ADMIN_GROUP)
             if admin_group:
-                user_group_members_repo().add_member(
+                members_repo.add_member(
                     user_id=user_id,
-                    group_id=admin_group[0],
+                    group_id=admin_group["id"],
                     source="system_seed",
                     added_by="app.main:seed_admin",
                 )
@@ -487,18 +506,14 @@ async def lifespan(app):
             # default reference packages). The seed admin not being in
             # Everyone meant their own Required grants didn't surface on
             # /catalog as Required for them, which read as a bug.
-            everyone_group = conn.execute(
-                "SELECT id FROM user_groups WHERE name = ?",
-                [SYSTEM_EVERYONE_GROUP],
-            ).fetchone()
+            everyone_group = groups_repo.get_by_name(SYSTEM_EVERYONE_GROUP)
             if everyone_group:
-                UserGroupMembersRepository(conn).add_member(
+                members_repo.add_member(
                     user_id=user_id,
-                    group_id=everyone_group[0],
+                    group_id=everyone_group["id"],
                     source="system_seed",
                     added_by="app.main:seed_admin",
                 )
-            conn.close()
         except Exception as e:
             logger.warning(f"Could not seed admin: {e}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.65.6"
+version = "0.65.7"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/tests/db_pg/test_parity_seed_admin_groups.py
+++ b/tests/db_pg/test_parity_seed_admin_groups.py
@@ -1,0 +1,94 @@
+"""Parity test for system-group seeding + seed-admin membership.
+
+A fresh instance must end up with the ``Admin`` and ``Everyone`` system groups
+and a seed admin who is actually a *member* of ``Admin`` (that membership is
+what grants admin access). On DuckDB ``src.db._seed_system_groups`` handles the
+groups on connect, but it never runs on Postgres — nothing seeded the groups
+there, and the lifespan seed-admin path then looked the Admin group up off a
+raw DuckDB connection, so the membership it wrote referenced a DuckDB-only
+group id that does not exist on Postgres → the seed admin had no admin access.
+
+The fix seeds the groups through the factory (``ensure_system``) and looks them
+up through the factory (``get_by_name``). These tests exercise that exact
+sequence and assert the seed admin resolves as an admin on DuckDB AND Postgres.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def _env(state_backend, tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    for sub in ("extracts", "analytics", "state", "notifications"):
+        (tmp_path / sub).mkdir(exist_ok=True)
+    if state_backend == "duckdb":
+        from src.db import close_system_db, get_system_db
+
+        close_system_db()
+        get_system_db()
+    return state_backend
+
+
+def _seed_like_lifespan(seed_admin_id: str, seed_email: str) -> None:
+    """Replay the lifespan seed sequence through the factory (the fixed path)."""
+    from src.db import _SYSTEM_GROUPS_SEED, SYSTEM_ADMIN_GROUP, SYSTEM_EVERYONE_GROUP
+    from src.repositories import (
+        user_group_members_repo,
+        user_groups_repo,
+        users_repo,
+    )
+
+    for name, desc in _SYSTEM_GROUPS_SEED:
+        user_groups_repo().ensure_system(name, desc)
+
+    users_repo().create(id=seed_admin_id, email=seed_email, name="Admin")
+
+    for group_name in (SYSTEM_ADMIN_GROUP, SYSTEM_EVERYONE_GROUP):
+        grp = user_groups_repo().get_by_name(group_name)
+        assert grp is not None, f"system group {group_name!r} not seeded"
+        user_group_members_repo().add_member(
+            user_id=seed_admin_id,
+            group_id=grp["id"],
+            source="system_seed",
+            added_by="test",
+        )
+
+
+def test_system_groups_seeded_on_both_backends(_env):
+    from src.db import SYSTEM_ADMIN_GROUP, SYSTEM_EVERYONE_GROUP
+    from src.repositories import user_groups_repo
+
+    _seed_like_lifespan("seed_admin", "seed@example.com")
+
+    names = {g["name"] for g in user_groups_repo().list_all()}
+    assert {SYSTEM_ADMIN_GROUP, SYSTEM_EVERYONE_GROUP} <= names, (
+        f"[{_env}] system groups missing after seed: {names}"
+    )
+
+
+def test_seed_admin_has_admin_access_on_both_backends(_env):
+    from app.auth.access import is_user_admin
+
+    _seed_like_lifespan("seed_admin", "seed@example.com")
+
+    assert is_user_admin("seed_admin") is True, (
+        f"[{_env}] seed admin lacks admin access — the Admin-group membership "
+        f"did not resolve on this backend (the pre-fix raw-DuckDB group lookup "
+        f"wrote a group id absent from Postgres)."
+    )
+
+
+def test_everyone_membership_resolves_on_both_backends(_env):
+    from src.db import SYSTEM_EVERYONE_GROUP
+    from app.auth.access import _user_group_ids
+    from src.repositories import user_groups_repo
+
+    _seed_like_lifespan("seed_admin", "seed@example.com")
+
+    everyone = user_groups_repo().get_by_name(SYSTEM_EVERYONE_GROUP)
+    assert everyone is not None
+    assert everyone["id"] in _user_group_ids("seed_admin"), (
+        f"[{_env}] seed admin not resolved into Everyone — Everyone-scoped "
+        f"grants would not surface for them."
+    )

--- a/tests/db_pg/test_parity_seed_admin_groups.py
+++ b/tests/db_pg/test_parity_seed_admin_groups.py
@@ -92,3 +92,21 @@ def test_everyone_membership_resolves_on_both_backends(_env):
         f"[{_env}] seed admin not resolved into Everyone — Everyone-scoped "
         f"grants would not surface for them."
     )
+
+
+def test_ensure_system_creates_absent_group_both_backends(_env):
+    """The fresh-PG bug was that nothing *creates* the system groups on Postgres
+    (Admin/Everyone are protected from deletion + the fixtures pre-seed them, so
+    they can't be removed to simulate empty). Exercise the create path the
+    lifespan relies on directly: ``ensure_system`` on a name that doesn't exist
+    yet must CREATE it (not just promote) as a system group — on both backends."""
+    from src.repositories import user_groups_repo
+
+    repo = user_groups_repo()
+    assert repo.get_by_name("ProbeSysGroup") is None, f"[{_env}] probe group pre-exists"
+
+    repo.ensure_system("ProbeSysGroup", "probe system group")
+
+    grp = repo.get_by_name("ProbeSysGroup")
+    assert grp is not None, f"[{_env}] ensure_system did not create the absent group"
+    assert grp["is_system"] is True, f"[{_env}] created group is not is_system"

--- a/tests/test_backend_split_guard.py
+++ b/tests/test_backend_split_guard.py
@@ -148,7 +148,10 @@ _GRANDFATHERED_DIRECT_INSTANTIATION: dict[str, set[str]] = {
     # ChatRepository.__init__ instantiates the *Pg repos only under `use_pg()`
     # and dispatches every method through them — not a backend-split.
     "app/chat/persistence.py": {"ChatMessagePgRepository", "ChatSessionPgRepository", "UserWorkdirPgRepository", "ChatSessionParticipantPgRepository"},
-    "app/main.py": {"UserGroupMembersRepository", "UserRepository"},
+    # main.py lifespan seed-admin: group membership now routes through
+    # user_group_members_repo() (factory); only the UserRepository read at the
+    # cowork-bundle path remains a direct DuckDB instantiation.
+    "app/main.py": {"UserRepository"},
     # Sanctioned `if conn is not None and not use_pg(): UserRepository(conn) else:
     # users_repo()` escape hatch (same pattern as app/auth/access.py). On Postgres
     # the read routes through the factory.


### PR DESCRIPTION
## What — critical fresh-Postgres bug

The `Admin` and `Everyone` system groups are created by `src.db._seed_system_groups`, which runs **only on a DuckDB connect**. Nothing seeds them on a Postgres instance:

- **No `Admin` group** → `require_admin` (the Admin god-mode group-membership check) can never pass — no one has admin access.
- **No `Everyone` group** → Everyone-scoped grants (Required onboarding, default reference packages) never surface for anyone.

And the lifespan seed-admin step made it worse: it looked the `Admin` group up off a **raw DuckDB connection** (`conn.execute("SELECT id FROM user_groups WHERE name='Admin'")`). On a PG instance `get_system_db()` still seeds the groups into the *DuckDB* file, so that lookup returned the **DuckDB** group id — and the membership row written to Postgres referenced a group id that doesn't exist there. The seed admin ended up with a dangling membership and no admin access.

(The test harness already worked around this: `state_backend` seeds the groups into PG explicitly "because the app doesn't" — a strong signal the gap was real.)

## Change

In the lifespan startup (`app/main.py`):
1. **Seed the system groups through the factory**, unconditionally: `user_groups_repo().ensure_system(name, desc)` for each of `_SYSTEM_GROUPS_SEED`. Idempotent; redundant-but-harmless on DuckDB, essential on Postgres.
2. **Seed-admin step routes through the factory**: `user_groups_repo().get_by_name(...)` for the group ids (active backend) + `user_group_members_repo().add_member(...)` for both Admin and Everyone membership. Removed the raw `get_system_db()` connection from that block.

Drops the now-stale `UserGroupMembersRepository` entry for `app/main.py` from the backend-split guard's residual list (only the cowork-bundle `UserRepository` read remains there).

## Test

`tests/db_pg/test_parity_seed_admin_groups.py` replays the lifespan seed sequence through the factory and asserts, on DuckDB **and** Postgres:
- both system groups exist after seeding;
- the seed admin resolves as `is_user_admin(...) == True`;
- the seed admin resolves into `Everyone` via `_user_group_ids`.

The `is_user_admin` / Everyone assertions fail on `[pg]` with the pre-fix raw-DuckDB group lookup. Full suite green (6966 passed; 5 unrelated xdist-isolation flakes confirmed passing in isolation).

## Stacking

Independent — branches off `main` (only depends on merged #527). Can merge in parallel with #532–#535.

🤖 Generated with [Claude Code](https://claude.com/claude-code)