### PR TITLE
fix(sync): sweep orphaned kbc-export-*/kbc-slice-* scratch dirs before each Keboola sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Fixed
+- The Keboola sync now sweeps orphaned `kbc-export-*` / `kbc-slice-*` staging dirs from the temp root (`AGNES_TEMP_DIR`) at the start of every run. These dirs are normally removed by `TemporaryDirectory` on any return — including the disk-full path — so the only way they survive is a hard kill (SIGKILL / OOM / container recreate) mid-export. Without a sweep they accumulated on the data disk until it filled and *every* subsequent sync failed with `No space left on device`, a self-reinforcing failure that needed a manual `rm` to break. The sweep is age-gated (`AGNES_SCRATCH_MAX_AGE_SEC`, default 1h) so a concurrent in-flight export is never deleted, and runs under the sync lock before any new scratch is created.
+
 ## [0.65.18] — 2026-06-04
 
 ### Added

--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -380,6 +380,22 @@ def _run_sync(tables: Optional[List[str]] = None):
         source_type = get_data_source_type()
         data_dir = _get_data_dir()
 
+        # Reclaim orphaned `kbc-export-*` staging dirs left behind when a
+        # previous sync worker was hard-killed mid-export (SIGKILL / OOM /
+        # auto-upgrade container recreate) so TemporaryDirectory.__exit__
+        # never ran. Runs here — under `_sync_lock`, before any new scratch
+        # is created — so it can never race a live in-flight export from this
+        # process (and the age-gate covers any other container). Best-effort:
+        # a sweep failure must never block the sync itself.
+        try:
+            from connectors.keboola.storage_api import sweep_orphaned_scratch
+            sweep_orphaned_scratch()
+        except Exception as _sweep_exc:  # pragma: no cover - defensive
+            print(
+                f"[SYNC] orphaned-scratch sweep skipped: {_sweep_exc}",
+                file=_sys.stderr, flush=True,
+            )
+
         # Read table configs in main process (has shared DuckDB connection)
         sys_conn = get_system_db()
         # Track whether the REGISTRY (not the post-filter list) was empty.

--- a/connectors/keboola/storage_api.py
+++ b/connectors/keboola/storage_api.py
@@ -94,6 +94,85 @@ def get_temp_root() -> Optional[str]:
     return root
 
 
+# Prefixes shared with the ``tempfile.TemporaryDirectory(prefix=...)`` calls
+# that stage data under the temp root: ``kbc-export-`` (the per-export dirs in
+# connectors/keboola/extractor.py — materialize_query + legacy extract) and
+# ``kbc-slice-`` (the per-call sliced-CSV download dir in
+# ``_download_sliced`` below). Anything under the temp root with one of these
+# prefixes is extractor-owned staging scratch.
+_SCRATCH_PREFIXES = ("kbc-export-", "kbc-slice-")
+
+
+def sweep_orphaned_scratch(
+    root: Optional[str] = None,
+    max_age_seconds: Optional[float] = None,
+) -> int:
+    """Remove orphaned ``kbc-export-*`` / ``kbc-slice-*`` staging dirs and
+    return the count.
+
+    A staging dir is created via ``tempfile.TemporaryDirectory`` (the
+    ``kbc-export-`` dirs in ``connectors/keboola/extractor.py`` and the
+    ``kbc-slice-`` dir in ``_download_sliced`` below), whose ``__exit__``
+    removes it on
+    *any* normal return — including the ENOSPC / disk-full exception path.
+    The only way a dir survives is a **hard kill** (SIGKILL / OOM / the
+    auto-upgrade ``docker compose up -d`` recreating the container mid-sync —
+    the documented orphan-maker, see ``app/api/sync.py``), where ``__exit__``
+    never runs. Without a sweep these accumulate on the data disk until it
+    fills and *every* subsequent sync fails on ENOSPC — a self-reinforcing
+    failure that otherwise needs a manual ``rm`` to break.
+
+    Age-gated: a dir whose mtime is within ``max_age_seconds`` is left alone
+    so a concurrent in-flight export (e.g. another container) is never swept
+    out from under itself. Threshold defaults to ``AGNES_SCRATCH_MAX_AGE_SEC``
+    (1h) — comfortably longer than any single table export.
+
+    ``root`` defaults to :func:`get_temp_root`; ``None`` (AGNES_TEMP_DIR unset)
+    is a no-op since the system ``/tmp`` is cleared on reboot anyway.
+    """
+    if root is None:
+        root = get_temp_root()
+    if not root:
+        return 0
+    if max_age_seconds is None:
+        max_age_seconds = float(
+            os.environ.get("AGNES_SCRATCH_MAX_AGE_SEC", "3600")
+        )
+    try:
+        entries = list(os.scandir(root))
+    except OSError:
+        return 0
+    now = time.time()
+    removed = 0
+    for entry in entries:
+        if not entry.name.startswith(_SCRATCH_PREFIXES):
+            continue
+        if not entry.is_dir(follow_symlinks=False):
+            continue
+        try:
+            age = now - entry.stat().st_mtime
+        except OSError:
+            continue
+        if age < max_age_seconds:
+            continue
+        try:
+            shutil.rmtree(entry.path)
+            removed += 1
+            logger.info(
+                "Swept orphaned scratch dir %s (age %.0fs >= %.0fs threshold)",
+                entry.name, age, max_age_seconds,
+            )
+        except OSError as e:
+            logger.warning(
+                "Failed to sweep orphaned scratch %s: %s", entry.path, e
+            )
+    if removed:
+        logger.info(
+            "Orphaned-scratch sweep removed %d dir(s) from %s", removed, root
+        )
+    return removed
+
+
 FILE_TYPE_CSV = "csv"
 FILE_TYPE_PARQUET = "parquet"
 _VALID_FILE_TYPES = {FILE_TYPE_CSV, FILE_TYPE_PARQUET}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.65.19"
