### PR TITLE
test(db): gate that alembic head materializes every Base.metadata table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Internal
+- Added a schema-parity gate (`tests/db_pg/test_schema_parity.py::test_alembic_head_materializes_every_model`)
+  asserting the alembic chain CREATES every table and column in
+  `Base.metadata`. The existing parity tests compare DuckDB ↔ SQLAlchemy
+  *models*; none checked that the alembic *revisions* actually build the full
+  model schema. A table in `src/models/` with a DuckDB `_vN` step but no
+  alembic revision passed every existing check yet shipped a Postgres image
+  where `alembic upgrade head` (the compose `migrate` one-shot) reached head
+  without creating it — then the `data-migrate` one-shot, which copies every
+  `Base.metadata` table, failed mid-copy with `relation "X" does not exist`,
+  and `app`/`scheduler` (gated on `data-migrate` exiting 0) never booted. The
+  gate locks the dual-backend-discipline invariant so that drift is caught at
+  CI instead of wedging a customer instance at startup.
+
 ## [0.65.14] — 2026-06-04
 
 ### Fixed
@@ -23,6 +37,7 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   skills installed via its own Customize → Skills UI (upstream limitation,
   anthropics/claude-code#50669), not workspace `.claude/skills/`.
 - **Cowork bundle connects over verified TLS on macOS without manual cert setup.** The generated `mcp_server.py` / `agnes.py` now build their HTTPS `ssl` context from a Mozilla CA bundle shipped in the ZIP as `cacert.pem` (also copied to `~/.config/agnes/` by `setup.py`), falling back to the OS trust store and honouring `SSL_CERT_FILE`. This fixes `CERTIFICATE_VERIFY_FAILED` on Pythons that lack a usable system CA store (notably macOS python.org builds) **without disabling certificate verification**. An explicit opt-out for genuinely broken environments remains via `AGNES_INSECURE_SKIP_TLS_VERIFY=1`.
+
 ## [0.65.13] — 2026-06-04
 
 ### Internal

--- a/tests/db_pg/test_schema_parity.py
+++ b/tests/db_pg/test_schema_parity.py
@@ -134,3 +134,62 @@ def test_no_pg_only_required_columns(tmp_path):
         pytest.fail(
             "PG schema has NOT NULL columns absent from DuckDB:\n" + "\n".join(errors)
         )
+
+
+def test_alembic_head_materializes_every_model(pg_engine_with_schema):
+    """The alembic chain must actually CREATE every table+column in
+    ``Base.metadata`` — not just be column-compatible with the models.
+
+    The two tests above compare DuckDB ↔ SQLAlchemy *models*. They do NOT
+    catch a table/column that lives in ``src/models/*.py`` (and so in
+    ``Base.metadata``) but that no alembic revision creates. That drift is
+    invisible to the model-vs-DuckDB checks yet fatal in production: the
+    compose ``migrate`` one-shot runs ``alembic upgrade head`` (reaches head
+    happily — the missing table simply isn't in any revision), then the
+    ``data-migrate`` one-shot iterates ``Base.metadata.sorted_tables`` and
+    copies each into PG. A table present in metadata but absent from the
+    alembic-built schema raises ``psycopg.errors.UndefinedTable``
+    (``relation "X" does not exist``) mid-copy → ``data-migrate`` exits
+    non-zero → ``app``/``scheduler`` (which gate on it via
+    ``service_completed_successfully``) never boot. A schema gap thus wedges
+    the whole instance at startup with an opaque error.
+
+    This locks the dual-backend-discipline invariant from CLAUDE.md — "an
+    alembic migration for PG must reach the same schema endpoint as the
+    models" — by diffing the alembic-head schema against ``Base.metadata``
+    at table and column grain.
+    """
+    import sqlalchemy as sa
+    import src.models  # noqa: F401 — registers every model
+    from src.db_pg import Base
+
+    inspector = sa.inspect(pg_engine_with_schema)
+    pg_tables = set(inspector.get_table_names())
+
+    errors: list[str] = []
+    for table in Base.metadata.sorted_tables:
+        if table.name not in pg_tables:
+            errors.append(
+                f"  Table '{table.name}' is in Base.metadata but NO alembic "
+                f"revision creates it"
+            )
+            continue
+        pg_cols = {c["name"] for c in inspector.get_columns(table.name)}
+        missing = {c.name for c in table.columns} - pg_cols
+        if missing:
+            errors.append(
+                f"  Table '{table.name}': alembic-built schema is missing "
+                f"columns {sorted(missing)} present on the model"
+            )
+
+    if errors:
+        pytest.fail(
+            "Base.metadata has tables/columns the alembic chain never creates "
+            "(would wedge `data-migrate` → app boot on a fresh Postgres "
+            "instance):\n"
+            + "\n".join(errors)
+            + "\n\nFix: add an alembic revision under migrations/versions/ that "
+            "creates the missing table/column (and the matching DuckDB "
+            "_vN_to_v(N+1) step in src/db.py — both ladders must reach the "
+            "same endpoint)."
+        )


### PR DESCRIPTION
## Why

Found while investigating a fresh-Postgres-VM boot wedge: the compose `data-migrate` one-shot iterates `Base.metadata.sorted_tables` and copies each into PG, gated behind the `migrate` one-shot (`alembic upgrade head`). `app` and `scheduler` block on `data-migrate` exiting 0.

The existing parity tests (`test_no_duckdb_columns_missing_from_pg_models`, `test_no_pg_only_required_columns`) compare DuckDB ↔ SQLAlchemy **models**. **None checks that the alembic *chain* actually creates the full model schema.** So a table added to `src/models/` (plus its DuckDB `_vN` step) but missing an alembic revision would:

- pass `test_schema_parity` (DuckDB ↔ models match),
- pass `test_db_schema_version` (DuckDB version bumped),
- yet ship a Postgres image where `alembic upgrade head` reaches head **without creating the table**.

Then `data-migrate` fails mid-copy with `relation "X" does not exist`, exits non-zero, and `app`/`scheduler` never boot — a schema gap silently wedges the whole instance at startup with an opaque error.

## Fix

Add `test_alembic_head_materializes_every_model`: run `alembic upgrade head` on a fresh PG (reusing the `pg_engine_with_schema` fixture) and diff the built schema against `Base.metadata` at **table and column** grain. Locks the dual-backend-discipline invariant from `CLAUDE.md` (the alembic ladder must reach the same endpoint as the models) so the drift is caught at CI instead of at a customer VM boot.

Empirically the schema matches today (61 tables == 61); this is a clean lock, not a fix for a current drift. Verified the gate has teeth with a phantom-table negative control.

## Verification

```
.venv/bin/pytest tests/db_pg/test_schema_parity.py -n auto -q
# 3 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->