### PR TITLE
test(db): make parity sweeps xdist-safe (single in-process diff)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Internal
+- **Fixed the DuckDB/Postgres status-parity sweeps being dead under
+  `pytest -n auto`.** `test_get_status_parity_sweep.py` and
+  `test_mutation_status_parity_sweep.py` stashed each backend's results in a
+  module-level dict for a second test to compare — but under `-n auto` (the
+  project's standard runner) each xdist worker is a separate process, so the
+  comparison test saw an empty dict and failed with "sweep didn't run on both
+  backends". Both sweeps now build both backends in a single in-process test
+  and diff inline (shared setup in `_parity_sweep_util.py`); the repo factory
+  reads the backend decision live per call, so flipping `AGNES_DB_URL` between
+  phases re-routes correctly. Kept the cross-backend diff rather than a flat
+  no-5xx assertion, so routes that 5xx identically on both backends in the bare
+  TestClient harness (lifespan-populated `app.state` slots) aren't false
+  positives. Added `test_first_time_setup_parity.py` pinning the
+  `/first-time-setup` 302-redirect-when-users-exist fix per backend.
+
 ## [0.65.12] — 2026-06-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.65.13] — 2026-06-04
+
 ### Internal
 - **Fixed the DuckDB/Postgres status-parity sweeps being dead under
   `pytest -n auto`.** `test_get_status_parity_sweep.py` and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.65.12"
+version = "0.65.13"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/tests/db_pg/_parity_sweep_util.py
+++ b/tests/db_pg/_parity_sweep_util.py
@@ -1,0 +1,153 @@
+"""Shared helper for the cross-backend status-parity sweeps.
+
+The sweeps build a fully-seeded ``TestClient`` on each backend and compare the
+HTTP status every parameter-free route returns. A status that *differs* between
+DuckDB and Postgres (e.g. 200 vs 302, or 200 vs 500) is the signature of a
+handler that reads state off a raw ``Depends(_get_db)`` connection — the
+backend-split class the static ``test_backend_split_guard.py`` ratchet can't see
+(it only scans ``get_system_db()`` callers + direct repo instantiation).
+
+Why both backends are driven from ONE test (not a parametrized fixture + a
+module-level result dict): the dict pattern silently dies under
+``pytest -n auto`` — each xdist worker is a separate process, so the comparison
+test sees an empty dict. Instead we collect both backends sequentially in a
+single test process. The repo factory (`src.repositories.use_pg`) reads the
+backend decision live on every ``*_repo()`` call, so flipping ``AGNES_DB_URL``
+between phases re-routes correctly; we fully collect one backend before
+switching to the next.
+
+Comparing (rather than asserting no-5xx) is deliberate: several routes 5xx
+identically on both backends in the bare TestClient harness (e.g. handlers that
+touch ``app.state`` slots only populated by the lifespan). Those are not
+backend-split bugs — a diff ignores them; a flat no-5xx assertion would flag
+them as false positives.
+"""
+from __future__ import annotations
+
+import importlib
+import uuid as _uuid
+from pathlib import Path
+
+
+def _alembic_upgrade(pg_engine) -> None:
+    from alembic import command
+    from alembic.config import Config
+
+    repo_root = Path(__file__).resolve().parents[2]
+    cfg = Config(str(repo_root / "alembic.ini"))
+    cfg.set_main_option("script_location", str(repo_root / "migrations"))
+    cfg.attributes["sqlalchemy.url"] = str(pg_engine.url)
+    command.upgrade(cfg, "head")
+
+
+def _seed_pg_system_groups(pg_engine) -> None:
+    import sqlalchemy as sa
+
+    with pg_engine.begin() as conn:
+        for name, desc in (
+            ("Admin", "System: full access to all data and admin actions"),
+            ("Everyone", "System: default group every user is implicitly a member of"),
+        ):
+            conn.execute(
+                sa.text(
+                    "INSERT INTO user_groups (id, name, description, is_system, created_by) "
+                    "VALUES (:id, :name, :desc, TRUE, 'system:seed') "
+                    "ON CONFLICT (name) DO UPDATE SET is_system = TRUE"
+                ),
+                {"id": _uuid.uuid4().hex, "name": name, "desc": desc},
+            )
+
+
+def build_seeded_client(backend, tmp_path, monkeypatch, pg_engine):
+    """Configure ``backend`` ('duckdb'|'pg'), seed admin+analyst users, and
+    return ``(TestClient, admin_token)``.
+
+    Mirrors the ``seeded_app_both`` fixture but as a plain callable so a single
+    test can build both backends in sequence.
+    """
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-minimum-32-characters!!")
+    for sub in ("extracts", "analytics", "state", "notifications"):
+        (tmp_path / sub).mkdir(parents=True, exist_ok=True)
+
+    if backend == "pg":
+        _alembic_upgrade(pg_engine)
+        _seed_pg_system_groups(pg_engine)
+        monkeypatch.setenv("AGNES_DB_URL", str(pg_engine.url))
+        import src.db_pg as db_pg
+
+        db_pg.dispose()
+    else:
+        monkeypatch.delenv("AGNES_DB_URL", raising=False)
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    # Pick up the env change on the next factory call.
+    import src.repositories
+
+    importlib.reload(src.repositories)
+
+    # Reset the system-DB singleton so it reopens under the current DATA_DIR.
+    from src.db import close_system_db, get_system_db
+
+    close_system_db()
+    if backend == "duckdb":
+        get_system_db()  # triggers _ensure_schema + _seed_system_groups
+
+    from src.repositories import users_repo, user_group_members_repo
+
+    u = users_repo()
+    u.create(id="admin1", email="admin@test.com", name="Admin")
+    u.create(id="analyst1", email="analyst@test.com", name="Analyst")
+
+    if backend == "duckdb":
+        admin_gid = get_system_db().execute(
+            "SELECT id FROM user_groups WHERE name = 'Admin'"
+        ).fetchone()[0]
+    else:
+        import sqlalchemy as sa
+        from src.db_pg import get_engine
+
+        with get_engine().connect() as conn:
+            admin_gid = conn.execute(
+                sa.text("SELECT id FROM user_groups WHERE name = 'Admin'")
+            ).scalar()
+    user_group_members_repo().add_member("admin1", admin_gid, source="system_seed")
+
+    from app.auth.jwt import create_access_token
+    from app.main import create_app
+    from fastapi.testclient import TestClient
+
+    client = TestClient(create_app())
+    return client, create_access_token("admin1", "admin@test.com")
+
+
+def collect_statuses(client, token, *, methods, skip_substr=()):
+    """Return ``{"METHOD path": status}`` for every parameter-free route whose
+    methods intersect ``methods`` and whose path contains no ``skip_substr``."""
+    auth = {"Authorization": f"Bearer {token}"}
+    seen: dict[str, int] = {}
+    want = set(methods)
+    for route in client.app.routes:
+        path = getattr(route, "path", "") or ""
+        if "{" in path or any(s in path for s in skip_substr):
+            continue
+        route_methods = set(getattr(route, "methods", None) or set())
+        for method in sorted(route_methods & want):
+            key = f"{method} {path}"
+            try:
+                if method == "GET":
+                    r = client.get(path, headers=auth, follow_redirects=False)
+                else:
+                    r = client.request(
+                        method, path, json={}, headers=auth, follow_redirects=False
+                    )
+                seen[key] = r.status_code
+            except Exception:  # noqa: BLE001 — record transport failure as a sentinel
+                seen[key] = -1
+    return seen
+
+
+def diff_statuses(duck, pg):
+    """Return ``{key: (duck_status, pg_status)}`` for keys that differ."""
+    keys = set(duck) | set(pg)
+    return {k: (duck.get(k), pg.get(k)) for k in keys if duck.get(k) != pg.get(k)}

--- a/tests/db_pg/test_first_time_setup_parity.py
+++ b/tests/db_pg/test_first_time_setup_parity.py
@@ -1,0 +1,31 @@
+"""Parity test: GET /first-time-setup redirects to /login on both backends when
+users already exist.
+
+The handler gates the wizard on "are there any users yet?". It counted users
+with a raw `SELECT count(*)` on the always-DuckDB `_get_db` connection — on a
+Postgres instance the DuckDB system DB is empty, so the wizard reported
+first-time even when PG already had users, rendering the setup page (200)
+instead of redirecting to /login (302). The count now goes through
+`users_repo().count_all()`, which routes to the active backend.
+
+`seeded_app_both` seeds an admin + analyst, so the wizard must redirect (302)
+on whichever backend is active.
+"""
+from __future__ import annotations
+
+
+def test_first_time_setup_redirects_when_users_exist(seeded_app_both):
+    backend = seeded_app_both["backend"]
+    client = seeded_app_both["client"]
+
+    r = client.get("/first-time-setup", follow_redirects=False)
+
+    assert r.status_code == 302, (
+        f"[{backend}] /first-time-setup returned {r.status_code}, expected 302 "
+        f"redirect — the wizard counted users off the wrong backend and thinks "
+        f"this is a fresh install."
+    )
+    assert r.headers.get("location", "").endswith("/login"), (
+        f"[{backend}] /first-time-setup redirected to "
+        f"{r.headers.get('location')!r}, expected /login"
+    )

--- a/tests/db_pg/test_get_status_parity_sweep.py
+++ b/tests/db_pg/test_get_status_parity_sweep.py
@@ -1,59 +1,50 @@
-"""Differential sweep: every param-free GET endpoint must return the SAME
-HTTP status on DuckDB and Postgres, given identical seeded state.
+"""Cross-backend GET status-parity sweep.
 
-A status that differs between backends (e.g. 200 on DuckDB, 500 on Postgres)
-is the signature of a backend-split bug on an endpoint no targeted parity test
-covers. This sweeps the whole live route table, so it catches divergences the
-hand-written cluster tests miss.
+Every parameter-free GET route is hit with a seeded admin token on DuckDB and on
+Postgres (identical seed) and the HTTP status must match. A status that differs
+between backends (e.g. 200 vs 302, or 200 vs 500) is the signature of a handler
+that reads state off a raw ``Depends(_get_db)`` connection — the backend-split
+class the static ``test_backend_split_guard.py`` ratchet can't see.
+
+This found ``/first-time-setup`` returning 200 on PG vs 302 on DuckDB (the
+wizard counted users off the always-DuckDB connection); that specific fix has a
+dedicated regression test in ``test_first_time_setup_parity.py``.
+
+Single test, both backends collected in-process — see ``_parity_sweep_util`` for
+why (the older parametrized-fixture + module-dict pattern was dead under
+``pytest -n auto``).
 """
 from __future__ import annotations
 
-_STATUS: dict[str, dict[str, int]] = {}
+from ._parity_sweep_util import (
+    build_seeded_client,
+    collect_statuses,
+    diff_statuses,
+)
 
-# Paths to skip: intentional-throw debug routes + streaming/SSE (would hang).
-_SKIP = {"/api/debug/throw", "/_debug/throw/exc"}
-
-
-def _is_sweepable(route) -> bool:
-    methods = getattr(route, "methods", None) or set()
-    path = getattr(route, "path", "") or ""
-    if "GET" not in methods or "{" in path or path in _SKIP:
-        return False
-    if "stream" in path or "sse" in path or path.endswith("/events"):
-        return False
-    return True
+# Intentional-throw debug routes + streaming/SSE (would hang) — never swept.
+_SKIP_SUBSTR = ("throw", "stream", "sse", "/events")
 
 
-def test_collect_get_statuses(seeded_app_both):
-    backend = seeded_app_both["backend"]
-    client = seeded_app_both["client"]
-    auth = {"Authorization": f"Bearer {seeded_app_both['admin_token']}"}
-    seen: dict[str, int] = {}
-    for route in client.app.routes:
-        if not _is_sweepable(route):
-            continue
-        path = route.path
-        try:
-            r = client.get(path, headers=auth, follow_redirects=False)
-            seen[path] = r.status_code
-        except Exception as exc:  # noqa: BLE001 — record, don't abort the sweep
-            seen[path] = -1  # transport-level failure
-            seen[f"{path}::exc"] = type(exc).__name__  # type: ignore[assignment]
-    _STATUS[backend] = seen
-
-
-def test_get_status_is_identical_across_backends():
-    assert {"duckdb", "pg"} <= set(_STATUS), (
-        f"sweep didn't run on both backends: {set(_STATUS)}"
+def test_get_status_is_identical_across_backends(tmp_path, monkeypatch, pg_engine):
+    duck_client, duck_token = build_seeded_client(
+        "duckdb", tmp_path / "duck", monkeypatch, pg_engine
     )
-    duck, pg = _STATUS["duckdb"], _STATUS["pg"]
-    paths = {p for p in (set(duck) | set(pg)) if "::exc" not in p}
-    divergences = {
-        p: (duck.get(p), pg.get(p)) for p in paths if duck.get(p) != pg.get(p)
-    }
+    duck = collect_statuses(
+        duck_client, duck_token, methods={"GET"}, skip_substr=_SKIP_SUBSTR
+    )
+
+    pg_client, pg_token = build_seeded_client(
+        "pg", tmp_path / "pg", monkeypatch, pg_engine
+    )
+    pg = collect_statuses(
+        pg_client, pg_token, methods={"GET"}, skip_substr=_SKIP_SUBSTR
+    )
+
+    divergences = diff_statuses(duck, pg)
     assert not divergences, (
         "GET status diverges between DuckDB and Postgres (backend-split):\n"
         + "\n".join(
-            f"  {p}: duck={d} pg={g}" for p, (d, g) in sorted(divergences.items())
+            f"  {k}: duck={d} pg={g}" for k, (d, g) in sorted(divergences.items())
         )
     )

--- a/tests/db_pg/test_mutation_status_parity_sweep.py
+++ b/tests/db_pg/test_mutation_status_parity_sweep.py
@@ -1,21 +1,29 @@
-"""Differential sweep for mutation endpoints (POST/PUT/PATCH/DELETE).
+"""Cross-backend mutation status-parity sweep (POST/PUT/PATCH/DELETE).
 
 Companion to the GET sweep: every parameter-free mutation route is called with
-an empty JSON body on DuckDB and on Postgres (identical seeded state) and the
-HTTP status must match. A status that differs between backends (e.g. 422 on
-DuckDB, 500 on Postgres) is the signature of a handler that reads state off a
-raw `Depends(_get_db)` connection during auth/validation — the backend-split
-class the static guard can't see.
+an empty JSON body on DuckDB and on Postgres (identical seed) and the HTTP
+status must match. A status that differs between backends (e.g. 422 on DuckDB,
+500 on Postgres) is the signature of a handler that reads state off a raw
+``Depends(_get_db)`` connection during auth/validation.
 
-Safe to run blindly: `seeded_app_both` uses per-test ephemeral databases, so a
-side-effecting mutation only touches a throwaway DB. Side-effecting / long
-endpoints (sync triggers, cache warmup, materialize, exports) are skipped both
-because they're slow and because an empty body wouldn't exercise the read path
-meaningfully anyway.
+Safe to run blindly: each backend client uses a per-test ephemeral database, so
+a side-effecting mutation only touches a throwaway DB. Heavy / side-effecting /
+binary / streaming endpoints are skipped — they're slow and an empty body
+wouldn't exercise the read path meaningfully anyway.
+
+Single test, both backends collected in-process — see ``_parity_sweep_util`` for
+why (the older parametrized-fixture + module-dict pattern was dead under
+``pytest -n auto``).
 """
 from __future__ import annotations
 
-_MUT_STATUS: dict[str, dict[str, int]] = {}
+from ._parity_sweep_util import (
+    build_seeded_client,
+    collect_statuses,
+    diff_statuses,
+)
+
+_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
 
 # Substrings of paths to skip: heavy/side-effecting ops + binary/stream routes.
 _SKIP_SUBSTR = (
@@ -25,49 +33,22 @@ _SKIP_SUBSTR = (
 )
 
 
-def _mutation_methods(route):
-    methods = set(getattr(route, "methods", None) or set())
-    return sorted(methods & {"POST", "PUT", "PATCH", "DELETE"})
-
-
-def _is_sweepable(route) -> bool:
-    path = getattr(route, "path", "") or ""
-    if "{" in path:
-        return False
-    if any(s in path for s in _SKIP_SUBSTR):
-        return False
-    return bool(_mutation_methods(route))
-
-
-def test_collect_mutation_statuses(seeded_app_both):
-    backend = seeded_app_both["backend"]
-    client = seeded_app_both["client"]
-    auth = {"Authorization": f"Bearer {seeded_app_both['admin_token']}"}
-    seen: dict[str, int] = {}
-    for route in client.app.routes:
-        if not _is_sweepable(route):
-            continue
-        for method in _mutation_methods(route):
-            key = f"{method} {route.path}"
-            try:
-                r = client.request(
-                    method, route.path, json={}, headers=auth, follow_redirects=False
-                )
-                seen[key] = r.status_code
-            except Exception:  # noqa: BLE001 — record as transport failure
-                seen[key] = -1
-    _MUT_STATUS[backend] = seen
-
-
-def test_mutation_status_is_identical_across_backends():
-    assert {"duckdb", "pg"} <= set(_MUT_STATUS), (
-        f"sweep didn't run on both backends: {set(_MUT_STATUS)}"
+def test_mutation_status_is_identical_across_backends(tmp_path, monkeypatch, pg_engine):
+    duck_client, duck_token = build_seeded_client(
+        "duckdb", tmp_path / "duck", monkeypatch, pg_engine
     )
-    duck, pg = _MUT_STATUS["duckdb"], _MUT_STATUS["pg"]
-    keys = set(duck) | set(pg)
-    divergences = {
-        k: (duck.get(k), pg.get(k)) for k in keys if duck.get(k) != pg.get(k)
-    }
+    duck = collect_statuses(
+        duck_client, duck_token, methods=_METHODS, skip_substr=_SKIP_SUBSTR
+    )
+
+    pg_client, pg_token = build_seeded_client(
+        "pg", tmp_path / "pg", monkeypatch, pg_engine
+    )
+    pg = collect_statuses(
+        pg_client, pg_token, methods=_METHODS, skip_substr=_SKIP_SUBSTR
+    )
+
+    divergences = diff_statuses(duck, pg)
     assert not divergences, (
         "Mutation status diverges between DuckDB and Postgres (backend-split):\n"
         + "\n".join(


### PR DESCRIPTION
## Why

The GET/mutation status-parity sweeps merged in #542 stash each backend's results in a **module-level dict** for a second test to compare. Under `pytest -n auto` (the project's standard runner — `pytest tests/ --tb=short -n auto -q`) each xdist worker is a separate process, so the comparison test sees an empty dict and fails:

```
AssertionError: sweep didn't run on both backends: set()
```

**`main` is currently red on these two tests** — confirmed by running the merged version under `-n auto` locally. Caught by the Devin review on #542, which landed after the PR had already merged.

## Fix

- Both sweeps now build **both backends in a single in-process test** and diff inline. The repo factory (`src.repositories.use_pg`) reads the backend decision live on every `*_repo()` call, so flipping `AGNES_DB_URL` between phases re-routes correctly — collect one backend fully, switch, collect the other, diff. Shared setup extracted to `_parity_sweep_util.py`.
- Kept the **cross-backend diff** (not a flat no-5xx assertion): several routes 5xx identically on both backends in the bare `TestClient` harness (handlers touching `app.state` slots only populated by the lifespan). Those aren't backend-split bugs — a diff ignores them; a no-5xx assertion would flag them as false positives.
- Added `test_first_time_setup_parity.py` pinning the `/first-time-setup` 302-redirect-when-users-exist fix with a focused per-backend test.

## Verification

```
.venv/bin/pytest tests/db_pg/test_get_status_parity_sweep.py \
  tests/db_pg/test_mutation_status_parity_sweep.py \
  tests/db_pg/test_first_time_setup_parity.py -n auto -q
# 4 passed

.venv/bin/pytest tests/db_pg/ -n auto -q
# 722 passed, 1 skipped
```

Sweep exercises 157 GET routes (incl. `/first-time-setup`); diff is empty → parity holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->