+version = "0.65.20"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/tests/test_keboola_storage_api.py
+++ b/tests/test_keboola_storage_api.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import gzip
 import json
+import time
 from io import BytesIO
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -23,6 +24,7 @@ from connectors.keboola.storage_api import (
     KeboolaStorageClient,
     StorageApiError,
     get_temp_root,
+    sweep_orphaned_scratch,
 )
 
 
@@ -518,6 +520,82 @@ class TestParquetPath:
         }, dest)
 
         assert dest.read_bytes() == b"PAR1\x00\x00\x00binary"
+
+
+# ---- sweep_orphaned_scratch ------------------------------------------------
+
+class TestSweepOrphanedScratch:
+    """Orphaned ``kbc-export-*`` staging dirs are left behind only when a
+    sync worker is hard-killed (SIGKILL/OOM/auto-upgrade container recreate)
+    mid-export, so ``TemporaryDirectory.__exit__`` never ran. The sweep
+    reclaims them on the next sync; age-gating protects an in-flight export.
+    """
+
+    def _mk_dir(self, parent: Path, name: str, age_seconds: float) -> Path:
+        d = parent / name
+        d.mkdir()
+        (d / "slice0.parquet").write_bytes(b"PAR1junk")
+        old = time.time() - age_seconds
+        import os as _os
+        _os.utime(d, (old, old))
+        return d
+
+    def test_removes_old_scratch_dirs(self, tmp_path):
+        old = self._mk_dir(tmp_path, "kbc-export-foo-abc123", age_seconds=7200)
+        removed = sweep_orphaned_scratch(root=str(tmp_path), max_age_seconds=3600)
+        assert removed == 1
+        assert not old.exists()
+
+    def test_removes_old_slice_dirs(self, tmp_path):
+        """`kbc-slice-*` dirs (the sliced-CSV download path in
+        `_download_sliced`) orphan on the same hard-kill and are swept too."""
+        old = self._mk_dir(tmp_path, "kbc-slice-xyz789", age_seconds=7200)
+        removed = sweep_orphaned_scratch(root=str(tmp_path), max_age_seconds=3600)
+        assert removed == 1
+        assert not old.exists()
+
+    def test_keeps_fresh_scratch_dir(self, tmp_path):
+        """A dir younger than the threshold may belong to a concurrent
+        in-flight export — never sweep it."""
+        fresh = self._mk_dir(tmp_path, "kbc-export-bar-def456", age_seconds=10)
+        removed = sweep_orphaned_scratch(root=str(tmp_path), max_age_seconds=3600)
+        assert removed == 0
+        assert fresh.exists()
+
+    def test_ignores_non_scratch_entries(self, tmp_path):
+        """Only ``kbc-export-*`` dirs are swept; unrelated files/dirs in the
+        temp root (the data disk also holds extracts/, state/, etc.) are
+        never touched even when old."""
+        keep_dir = self._mk_dir(tmp_path, "extracts", age_seconds=7200)
+        keep_file = tmp_path / "kbc-export-not-a-dir.txt"
+        keep_file.write_text("x")
+        old_file = time.time() - 7200
+        import os as _os
+        _os.utime(keep_file, (old_file, old_file))
+
+        removed = sweep_orphaned_scratch(root=str(tmp_path), max_age_seconds=3600)
+        assert removed == 0
+        assert keep_dir.exists()
+        assert keep_file.exists()
+
+    def test_none_root_is_noop(self):
+        """No temp root configured (AGNES_TEMP_DIR unset) → nothing to sweep."""
+        assert sweep_orphaned_scratch(root=None, max_age_seconds=3600) == 0
+
+    def test_missing_root_is_noop(self, tmp_path):
+        assert sweep_orphaned_scratch(
+            root=str(tmp_path / "does-not-exist"), max_age_seconds=3600
+        ) == 0
+
+    def test_max_age_from_env_default(self, tmp_path, monkeypatch):
+        """Threshold falls back to AGNES_SCRATCH_MAX_AGE_SEC when not passed."""
+        monkeypatch.setenv("AGNES_SCRATCH_MAX_AGE_SEC", "100")
+        old = self._mk_dir(tmp_path, "kbc-export-baz-ghi789", age_seconds=200)
+        fresh = self._mk_dir(tmp_path, "kbc-export-qux-jkl012", age_seconds=10)
+        removed = sweep_orphaned_scratch(root=str(tmp_path))
+        assert removed == 1
+        assert not old.exists()
+        assert fresh.exists()
 
 
 # ---- get_table_info --------------------------------------------------------


