### PR TITLE
fix(db): route internal-table /sample preview through the active backend (Postgres)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.65.6] — 2026-06-04
+
 ### Fixed
 - **Postgres backend: catalog `/sample` preview was empty for internal tables.**
   The preview for an internal source (`agnes_audit` / `agnes_sessions` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Fixed
+- **Postgres backend: catalog `/sample` preview was empty for internal tables.**
+  The preview for an internal source (`agnes_audit` / `agnes_sessions` /
+  `agnes_telemetry`) read the physical state table (`audit_log` etc.) off a raw
+  always-DuckDB connection, so on a Postgres instance it returned zero rows. The
+  read now routes through `connectors.internal.access.sample_internal_rows`,
+  which dispatches on `use_pg()` (Postgres via the engine, DuckDB via the system
+  connection) while keeping the same RBAC row filter. Pinned by a both-backends
+  parity test (`tests/db_pg/test_parity_internal_sample.py`).
+
 ## [0.65.5] — 2026-06-04
 
 ### Fixed

--- a/app/api/v2_sample.py
+++ b/app/api/v2_sample.py
@@ -114,9 +114,8 @@ def build_sample(
     # entirely is the right trade-off.
     if source_type == "internal":
         from connectors.internal.access import (
-            INTERNAL_TABLES_BY_ID, build_filter_clause,
+            INTERNAL_TABLES_BY_ID, build_filter_clause, sample_internal_rows,
         )
-        from src.db import _get_state_dir
         from app.auth.access import is_user_admin as _is_admin
         from app.auth.session_principal import SessionPrincipal
         if table_id not in INTERNAL_TABLES_BY_ID:
@@ -135,20 +134,10 @@ def build_sample(
             is_admin = _is_admin(user.get("id"), conn) if user.get("id") else False
             user_dict_shim = user
         where_clause = build_filter_clause(internal_def, user_dict_shim, is_admin)
-        # Reuse the shared system.duckdb connection via cursor — opening a
-        # parallel handle to the same file is rejected process-wide
-        # (DuckDB serialises file handles, even for ATTACH). The SELECT is
-        # constrained to system.duckdb-resident tables, scoped by the
-        # RBAC clause; no writes happen here.
-        from src.db import get_system_db
-        cur = get_system_db().cursor()
-        try:
-            df = cur.execute(
-                f"SELECT * FROM {internal_def.source_table} {where_clause} LIMIT {n}",
-            ).fetchdf()
-            rows = df.to_dict(orient="records")
-        finally:
-            cur.close()
+        # The source rows live in the active state backend (DuckDB or Postgres);
+        # sample_internal_rows dispatches on use_pg() so the preview is correct
+        # on either — a raw always-DuckDB read returned nothing on Postgres.
+        rows = sample_internal_rows(internal_def, where_clause, n)
         return {"table_id": table_id, "rows": _sanitize_for_json(rows), "source": source_type}
 
     cache_key = f"{table_id}|{n}"

--- a/connectors/internal/access.py
+++ b/connectors/internal/access.py
@@ -164,6 +164,43 @@ def build_filter_clause(table: InternalTable, user: dict[str, Any], is_admin: bo
     return f"WHERE {table.filter_column} = '{safe}'"
 
 
+def sample_internal_rows(
+    table: InternalTable, where_clause: str, n: int
+) -> list[dict[str, Any]]:
+    """Read up to ``n`` rows from an internal table's physical source on the
+    ACTIVE state backend (DuckDB or Postgres), applying the RBAC ``where_clause``.
+
+    Internal-table rows live in the state backend; reading them off a raw
+    DuckDB connection returns nothing on a Postgres instance (the catalog
+    ``/sample`` preview then shows an empty table). Dispatching on ``use_pg()``
+    keeps the preview correct on either backend.
+
+    ``where_clause`` comes from :func:`build_filter_clause` — an ANSI
+    ``WHERE col = '<escaped>'`` (single quotes doubled, value regex-validated),
+    so the same statement runs unchanged on DuckDB and Postgres. The Postgres
+    path uses ``exec_driver_sql`` (raw DBAPI) so SQLAlchemy never reinterprets a
+    ``:token`` in the literal as a bind parameter.
+    """
+    n = max(1, int(n))
+    sql = f"SELECT * FROM {table.source_table} {where_clause} LIMIT {n}"
+
+    from src.repositories import use_pg
+
+    if use_pg():
+        from src.db_pg import get_engine
+
+        with get_engine().connect() as conn:
+            return [dict(r) for r in conn.exec_driver_sql(sql).mappings().all()]
+
+    from src.db import get_system_db
+
+    cur = get_system_db().cursor()
+    try:
+        return cur.execute(sql).fetchdf().to_dict(orient="records")
+    finally:
+        cur.close()
+
+
 # ---------------------------------------------------------------------------
 # Query execution
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.65.5"
+version = "0.65.6"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/tests/db_pg/test_parity_internal_sample.py
+++ b/tests/db_pg/test_parity_internal_sample.py
@@ -1,0 +1,80 @@
+"""Parity test for internal-table sampling across both backends.
+
+The catalog ``/sample`` preview for an internal source (``agnes_audit`` /
+``agnes_sessions`` / ``agnes_telemetry``) reads the physical state table
+(``audit_log`` etc.) through ``connectors.internal.access.sample_internal_rows``.
+That row data lives in the active state backend; the old code read it off a raw
+always-DuckDB connection, so on a Postgres instance the preview came back empty.
+
+These tests seed an ``audit_log`` row through the factory and assert
+``sample_internal_rows`` returns it under the RBAC filter on DuckDB AND Postgres.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def _env(state_backend, tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    for sub in ("extracts", "analytics", "state", "notifications"):
+        (tmp_path / sub).mkdir(exist_ok=True)
+    if state_backend == "duckdb":
+        from src.db import close_system_db, get_system_db
+
+        close_system_db()
+        get_system_db()
+    return state_backend
+
+
+def test_sample_internal_rows_scopes_to_user_on_both_backends(_env):
+    from connectors.internal.access import (
+        INTERNAL_TABLES_BY_ID,
+        build_filter_clause,
+        sample_internal_rows,
+    )
+    from src.repositories import audit_repo
+
+    # Seed two audit rows for different users through the factory (→ active
+    # backend). The non-admin filter must return only the caller's row.
+    audit_repo().log(user_id="analyst1", action="probe.mine", resource="r1")
+    audit_repo().log(user_id="someone_else", action="probe.theirs", resource="r2")
+
+    audit_def = INTERNAL_TABLES_BY_ID["agnes_audit"]
+    where = build_filter_clause(
+        audit_def, {"id": "analyst1", "email": "analyst@test.com"}, is_admin=False
+    )
+    rows = sample_internal_rows(audit_def, where, 50)
+
+    actions = {r.get("action") for r in rows}
+    user_ids = {r.get("user_id") for r in rows}
+    assert "probe.mine" in actions, (
+        f"[{_env}] seeded audit row missing from internal sample — "
+        f"sample_internal_rows read the wrong backend. got actions={actions}"
+    )
+    assert "probe.theirs" not in actions, (
+        f"[{_env}] RBAC filter leaked another user's row: {actions}"
+    )
+    assert user_ids == {"analyst1"}, f"[{_env}] unexpected user_ids: {user_ids}"
+
+
+def test_sample_internal_rows_admin_sees_all_on_both_backends(_env):
+    from connectors.internal.access import (
+        INTERNAL_TABLES_BY_ID,
+        build_filter_clause,
+        sample_internal_rows,
+    )
+    from src.repositories import audit_repo
+
+    audit_repo().log(user_id="u_a", action="probe.a", resource="r")
+    audit_repo().log(user_id="u_b", action="probe.b", resource="r")
+
+    audit_def = INTERNAL_TABLES_BY_ID["agnes_audit"]
+    # Admin → empty where clause → unscoped.
+    where = build_filter_clause(audit_def, {"id": "admin1"}, is_admin=True)
+    assert where == ""
+    rows = sample_internal_rows(audit_def, where, 50)
+    actions = {r.get("action") for r in rows}
+    assert {"probe.a", "probe.b"} <= actions, (
+        f"[{_env}] admin unscoped sample missing rows: {actions}"
+    )

--- a/tests/test_backend_split_guard.py
+++ b/tests/test_backend_split_guard.py
@@ -186,7 +186,8 @@ _GRANDFATHERED_GET_SYSTEM_DB: set[str] = {
     "app/api/scripts.py",
     "app/api/sync.py",
     "app/api/upload.py",
-    "app/api/v2_sample.py",
+    # app/api/v2_sample.py — internal-table sampling now routes through
+    # connectors.internal.access.sample_internal_rows (use_pg() dispatch).
     "app/auth/access.py",
     "app/auth/dependencies.py",
     # app/auth/pat_resolver.py — co-session resolution now routes through


### PR DESCRIPTION
Re-opening #535 (closed unexpectedly; PR head ref was stuck). Continues PG hardening sweep.

## Bug
Catalog `/sample` preview for internal sources (`agnes_audit` / `agnes_sessions` / `agnes_telemetry`) read the physical state table off a raw always-DuckDB connection, returning zero rows on a Postgres instance.

## Fix
Routes the preview through a new `render_internal_sample` helper that dispatches on `use_pg()` (Postgres via the engine, DuckDB via the system connection) while keeping the same RBAC row filter. Pinned by a both-backends parity test (`tests/db_pg/test_parity_internal_sample.py`).

Release-cut **0.65.6** (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->