### PR TITLE
fix(v2): resolve local parquet by extract dir, not source_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Fixed
+- **`agnes schema` / `agnes describe` / sample / scan 500'd for any extract
+  whose directory name differs from its `source_type`.** The v2 endpoints
+  (`/api/v2/schema`, `/api/v2/sample`, `/api/v2/scan`, and the catalog
+  size-hint) built the local-parquet path as
+  `extracts/<source_type>/data/<id>.parquet`, assuming the extract directory is
+  named after the registry `source_type`. That holds for the built-in
+  `keboola`/`bigquery` connectors but not for a generic `extract.duckdb`: e.g.
+  the bundled demo extract registers its tables with `source_type='local'`
+  while its parquets live under `extracts/demo/`, so the lookup hit a
+  nonexistent path and `read_parquet` raised → HTTP 500. Path resolution now
+  goes through `app.utils.resolve_local_parquet`, a source-name-agnostic lookup
+  (the same `rglob("data/<id>.parquet")` strategy `catalog.py`/`data.py`
+  already use), with the `source_type` directory kept as a fast path. A missing
+  parquet now returns a clean 404 instead of 500.
+
 ## [0.65.5] — 2026-06-04
 
 ### Fixed

--- a/app/api/v2_catalog.py
+++ b/app/api/v2_catalog.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import logging
 import time
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Any
 
 import duckdb
@@ -25,7 +24,6 @@ from fastapi import APIRouter, Depends
 
 from app.api.v2_cache import TTLCache
 from app.auth.dependencies import _get_db, get_current_user
-from app.utils import get_data_dir as _get_data_dir
 from src.audit_helpers import client_kind_from_user
 from src.rbac import can_access_table
 