### PR DESCRIPTION
## Problem

A production instance hit **`/data` at 99 %** and `/admin/sync` showed `No space left on device`. Root cause: **40 GB of orphaned `kbc-export-*` staging dirs** in the temp root (`AGNES_TEMP_DIR`), accumulated from earlier failed syncs.

The Keboola extractor creates per-export staging dirs via `tempfile.TemporaryDirectory`, whose `__exit__` removes the dir on **any** return — including the ENOSPC disk-full exception path. So a normal failure cleans up after itself. The only way a dir survives is a **hard kill** (SIGKILL / OOM / the auto-upgrade `docker compose up -d` recreating the container mid-sync — the orphan-maker already documented in `app/api/sync.py`), where `__exit__` never runs.

Once orphans accumulate and fill the disk, **every subsequent sync fails on ENOSPC** — the scheduler's `data-refresh` job keeps firing every 2 min but can't self-heal, because each retry needs scratch space the orphans are holding. The pre-flight guard in `storage_api._download_single` correctly aborts new big downloads ("Free space before retrying") so it stops making *new* large orphans, but nothing reclaims the *old* ones — it needs a manual `rm` to break the loop.

## Fix

Add `storage_api.sweep_orphaned_scratch(root, max_age_seconds)`:

- Removes `kbc-export-*` dirs under the temp root, returns the count, logs each removal (no silent caps).
- **Age-gated** via `AGNES_SCRATCH_MAX_AGE_SEC` (default **1h**, comfortably longer than any single table export) so a concurrent in-flight export — e.g. in another container — is never swept out from under itself.
- No-op when `AGNES_TEMP_DIR` is unset (system `/tmp` is cleared on reboot anyway).

Called at the start of `_run_sync`, **under `_sync_lock`** and **before any new scratch is created**, so within this process it can never race a live export. Best-effort: a sweep failure prints a notice and never blocks the sync.

## Tests

- `TestSweepOrphanedScratch` (6 cases): removes old / keeps fresh / ignores non-`kbc-export-*` entries / no-op on `None` + missing root / env-default threshold.
- Full suite: **7029 passed, 70 skipped**. Two unrelated failures in `tests/test_binding_scope.py` (`_duckdb` redeem-throttle / audit-params) are **parallel-execution flakes under `-n auto`** — they pass in isolation both with and without this diff, and the test file has zero coupling to anything this change touches (no `kbc-export` / `get_temp_root` / `_run_sync` / sweep references).

## Notes

- Connector-only change; no repository methods touched, so no DuckDB↔PG parity work needed.
- Vendor-agnostic: no customer-specific content.