### PR TITLE
fix(db): persist Slack identity binding in the active backend (Postgres) + fix code TTL tz skew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,34 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Fixed
+- **Postgres backend: Slack identity binding silently failed.** The
+  `users.slack_user_id` column (mapping a Slack user to an Agnes account) was
+  only ever lazy-`ALTER`-ed into the DuckDB system file by the Slack bot, so it
+  never existed on a Postgres instance — and the bind wrote / the lookup read it
+  through a raw DuckDB connection the factory-backed reads never consult. On a
+  PG instance a redeemed `/agnes` code bound nothing and `/agnes` looped on
+  "bind your identity first". The column is now part of the formal schema
+  (DuckDB schema **v71** / alembic `0018`, additive + nullable, mirrored in the
+  `users` SQLAlchemy model), and `lookup_user_email` / the redeem bind route
+  through `users_repo()` (new `get_by_slack_user_id` + `slack_user_id` on the
+  update allow-list, both backends). Pinned by both-backends parity + contract
+  tests.
+- **Slack verification codes expired immediately on non-UTC hosts.** The redeem
+  TTL check compared a SQL `current_timestamp` (naive UTC) `issued_at` against
+  Python `datetime.now()` (local time), so on a host whose timezone was ahead of
+  UTC every code looked already-expired (and on UTC-behind hosts, never
+  expired). The code now stores and compares `issued_at` in naive UTC on both
+  sides, so the TTL is correct regardless of the server timezone.
+
+### Internal
+- Schema **v71** (DuckDB `_v70_to_v71` + alembic `0018_slack_user_id_v71`):
+  adds the nullable `users.slack_user_id` column on both backends. Additive,
+  idempotent (tolerates the pre-existing lazy ALTER). No `UNIQUE` constraint —
+  DuckDB rejects multiple NULLs in a UNIQUE index, which the many unbound users
+  would violate; the one-code-per-Slack-user issue flow already prevents
+  duplicate bindings.
+
 ## [0.65.6] — 2026-06-04
 
 ### Fixed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -214,7 +214,7 @@ Files NOT to modify: `connectors/jira/file_lock.py`, `connectors/jira/transform.
 
 ### system.duckdb — `{DATA_DIR}/state/system.duckdb`
 
-Current schema version: **69** (auto-migrated from any earlier version on startup — see `src/db.py`).
+Current schema version: **71** (auto-migrated from any earlier version on startup — see `src/db.py`).
 
 | Table | Purpose |
 |-------|---------|

--- a/migrations/versions/0018_slack_user_id_v71.py
+++ b/migrations/versions/0018_slack_user_id_v71.py
@@ -1,0 +1,36 @@
+"""Slack identity binding column (DuckDB v71 parity).
+
+Additive-only, reaching the same endpoint as DuckDB ``_v70_to_v71``:
+  - users.slack_user_id (VARCHAR, nullable)
+
+Maps a Slack ``user_id`` to an Agnes account so the Slack bot can resolve
+who is talking. Previously this column was lazily ``ALTER``-ed only into the
+DuckDB system file by ``services/slack_bot/binding.py``, so it never existed
+on a Postgres instance and Slack identity binding silently failed there.
+
+Revision ID: 0018_slack_user_id_v71
+Revises: 0017_cloud_chat_v70
+Create Date: 2026-06-04
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0018_slack_user_id_v71"
+down_revision: Union[str, None] = "0017_cloud_chat_v70"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("slack_user_id", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "slack_user_id")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.65.8"
+version = "0.65.9"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/services/slack_bot/binding.py
+++ b/services/slack_bot/binding.py
@@ -19,9 +19,8 @@ SR-12 hardening:
 """
 from __future__ import annotations
 
-import json
 import secrets
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 import duckdb
@@ -66,10 +65,9 @@ def _ensure_table(conn: duckdb.DuckDBPyConnection) -> None:
         " attempted_at TIMESTAMP NOT NULL"
         ")"
     )
-    # users table is assumed to exist; add a nullable slack_user_id column
-    cols = {r[1] for r in conn.execute("PRAGMA table_info(users)").fetchall()}
-    if "slack_user_id" not in cols:
-        conn.execute("ALTER TABLE users ADD COLUMN slack_user_id VARCHAR")
+    # users.slack_user_id is part of the formal schema as of v71 (DuckDB
+    # _v70_to_v71 / alembic 0018), so no lazy ALTER is needed here anymore —
+    # and the binding must live in the active state backend, not just DuckDB.
 
 
 def issue_verification_code(conn: duckdb.DuckDBPyConnection, *, slack_user_id: str) -> str:
@@ -92,10 +90,16 @@ def issue_verification_code(conn: duckdb.DuckDBPyConnection, *, slack_user_id: s
     # One active code per user — delete any prior outstanding code.
     conn.execute("DELETE FROM slack_binding_codes WHERE slack_user_id = ?", [slack_user_id])
     code = f"{secrets.randbelow(1_000_000):06d}"
+    # Store issued_at as naive UTC from Python (not SQL current_timestamp): the
+    # redeem TTL check compares it against datetime.now(UTC), and DuckDB's
+    # current_timestamp timezone basis is not guaranteed to match Python's, so
+    # mixing the two skewed the TTL by the host's UTC offset. Python-UTC on both
+    # sides keeps the expiry correct on any host.
+    issued_at = datetime.now(timezone.utc).replace(tzinfo=None)
     conn.execute(
         "INSERT INTO slack_binding_codes(code, slack_user_id, issued_at, attempts) "
-        "VALUES (?, ?, current_timestamp, 0)",
-        [code, slack_user_id],
+        "VALUES (?, ?, ?, 0)",
+        [code, slack_user_id, issued_at],
     )
     conn.execute(
         "INSERT INTO slack_binding_issue_log(slack_user_id, issued_at) "
@@ -158,33 +162,35 @@ def redeem_verification_code(
         _record_failure()
         return False
     slack_user_id, issued_at = row
-    # DuckDB returns naive datetimes in local time (current_timestamp semantics)
-    now = datetime.now()
+    # ``issued_at`` was written with SQL ``current_timestamp``, which is naive
+    # UTC. Compare against naive UTC — ``datetime.now()`` is local time, so on a
+    # host whose timezone is not UTC the TTL was skewed by the UTC offset
+    # (codes expired early on UTC+ hosts, never on UTC- hosts).
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
     if (now - issued_at).total_seconds() > _CODE_TTL_SECONDS:
         conn.execute("DELETE FROM slack_binding_codes WHERE code = ?", [code])
         _record_failure()
         return False
-    # Bind: write slack_user_id to the user row.
-    conn.execute("UPDATE users SET slack_user_id = ? WHERE email = ?", [slack_user_id, user_email])
+    # Bind: write slack_user_id to the user row through the factory so the
+    # binding lands in the active state backend (Postgres or DuckDB) — a raw
+    # UPDATE on the DuckDB connection never reached the PG-resident users table.
+    from src.repositories import users_repo
+    _u = users_repo().get_by_email(user_email)
+    if _u:
+        users_repo().update(id=_u["id"], slack_user_id=slack_user_id)
     conn.execute("DELETE FROM slack_binding_codes WHERE code = ?", [code])
     # Success — clear this caller's failed-attempt history so a future
     # legitimate re-bind isn't penalised by earlier typos.
     conn.execute("DELETE FROM slack_binding_redeem_log WHERE user_email = ?", [user_email])
     # Audit (best-effort — missing audit_log table or factory not initialised
-    # must never block the bind itself).
-    # Use json.dumps for the params value — f-string interpolation of
-    # slack_user_id or user_email allows injection of arbitrary JSON keys
-    # (e.g. a Slack user ID containing '"injected":"yes' would produce
-    # malformed/injected audit JSON).
+    # must never block the bind itself). audit_repo() serializes params safely,
+    # so a Slack user id containing JSON metacharacters cannot inject keys.
     try:
-        conn.execute(
-            "INSERT INTO audit_log (id, timestamp, user_id, action, params) "
-            "VALUES (?, current_timestamp, ?, 'slack.bind', ?)",
-            [
-                f"aud_{secrets.token_hex(8)}",
-                user_email,
-                json.dumps({"slack_user_id": slack_user_id, "email": user_email}),
-            ],
+        from src.repositories import audit_repo
+        audit_repo().log(
+            user_id=user_email,
+            action="slack.bind",
+            params={"slack_user_id": slack_user_id, "email": user_email},
         )
     except Exception:
         pass
@@ -213,7 +219,10 @@ def is_channel_allowlisted(conn: duckdb.DuckDBPyConnection, channel_id: str) -> 
 
 
 def lookup_user_email(repo, slack_user_id: str) -> Optional[str]:
-    row = repo._conn.execute(
-        "SELECT email FROM users WHERE slack_user_id = ?", [slack_user_id]
-    ).fetchone()
-    return row[0] if row else None
+    # Resolve through the factory so the Slack→Agnes identity binding is read
+    # from the active state backend (the binding is persisted there as of v71);
+    # the raw repo._conn read returned nothing on a Postgres instance. ``repo``
+    # is kept for signature/call-site stability.
+    from src.repositories import users_repo
+    u = users_repo().get_by_slack_user_id(slack_user_id)
+    return u["email"] if u else None

--- a/src/db.py
+++ b/src/db.py
@@ -47,7 +47,7 @@ from src.duckdb_conn import _open_duckdb  # noqa: F401, E402  (re-export)
 
 _SAFE_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,63}$")
 
-SCHEMA_VERSION = 70
+SCHEMA_VERSION = 71
 
 _SYSTEM_SCHEMA = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -82,7 +82,14 @@ CREATE TABLE IF NOT EXISTS users (
     -- so `agnes pull` (and the SessionStart hook that wraps it) imprints
     -- the user's last sync time. Powers the /home status frame's "Last
     -- sync" card.
-    last_pull_at TIMESTAMP
+    last_pull_at TIMESTAMP,
+    -- v71: Slack identity binding. NULL until the analyst redeems a
+    -- /agnes verification code; maps a Slack user_id to this account so the
+    -- Slack bot can resolve who is talking. Formalized in the schema (was a
+    -- lazy ALTER in services/slack_bot/binding.py) so it lives in the active
+    -- state backend — the binding broke on Postgres when it only existed in
+    -- the DuckDB system file.
+    slack_user_id VARCHAR
 );
 
 CREATE TABLE IF NOT EXISTS sync_state (
@@ -4877,6 +4884,24 @@ def _v69_to_v70(conn: duckdb.DuckDBPyConnection) -> None:
     conn.execute("UPDATE schema_version SET version = 70")
 
 
+def _v70_to_v71(conn: duckdb.DuckDBPyConnection) -> None:
+    """v71: formalize ``users.slack_user_id`` into the schema.
+
+    Previously this column was lazily ``ALTER``-ed in
+    ``services/slack_bot/binding.py`` only when the Slack bot ran — so it
+    existed only in the DuckDB system file and never on a Postgres instance,
+    which broke Slack identity binding on Postgres (the binding was written to
+    a DuckDB ``users`` table the factory-backed reads never consult). Adding it
+    to the schema lets the binding route through ``users_repo()`` on either
+    backend. Additive + nullable; idempotent (the lazy ALTER may already have
+    added it on existing DuckDB instances).
+    """
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(users)").fetchall()}
+    if "slack_user_id" not in cols:
+        conn.execute("ALTER TABLE users ADD COLUMN slack_user_id VARCHAR")
+    conn.execute("UPDATE schema_version SET version = 71")
+
+
 def _v57_to_v58(conn: duckdb.DuckDBPyConnection) -> None:
     """v55: ``memory_domain_suggestions`` table — non-admin "Suggest a
     domain" affordance + admin moderation queue.
@@ -5197,6 +5222,9 @@ def _ensure_schema(conn: duckdb.DuckDBPyConnection) -> None:
             # chat_session_participants. Additive; _SYSTEM_SCHEMA builds it
             # on fresh installs (no-op here).
             _v69_to_v70(conn)
+            # v70→v71: formalize users.slack_user_id. _SYSTEM_SCHEMA already
+            # creates it on fresh installs (no-op here).
+            _v70_to_v71(conn)
             # Fresh-install seed is handled by the unconditional
             # _seed_core_roles call at the bottom of _ensure_schema —
             # left as a no-op branch here so the migration ladder still
@@ -5390,6 +5418,8 @@ def _ensure_schema(conn: duckdb.DuckDBPyConnection) -> None:
                 _v68_to_v69(conn)
             if current < 70:
                 _v69_to_v70(conn)
+            if current < 71:
+                _v70_to_v71(conn)
             conn.execute(
                 "UPDATE schema_version SET version = ?, applied_at = current_timestamp",
                 [SCHEMA_VERSION],

--- a/src/models/rbac.py
+++ b/src/models/rbac.py
@@ -48,6 +48,8 @@ class User(Base):
     updated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     onboarded: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("FALSE"))
     last_pull_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # v71: Slack identity binding (NULL until /agnes verification code redeemed).
+    slack_user_id: Mapped[str | None] = mapped_column(String, nullable=True)
 
 
 class UserGroup(Base):

--- a/src/repositories/users.py
+++ b/src/repositories/users.py
@@ -24,6 +24,15 @@ class UserRepository:
         result = self.conn.execute("SELECT * FROM users WHERE email = ?", [email]).fetchone()
         return self._row_to_dict(result)
 
+    def get_by_slack_user_id(self, slack_user_id: str) -> Optional[Dict[str, Any]]:
+        """Resolve the account bound to a Slack ``user_id`` (NULL until the
+        analyst redeems a /agnes verification code). Used by the Slack bot to
+        map an incoming Slack identity to an Agnes user."""
+        result = self.conn.execute(
+            "SELECT * FROM users WHERE slack_user_id = ?", [slack_user_id]
+        ).fetchone()
+        return self._row_to_dict(result)
+
     def list_all(self) -> List[Dict[str, Any]]:
         """Return EVERY user row. Used by bootstrap-lock + startup
         warning paths that need to inspect the whole table (see
@@ -103,6 +112,9 @@ class UserRepository:
             "onboarded",
             # v44: per-user pull timestamp — bumped on /api/sync/manifest.
             "last_pull_at",
+            # v71: Slack identity binding — set when the analyst redeems a
+            # /agnes verification code (services/slack_bot/binding.py).
+            "slack_user_id",
         }
         updates = {k: v for k, v in kwargs.items() if k in allowed}
         if not updates:

--- a/src/repositories/users_pg.py
+++ b/src/repositories/users_pg.py
@@ -30,6 +30,16 @@ class UsersPgRepository:
             ).mappings().first()
         return dict(row) if row else None
 
+    def get_by_slack_user_id(self, slack_user_id: str) -> Optional[Dict[str, Any]]:
+        """Resolve the account bound to a Slack ``user_id`` (NULL until the
+        analyst redeems a /agnes verification code)."""
+        with self._engine.connect() as conn:
+            row = conn.execute(
+                sa.text("SELECT * FROM users WHERE slack_user_id = :sid"),
+                {"sid": slack_user_id},
+            ).mappings().first()
+        return dict(row) if row else None
+
     def list_all(self) -> List[Dict[str, Any]]:
         """Exhaustive enumeration of users (no pagination).
 
@@ -85,6 +95,7 @@ class UsersPgRepository:
             "setup_token_created", "reset_token", "reset_token_created",
             "active", "deactivated_at", "deactivated_by",
             "onboarded", "last_pull_at",
+            "slack_user_id",
         }
         updates = {k: v for k, v in kwargs.items() if k in allowed}
         if not updates:

--- a/tests/db_pg/test_parity_slack_binding.py
+++ b/tests/db_pg/test_parity_slack_binding.py
@@ -1,0 +1,81 @@
+"""Parity test for Slack identity binding across both backends.
+
+The Slack bot binds a Slack ``user_id`` to an Agnes account via a /agnes
+verification code: ``issue_verification_code`` → user pastes it →
+``redeem_verification_code`` writes ``users.slack_user_id`` → later
+``lookup_user_email`` maps the Slack id back to the account.
+
+The binding persistence (``users.slack_user_id``) previously went through a raw
+DuckDB connection, so on a Postgres instance the redeem wrote to a DuckDB
+``users`` table the factory-backed reads never consult — binding silently
+failed and ``/agnes`` looped on "bind your identity first". v71 formalizes the
+column and routes the binding read/write through ``users_repo()``.
+
+The transient verification-code tables stay DuckDB-only by design (ephemeral
+operational state), so issue/redeem still take a DuckDB ``conn`` — these tests
+pass ``get_system_db()`` for that, while the user + binding live in whichever
+state backend is active.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def _env(state_backend, tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    for sub in ("extracts", "analytics", "state", "notifications"):
+        (tmp_path / sub).mkdir(exist_ok=True)
+    if state_backend == "duckdb":
+        from src.db import close_system_db, get_system_db
+
+        close_system_db()
+        get_system_db()
+    return state_backend
+
+
+def test_issue_redeem_lookup_round_trip_both_backends(_env):
+    from types import SimpleNamespace
+
+    from services.slack_bot.binding import (
+        issue_verification_code,
+        lookup_user_email,
+        redeem_verification_code,
+    )
+    from src.db import get_system_db
+    from src.repositories import users_repo
+
+    # The analyst account lives in the active state backend (PG on [pg]).
+    users_repo().create(id="u_slack", email="slack@example.com", name="Slacker")
+
+    # Verification codes are DuckDB-only operational state → DuckDB conn.
+    conn = get_system_db()
+    code = issue_verification_code(conn, slack_user_id="U_PARITY")
+
+    # Before redeem, the Slack id resolves to nobody.
+    assert lookup_user_email(SimpleNamespace(_conn=conn), "U_PARITY") is None
+
+    ok = redeem_verification_code(conn, user_email="slack@example.com", code=code)
+    assert ok is True, f"[{_env}] redeem failed"
+
+    # The binding must persist in the active backend and resolve back.
+    bound = users_repo().get_by_slack_user_id("U_PARITY")
+    assert bound is not None, (
+        f"[{_env}] slack_user_id binding did not persist in the active backend "
+        f"— redeem wrote to the wrong store."
+    )
+    assert bound["email"] == "slack@example.com"
+    assert lookup_user_email(SimpleNamespace(_conn=conn), "U_PARITY") == "slack@example.com"
+
+
+def test_redeem_wrong_code_does_not_bind_both_backends(_env):
+    from services.slack_bot.binding import redeem_verification_code
+    from src.db import get_system_db
+    from src.repositories import users_repo
+
+    users_repo().create(id="u_nb", email="nb@example.com", name="NB")
+    conn = get_system_db()
+
+    ok = redeem_verification_code(conn, user_email="nb@example.com", code="000000")
+    assert ok is False
+    assert users_repo().get_by_id("u_nb")["slack_user_id"] is None

--- a/tests/db_pg/test_users_contract.py
+++ b/tests/db_pg/test_users_contract.py
@@ -145,3 +145,23 @@ def test_delete_removes_user(users_repo):
     assert repo.get_by_id("user-1") is not None
     repo.delete("user-1")
     assert repo.get_by_id("user-1") is None
+
+
+def test_set_and_get_by_slack_user_id(users_repo):
+    """v71: the Slack identity binding round-trips identically on both engines
+    (update(slack_user_id=...) + get_by_slack_user_id)."""
+    repo, _, _ = users_repo
+    _make_user(repo)
+
+    # Unbound: no slack_user_id, lookup misses.
+    row = repo.get_by_id("user-1")
+    assert row.get("slack_user_id") is None
+    assert repo.get_by_slack_user_id("U999") is None
+
+    repo.update("user-1", slack_user_id="U999")
+    row = repo.get_by_id("user-1")
+    assert row["slack_user_id"] == "U999"
+
+    bound = repo.get_by_slack_user_id("U999")
+    assert bound is not None
+    assert bound["id"] == "user-1"

--- a/tests/e2e/test_slack_roundtrip.py
+++ b/tests/e2e/test_slack_roundtrip.py
@@ -45,7 +45,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from src.db import _ensure_schema
+from src.db import _ensure_schema, get_system_db
 from app.api.slack import router as slack_router
 from app.api.chat import router as chat_router
 from app.auth.dependencies import get_current_user
@@ -79,8 +79,10 @@ def _build_app(
     app.include_router(slack_router)
     app.include_router(chat_router)
 
-    # Bog-standard DuckDB with the schema migration applied + one user row.
-    conn = duckdb.connect(":memory:")
+    # Shared system DuckDB (get_system_db is patched to a per-test in-memory
+    # conn by the _shared_e2e_db autouse fixture) so the factory-routed Slack
+    # binding (users_repo) and this test's inspection see the same rows.
+    conn = get_system_db()
     _ensure_schema(conn)
     conn.execute(
         "INSERT INTO users(id, email, name) VALUES (?, ?, ?)",
@@ -178,6 +180,23 @@ def _slack_headers(body_bytes: bytes, secret: str) -> dict[str, str]:
         "X-Slack-Signature": sig,
         "Content-Type": "application/json",
     }
+
+
+@pytest.fixture(autouse=True)
+def _shared_e2e_db(monkeypatch):
+    """Slack binding now reads/writes through the repo factory; point
+    get_system_db() and the factory at one shared in-memory DuckDB so the
+    bind persists where this test inspects it."""
+    shared = duckdb.connect(":memory:")
+    _ensure_schema(shared)
+    # This module imported get_system_db at module load, so patch that binding
+    # (not just src.db's) plus the repo factory's.
+    monkeypatch.setattr(
+        "tests.e2e.test_slack_roundtrip.get_system_db", lambda: shared, raising=False
+    )
+    monkeypatch.setattr("src.db.get_system_db", lambda: shared)
+    monkeypatch.setattr("src.repositories.get_system_db", lambda: shared)
+    yield shared
 
 
 @pytest.fixture

--- a/tests/test_chat_v70_migration.py
+++ b/tests/test_chat_v70_migration.py
@@ -21,7 +21,7 @@ def _cols(conn, table):
 def test_fresh_install_has_v70_shape(tmp_path):
     conn = duckdb.connect(str(tmp_path / "system.duckdb"))
     _ensure_schema(conn)
-    assert get_schema_version(conn) == SCHEMA_VERSION == 70
+    assert get_schema_version(conn) == SCHEMA_VERSION
     # main's v69 MCP-env addition.
     assert "env" in _cols(conn, "mcp_sources")
     # our v70 co-presence additions.
@@ -73,7 +73,7 @@ def test_v68_db_migrates_to_v70_with_backfill(tmp_path):
 
     _ensure_schema(conn)
 
-    assert get_schema_version(conn) == SCHEMA_VERSION == 70
+    assert get_schema_version(conn) == SCHEMA_VERSION
     # v69 MCP-env step ran.
     assert "env" in _cols(conn, "mcp_sources")
     # v70 co-presence step ran.

--- a/tests/test_slack_bot.py
+++ b/tests/test_slack_bot.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import duckdb
 import pytest
-from src.db import _ensure_schema
+from src.db import _ensure_schema, get_system_db
 
 from services.slack_bot.binding import (
     issue_verification_code,
@@ -18,9 +18,25 @@ from services.slack_bot.binding import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _shared_slack_db(monkeypatch):
+    """Slack identity binding now reads/writes through the repo factory
+    (``users_repo()`` → ``get_system_db()``), not the test's standalone conn.
+    Point both the test module's ``get_system_db`` and the factory's at one
+    shared in-memory DuckDB so a user seeded in a test is visible to the
+    binding lookup/redeem on the (default DuckDB) backend."""
+    shared = duckdb.connect(":memory:")
+    _ensure_schema(shared)
+    monkeypatch.setattr(
+        "tests.test_slack_bot.get_system_db", lambda: shared, raising=False
+    )
+    monkeypatch.setattr("src.repositories.get_system_db", lambda: shared)
+    yield shared
+
+
 @pytest.fixture
 def conn():
-    c = duckdb.connect(":memory:")
+    c = get_system_db()
     _ensure_schema(c)
     c.execute("INSERT INTO users(id, email, name) VALUES ('uid1', 'u@x', 'U')")
     return c
@@ -144,7 +160,7 @@ def _build_slack_app_state():
     from app.chat.types import ChatSession, Surface
     from datetime import datetime, timezone
 
-    conn = duckdb.connect(":memory:")
+    conn = get_system_db()
     _ensure_schema(conn)
     conn.execute(
         "INSERT INTO users(id, email, name) VALUES ('uid1', 'bob@example.com', 'Bob')"
@@ -530,7 +546,7 @@ def test_mention_bot_loop_guard_returns_silently(monkeypatch):
     import services.slack_bot.events as ev
     posts = []
     monkeypatch.setattr(ev, "send_ephemeral_to_user", lambda *a, **k: posts.append(a))
-    conn = duckdb.connect(":memory:"); _ensure_schema(conn)
+    conn = get_system_db(); _ensure_schema(conn)
     mgr = _FakeMgr()
     app = _FakeApp(conn=conn, mgr=mgr)
     asyncio.run(ev._handle_mention(app, {"bot_id": "B1", "channel": "C1", "ts": "1.0", "user": "U07BOT"}))
@@ -542,7 +558,7 @@ def test_mention_self_user_loop_guard_returns_silently(monkeypatch):
     import services.slack_bot.events as ev
     posts = []
     monkeypatch.setattr(ev, "send_ephemeral_to_user", lambda *a, **k: posts.append(a))
-    conn = duckdb.connect(":memory:"); _ensure_schema(conn)
+    conn = get_system_db(); _ensure_schema(conn)
     mgr = _FakeMgr()
     app = _FakeApp(conn=conn, mgr=mgr)
     asyncio.run(ev._handle_mention(app, {"channel": "C1", "ts": "1.0", "user": "U07BOT", "text": "<@U07BOT> hi"}))
@@ -556,7 +572,7 @@ def test_mention_not_allowlisted_ephemeral_deny(monkeypatch):
     posts = []
     async def _fake_ep(ch, u, txt): posts.append((ch, u, txt))
     monkeypatch.setattr(ev, "send_ephemeral_to_user", _fake_ep)
-    conn = duckdb.connect(":memory:"); _ensure_schema(conn); _ensure_table(conn)
+    conn = get_system_db(); _ensure_schema(conn); _ensure_table(conn)
     mgr = _FakeMgr()
     app = _FakeApp(conn=conn, mgr=mgr)
     asyncio.run(ev._handle_mention(app, {"channel": "C_X", "ts": "1.0", "user": "U1", "text": "<@U07BOT> hi"}))
@@ -571,7 +587,7 @@ def test_mention_unbound_user_gets_code(monkeypatch):
     posts = []
     async def _fake_ep(ch, u, txt): posts.append((ch, u, txt))
     monkeypatch.setattr(ev, "send_ephemeral_to_user", _fake_ep)
-    conn = duckdb.connect(":memory:"); _ensure_schema(conn); _ensure_table(conn)
+    conn = get_system_db(); _ensure_schema(conn); _ensure_table(conn)
     gid = conn.execute("SELECT id FROM user_groups WHERE name='Everyone'").fetchone()[0]
     conn.execute(
         "INSERT INTO resource_grants(id, group_id, resource_type, resource_id) "
@@ -616,7 +632,7 @@ def test_mention_happy_path_creates_thread_and_sends(monkeypatch):
     import asyncio
     import services.slack_bot.events as ev
     monkeypatch.setattr(ev, "send_ephemeral_to_user", lambda *a, **k: None)
-    conn = duckdb.connect(":memory:"); _ensure_schema(conn)
+    conn = get_system_db(); _ensure_schema(conn)
     _seed_bound_chat_user(conn)
     _allow_channel(conn)
     mgr = _FakeMgr()
@@ -642,7 +658,7 @@ def test_mention_ownership_reject_ephemeral(monkeypatch):
     posts = []
     async def _fake_ep(ch, u, txt): posts.append(txt)
     monkeypatch.setattr(ev, "send_ephemeral_to_user", _fake_ep)
-    conn = duckdb.connect(":memory:"); _ensure_schema(conn)
+    conn = get_system_db(); _ensure_schema(conn)
     _seed_bound_chat_user(conn, email="owner@x", slack_id="U_OWNER")
     _seed_bound_chat_user(conn, email="other@x", slack_id="U_OTHER")
     _allow_channel(conn)
@@ -668,7 +684,7 @@ def test_mention_same_thread_reuses_session(monkeypatch):
     import asyncio
     import services.slack_bot.events as ev
     monkeypatch.setattr(ev, "send_ephemeral_to_user", lambda *a, **k: None)
-    conn = duckdb.connect(":memory:"); _ensure_schema(conn)
+    conn = get_system_db(); _ensure_schema(conn)
     _seed_bound_chat_user(conn)
     _allow_channel(conn)
     # existing session owned by the SAME user (column is started_at)
@@ -689,7 +705,7 @@ def test_mention_attach_not_awaited_returns_under_budget(monkeypatch):
     import asyncio
     import services.slack_bot.events as ev
     monkeypatch.setattr(ev, "send_ephemeral_to_user", lambda *a, **k: None)
-    conn = duckdb.connect(":memory:"); _ensure_schema(conn)
+    conn = get_system_db(); _ensure_schema(conn)
     _seed_bound_chat_user(conn)
     _allow_channel(conn)
 
@@ -727,7 +743,7 @@ def test_slack_app_mention_dispatches(monkeypatch):
     async def _fake_ep(ch, u, txt): posts.append((ch, u, txt))
     monkeypatch.setattr(ev, "send_ephemeral_to_user", _fake_ep)
 
-    conn = duckdb.connect(":memory:"); _ensure_schema(conn)
+    conn = get_system_db(); _ensure_schema(conn)
     from services.slack_bot.binding import _ensure_table
     _ensure_table(conn)
     mgr = _FakeMgr()

--- a/tests/test_slack_commands.py
+++ b/tests/test_slack_commands.py
@@ -6,6 +6,22 @@ import asyncio
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _shared_slack_db(monkeypatch):
+    """Point get_system_db() and the repo factory at one shared in-memory
+    DuckDB. The Slack command handler resolves the caller via users_repo()
+    (factory) now, not repo._conn, so a user seeded in _agnes_app must be
+    visible through the factory on the default DuckDB backend."""
+    import duckdb
+    from src.db import _ensure_schema
+
+    shared = duckdb.connect(":memory:")
+    _ensure_schema(shared)
+    monkeypatch.setattr("src.db.get_system_db", lambda: shared)
+    monkeypatch.setattr("src.repositories.get_system_db", lambda: shared)
+    yield shared
+
+
 def test_send_ephemeral_posts_to_response_url(monkeypatch):
     from services.slack_bot import sender as snd
 
@@ -127,20 +143,24 @@ def test_commands_schedules_dispatch(monkeypatch):
 
 def _agnes_app(monkeypatch, *, bound=True, can_chat=True):
     from types import SimpleNamespace
-    import duckdb
-    from src.db import _ensure_schema
+    from src.db import _ensure_schema, get_system_db
     from app.chat.persistence import ChatRepository
     from app.chat.types import ChatSession, Surface
     from datetime import datetime, timezone
     from services.slack_bot.binding import _ensure_table
 
-    conn = duckdb.connect(":memory:")
+    # get_system_db is patched by the autouse _shared_slack_db fixture to a
+    # shared in-memory conn that the repo factory (users_repo) also resolves to,
+    # so a user seeded here is visible to the factory-routed Slack binding
+    # lookup (which no longer reads repo._conn directly).
+    conn = get_system_db()
     _ensure_schema(conn)
     conn.execute("INSERT INTO users(id, email, name) VALUES ('uid1','bob@example.com','Bob')")
     repo = ChatRepository(conn)
     _ensure_table(conn)
     if bound:
-        conn.execute("UPDATE users SET slack_user_id='U1' WHERE email='bob@example.com'")
+        from src.repositories import users_repo
+        users_repo().update(id="uid1", slack_user_id="U1")
 
     created: list = []
     attached: list = []


### PR DESCRIPTION
## What

Two bugs in the Slack `/agnes` identity-binding flow.

### 1. Binding silently failed on Postgres
`users.slack_user_id` maps a Slack user to an Agnes account. It was **only ever lazy-`ALTER`-ed into the DuckDB system file** by `services/slack_bot/binding.py::_ensure_table`, so:
- it never existed on a Postgres instance, and
- `redeem_verification_code` wrote it (and `lookup_user_email` read it) through a **raw DuckDB connection** the factory-backed reads never consult.

On a PG instance the analyst's real account lives in PG, so a redeemed code bound nothing and `/agnes` looped forever on "bind your identity first".

**Fix:**
- Formalize `users.slack_user_id` in the schema — DuckDB **v71** (`_v70_to_v71` + `_SYSTEM_SCHEMA`) and alembic **`0018`**, additive + nullable, mirrored in the `users` SQLAlchemy model (so `test_schema_parity` / `test_alembic_roundtrip` stay green). Both ladders reach v71.
- Route `lookup_user_email` and the redeem bind through `users_repo()` — new `get_by_slack_user_id()` + `slack_user_id` on the `update` allow-list, on **both** backends.
- The ephemeral verification-code tables (`slack_binding_codes` / `*_issue_log` / `*_redeem_log`) stay DuckDB-only **by design** (short-lived operational state; issue+redeem use the same passed conn consistently).

### 2. Verification codes expired immediately on non-UTC hosts (pre-existing)
`redeem` compared a SQL `current_timestamp` (naive **UTC**) `issued_at` against Python `datetime.now()` (**local** time). On a host ahead of UTC every code looked already-expired; on UTC-behind hosts it never expired. `issued_at` is now stored + compared in naive UTC on both sides — correct regardless of server timezone. (This surfaced because the existing tests never asserted a *successful* clean redeem.)

## Test

- `tests/db_pg/test_parity_slack_binding.py` — issue → redeem → lookup round-trip on DuckDB **and** Postgres; wrong-code does not bind. (`[pg]` fails before the fix.)
- `tests/db_pg/test_users_contract.py` — `get_by_slack_user_id` + `update(slack_user_id=...)` round-trip on both backends.
- Existing slack unit/e2e tests (`test_slack_bot`, `test_slack_commands`, `e2e/test_slack_roundtrip`) updated to seed users through the factory (the binding no longer reads `repo._conn`).
- `test_chat_v70_migration` de-hardcoded from `== 70` to `== SCHEMA_VERSION`.

Full suite green (6971 passed; 1 unrelated xdist-isolation flake confirmed passing in isolation).

## Stacking

Independent — branches off `main` (depends only on merged #527). Touches schema (v71 / alembic 0018) — the dual-backend ladder + parity tests are the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)