@@ -116,17 +114,17 @@ def _materialized_parquet_size_bucket(
     """Size hint for rows whose data is on the server filesystem
     (``local`` or ``materialized``). Cheap ``Path.stat()``; never blocks.
 
-    Layout matches the v2 extract.duckdb contract:
-      ${DATA_DIR}/extracts/<source_type>/data/<table_id>.parquet
+    Resolves the parquet by source-name-agnostic lookup: the extract directory
+    is not necessarily the ``source_type`` (e.g. the bundled `demo` extract
+    registers tables as 'local' but lives under ``extracts/demo/``), so keying
+    the path off ``source_type`` silently lost the size hint for such rows.
     """
     if not source_type:
         return None
     try:
-        path = (
-            Path(_get_data_dir()) / "extracts" / source_type / "data"
-            / f"{table_id}.parquet"
-        )
-        if not path.exists():
+        from app.utils import resolve_local_parquet
+        path = resolve_local_parquet(table_id, source_type)
+        if path is None:
             return None
         return _bucket_size(path.stat().st_size)
     except Exception:

--- a/app/api/v2_sample.py
+++ b/app/api/v2_sample.py
@@ -159,8 +159,12 @@ def build_sample(
     if source_type == "bigquery" and (row.get("query_mode") or "") != "materialized":
         rows = _fetch_bq_sample(bq, row.get("bucket") or "", row.get("source_table") or table_id, n)
     else:
-        from app.utils import get_data_dir
-        parquet = get_data_dir() / "extracts" / source_type / "data" / f"{table_id}.parquet"
+        # Resolve by source-name-agnostic lookup — the extract directory is not
+        # necessarily the source_type (e.g. the bundled `demo` extract).
+        from app.utils import resolve_local_parquet
+        parquet = resolve_local_parquet(table_id, source_type)
+        if parquet is None:
+            raise FileNotFoundError(table_id)
         c = _open_duckdb(":memory:")
         try:
             df = c.execute(

--- a/app/api/v2_scan.py
+++ b/app/api/v2_scan.py
@@ -387,13 +387,15 @@ def run_scan(
 
     with quota.acquire(user=user_id):
         if source_type != "bigquery":
-            # Local source: query parquet directly. `source_type` extracted above
-            # because `row["source_type"]` could be NULL for legacy registry rows
-            # and `Path(...) / None` raises TypeError.
-            from app.utils import get_data_dir
-            parquet = (
-                get_data_dir() / "extracts" / source_type / "data" / f"{req.table_id}.parquet"
-            )
+            # Local source: query parquet directly. Resolve by source-name-agnostic
+            # lookup — the extract directory is not necessarily the source_type
+            # (e.g. the bundled `demo` extract registers tables as 'local' but
+            # lives under extracts/demo/), and `source_type` may be NULL/empty for
+            # legacy rows. resolve_local_parquet handles both.
+            from app.utils import resolve_local_parquet
+            parquet = resolve_local_parquet(req.table_id, source_type)
+            if parquet is None:
+                raise FileNotFoundError(req.table_id)
             local = _open_duckdb(":memory:")
             try:
                 projection = ", ".join(f'"{c}"' for c in req.select) if req.select else "*"

--- a/app/api/v2_schema.py
+++ b/app/api/v2_schema.py
@@ -186,11 +186,14 @@ def build_schema_uncached(
             "where_dialect_hints": _BQ_DIALECT_HINTS,
         }
     else:
-        # Local source — read schema from the parquet via DuckDB
-        from app.utils import get_data_dir
-        parquet = (
-            get_data_dir() / "extracts" / source_type / "data" / f"{table_id}.parquet"
-        )
+        # Local source — read schema from the parquet via DuckDB. Resolve the
+        # parquet by source-name-agnostic lookup: the extract directory is not
+        # necessarily the source_type (e.g. the bundled `demo` extract registers
+        # tables as source_type='local' but lives under extracts/demo/).
+        from app.utils import resolve_local_parquet
+        parquet = resolve_local_parquet(table_id, source_type)
+        if parquet is None:
+            raise NotFound(table_id)
         local_conn = _open_duckdb(":memory:")
         try:
             cols = local_conn.execute(

--- a/app/utils.py
+++ b/app/utils.py
@@ -8,6 +8,38 @@ def get_data_dir() -> Path:
     return Path(os.environ.get("DATA_DIR", "./data"))
 
 
+def resolve_local_parquet(table_id: str, source_type: str | None = None) -> Path | None:
+    """Resolve the on-disk parquet for a local/materialized table.
+
+    The v2 extract.duckdb contract lays parquets out at
+    ``${DATA_DIR}/extracts/<source>/data/<table_id>.parquet`` where ``<source>``
+    is the extract DIRECTORY NAME the orchestrator scanned — which is NOT
+    necessarily equal to the registry ``source_type``. Built-in connectors
+    happen to use a directory named after their source_type
+    (``keboola``/``bigquery``), but a generic extract.duckdb may live under any
+    directory name: e.g. the bundled ``demo`` extract registers its tables with
+    ``source_type='local'`` while its parquets live under ``extracts/demo/``.
+    Keying the path off ``source_type`` therefore looked up
+    ``extracts/local/data/<id>.parquet`` (nonexistent) and crashed ``read_parquet``.
+
+    Resolve by searching for ``data/<table_id>.parquet`` anywhere under the
+    extracts tree — the same source-name-agnostic lookup ``app/api/catalog.py``
+    and ``app/api/data.py`` already use. ``source_type``, when supplied, is
+    tried first as a fast path (preserves the historical layout/behavior for
+    built-in connectors and disambiguates the rare case of the same table_id
+    appearing under two sources). Returns ``None`` when no parquet exists.
+    """
+    extracts = get_data_dir() / "extracts"
+    if not extracts.exists():
+        return None
+    if source_type:
+        direct = extracts / source_type / "data" / f"{table_id}.parquet"
+        if direct.exists():
+            return direct
+    matches = list(extracts.rglob(f"data/{table_id}.parquet"))
+    return matches[0] if matches else None
+
+
 def get_marketplaces_dir() -> Path:
     """Path where marketplace git repos are cloned by the nightly sync."""
     return get_data_dir() / "marketplaces"

--- a/tests/test_resolve_local_parquet.py
+++ b/tests/test_resolve_local_parquet.py
@@ -1,0 +1,80 @@
+"""`app.utils.resolve_local_parquet` resolves a local table's parquet by the
+extract DIRECTORY NAME, not by `source_type`.
+
+Regression for the demo-instance bug: the bundled `demo` extract registers its
+tables with `source_type='local'` but bakes its parquets under
+`extracts/demo/data/`. The v2 endpoints used to key the path off `source_type`
+(`extracts/local/data/<id>.parquet`), which does not exist, so `read_parquet`
+crashed and `/api/v2/schema` (+ sample/scan) returned HTTP 500. The helper now
+falls back to a source-name-agnostic rglob so any extract directory resolves.
+"""
+
+from pathlib import Path
+
+import duckdb
+
+from app.utils import resolve_local_parquet
+
+
+def _make_parquet(dir_path: Path, table_id: str) -> Path:
+    dir_path.mkdir(parents=True, exist_ok=True)
+    pq = dir_path / f"{table_id}.parquet"
+    conn = duckdb.connect(":memory:")
+    conn.execute(f"COPY (SELECT 1 AS a) TO '{pq}' (FORMAT PARQUET)")
+    conn.close()
+    return pq
+
+
+def test_resolves_when_dir_matches_source_type(tmp_path: Path, monkeypatch):
+    """Built-in connector layout (dir == source_type) — fast path hits."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    pq = _make_parquet(tmp_path / "extracts" / "keboola" / "data", "orders")
+    assert resolve_local_parquet("orders", "keboola") == pq
+
+
+def test_resolves_when_dir_differs_from_source_type(tmp_path: Path, monkeypatch):
+    """The demo case: parquet under extracts/demo/ but source_type='local'.
+
+    The source_type fast-path misses; the rglob fallback must still find it.
+    This is the exact scenario that produced the 500 before the fix.
+    """
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    pq = _make_parquet(tmp_path / "extracts" / "demo" / "data", "orders_demo")
+    # No extracts/local/data/orders_demo.parquet exists — the old code looked there.
+    assert not (tmp_path / "extracts" / "local" / "data" / "orders_demo.parquet").exists()
+    assert resolve_local_parquet("orders_demo", "local") == pq
+
+
+def test_resolves_without_source_type_hint(tmp_path: Path, monkeypatch):
+    """Legacy rows may carry a NULL/empty source_type — rglob still resolves."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    pq = _make_parquet(tmp_path / "extracts" / "demo" / "data", "customers_demo")
+    assert resolve_local_parquet("customers_demo", None) == pq
+    assert resolve_local_parquet("customers_demo", "") == pq
+
+
+def test_returns_none_when_missing(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    (tmp_path / "extracts").mkdir()
+    assert resolve_local_parquet("nope", "local") is None
+
+
+def test_returns_none_when_extracts_dir_absent(tmp_path: Path, monkeypatch):
+    """No extracts tree at all (fresh instance) — None, never an exception."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    assert resolve_local_parquet("anything", "local") is None
+
+
+def test_v2_schema_local_dir_mismatch_does_not_500(tmp_path: Path, monkeypatch):
+    """End-to-end through build_schema_uncached: a source_type='local' row whose
+    parquet lives under extracts/demo/ must yield a real schema, not raise."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    _make_parquet(tmp_path / "extracts" / "demo" / "data", "orders_demo")
+
+    from app.api.v2_schema import build_schema_uncached
+    row = {"id": "orders_demo", "source_type": "local", "query_mode": "local"}
+    result = build_schema_uncached(
+        conn=None, table_id="orders_demo", bq=object(), row=row,
+    )
+    assert result["sql_flavor"] == "duckdb"
+    assert {c["name"] for c in result["columns"]} == {"a"}


### PR DESCRIPTION
## Problem

`agnes schema`, `agnes describe`, sample and scan returned **HTTP 500** for any
local table whose extract directory name differs from its registry
`source_type`. Surfaced while exercising the bundled demo extract end-to-end:
`agnes schema orders_demo` → 500.

Root cause: the v2 endpoints (`/api/v2/schema`, `/api/v2/sample`,
`/api/v2/scan`, and the `/api/v2/catalog` size-hint) built the local-parquet
path as `extracts/<source_type>/data/<id>.parquet`, assuming the extract
directory is named after the registry `source_type`. That assumption holds for
the built-in `keboola`/`bigquery` connectors (dir == source_type) but **not**
for a generic `extract.duckdb`: the bundled demo extract registers its tables
with `source_type='local'` while baking parquets under `extracts/demo/`. The
lookup resolved to a nonexistent `extracts/local/data/<id>.parquet`, so
`read_parquet` raised → 500.

Distribution (`agnes pull`/`agnes query`) was unaffected because it resolves
paths via the manifest / `rglob`, not via `source_type`.

## Fix

- New `app.utils.resolve_local_parquet(table_id, source_type)`: source-name-
  agnostic lookup using the same `rglob("data/<id>.parquet")` strategy
  `app/api/catalog.py` and `app/api/data.py` already use, with the
  `source_type` directory kept as a fast path (no behavior change for built-in
  connectors).
- `v2_schema.py`, `v2_sample.py`, `v2_scan.py`, and the `v2_catalog.py`
  size-hint now resolve through the helper. A missing parquet returns a clean
  **404** instead of 500. Dropped now-unused `Path`/`get_data_dir` imports in
  `v2_catalog.py`.
- `admin.py`'s materialized-parquet cleanup is intentionally left as-is — it is
  guarded to `source_type in ("bigquery","keboola")`, where dir == source_type
  holds by construction.

## Tests

- `tests/test_resolve_local_parquet.py` (6): fast-path hit, dir≠source_type
  fallback (the demo regression), no-hint/legacy rows, missing parquet, absent
  extracts tree, and an end-to-end `build_schema_uncached` check.
- Neighboring v2 suites green (schema/sample/scan/catalog).
- Full suite: 6981 passed. Two runs showed 5 unrelated `-n auto` flakes
  (chat-auto-title, data-package, mcp tool-count — shared-DuckDB-state /
  xdist scheduling); they pass in isolation and vanished on re-run, and none
  import the touched modules' path logic.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->