### PR TITLE
fix(db): route the MCP secret vault through the repo factory (Postgres)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,33 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 ## [0.65.5] — 2026-06-04
 
 ### Fixed
+- **Postgres backend: per-user MCP credentials were ignored at call time.**
+  When forwarding to an upstream MCP source, `connectors.mcp.client.`
+  `_lookup_secret_for_source` read the caller's per-user secret off a raw
+  always-DuckDB connection. Per-user secrets are stored in Postgres (#530), so
+  on a PG instance the analyst's own credential was never found and the call
+  silently fell through to the shared/env path (wrong identity, or unauthorized).
+  Both the per-user and shared lookups now route through the repo factory
+  (`per_user_secrets_repo()` / `shared_secrets_repo()`).
+- **Postgres backend: the shared MCP vault lived only in DuckDB.** The
+  server-wide `mcp_secrets` vault had no Postgres repository, so admin-set shared
+  credentials were written to and read from the DuckDB system file even on a PG
+  instance — lost on a DuckDB reset and inconsistent with the PG-resident
+  per-user secrets. Added `SharedSecretsPgRepository` + a `shared_secrets_repo()`
+  factory, and routed the admin MCP source endpoints (`app/api/admin_mcp.py`)
+  through it. The `mcp_secrets` table already exists in the PG schema (migration
+  0014), so no new migration is needed. Both fixes pinned by both-backends
+  parity tests (`tests/db_pg/test_parity_mcp_shared_vault.py`).
+- **Postgres backend: catalog `/sample` preview was empty for internal tables.**
+  The preview for an internal source (`agnes_audit` / `agnes_sessions` /
+  `agnes_telemetry`) read the physical state table (`audit_log` etc.) off a raw
+  always-DuckDB connection, so on a Postgres instance it returned zero rows. The
+  read now routes through `connectors.internal.access.sample_internal_rows`,
+  which dispatches on `use_pg()` (Postgres via the engine, DuckDB via the system
+  connection) while keeping the same RBAC row filter. Pinned by a both-backends
+  parity test (`tests/db_pg/test_parity_internal_sample.py`).
+
+
 - **Postgres backend: deleting an MCP source leaked its per-user secrets.**
   `DELETE /api/admin/mcp-sources/{id}` purged per-user vault rows via a raw
   `PerUserSecretsRepository(conn)` off the always-DuckDB connection. Per-user

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.65.8] — 2026-06-04
+
+### Fixed
+- **Postgres backend: per-user MCP credentials were ignored at call time.**
+  When forwarding to an upstream MCP source, `connectors.mcp.client.`
+  `_lookup_secret_for_source` read the caller's per-user secret off a raw
+  always-DuckDB connection. Per-user secrets are stored in Postgres (#530), so
+  on a PG instance the analyst's own credential was never found and the call
+  silently fell through to the shared/env path (wrong identity, or unauthorized).
+  Both the per-user and shared lookups now route through the repo factory
+  (`per_user_secrets_repo()` / `shared_secrets_repo()`). (#537)
+- **Postgres backend: the shared MCP vault lived only in DuckDB.** The
+  server-wide `mcp_secrets` vault had no Postgres repository, so admin-set shared
+  credentials were written to and read from the DuckDB system file even on a PG
+  instance — lost on a DuckDB reset and inconsistent with the PG-resident
+  per-user secrets. Added `SharedSecretsPgRepository` + a `shared_secrets_repo()`
+  factory, and routed the admin MCP source endpoints (`app/api/admin_mcp.py`)
+  through it. The `mcp_secrets` table already exists in the PG schema (migration
+  0014), so no new migration is needed. Both fixes pinned by both-backends
+  parity tests (`tests/db_pg/test_parity_mcp_shared_vault.py`). Closes the
+  deferred follow-up flagged in #530's merge body. (#537)
+
 ## [0.65.7] — 2026-06-04
 
 ### Fixed
@@ -35,29 +57,6 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   which dispatches on `use_pg()` (Postgres via the engine, DuckDB via the system
   connection) while keeping the same RBAC row filter. Pinned by a both-backends
   parity test (`tests/db_pg/test_parity_internal_sample.py`).
-
-## [0.65.8] — 2026-06-04
-
-### Fixed
-- **Postgres backend: per-user MCP credentials were ignored at call time.**
-  When forwarding to an upstream MCP source, `connectors.mcp.client.`
-  `_lookup_secret_for_source` read the caller's per-user secret off a raw
-  always-DuckDB connection. Per-user secrets are stored in Postgres (#530), so
-  on a PG instance the analyst's own credential was never found and the call
-  silently fell through to the shared/env path (wrong identity, or unauthorized).
-  Both the per-user and shared lookups now route through the repo factory
-  (`per_user_secrets_repo()` / `shared_secrets_repo()`). (#537)
-- **Postgres backend: the shared MCP vault lived only in DuckDB.** The
-  server-wide `mcp_secrets` vault had no Postgres repository, so admin-set shared
-  credentials were written to and read from the DuckDB system file even on a PG
-  instance — lost on a DuckDB reset and inconsistent with the PG-resident
-  per-user secrets. Added `SharedSecretsPgRepository` + a `shared_secrets_repo()`
-  factory, and routed the admin MCP source endpoints (`app/api/admin_mcp.py`)
-  through it. The `mcp_secrets` table already exists in the PG schema (migration
-  0014), so no new migration is needed. Both fixes pinned by both-backends
-  parity tests (`tests/db_pg/test_parity_mcp_shared_vault.py`). Closes the
-  deferred follow-up flagged in #530's merge body. (#537)
-
 ## [0.65.5] — 2026-06-04
 
 ### Fixed

--- a/app/api/admin_mcp.py
+++ b/app/api/admin_mcp.py
@@ -42,7 +42,6 @@ from pydantic import BaseModel, field_validator
 from app.auth.access import require_admin
 from app.auth.dependencies import _get_db
 from app.secrets_vault import (
-    SharedSecretsRepository,
     VaultKeyNotConfiguredError,
 )
 from connectors.mcp import classifier as mcp_classifier
@@ -50,6 +49,7 @@ from connectors.mcp import extractor as mcp_extractor
 from src.repositories import (
     mcp_sources_repo,
     per_user_secrets_repo,
+    shared_secrets_repo,
     tool_registry_repo,
 )
 from src.repositories.audit import AuditRepository
@@ -407,7 +407,7 @@ async def list_mcp_sources(
 ):
     repo = mcp_sources_repo()
     rows = repo.list_all(enabled_only=enabled_only)
-    secrets = SharedSecretsRepository(conn)
+    secrets = shared_secrets_repo()
     return [
         _serialize_source(r, has_vault_secret=secrets.has(r["id"])) for r in rows
     ]
@@ -427,7 +427,7 @@ async def get_mcp_source(
     tools_repo = tool_registry_repo()
     tools = tools_repo.list_for_source(source_id)
     out = _serialize_source(
-        src, has_vault_secret=SharedSecretsRepository(conn).has(source_id)
+        src, has_vault_secret=shared_secrets_repo().has(source_id)
     )
     out["tools"] = [_serialize_tool(t) for t in tools]
     return out
@@ -473,7 +473,7 @@ async def update_mcp_source(
     )
     return (
         _serialize_source(
-            fresh, has_vault_secret=SharedSecretsRepository(conn).has(source_id)
+            fresh, has_vault_secret=shared_secrets_repo().has(source_id)
         )
         if fresh
         else {"id": source_id}
@@ -499,7 +499,7 @@ async def delete_mcp_source(
     src_repo.delete(source_id)
     # Clean up vault secrets so a deleted source leaves no orphaned encrypted
     # blobs — the shared secret plus any per-user rows. (Devin Review on #530.)
-    SharedSecretsRepository(conn).delete(source_id)
+    shared_secrets_repo().delete(source_id)
     # Per-user secrets were migrated to Postgres (#530), so they must be dropped
     # through the factory — a raw PerUserSecretsRepository(conn) deletes from the
     # always-DuckDB connection and leaves orphaned rows on a PG instance.
@@ -545,7 +545,7 @@ async def set_mcp_source_secret(
     if not body.value:
         raise HTTPException(status_code=400, detail="secret value required")
     try:
-        SharedSecretsRepository(conn).upsert(source_id, body.value)
+        shared_secrets_repo().upsert(source_id, body.value)
     except VaultKeyNotConfiguredError as exc:
         raise HTTPException(
             status_code=409,
@@ -568,7 +568,7 @@ async def delete_mcp_source_secret(
     src_repo = mcp_sources_repo()
     if not src_repo.get(source_id):
         raise HTTPException(status_code=404, detail="mcp_source_not_found")
-    SharedSecretsRepository(conn).delete(source_id)
+    shared_secrets_repo().delete(source_id)
     _audit(
         conn, user["id"], "mcp_source.secret.delete",
         f"mcp_source:{source_id}", {},

--- a/connectors/mcp/client.py
+++ b/connectors/mcp/client.py
@@ -100,26 +100,22 @@ def _lookup_secret_for_source(
             # Local import avoids dragging the vault module into the
             # connector's import surface — keeps stdio MCP startup fast
             # when no DB is around (tests, headless POC scripts).
-            from src.db import get_system_db
-            from app.secrets_vault import (
-                PerUserSecretsRepository,
-                SharedSecretsRepository,
-            )
+            #
+            # Route through the repo factory: per-user secrets live in the
+            # active state backend (Postgres once migrated, #530). Reading them
+            # off a raw always-DuckDB connection meant an analyst's own
+            # credential was invisible at forward time on a PG instance, so the
+            # call silently fell through to the shared/env path.
+            from src.repositories import per_user_secrets_repo, shared_secrets_repo
 
-            conn = get_system_db()
-            try:
-                if scope == "per_user" and caller_user_id:
-                    value = PerUserSecretsRepository(conn).get(
-                        source_id, caller_user_id
-                    )
-                    if value:
-                        return value
-                # Either scope='shared', or per_user with no row → shared fallback
-                value = SharedSecretsRepository(conn).get(source_id)
+            if scope == "per_user" and caller_user_id:
+                value = per_user_secrets_repo().get(source_id, caller_user_id)
                 if value:
                     return value
-            finally:
-                conn.close()
+            # Either scope='shared', or per_user with no row → shared fallback
+            value = shared_secrets_repo().get(source_id)
+            if value:
+                return value
         except Exception:
             # System DB unavailable (test fixtures, fresh setup before
             # migration) — silently fall through to the env-var path.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.65.7"
+version = "0.65.8"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/src/repositories/__init__.py
+++ b/src/repositories/__init__.py
@@ -85,6 +85,7 @@ __all__ = [
     # MCP / Cowork
     "mcp_sources_repo",
     "per_user_secrets_repo",
+    "shared_secrets_repo",
     "tool_registry_repo",
     "setup_tokens_repo",
     # Cloud chat
@@ -485,6 +486,14 @@ def per_user_secrets_repo() -> Any:
         return PerUserSecretsPgRepository(_pg_engine())
     from app.secrets_vault import PerUserSecretsRepository
     return PerUserSecretsRepository(get_system_db())
+
+
+def shared_secrets_repo() -> Any:
+    if use_pg():
+        from src.repositories.secrets_vault_pg import SharedSecretsPgRepository
+        return SharedSecretsPgRepository(_pg_engine())
+    from app.secrets_vault import SharedSecretsRepository
+    return SharedSecretsRepository(get_system_db())
 
 
 def tool_registry_repo() -> Any:

--- a/src/repositories/secrets_vault_pg.py
+++ b/src/repositories/secrets_vault_pg.py
@@ -27,6 +27,78 @@ from app.secrets_vault import decrypt_secret, encrypt_secret
 logger = logging.getLogger(__name__)
 
 
+class SharedSecretsPgRepository:
+    """Server-wide MCP source secrets (PG). One row per ``source_id``.
+
+    Signature-compatible with ``app.secrets_vault.SharedSecretsRepository``.
+    Without this, shared MCP credentials lived only in the DuckDB system file
+    even on a Postgres instance — lost on a DuckDB reset, and inconsistent with
+    the per-user secrets that already moved to PG.
+    """
+
+    def __init__(self, engine: Engine):
+        self._engine = engine
+
+    def upsert(self, source_id: str, value: str) -> None:
+        token = encrypt_secret(value)
+        with self._engine.begin() as conn:
+            conn.execute(
+                sa.text(
+                    """INSERT INTO mcp_secrets
+                           (source_id, secret_value_enc, updated_at)
+                       VALUES (:source_id, :token, CURRENT_TIMESTAMP)
+                       ON CONFLICT (source_id) DO UPDATE SET
+                           secret_value_enc = EXCLUDED.secret_value_enc,
+                           updated_at       = EXCLUDED.updated_at"""
+                ),
+                {"source_id": source_id, "token": token},
+            )
+
+    def get(self, source_id: str) -> Optional[str]:
+        """Decrypted secret for ``source_id`` or ``None`` if absent or
+        undecryptable (key rotation). Junk decrypt returns ``None`` so the
+        caller can fall back to the env-var path."""
+        with self._engine.connect() as conn:
+            row = conn.execute(
+                sa.text(
+                    "SELECT secret_value_enc FROM mcp_secrets "
+                    "WHERE source_id = :source_id"
+                ),
+                {"source_id": source_id},
+            ).fetchone()
+        if row is None:
+            return None
+        token = row[0]
+        if not isinstance(token, (bytes, bytearray, memoryview)):
+            return None
+        try:
+            return decrypt_secret(bytes(token))
+        except InvalidToken:
+            logger.warning(
+                "mcp_secrets row for %s failed to decrypt — vault key rotated? "
+                "Falling back to env-var lookup.",
+                source_id,
+            )
+            return None
+
+    def delete(self, source_id: str) -> None:
+        with self._engine.begin() as conn:
+            conn.execute(
+                sa.text("DELETE FROM mcp_secrets WHERE source_id = :source_id"),
+                {"source_id": source_id},
+            )
+
+    def has(self, source_id: str) -> bool:
+        with self._engine.connect() as conn:
+            row = conn.execute(
+                sa.text(
+                    "SELECT 1 FROM mcp_secrets WHERE source_id = :source_id LIMIT 1"
+                ),
+                {"source_id": source_id},
+            ).fetchone()
+        return row is not None
+
+
 class PerUserSecretsPgRepository:
     """Per-user MCP source secrets (PG). One row per ``(source_id, user_id)``.
 

--- a/tests/db_pg/test_parity_mcp_shared_vault.py
+++ b/tests/db_pg/test_parity_mcp_shared_vault.py
@@ -1,0 +1,110 @@
+"""Parity tests for the MCP secret vault at forward time, across both backends.
+
+Two problems this pins:
+
+1. **Shared vault on Postgres.** ``SharedSecretsRepository`` (the server-wide
+   ``mcp_secrets`` vault) had no Postgres implementation, so shared MCP
+   credentials lived only in the DuckDB system file even on a PG instance —
+   inconsistent with the per-user secrets that moved to PG (#530) and lost on a
+   DuckDB reset. A new ``SharedSecretsPgRepository`` + ``shared_secrets_repo()``
+   factory fix that.
+
+2. **Per-user secret invisible at forward time on Postgres (active bug).**
+   ``connectors.mcp.client._lookup_secret_for_source`` read the per-user secret
+   off a raw always-DuckDB connection. Per-user secrets are stored in Postgres,
+   so on a PG instance the analyst's own credential was never found at call time
+   and the call silently fell through to the shared/env path. Both reads now go
+   through the factory.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _vault_key(monkeypatch):
+    from cryptography.fernet import Fernet
+
+    monkeypatch.setenv("AGNES_VAULT_KEY", Fernet.generate_key().decode("ascii"))
+
+
+@pytest.fixture
+def _env(state_backend, tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    for sub in ("extracts", "analytics", "state", "notifications"):
+        (tmp_path / sub).mkdir(exist_ok=True)
+    if state_backend == "duckdb":
+        from src.db import close_system_db, get_system_db
+
+        close_system_db()
+        get_system_db()
+    return state_backend
+
+
+def test_shared_secret_round_trip_both_backends(_env):
+    from src.repositories import shared_secrets_repo
+
+    repo = shared_secrets_repo()
+    repo.upsert("src_shared", "sh-secret-value")
+    assert repo.has("src_shared") is True
+    assert repo.get("src_shared") == "sh-secret-value"
+
+    repo.delete("src_shared")
+    assert repo.has("src_shared") is False
+    assert repo.get("src_shared") is None
+
+
+def test_lookup_resolves_per_user_secret_both_backends(_env):
+    """scope='per_user' with the caller's own stored secret → that secret,
+    resolved through the factory on either backend (the active PG bug)."""
+    from connectors.mcp.client import _lookup_secret_for_source
+    from src.repositories import per_user_secrets_repo
+
+    per_user_secrets_repo().upsert("src_pu", "user1", "alice-token")
+    src = {"id": "src_pu", "scope": "per_user", "auth_secret_env": ""}
+
+    value = _lookup_secret_for_source(src, caller_user_id="user1")
+    assert value == "alice-token", (
+        f"[{_env}] per-user secret not resolved at forward time — it is stored "
+        f"in the active backend but was read off the always-DuckDB connection."
+    )
+
+
+def test_lookup_falls_back_to_shared_both_backends(_env):
+    """No per-user row → shared vault; and scope='shared' → shared vault.
+    Both resolved through the factory on either backend."""
+    from connectors.mcp.client import _lookup_secret_for_source
+    from src.repositories import shared_secrets_repo
+
+    shared_secrets_repo().upsert("src_sh", "shared-token")
+
+    # per_user scope, but this caller has no per-user row → shared fallback.
+    per_user = {"id": "src_sh", "scope": "per_user", "auth_secret_env": ""}
+    assert _lookup_secret_for_source(per_user, caller_user_id="nobody") == "shared-token"
+
+    # plain shared scope.
+    shared = {"id": "src_sh", "scope": "shared", "auth_secret_env": ""}
+    assert _lookup_secret_for_source(shared) == "shared-token"
+
+
+def test_admin_delete_secret_clears_shared_vault_both_backends(seeded_app_both):
+    """DELETE /api/admin/mcp-sources/{id}/secret drops the shared row on both
+    backends (the endpoint routes through shared_secrets_repo())."""
+    from src.repositories import mcp_sources_repo, shared_secrets_repo
+
+    sid = "src_admin_del"
+    mcp_sources_repo().upsert(
+        id=sid, name="probe", transport="http",
+        url="https://example.com/mcp", scope="shared",
+    )
+    shared_secrets_repo().upsert(sid, "to-clear")
+    assert shared_secrets_repo().has(sid) is True
+
+    r = seeded_app_both["client"].delete(
+        f"/api/admin/mcp-sources/{sid}/secret",
+        headers={"Authorization": f"Bearer {seeded_app_both['admin_token']}"},
+    )
+    assert r.status_code == 204, f"[{seeded_app_both['backend']}] {r.text}"
+    assert shared_secrets_repo().has(sid) is False, (
+        f"[{seeded_app_both['backend']}] shared secret survived admin delete"
+    )


### PR DESCRIPTION
## What

Two MCP-secret backend-split sites the backend-split guard can't see — the DuckDB secret-vault classes (`SharedSecretsRepository` / `PerUserSecretsRepository`) live in `app/secrets_vault.py`, outside `src/repositories/`, so the guard's class-pairing detector never tracked them.

### 1. Per-user MCP credentials ignored at call time (active bug)
`connectors/mcp/client._lookup_secret_for_source` resolves the upstream auth token when forwarding to an MCP source. It read the caller's **per-user** secret off a raw `get_system_db()` (always DuckDB) connection. Per-user secrets are stored in **Postgres** (#530, via the `/my-secret` PUT). So on a PG instance the analyst's own credential was never found at forward time → the call silently fell through to the shared/env path (wrong identity, or unauthorized connect). Both the per-user and shared lookups now go through the factory (`per_user_secrets_repo()` / `shared_secrets_repo()`).

### 2. Shared MCP vault lived only in DuckDB (durability + consistency)
The server-wide `mcp_secrets` vault had no Postgres repository, so admin-set shared credentials were written to and read from the DuckDB system file even on a PG instance — lost on a DuckDB reset and inconsistent with the PG-resident per-user secrets. Added `SharedSecretsPgRepository` (mirrors `PerUserSecretsPgRepository`) + a `shared_secrets_repo()` factory, and routed the six `app/api/admin_mcp.py` shared-secret sites through it.

The `mcp_secrets` table already exists in the PG schema (migration `0014`), so **no new migration** is needed.

## Test

`tests/db_pg/test_parity_mcp_shared_vault.py` — on DuckDB **and** Postgres:
- `SharedSecretsPgRepository` upsert/get/has/delete round-trip;
- `_lookup_secret_for_source` resolves a factory-seeded per-user secret (fails on `[pg]` before the fix);
- per-user-absent and shared-scope both fall back to the shared vault;
- `DELETE /api/admin/mcp-sources/{id}/secret` clears the shared row.

Full suite green (6983 passed).

## Stacking

Stacked on #535 (base `zs/pg-internal-sample`) because it also edits `app/api/admin_mcp.py` imports (#534 added `per_user_secrets_repo`; this adds `shared_secrets_repo`). Auto-retargets to `main` as the stack lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)