### PR TITLE
feat: manage Slack bot tokens from the admin UI (vault, env > vault > none)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Added
+- Slack bot tokens (`SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, `SLACK_SIGNING_SECRET`) can now be set, rotated, and cleared from the admin UI (`/admin/server-config` → Slack bot secrets), stored encrypted in the server vault. Environment variables still take precedence, so Terraform-managed deployments are unaffected. Requires `AGNES_VAULT_KEY` on the server.
+
 ## [0.65.20] — 2026-06-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+## [0.66.0] — 2026-06-04
+
 ### Added
 - Slack bot tokens (`SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, `SLACK_SIGNING_SECRET`) can now be set, rotated, and cleared from the admin UI (`/admin/server-config` → Slack bot secrets), stored encrypted in the server vault. Environment variables still take precedence, so Terraform-managed deployments are unaffected. Requires `AGNES_VAULT_KEY` on the server.
 

--- a/app/api/admin_slack_secrets.py
+++ b/app/api/admin_slack_secrets.py
@@ -1,0 +1,100 @@
+"""Admin REST API for server-wide Slack bot secrets (vault-backed).
+
+  - GET    /api/admin/slack-secrets          — presence/source status (no values)
+  - PUT    /api/admin/slack-secrets/{name}    — set / rotate (write-only)
+  - DELETE /api/admin/slack-secrets/{name}    — clear
+
+All gated by ``require_admin``. The secret value lives only in the request
+body -> Fernet-encrypted at rest in ``system_secrets``. It is never returned
+by any endpoint and never placed in an audit record (audit params are empty,
+mirroring the MCP secret endpoints).
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+import duckdb
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from app.auth.access import require_admin
+from app.auth.dependencies import _get_db
+from app.secrets_vault import VaultKeyNotConfiguredError
+from services.slack_bot.secrets import SLACK_SECRET_NAMES
+from src.repositories import system_secrets_repo
+from src.repositories.audit import AuditRepository
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/admin", tags=["admin-slack-secrets"])
+
+
+class SlackSecretBody(BaseModel):
+    value: str
+
+
+def _audit(
+    conn: duckdb.DuckDBPyConnection,
+    actor_id: str,
+    action: str,
+    resource: str,
+    params: Optional[Dict[str, Any]] = None,
+) -> None:
+    try:
+        AuditRepository(conn).log(
+            user_id=actor_id, action=action, resource=resource, params=params or {}
+        )
+    except Exception:
+        logger.warning("audit log failed for %s/%s", action, resource)
+
+
+@router.get("/slack-secrets")
+async def list_slack_secrets(user: dict = Depends(require_admin)):
+    """Presence/source status for the three Slack tokens. Never leaks values."""
+    repo = system_secrets_repo()
+    out = []
+    for name in SLACK_SECRET_NAMES:
+        if os.environ.get(name):
+            source, has_value = "env", True
+        elif repo.has(name):
+            source, has_value = "vault", True
+        else:
+            source, has_value = "unset", False
+        out.append({"name": name, "source": source, "has_value": has_value})
+    return {"secrets": out}
+
+
+@router.put("/slack-secrets/{name}", status_code=204)
+async def set_slack_secret(
+    name: str,
+    body: SlackSecretBody,
+    user: dict = Depends(require_admin),
+    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
+):
+    """Store (or rotate) the vault secret for ``name``. Write-only."""
+    if name not in SLACK_SECRET_NAMES:
+        raise HTTPException(status_code=400, detail="unknown_slack_secret")
+    if not body.value:
+        raise HTTPException(status_code=400, detail="secret value required")
+    try:
+        system_secrets_repo().upsert(name, body.value)
+    except VaultKeyNotConfiguredError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail="vault_key_not_configured: set AGNES_VAULT_KEY on the server before storing secrets",
+        ) from exc
+    _audit(conn, user["id"], "slack.secret.set", f"slack_secret:{name}", {})
+
+
+@router.delete("/slack-secrets/{name}", status_code=204)
+async def delete_slack_secret(
+    name: str,
+    user: dict = Depends(require_admin),
+    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
+):
+    """Drop the vault row for ``name``. Resolution falls back to env / disabled."""
+    if name not in SLACK_SECRET_NAMES:
+        raise HTTPException(status_code=400, detail="unknown_slack_secret")
+    system_secrets_repo().delete(name)
+    _audit(conn, user["id"], "slack.secret.clear", f"slack_secret:{name}", {})

--- a/app/api/admin_slack_secrets.py
+++ b/app/api/admin_slack_secrets.py
@@ -13,18 +13,14 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Dict, Optional
 
-import duckdb
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from app.auth.access import require_admin
-from app.auth.dependencies import _get_db
 from app.secrets_vault import VaultKeyNotConfiguredError
 from services.slack_bot.secrets import SLACK_SECRET_NAMES
-from src.repositories import system_secrets_repo
-from src.repositories.audit import AuditRepository
+from src.repositories import audit_repo, system_secrets_repo
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/admin", tags=["admin-slack-secrets"])
@@ -34,16 +30,13 @@ class SlackSecretBody(BaseModel):
     value: str
 
 
-def _audit(
-    conn: duckdb.DuckDBPyConnection,
-    actor_id: str,
-    action: str,
-    resource: str,
-    params: Optional[Dict[str, Any]] = None,
-) -> None:
+def _audit(actor_id: str, action: str, resource: str) -> None:
+    """Best-effort audit row. Params are intentionally empty — the secret
+    value never enters the audit record (mirrors the MCP secret endpoints).
+    Routed through the ``audit_repo()`` factory so it works on either backend."""
     try:
-        AuditRepository(conn).log(
-            user_id=actor_id, action=action, resource=resource, params=params or {}
+        audit_repo().log(
+            user_id=actor_id, action=action, resource=resource, params={}
         )
     except Exception:
         logger.warning("audit log failed for %s/%s", action, resource)
@@ -70,7 +63,6 @@ async def set_slack_secret(
     name: str,
     body: SlackSecretBody,
     user: dict = Depends(require_admin),
-    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
 ):
     """Store (or rotate) the vault secret for ``name``. Write-only."""
     if name not in SLACK_SECRET_NAMES:
@@ -84,17 +76,16 @@ async def set_slack_secret(
             status_code=409,
             detail="vault_key_not_configured: set AGNES_VAULT_KEY on the server before storing secrets",
         ) from exc
-    _audit(conn, user["id"], "slack.secret.set", f"slack_secret:{name}", {})
+    _audit(user["id"], "slack.secret.set", f"slack_secret:{name}")
 
 
 @router.delete("/slack-secrets/{name}", status_code=204)
 async def delete_slack_secret(
     name: str,
     user: dict = Depends(require_admin),
-    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
 ):
     """Drop the vault row for ``name``. Resolution falls back to env / disabled."""
     if name not in SLACK_SECRET_NAMES:
         raise HTTPException(status_code=400, detail="unknown_slack_secret")
     system_secrets_repo().delete(name)
-    _audit(conn, user["id"], "slack.secret.clear", f"slack_secret:{name}", {})
+    _audit(user["id"], "slack.secret.clear", f"slack_secret:{name}")

--- a/app/api/slack.py
+++ b/app/api/slack.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from pydantic import BaseModel
@@ -23,6 +22,7 @@ from services.slack_bot.commands import (
 )
 from services.slack_bot.events import _run_logged, _schedule, dispatch_event
 from services.slack_bot.interactivity import dispatch_interaction, parse_interaction
+from services.slack_bot.secrets import slack_secret
 from services.slack_bot.sigverify import verify_slack_signature
 
 logger = logging.getLogger(__name__)
@@ -34,7 +34,7 @@ async def slack_events(request: Request):
     body = await request.body()
     ts = request.headers.get("X-Slack-Request-Timestamp", "")
     sig = request.headers.get("X-Slack-Signature", "")
-    secret = os.environ.get("SLACK_SIGNING_SECRET", "")
+    secret = slack_secret("SLACK_SIGNING_SECRET") or ""
     if not secret or not verify_slack_signature(secret, ts, sig, body):
         raise HTTPException(401, "bad_signature")
     payload = await request.json()
@@ -57,7 +57,7 @@ async def slack_commands(request: Request):
     body = await request.body()
     ts = request.headers.get("X-Slack-Request-Timestamp", "")
     sig = request.headers.get("X-Slack-Signature", "")
-    secret = os.environ.get("SLACK_SIGNING_SECRET", "")
+    secret = slack_secret("SLACK_SIGNING_SECRET") or ""
     if not secret or not verify_slack_signature(secret, ts, sig, body):
         raise HTTPException(401, "bad_signature")
     form = {k: v[0] for k, v in parse_qs(body.decode()).items()}
@@ -79,7 +79,7 @@ async def slack_interactivity(request: Request):
     body = await request.body()                       # raw bytes — Slack signs these
     ts = request.headers.get("X-Slack-Request-Timestamp", "")
     sig = request.headers.get("X-Slack-Signature", "")
-    secret = os.environ.get("SLACK_SIGNING_SECRET", "")
+    secret = slack_secret("SLACK_SIGNING_SECRET") or ""
     if not secret or not verify_slack_signature(secret, ts, sig, body):
         raise HTTPException(401, "bad_signature")
     form = {k: v[0] for k, v in parse_qs(body.decode()).items()}

--- a/app/chat/config.py
+++ b/app/chat/config.py
@@ -16,8 +16,9 @@ class SlackConfig:
     # "http" (default, Events API webhook) | "socket" (Socket Mode WS).
     # Unknown values are normalized to "http" at parse time with a warning.
     # Tokens (SLACK_BOT_TOKEN / SLACK_APP_TOKEN / SLACK_SIGNING_SECRET) are
-    # deliberately NOT stored here — read from env at use site so they never
-    # leak into a frozen-config echo (e.g. /admin/server-config).
+    # deliberately NOT stored here — resolved at use site via slack_secret
+    # (env > vault) so they never leak into a frozen-config echo (e.g.
+    # /admin/server-config).
     transport: str = "http"
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -240,6 +240,7 @@ from app.api.v2_marketplace import router as v2_marketplace_router
 from app.api.marketplaces import router as marketplaces_router
 from app.api.data_packages import router as data_packages_router
 from app.api.admin_mcp import router as admin_mcp_router
+from app.api.admin_slack_secrets import router as admin_slack_secrets_router
 from app.api.mcp_passthrough import router as mcp_passthrough_router
 from app.api.mcp_per_table import router as mcp_per_table_router
 from app.api.mcp_user_secrets import router as mcp_user_secrets_router
@@ -1164,6 +1165,7 @@ def create_app() -> FastAPI:
     app.include_router(marketplaces_router)
     app.include_router(data_packages_router)
     app.include_router(admin_mcp_router)
+    app.include_router(admin_slack_secrets_router)
     app.include_router(mcp_passthrough_router)
     app.include_router(mcp_user_secrets_router)
     app.include_router(mcp_per_table_router)

--- a/app/main.py
+++ b/app/main.py
@@ -321,8 +321,9 @@ async def _start_slack_socket_transport(app) -> None:
     app.state.slack_socket_dispatcher = None
     if get_slack_transport() != "socket":
         return
-    app_token = os.environ.get("SLACK_APP_TOKEN", "")
-    bot_token = os.environ.get("SLACK_BOT_TOKEN", "")
+    from services.slack_bot.secrets import slack_secret
+    app_token = slack_secret("SLACK_APP_TOKEN") or ""
+    bot_token = slack_secret("SLACK_BOT_TOKEN") or ""
     try:
         workers = int(os.environ.get("UVICORN_WORKERS", "1"))
     except ValueError:

--- a/app/secrets_vault.py
+++ b/app/secrets_vault.py
@@ -198,6 +198,64 @@ class SharedSecretsRepository:
 
 
 # ---------------------------------------------------------------------------
+# Repository — server-wide system secrets (system_secrets table)
+# ---------------------------------------------------------------------------
+
+
+class SystemSecretsRepository:
+    """Server-wide system secrets keyed by ``name`` (Slack bot tokens)."""
+
+    def __init__(self, conn: duckdb.DuckDBPyConnection):
+        self.conn = conn
+
+    def upsert(self, name: str, value: str) -> None:
+        """Store the encrypted secret for ``name``. Replaces any prior row."""
+        token = encrypt_secret(value)
+        self.conn.execute(
+            """INSERT INTO system_secrets (name, secret_value_enc, updated_at)
+               VALUES (?, ?, current_timestamp)
+               ON CONFLICT (name) DO UPDATE SET
+                 secret_value_enc = excluded.secret_value_enc,
+                 updated_at       = excluded.updated_at""",
+            [name, token],
+        )
+
+    def get(self, name: str) -> Optional[str]:
+        """Decrypted secret for ``name`` or ``None`` when absent or
+        undecryptable. Catches both ``InvalidToken`` (vault key rotated) and
+        ``RuntimeError`` (``AGNES_VAULT_KEY`` set-but-malformed) so a bad key
+        fails closed (feature disabled) instead of 500-ing every Slack request."""
+        row = self.conn.execute(
+            "SELECT secret_value_enc FROM system_secrets WHERE name = ?",
+            [name],
+        ).fetchone()
+        if row is None:
+            return None
+        token = row[0]
+        if not isinstance(token, (bytes, bytearray)):
+            return None
+        try:
+            return decrypt_secret(bytes(token))
+        except (InvalidToken, RuntimeError):
+            logger.warning(
+                "system_secrets row for %s failed to decrypt — vault key "
+                "rotated or malformed? Treating as unset.",
+                name,
+            )
+            return None
+
+    def delete(self, name: str) -> None:
+        self.conn.execute("DELETE FROM system_secrets WHERE name = ?", [name])
+
+    def has(self, name: str) -> bool:
+        row = self.conn.execute(
+            "SELECT 1 FROM system_secrets WHERE name = ? LIMIT 1",
+            [name],
+        ).fetchone()
+        return row is not None
+
+
+# ---------------------------------------------------------------------------
 # Repository — per-user source secrets (mcp_user_secrets table)
 # ---------------------------------------------------------------------------
 

--- a/app/web/templates/admin_server_config.html
+++ b/app/web/templates/admin_server_config.html
@@ -330,6 +330,46 @@
       <span class="chat-test-result" hidden style="margin-left: 8px; font-size: 13px;"></span>
     </div>
   </section>
+
+  <!-- Slack bot secrets — server-wide tokens stored encrypted in the vault
+       (system_secrets), routed through the env > vault > none resolver. Like
+       Cloud chat, these are NOT part of the instance.yaml form: presence/source
+       comes from /admin/slack-secrets, writes hit PUT /admin/slack-secrets/{name}. -->
+  <section class="cfg-section" id="slack-secrets-section">
+    <header>
+      <div>
+        <h3>Slack bot secrets</h3>
+        <div class="section-help">
+          Tokens for the Slack bot, stored encrypted in the server vault.
+          Environment variables (e.g. set via Terraform) always take
+          precedence — a token shown as <code>env</code> can't be changed
+          here. Storing a token requires <code>AGNES_VAULT_KEY</code> on the
+          server.
+        </div>
+      </div>
+    </header>
+    <div class="section-body">
+      <div id="slack-secrets-status" class="cfg-loading">Loading…</div>
+      <div class="iw-form-field">
+        <label for="slack-bot-token">SLACK_BOT_TOKEN</label>
+        <input type="password" id="slack-bot-token" data-secret="SLACK_BOT_TOKEN"
+               placeholder="(leave blank to keep existing)" autocomplete="off">
+      </div>
+      <div class="iw-form-field">
+        <label for="slack-app-token">SLACK_APP_TOKEN</label>
+        <input type="password" id="slack-app-token" data-secret="SLACK_APP_TOKEN"
+               placeholder="(leave blank to keep existing)" autocomplete="off">
+      </div>
+      <div class="iw-form-field">
+        <label for="slack-signing-secret">SLACK_SIGNING_SECRET</label>
+        <input type="password" id="slack-signing-secret" data-secret="SLACK_SIGNING_SECRET"
+               placeholder="(leave blank to keep existing)" autocomplete="off">
+      </div>
+    </div>
+    <div class="section-actions">
+      <button type="button" class="btn btn-primary" id="slack-secrets-save-btn">Save secrets</button>
+    </div>
+  </section>
     </div><!-- /.cfg-main -->
   </div><!-- /.cfg-body -->
 </div><!-- /.cfg-page -->
@@ -1838,5 +1878,109 @@ async function chatTestSecrets(btn) {
 document.getElementById("chat-save-btn").addEventListener("click", (e) => chatSaveSecrets(e.currentTarget));
 document.getElementById("chat-test-btn").addEventListener("click", (e) => chatTestSecrets(e.currentTarget));
 chatReadinessLoad();
+
+// ════════════════════════════════════════════════════════════════════════
+// Slack bot secrets — vault-backed server-wide tokens. Same lifecycle as the
+// Cloud chat keys: presence/source from GET /admin/slack-secrets, write-only
+// rotation via PUT /admin/slack-secrets/{name}. Cookie-session auth
+// (credentials: "include"), same showBanner() feedback.
+// ════════════════════════════════════════════════════════════════════════
+
+const SLACK_SECRETS_API = "/api/admin/slack-secrets";
+const SLACK_SECRET_INPUTS = [
+  "slack-bot-token",
+  "slack-app-token",
+  "slack-signing-secret",
+];
+
+function slackSourceBadge(source) {
+  if (source === "env") return '<span style="color: #888;">env (from environment, locked)</span>';
+  if (source === "vault") return '<span style="color: #2a8c4a;">✓ vault</span>';
+  return '<span style="color: #888;">— unset</span>';
+}
+
+async function slackSecretsLoad() {
+  const el = document.getElementById("slack-secrets-status");
+  if (!el) return;
+  try {
+    const r = await fetch(SLACK_SECRETS_API, { credentials: "include" });
+    if (!r.ok) throw new Error("HTTP " + r.status);
+    const s = await r.json();
+    el.className = "";
+    el.innerHTML =
+      '<ul style="list-style: none; padding: 0; margin: 0;">' +
+      (s.secrets || []).map((row) => {
+        // Only vault-stored tokens can be cleared from the UI: env tokens are
+        // owned by the environment, unset tokens have nothing to clear.
+        const clear = row.source === "vault"
+          ? ` <button type="button" class="btn btn-secondary btn-sm" data-slack-clear="${escHtml(row.name)}" style="margin-left: 6px;">Clear</button>`
+          : "";
+        return `<li style="padding: 2px 0;"><code>${escHtml(row.name)}</code> — ${slackSourceBadge(row.source)}${clear}</li>`;
+      }).join("") +
+      '</ul>';
+    el.querySelectorAll("[data-slack-clear]").forEach((btn) =>
+      btn.addEventListener("click", (e) => slackSecretClear(e.currentTarget))
+    );
+  } catch (e) {
+    el.className = "";
+    el.innerHTML = '<span style="color: #c0392b;">Failed to load Slack secrets: ' + escHtml(e.message) + '</span>';
+  }
+}
+
+async function slackSecretClear(btn) {
+  const name = btn.dataset.slackClear;
+  btn.disabled = true;
+  try {
+    const r = await fetch(SLACK_SECRETS_API + "/" + encodeURIComponent(name), {
+      method: "DELETE",
+      credentials: "include",
+    });
+    if (!r.ok) throw new Error("HTTP " + r.status);
+    showBanner("Cleared " + name + ".", "success");
+  } catch (e) {
+    showBanner("Failed to clear " + name + ": " + e.message, "error");
+  } finally {
+    slackSecretsLoad();
+  }
+}
+
+async function slackSecretsSave(btn) {
+  const entered = SLACK_SECRET_INPUTS
+    .map((id) => document.getElementById(id))
+    .filter((inp) => inp && inp.value.trim())
+    .map((inp) => ({ inp, name: inp.dataset.secret, value: inp.value.trim() }));
+  if (entered.length === 0) {
+    showBanner("No secret entered.", "error");
+    return;
+  }
+  btn.disabled = true;
+  const saved = [];
+  try {
+    for (const { inp, name, value } of entered) {
+      const r = await fetch(SLACK_SECRETS_API + "/" + encodeURIComponent(name), {
+        method: "PUT",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value }),
+      });
+      if (r.status === 409) {
+        showBanner("AGNES_VAULT_KEY is not configured on the server — cannot store Slack secrets.", "error");
+        return;
+      }
+      if (!r.ok) throw new Error("HTTP " + r.status);
+      inp.value = "";  // don't let the secret linger in the DOM
+      saved.push(name);
+    }
+    showBanner("Saved " + saved.join(", ") + ".", "success");
+  } catch (e) {
+    showBanner("Failed to save Slack secrets: " + e.message, "error");
+  } finally {
+    btn.disabled = false;
+    slackSecretsLoad();
+  }
+}
+
+document.getElementById("slack-secrets-save-btn").addEventListener("click", (e) => slackSecretsSave(e.currentTarget));
+slackSecretsLoad();
 </script>
 {% endblock %}

--- a/config/.env.template
+++ b/config/.env.template
@@ -58,6 +58,11 @@ AGNES_VAULT_KEY=
 
 # ── OPTIONAL SERVICES ───────────────────────────────
 # TELEGRAM_BOT_TOKEN=
+# Slack bot tokens may also be set from the admin UI (stored encrypted in the
+# server vault). If set here in the environment, the env value always wins.
+# SLACK_BOT_TOKEN=
+# SLACK_APP_TOKEN=
+# SLACK_SIGNING_SECRET=
 # JIRA_WEBHOOK_SECRET=
 # JIRA_API_TOKEN=
 # ANTHROPIC_API_KEY=

--- a/docs/slack-manifest-http.md
+++ b/docs/slack-manifest-http.md
@@ -46,3 +46,4 @@ settings:
 - `SLACK_SIGNING_SECRET`
 - `chat.slack.transport: http` in `instance.yaml` (or `SLACK_TRANSPORT=http`,
   or leave unset — `http` is the default).
+- These tokens may instead be set from the admin UI (`/admin/server-config` → Slack bot secrets), stored encrypted in the vault (`AGNES_VAULT_KEY` required). Environment variables, if present, take precedence.

--- a/docs/slack-manifest-socket.md
+++ b/docs/slack-manifest-socket.md
@@ -49,6 +49,7 @@ After creating the app, generate an **app-level token** (`xapp-…`) with the
 - `SLACK_SIGNING_SECRET`
 - `chat.slack.transport: socket` in `instance.yaml` (or `SLACK_TRANSPORT=socket`)
 - Install the optional dependency: `pip install '.[slack-socket]'`
+- These tokens may instead be set from the admin UI (`/admin/server-config` → Slack bot secrets), stored encrypted in the vault (`AGNES_VAULT_KEY` required). Environment variables, if present, take precedence.
 
 ## Constraints
 

--- a/docs/superpowers/plans/2026-06-04-slack-bot-tokens-vault.md
+++ b/docs/superpowers/plans/2026-06-04-slack-bot-tokens-vault.md
@@ -1,0 +1,1131 @@
+# Slack bot tokens in the vault — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the three server-wide Slack bot secrets (`SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, `SLACK_SIGNING_SECRET`) settable/rotatable from the admin UI via the encrypted secret vault, resolved as `env > vault > none`.
+
+**Architecture:** A new `system_secrets` vault scope (DuckDB + Postgres, dual-backend via the repo factory) stores the Fernet-encrypted tokens keyed by name. A single `slack_secret()` accessor resolves `env > vault > none` and replaces the 12 direct `os.environ.get("SLACK_…")` reads. New admin endpoints (`/api/admin/slack-secrets`) write to the vault (never the config overlay) with write-only semantics, surfaced as a section on `/admin/server-config`.
+
+**Tech Stack:** Python, FastAPI, DuckDB, SQLAlchemy/Alembic (Postgres), Fernet (`cryptography`), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-06-04-slack-bot-tokens-vault-design.md`
+
+**Run tests with:** `.venv/bin/pytest <path> --tb=short -q` (full suite: `.venv/bin/pytest tests/ --tb=short -n auto -q`).
+
+---
+
+## File Structure
+
+- `src/db.py` — DuckDB migration `_v71_to_v72` + `SCHEMA_VERSION` 71→72 + ladder wiring (2 sites).
+- `migrations/versions/0019_system_secrets_v72.py` — Alembic migration (new).
+- `src/models/vault.py` — `SystemSecret` ORM model (new).
+- `src/models/__init__.py` — register `SystemSecret`.
+- `scripts/migrate_duckdb_to_pg/__init__.py` — add `"system_secrets": ["name"]` to `_PK_COLUMNS`.
+- `app/secrets_vault.py` — `SystemSecretsRepository` (DuckDB).
+- `src/repositories/secrets_vault_pg.py` — `SystemSecretsPgRepository`.
+- `src/repositories/__init__.py` — `system_secrets_repo()` factory + export.
+- `tests/db_pg/test_system_secrets_contract.py` — cross-engine contract test (new).
+- `services/slack_bot/secrets.py` — `slack_secret()` resolver + allow-list (new).
+- `tests/test_slack_secret_resolver.py` — resolver unit tests (new).
+- 4 read-site files — swap `os.environ.get("SLACK_…")` → `slack_secret("SLACK_…")`.
+- `app/api/admin_slack_secrets.py` — admin endpoints (new).
+- `app/main.py` — register the new router.
+- `tests/test_admin_slack_secrets.py` — API tests (new).
+- `app/web/templates/admin_server_config.html` — Slack secrets UI section.
+- `CHANGELOG.md`, `config/.env.template`, `docs/slack-manifest-http.md`, `docs/slack-manifest-socket.md` — docs.
+- `pyproject.toml` + `CHANGELOG.md` — release-cut to 0.66.0.
+
+---
+
+## Task 1: DuckDB `system_secrets` migration (v71 → v72)
+
+**Files:**
+- Modify: `src/db.py` (line 50 `SCHEMA_VERSION`; add `_v71_to_v72` near line 4903; wire into both ladders ~5227 and ~5422)
+- Test: `tests/test_db_schema_version.py` (existing gate — no new test file; we run it)
+
+- [ ] **Step 1: Add the migration function** after `_v70_to_v71` (around line 4903 in `src/db.py`):
+
+```python
+def _v71_to_v72(conn: duckdb.DuckDBPyConnection) -> None:
+    """v72: ``system_secrets`` table — server-wide vault for system-level
+    secrets keyed by name (Slack bot tokens).
+
+    Distinct from ``mcp_secrets`` (keyed by ``source_id``, MCP data sources):
+    this scope holds server-wide secrets that are not tied to any MCP source,
+    starting with the three Slack bot tokens. Fernet-encrypted at rest, read
+    via ``env > vault`` by ``services/slack_bot/secrets.slack_secret``.
+
+    Idempotent CREATE TABLE IF NOT EXISTS — safe on fresh and upgrade paths.
+    """
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS system_secrets (
+            name             VARCHAR PRIMARY KEY,
+            secret_value_enc BLOB NOT NULL,
+            created_at       TIMESTAMP NOT NULL DEFAULT current_timestamp,
+            updated_at       TIMESTAMP NOT NULL DEFAULT current_timestamp
+        )
+    """)
+    conn.execute("UPDATE schema_version SET version = 72")
+```
+
+- [ ] **Step 2: Bump the version constant** at `src/db.py:50`:
+
+```python
+SCHEMA_VERSION = 72
+```
+
+- [ ] **Step 3: Wire into the fresh-install ladder** — after the `_v70_to_v71(conn)` call (around line 5227), add:
+
+```python
+            # v71→v72: system_secrets — server-wide vault for Slack bot tokens.
+            _v71_to_v72(conn)
+```
+
+- [ ] **Step 4: Wire into the sequential-upgrade ladder** — after the `if current < 71: _v70_to_v71(conn)` block (around line 5422), add:
+
+```python
+            if current < 72:
+                _v71_to_v72(conn)
+```
+
+- [ ] **Step 5: Run the schema-version gate**
+
+Run: `.venv/bin/pytest tests/test_db_schema_version.py --tb=short -q`
+Expected: PASS (DuckDB reaches v72; the test will also check Alembic parity — that comes in Task 2, so if this test asserts cross-backend parity it may fail until Task 2. If it fails only on the Alembic-head comparison, proceed to Task 2 and re-run at the end of Task 2.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/db.py
+git commit -m "feat(db): system_secrets table (DuckDB v72)"
+```
+
+---
+
+## Task 2: Postgres parity — Alembic migration + ORM model + migrator PK
+
+**Files:**
+- Create: `migrations/versions/0019_system_secrets_v72.py`
+- Create: `src/models/vault.py`
+- Modify: `src/models/__init__.py` (import + `__all__`)
+- Modify: `scripts/migrate_duckdb_to_pg/__init__.py` (`_PK_COLUMNS`)
+- Test: `tests/db_pg/test_schema_parity.py`, `tests/db_pg/test_data_migration.py`
+
+- [ ] **Step 1: Create the Alembic migration** `migrations/versions/0019_system_secrets_v72.py`:
+
+```python
+"""system_secrets table (DuckDB v72 parity).
+
+Server-wide vault for system-level secrets keyed by name (Slack bot tokens).
+Mirrors DuckDB ``_v71_to_v72``. Additive-only.
+
+Revision ID: 0019_system_secrets_v72
+Revises: 0018_slack_user_id_v71
+Create Date: 2026-06-04
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0019_system_secrets_v72"
+down_revision: Union[str, None] = "0018_slack_user_id_v71"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "system_secrets",
+        sa.Column("name", sa.String(), primary_key=True),
+        sa.Column("secret_value_enc", sa.LargeBinary(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("system_secrets")
+```
+
+- [ ] **Step 2: Create the ORM model** `src/models/vault.py`:
+
+```python
+"""SQLAlchemy model for the system-secrets vault.
+
+Mirrors:
+  - system_secrets (src/db.py v72)
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, LargeBinary, String, text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.db_pg import Base
+
+
+class SystemSecret(Base):
+    """Server-wide vault for system-level secrets keyed by name (v72).
+
+    Holds the Fernet ciphertext of server-wide secrets not tied to an MCP
+    source — currently the three Slack bot tokens.
+    """
+    __tablename__ = "system_secrets"
+
+    name: Mapped[str] = mapped_column(String, primary_key=True)
+    secret_value_enc: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=text("CURRENT_TIMESTAMP"),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=text("CURRENT_TIMESTAMP"),
+        nullable=False,
+    )
+```
+
+- [ ] **Step 3: Register the model** in `src/models/__init__.py` — add the import (after the `from src.models.telemetry import (...)` block, before or after the mcp import) and the `__all__` entry:
+
+```python
+from src.models.vault import SystemSecret
+```
+
+And add `"SystemSecret",` to the `__all__` list (keep it roughly alphabetical, e.g. after `"SyncState",`).
+
+- [ ] **Step 4: Add the non-`id` PK mapping** in `scripts/migrate_duckdb_to_pg/__init__.py` — inside `_PK_COLUMNS` (near the MCP entries, ~line 103), add:
+
+```python
+    "system_secrets": ["name"],
+```
+
+- [ ] **Step 5: Run the schema parity + migrator gates**
+
+Run: `.venv/bin/pytest tests/db_pg/test_schema_parity.py tests/db_pg/test_data_migration.py tests/test_db_schema_version.py --tb=short -q`
+Expected: PASS — `test_alembic_head_materializes_every_model` sees `system_secrets`, and `test_non_id_pk_tables_are_in_pk_columns_map` accepts the `name` PK.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add migrations/versions/0019_system_secrets_v72.py src/models/vault.py src/models/__init__.py scripts/migrate_duckdb_to_pg/__init__.py
+git commit -m "feat(db): system_secrets Postgres parity (alembic 0019 + model + migrator PK)"
+```
+
+---
+
+## Task 3: `SystemSecretsRepository` (DuckDB)
+
+**Files:**
+- Modify: `app/secrets_vault.py` (add class after `SharedSecretsRepository`, ~line 198)
+
+- [ ] **Step 1: Add the repository** in `app/secrets_vault.py` (after `SharedSecretsRepository`):
+
+```python
+# ---------------------------------------------------------------------------
+# Repository — server-wide system secrets (system_secrets table)
+# ---------------------------------------------------------------------------
+
+
+class SystemSecretsRepository:
+    """Server-wide system secrets keyed by ``name`` (Slack bot tokens)."""
+
+    def __init__(self, conn: duckdb.DuckDBPyConnection):
+        self.conn = conn
+
+    def upsert(self, name: str, value: str) -> None:
+        """Store the encrypted secret for ``name``. Replaces any prior row."""
+        token = encrypt_secret(value)
+        self.conn.execute(
+            """INSERT INTO system_secrets (name, secret_value_enc, updated_at)
+               VALUES (?, ?, current_timestamp)
+               ON CONFLICT (name) DO UPDATE SET
+                 secret_value_enc = excluded.secret_value_enc,
+                 updated_at       = excluded.updated_at""",
+            [name, token],
+        )
+
+    def get(self, name: str) -> Optional[str]:
+        """Decrypted secret for ``name`` or ``None`` when absent or
+        undecryptable. Catches both ``InvalidToken`` (vault key rotated) and
+        ``RuntimeError`` (``AGNES_VAULT_KEY`` set-but-malformed) so a bad key
+        fails closed (feature disabled) instead of 500-ing every Slack request."""
+        row = self.conn.execute(
+            "SELECT secret_value_enc FROM system_secrets WHERE name = ?",
+            [name],
+        ).fetchone()
+        if row is None:
+            return None
+        token = row[0]
+        if not isinstance(token, (bytes, bytearray)):
+            return None
+        try:
+            return decrypt_secret(bytes(token))
+        except (InvalidToken, RuntimeError):
+            logger.warning(
+                "system_secrets row for %s failed to decrypt — vault key "
+                "rotated or malformed? Treating as unset.",
+                name,
+            )
+            return None
+
+    def delete(self, name: str) -> None:
+        self.conn.execute("DELETE FROM system_secrets WHERE name = ?", [name])
+
+    def has(self, name: str) -> bool:
+        row = self.conn.execute(
+            "SELECT 1 FROM system_secrets WHERE name = ? LIMIT 1",
+            [name],
+        ).fetchone()
+        return row is not None
+```
+
+(`InvalidToken`, `encrypt_secret`, `decrypt_secret`, `logger`, `Optional`, `duckdb` are already imported at the top of this module.)
+
+- [ ] **Step 2: Commit** (no standalone test yet — the contract test in Task 5 exercises this):
+
+```bash
+git add app/secrets_vault.py
+git commit -m "feat(vault): SystemSecretsRepository (DuckDB)"
+```
+
+---
+
+## Task 4: `SystemSecretsPgRepository` + factory
+
+**Files:**
+- Modify: `src/repositories/secrets_vault_pg.py` (add class after `SharedSecretsPgRepository`)
+- Modify: `src/repositories/__init__.py` (add `system_secrets_repo()` ~after line 496; add export to the `__all__`-style list ~line 88)
+
+- [ ] **Step 1: Add the PG repository** in `src/repositories/secrets_vault_pg.py` (after `SharedSecretsPgRepository`, before `PerUserSecretsPgRepository`):
+
+```python
+class SystemSecretsPgRepository:
+    """Server-wide system secrets keyed by ``name`` (PG).
+
+    Signature-compatible with ``app.secrets_vault.SystemSecretsRepository``.
+    """
+
+    def __init__(self, engine: Engine):
+        self._engine = engine
+
+    def upsert(self, name: str, value: str) -> None:
+        token = encrypt_secret(value)
+        with self._engine.begin() as conn:
+            conn.execute(
+                sa.text(
+                    """INSERT INTO system_secrets
+                           (name, secret_value_enc, updated_at)
+                       VALUES (:name, :token, CURRENT_TIMESTAMP)
+                       ON CONFLICT (name) DO UPDATE SET
+                           secret_value_enc = EXCLUDED.secret_value_enc,
+                           updated_at       = EXCLUDED.updated_at"""
+                ),
+                {"name": name, "token": token},
+            )
+
+    def get(self, name: str) -> Optional[str]:
+        with self._engine.connect() as conn:
+            row = conn.execute(
+                sa.text(
+                    "SELECT secret_value_enc FROM system_secrets WHERE name = :name"
+                ),
+                {"name": name},
+            ).fetchone()
+        if row is None:
+            return None
+        token = row[0]
+        if not isinstance(token, (bytes, bytearray, memoryview)):
+            return None
+        try:
+            return decrypt_secret(bytes(token))
+        except (InvalidToken, RuntimeError):
+            logger.warning(
+                "system_secrets row for %s failed to decrypt — vault key "
+                "rotated or malformed? Treating as unset.",
+                name,
+            )
+            return None
+
+    def delete(self, name: str) -> None:
+        with self._engine.begin() as conn:
+            conn.execute(
+                sa.text("DELETE FROM system_secrets WHERE name = :name"),
+                {"name": name},
+            )
+
+    def has(self, name: str) -> bool:
+        with self._engine.connect() as conn:
+            row = conn.execute(
+                sa.text("SELECT 1 FROM system_secrets WHERE name = :name LIMIT 1"),
+                {"name": name},
+            ).fetchone()
+        return row is not None
+```
+
+(`sa`, `InvalidToken`, `Engine`, `encrypt_secret`, `decrypt_secret`, `logger`, `Optional` are already imported in this module.)
+
+- [ ] **Step 2: Add the factory** in `src/repositories/__init__.py` after `shared_secrets_repo()` (~line 497):
+
+```python
+def system_secrets_repo() -> Any:
+    if use_pg():
+        from src.repositories.secrets_vault_pg import SystemSecretsPgRepository
+        return SystemSecretsPgRepository(_pg_engine())
+    from app.secrets_vault import SystemSecretsRepository
+    return SystemSecretsRepository(get_system_db())
+```
+
+- [ ] **Step 3: Export the factory** — add `"system_secrets_repo",` to the exported-names list near line 88 (the one containing `"shared_secrets_repo"`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/repositories/secrets_vault_pg.py src/repositories/__init__.py
+git commit -m "feat(vault): SystemSecretsPgRepository + system_secrets_repo factory"
+```
+
+---
+
+## Task 5: Cross-engine contract test
+
+**Files:**
+- Create: `tests/db_pg/test_system_secrets_contract.py`
+
+- [ ] **Step 1: Write the contract test** (mirrors `tests/db_pg/test_parity_mcp_shared_vault.py`; `state_backend` is the parametrized fixture from `tests/db_pg/conftest.py`):
+
+```python
+"""Cross-engine contract for the system_secrets vault (Slack bot tokens).
+
+This repo lives in app/secrets_vault.py (DuckDB) + src/repositories/
+secrets_vault_pg.py (PG), so the automatic method-parity sweep
+(tests/db_pg/test_repo_method_parity.py, which only scans
+src/repositories/*.py) does NOT cover it. This test is the sole mechanical
+guard against DuckDB/PG drift — keep it in lockstep with the repo methods.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _vault_key(monkeypatch):
+    from cryptography.fernet import Fernet
+
+    monkeypatch.setenv("AGNES_VAULT_KEY", Fernet.generate_key().decode("ascii"))
+
+
+@pytest.fixture
+def _env(state_backend, tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    for sub in ("extracts", "analytics", "state", "notifications"):
+        (tmp_path / sub).mkdir(exist_ok=True)
+    if state_backend == "duckdb":
+        from src.db import close_system_db, get_system_db
+
+        close_system_db()
+        get_system_db()
+    return state_backend
+
+
+def test_system_secret_round_trip_both_backends(_env):
+    from src.repositories import system_secrets_repo
+
+    repo = system_secrets_repo()
+    repo.upsert("SLACK_BOT_TOKEN", "xoxb-original")
+    assert repo.has("SLACK_BOT_TOKEN") is True
+    assert repo.get("SLACK_BOT_TOKEN") == "xoxb-original"
+
+    # rotate
+    repo.upsert("SLACK_BOT_TOKEN", "xoxb-rotated")
+    assert repo.get("SLACK_BOT_TOKEN") == "xoxb-rotated"
+
+    repo.delete("SLACK_BOT_TOKEN")
+    assert repo.has("SLACK_BOT_TOKEN") is False
+    assert repo.get("SLACK_BOT_TOKEN") is None
+
+
+def test_system_secret_absent_returns_none_both_backends(_env):
+    from src.repositories import system_secrets_repo
+
+    assert system_secrets_repo().get("SLACK_APP_TOKEN") is None
+    assert system_secrets_repo().has("SLACK_APP_TOKEN") is False
+```
+
+- [ ] **Step 2: Run the contract test**
+
+Run: `.venv/bin/pytest tests/db_pg/test_system_secrets_contract.py --tb=short -q`
+Expected: PASS for the DuckDB parametrization. (The PG parametrization runs only when the PG test backend is configured in CI; if it's skipped locally, that's expected.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/db_pg/test_system_secrets_contract.py
+git commit -m "test(vault): cross-engine contract for system_secrets"
+```
+
+---
+
+## Task 6: `slack_secret()` resolver + allow-list
+
+**Files:**
+- Create: `services/slack_bot/secrets.py`
+- Test: `tests/test_slack_secret_resolver.py`
+
+- [ ] **Step 1: Write the failing test** `tests/test_slack_secret_resolver.py`:
+
+```python
+"""Unit tests for the env > vault > none Slack secret resolver."""
+from __future__ import annotations
+
+import pytest
+
+from services.slack_bot.secrets import SLACK_SECRET_NAMES, slack_secret
+
+
+def test_env_wins_over_vault(monkeypatch):
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-from-env")
+    # Even if the vault would return something, env must win and the vault
+    # must not be consulted. Make the vault raise to prove it isn't called.
+    import services.slack_bot.secrets as mod
+
+    def _boom():
+        raise AssertionError("vault must not be consulted when env is set")
+
+    monkeypatch.setattr(
+        "src.repositories.system_secrets_repo", _boom, raising=False
+    )
+    assert slack_secret("SLACK_BOT_TOKEN") == "xoxb-from-env"
+
+
+def test_vault_used_when_env_unset(monkeypatch):
+    monkeypatch.delenv("SLACK_APP_TOKEN", raising=False)
+
+    class _Repo:
+        def get(self, name):
+            return "xapp-from-vault" if name == "SLACK_APP_TOKEN" else None
+
+    monkeypatch.setattr(
+        "src.repositories.system_secrets_repo", lambda: _Repo()
+    )
+    assert slack_secret("SLACK_APP_TOKEN") == "xapp-from-vault"
+
+
+def test_none_when_neither(monkeypatch):
+    monkeypatch.delenv("SLACK_SIGNING_SECRET", raising=False)
+
+    class _Repo:
+        def get(self, name):
+            return None
+
+    monkeypatch.setattr(
+        "src.repositories.system_secrets_repo", lambda: _Repo()
+    )
+    assert slack_secret("SLACK_SIGNING_SECRET") is None
+
+
+def test_non_allow_listed_name_raises(monkeypatch):
+    with pytest.raises(ValueError):
+        slack_secret("DATABASE_URL")
+
+
+def test_vault_failure_is_swallowed(monkeypatch):
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+
+    def _boom():
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr("src.repositories.system_secrets_repo", _boom)
+    # A vault hiccup must not propagate — resolver returns None (fail-closed).
+    assert slack_secret("SLACK_BOT_TOKEN") is None
+
+
+def test_allow_list_contents():
+    assert SLACK_SECRET_NAMES == (
+        "SLACK_BOT_TOKEN",
+        "SLACK_APP_TOKEN",
+        "SLACK_SIGNING_SECRET",
+    )
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_slack_secret_resolver.py --tb=short -q`
+Expected: FAIL with `ModuleNotFoundError: services.slack_bot.secrets`.
+
+- [ ] **Step 3: Write the resolver** `services/slack_bot/secrets.py`:
+
+```python
+"""Resolve Slack bot secrets: env > vault > None.
+
+Environment variables are authoritative (Terraform / secret-manager
+deployments stay in control); the ``system_secrets`` vault is the
+UI-managed fallback. Only the three known Slack secret names are
+resolvable via the vault — the allow-list prevents using the vault
+namespace to read arbitrary environment variables.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+SLACK_SECRET_NAMES = (
+    "SLACK_BOT_TOKEN",
+    "SLACK_APP_TOKEN",
+    "SLACK_SIGNING_SECRET",
+)
+
+
+def slack_secret(name: str) -> Optional[str]:
+    """Return the value for ``name`` resolving env > vault > None.
+
+    Raises ``ValueError`` for any name outside the Slack allow-list. A vault
+    lookup failure (DB unavailable, etc.) is swallowed and treated as unset
+    so signature verification fails closed (401) rather than 500-ing.
+    """
+    if name not in SLACK_SECRET_NAMES:
+        raise ValueError(f"{name!r} is not a Slack secret name")
+    env = os.environ.get(name)
+    if env:
+        return env
+    try:
+        from src.repositories import system_secrets_repo
+
+        return system_secrets_repo().get(name)
+    except Exception:
+        logger.warning("vault lookup for %s failed; treating as unset", name)
+        return None
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_slack_secret_resolver.py --tb=short -q`
+Expected: PASS (all 6).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/slack_bot/secrets.py tests/test_slack_secret_resolver.py
+git commit -m "feat(slack): env > vault > none secret resolver"
+```
+
+---
+
+## Task 7: Swap the 12 read sites onto `slack_secret()`
+
+**Files:**
+- Modify: `app/main.py:324-325`
+- Modify: `app/api/slack.py:37,60,82` (+ remove now-unused `import os`)
+- Modify: `services/slack_bot/sender.py` (6 sites)
+- Modify: `services/slack_bot/identity.py:20`
+
+- [ ] **Step 1: `app/main.py`** — replace lines 324-325:
+
+```python
+    from services.slack_bot.secrets import slack_secret
+    app_token = slack_secret("SLACK_APP_TOKEN") or ""
+    bot_token = slack_secret("SLACK_BOT_TOKEN") or ""
+```
+
+(Place the import at the top of the function or module per the file's existing style; the `or ""` preserves the prior empty-string default that `socket_mode_preflight` expects.)
+
+- [ ] **Step 2: `app/api/slack.py`** — add the import near the top:
+
+```python
+from services.slack_bot.secrets import slack_secret
+```
+
+Replace each of the three `secret = os.environ.get("SLACK_SIGNING_SECRET", "")` (lines 37, 60, 82) with:
+
+```python
+    secret = slack_secret("SLACK_SIGNING_SECRET") or ""
+```
+
+Then remove the now-unused `import os` (line 6) — verify with `grep -n "os\." app/api/slack.py` that no other `os.` usage remains before deleting.
+
+- [ ] **Step 3: `services/slack_bot/sender.py`** — add the import:
+
+```python
+from services.slack_bot.secrets import slack_secret
+```
+
+Replace each of the 6 `token = os.environ.get("SLACK_BOT_TOKEN")` with:
+
+```python
+    token = slack_secret("SLACK_BOT_TOKEN")
+```
+
+Remove the now-unused `import os` if no other `os.` usage remains (`grep -n "os\." services/slack_bot/sender.py`).
+
+- [ ] **Step 4: `services/slack_bot/identity.py`** — add the import and replace line 20:
+
+```python
+from services.slack_bot.secrets import slack_secret
+```
+```python
+    token = slack_secret("SLACK_BOT_TOKEN")
+```
+
+Remove the now-unused `import os` if nothing else uses it.
+
+- [ ] **Step 5: Run the Slack regression suite**
+
+Run: `.venv/bin/pytest tests/ -k slack --tb=short -q`
+Expected: PASS — existing tests monkeypatch `os.environ["SLACK_…"]`, and `slack_secret` checks env first, so they are unaffected.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/main.py app/api/slack.py services/slack_bot/sender.py services/slack_bot/identity.py
+git commit -m "refactor(slack): resolve bot tokens via slack_secret (env > vault)"
+```
+
+---
+
+## Task 8: Admin API — `/api/admin/slack-secrets`
+
+**Files:**
+- Create: `app/api/admin_slack_secrets.py`
+- Modify: `app/main.py` (import ~line 242 area; `include_router` ~line 1165 after `admin_mcp_router`)
+- Test: `tests/test_admin_slack_secrets.py`
+
+- [ ] **Step 1: Write the failing test** `tests/test_admin_slack_secrets.py` (uses the `seeded_app` fixture: `client`, `admin_token`, `analyst_token`):
+
+```python
+"""Tests for /api/admin/slack-secrets — admin-gated, write-only, vault-backed."""
+from __future__ import annotations
+
+import pytest
+from cryptography.fernet import Fernet
+
+from app.secrets_vault import _reset_ephemeral_key_for_tests
+
+
+@pytest.fixture(autouse=True)
+def _stable_vault_key(monkeypatch):
+    monkeypatch.setenv("AGNES_VAULT_KEY", Fernet.generate_key().decode())
+    _reset_ephemeral_key_for_tests()
+    yield
+    _reset_ephemeral_key_for_tests()
+
+
+def test_set_requires_admin(seeded_app):
+    client = seeded_app["client"]
+    r = client.put(
+        "/api/admin/slack-secrets/SLACK_BOT_TOKEN",
+        headers={"Authorization": f"Bearer {seeded_app['analyst_token']}"},
+        json={"value": "xoxb-x"},
+    )
+    assert r.status_code == 403
+
+
+def test_set_rejects_unknown_name(seeded_app):
+    client = seeded_app["client"]
+    r = client.put(
+        "/api/admin/slack-secrets/DATABASE_URL",
+        headers={"Authorization": f"Bearer {seeded_app['admin_token']}"},
+        json={"value": "x"},
+    )
+    assert r.status_code == 400
+
+
+def test_set_rejects_empty(seeded_app):
+    client = seeded_app["client"]
+    r = client.put(
+        "/api/admin/slack-secrets/SLACK_BOT_TOKEN",
+        headers={"Authorization": f"Bearer {seeded_app['admin_token']}"},
+        json={"value": ""},
+    )
+    assert r.status_code == 400
+
+
+def test_set_then_status_reports_vault(seeded_app, monkeypatch):
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+    client = seeded_app["client"]
+    admin = {"Authorization": f"Bearer {seeded_app['admin_token']}"}
+
+    r = client.put(
+        "/api/admin/slack-secrets/SLACK_BOT_TOKEN", headers=admin,
+        json={"value": "xoxb-secret"},
+    )
+    assert r.status_code == 204
+
+    r = client.get("/api/admin/slack-secrets", headers=admin)
+    assert r.status_code == 200
+    by_name = {s["name"]: s for s in r.json()["secrets"]}
+    assert by_name["SLACK_BOT_TOKEN"]["source"] == "vault"
+    assert by_name["SLACK_BOT_TOKEN"]["has_value"] is True
+    # value is never echoed
+    assert "value" not in by_name["SLACK_BOT_TOKEN"]
+
+
+def test_env_shadows_vault_in_status(seeded_app, monkeypatch):
+    monkeypatch.setenv("SLACK_APP_TOKEN", "xapp-env")
+    client = seeded_app["client"]
+    admin = {"Authorization": f"Bearer {seeded_app['admin_token']}"}
+    r = client.get("/api/admin/slack-secrets", headers=admin)
+    by_name = {s["name"]: s for s in r.json()["secrets"]}
+    assert by_name["SLACK_APP_TOKEN"]["source"] == "env"
+
+
+def test_delete_clears(seeded_app, monkeypatch):
+    monkeypatch.delenv("SLACK_SIGNING_SECRET", raising=False)
+    client = seeded_app["client"]
+    admin = {"Authorization": f"Bearer {seeded_app['admin_token']}"}
+    client.put(
+        "/api/admin/slack-secrets/SLACK_SIGNING_SECRET", headers=admin,
+        json={"value": "shh"},
+    )
+    r = client.delete("/api/admin/slack-secrets/SLACK_SIGNING_SECRET", headers=admin)
+    assert r.status_code == 204
+    r = client.get("/api/admin/slack-secrets", headers=admin)
+    by_name = {s["name"]: s for s in r.json()["secrets"]}
+    assert by_name["SLACK_SIGNING_SECRET"]["source"] == "unset"
+    assert by_name["SLACK_SIGNING_SECRET"]["has_value"] is False
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_admin_slack_secrets.py --tb=short -q`
+Expected: FAIL (404s — router not registered yet).
+
+- [ ] **Step 3: Write the router** `app/api/admin_slack_secrets.py`:
+
+```python
+"""Admin REST API for server-wide Slack bot secrets (vault-backed).
+
+  - GET    /api/admin/slack-secrets          — presence/source status (no values)
+  - PUT    /api/admin/slack-secrets/{name}    — set / rotate (write-only)
+  - DELETE /api/admin/slack-secrets/{name}    — clear
+
+All gated by ``require_admin``. The secret value lives only in the request
+body → Fernet-encrypted at rest in ``system_secrets``. It is never returned
+by any endpoint and never placed in an audit record (audit params are empty,
+mirroring the MCP secret endpoints).
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+import duckdb
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from app.auth.access import require_admin
+from app.auth.dependencies import _get_db
+from app.secrets_vault import VaultKeyNotConfiguredError
+from services.slack_bot.secrets import SLACK_SECRET_NAMES
+from src.repositories import system_secrets_repo
+from src.repositories.audit import AuditRepository
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/admin", tags=["admin-slack-secrets"])
+
+
+class SlackSecretBody(BaseModel):
+    value: str
+
+
+def _audit(
+    conn: duckdb.DuckDBPyConnection,
+    actor_id: str,
+    action: str,
+    resource: str,
+    params: Optional[Dict[str, Any]] = None,
+) -> None:
+    try:
+        AuditRepository(conn).log(
+            user_id=actor_id, action=action, resource=resource, params=params or {}
+        )
+    except Exception:
+        logger.warning("audit log failed for %s/%s", action, resource)
+
+
+@router.get("/slack-secrets")
+async def list_slack_secrets(user: dict = Depends(require_admin)):
+    """Presence/source status for the three Slack tokens. Never leaks values."""
+    repo = system_secrets_repo()
+    out = []
+    for name in SLACK_SECRET_NAMES:
+        if os.environ.get(name):
+            source, has_value = "env", True
+        elif repo.has(name):
+            source, has_value = "vault", True
+        else:
+            source, has_value = "unset", False
+        out.append({"name": name, "source": source, "has_value": has_value})
+    return {"secrets": out}
+
+
+@router.put("/slack-secrets/{name}", status_code=204)
+async def set_slack_secret(
+    name: str,
+    body: SlackSecretBody,
+    user: dict = Depends(require_admin),
+    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
+):
+    """Store (or rotate) the vault secret for ``name``. Write-only."""
+    if name not in SLACK_SECRET_NAMES:
+        raise HTTPException(status_code=400, detail="unknown_slack_secret")
+    if not body.value:
+        raise HTTPException(status_code=400, detail="secret value required")
+    try:
+        system_secrets_repo().upsert(name, body.value)
+    except VaultKeyNotConfiguredError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail="vault_key_not_configured: set AGNES_VAULT_KEY on the server before storing secrets",
+        ) from exc
+    _audit(conn, user["id"], "slack.secret.set", f"slack_secret:{name}", {})
+
+
+@router.delete("/slack-secrets/{name}", status_code=204)
+async def delete_slack_secret(
+    name: str,
+    user: dict = Depends(require_admin),
+    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
+):
+    """Drop the vault row for ``name``. Resolution falls back to env / disabled."""
+    if name not in SLACK_SECRET_NAMES:
+        raise HTTPException(status_code=400, detail="unknown_slack_secret")
+    system_secrets_repo().delete(name)
+    _audit(conn, user["id"], "slack.secret.clear", f"slack_secret:{name}", {})
+```
+
+- [ ] **Step 4: Register the router** in `app/main.py`. Add the import next to the other admin router imports (~line 242):
+
+```python
+from app.api.admin_slack_secrets import router as admin_slack_secrets_router
+```
+
+And the include next to `app.include_router(admin_mcp_router)` (~line 1165):
+
+```python
+    app.include_router(admin_slack_secrets_router)
+```
+
+- [ ] **Step 5: Run the API tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_admin_slack_secrets.py --tb=short -q`
+Expected: PASS (all 6).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/api/admin_slack_secrets.py app/main.py tests/test_admin_slack_secrets.py
+git commit -m "feat(admin): /api/admin/slack-secrets vault endpoints"
+```
+
+---
+
+## Task 9: Admin UI — Slack secrets section
+
+**Files:**
+- Modify: `app/web/templates/admin_server_config.html` (add a section + JS, mirroring the existing `#chat-section` secret-presence pattern at ~line 299)
+
+- [ ] **Step 1: Add the section markup** after the `#chat-section` `</section>` (~line 333). Mirror the chat section's structure (write-only password inputs + presence status, no value rendered):
+
+```html
+  <!-- Slack bot secrets — vault-backed (system_secrets), set/rotate/clear from UI.
+       Written to the encrypted vault via /api/admin/slack-secrets, NOT to the
+       instance.yaml overlay. Status is presence-only; values are never returned. -->
+  <section class="cfg-section" id="slack-secrets-section">
+    <div class="section-head">
+      <div>
+        <h3>Slack bot secrets</h3>
+        <p class="sub">
+          Stored encrypted in the server vault. Environment variables (e.g. set
+          via Terraform) always take precedence — when a token shows
+          <code>env</code> it is pinned in the environment and cannot be changed
+          here. Requires <code>AGNES_VAULT_KEY</code> on the server.
+        </p>
+      </div>
+    </div>
+    <div class="section-body" id="slack-secrets-body">
+      <div id="slack-secrets-status" class="cfg-loading">Loading…</div>
+      <div class="cfg-field">
+        <label for="slack-bot-token">SLACK_BOT_TOKEN</label>
+        <input type="password" id="slack-bot-token" autocomplete="off"
+               placeholder="xoxb-… (leave blank to keep existing)">
+      </div>
+      <div class="cfg-field">
+        <label for="slack-app-token">SLACK_APP_TOKEN</label>
+        <input type="password" id="slack-app-token" autocomplete="off"
+               placeholder="xapp-… (leave blank to keep existing)">
+      </div>
+      <div class="cfg-field">
+        <label for="slack-signing-secret">SLACK_SIGNING_SECRET</label>
+        <input type="password" id="slack-signing-secret" autocomplete="off"
+               placeholder="(leave blank to keep existing)">
+      </div>
+    </div>
+    <div class="section-actions">
+      <button type="button" class="btn btn-primary" id="slack-secrets-save-btn">Save secrets</button>
+    </div>
+  </section>
+```
+
+- [ ] **Step 2: Add the JS** mirroring the chat-secrets save/refresh logic already in this file. Find the chat-secrets `fetch('/api/admin/chat/secrets', ...)` block and add an analogous one. The save handler PUTs each non-empty input to `/api/admin/slack-secrets/{NAME}`, then refreshes status from `GET /api/admin/slack-secrets`:
+
+```javascript
+  const SLACK_FIELDS = [
+    ["SLACK_BOT_TOKEN", "slack-bot-token"],
+    ["SLACK_APP_TOKEN", "slack-app-token"],
+    ["SLACK_SIGNING_SECRET", "slack-signing-secret"],
+  ];
+
+  async function refreshSlackSecrets() {
+    const el = document.getElementById("slack-secrets-status");
+    try {
+      const r = await fetch("/api/admin/slack-secrets");
+      const data = await r.json();
+      el.classList.remove("cfg-loading");
+      el.innerHTML = data.secrets.map(s =>
+        `<div><code>${s.name}</code>: <strong>${s.source}</strong></div>`
+      ).join("");
+    } catch (e) {
+      el.textContent = "Could not load Slack secret status.";
+    }
+  }
+
+  document.getElementById("slack-secrets-save-btn").addEventListener("click", async () => {
+    let any = false, vaultKeyMissing = false;
+    for (const [name, inputId] of SLACK_FIELDS) {
+      const v = document.getElementById(inputId).value.trim();
+      if (!v) continue;
+      any = true;
+      const r = await fetch(`/api/admin/slack-secrets/${name}`, {
+        method: "PUT",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify({value: v}),
+      });
+      if (r.status === 409) vaultKeyMissing = true;
+      document.getElementById(inputId).value = "";
+    }
+    const banner = document.getElementById("cfg-banner");
+    if (!any) { banner.textContent = "No secret entered."; }
+    else if (vaultKeyMissing) { banner.textContent = "AGNES_VAULT_KEY is not configured on the server."; }
+    else { banner.textContent = "Slack secrets saved."; }
+    await refreshSlackSecrets();
+  });
+
+  refreshSlackSecrets();
+```
+
+(Adapt selector/banner names to match the file's existing helpers if they differ — follow the chat-section's exact idiom for `fetch`, auth, and banner display.)
+
+- [ ] **Step 3: Verify the design-system contract guard still passes** (the template must not introduce raw hex / `var(--primary)` etc.):
+
+Run: `.venv/bin/pytest tests/test_design_system_contract.py --tb=short -q`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/web/templates/admin_server_config.html
+git commit -m "feat(web): Slack bot secrets section on /admin/server-config"
+```
+
+---
+
+## Task 10: Docs + CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md` (Added bullet under `## [Unreleased]`)
+- Modify: `config/.env.template` (note env precedence)
+- Modify: `docs/slack-manifest-http.md`, `docs/slack-manifest-socket.md` (mention UI/vault option)
+
+- [ ] **Step 1: CHANGELOG** — add under `## [Unreleased]` → `### Added`:
+
+```markdown
+- Slack bot tokens (`SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, `SLACK_SIGNING_SECRET`) can now be set and rotated from the admin UI (`/admin/server-config` → Slack bot secrets), stored encrypted in the server vault. Environment variables still take precedence, so Terraform-managed deployments are unaffected. Requires `AGNES_VAULT_KEY` on the server.
+```
+
+- [ ] **Step 2: `config/.env.template`** — near the existing Slack vars, add a comment:
+
+```bash
+# Slack bot tokens may also be set from the admin UI (stored encrypted in the
+# server vault). If set here in the environment, the env value always wins.
+```
+
+- [ ] **Step 3: `docs/slack-manifest-http.md` and `docs/slack-manifest-socket.md`** — under "Required environment", add a line to each:
+
+```markdown
+- These tokens may instead be set from the admin UI (`/admin/server-config` → Slack bot secrets), stored encrypted in the vault (`AGNES_VAULT_KEY` required). Environment variables, if present, take precedence.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md config/.env.template docs/slack-manifest-http.md docs/slack-manifest-socket.md
+git commit -m "docs: Slack bot tokens via admin UI / vault"
+```
+
+---
+
+## Task 11: Full suite + release-cut (0.66.0)
+
+**Files:**
+- Modify: `pyproject.toml` (version → `0.66.0`)
+- Modify: `CHANGELOG.md` (rename `[Unreleased]` → `[0.66.0] - 2026-06-04`; add fresh empty `[Unreleased]`)
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `.venv/bin/pytest tests/ --tb=short -n auto -q`
+Expected: PASS. Failures in code you touched → fix before proceeding. Pre-existing unrelated failures → confirm on a clean tree (`git stash`), note in PR body, don't block.
+
+- [ ] **Step 2: Bump the version** in `pyproject.toml` (line ~3):
+
+```toml
+version = "0.66.0"
+```
+
+- [ ] **Step 3: Cut the CHANGELOG** — rename the `## [Unreleased]` heading to `## [0.66.0] - 2026-06-04` and insert a fresh empty section above it:
+
+```markdown
+## [Unreleased]
+
+## [0.66.0] - 2026-06-04
+```
+
+- [ ] **Step 4: Commit the release-cut** (last commit on the PR):
+
+```bash
+git add pyproject.toml CHANGELOG.md
+git commit -m "chore(release): 0.66.0"
+```
+
+- [ ] **Step 5: Push + open PR** (only when the user asks to merge — per project workflow the release tag + GitHub Release happen after merge):
+
+```bash
+git push -u origin zs/slack-bot-tokens-vault
+```
+
+---
+
+## Final verification checklist (run before requesting review)
+
+- [ ] `.venv/bin/pytest tests/ --tb=short -n auto -q` green.
+- [ ] `.venv/bin/pytest tests/db_pg/test_system_secrets_contract.py tests/db_pg/test_schema_parity.py tests/db_pg/test_data_migration.py --tb=short -q` green.
+- [ ] `grep -rn 'os.environ.get("SLACK_' app/ services/` returns only `services/slack_bot/secrets.py` (the resolver) — all other reads now go through `slack_secret()`.
+- [ ] No secret value appears in any API response or audit row (covered by `tests/test_admin_slack_secrets.py`).
+- [ ] CHANGELOG has the Added bullet and the release-cut.

--- a/docs/superpowers/specs/2026-06-04-slack-bot-tokens-vault-design.md
+++ b/docs/superpowers/specs/2026-06-04-slack-bot-tokens-vault-design.md
@@ -1,0 +1,133 @@
+# Slack bot tokens in the vault — design
+
+**Date:** 2026-06-04
+**Status:** Approved (brainstorm), pre-implementation
+**Scope:** Make the three server-wide Slack bot secrets manageable from the admin UI via the encrypted secret vault, while keeping environment variables authoritative.
+
+## Problem
+
+The Slack bot integration reads its three secrets — `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, `SLACK_SIGNING_SECRET` — directly from `os.environ` at every use site (15 reads across `app/main.py`, `app/api/slack.py`, `services/slack_bot/sender.py`, `services/slack_bot/identity.py`, `services/slack_bot/socket_mode_client.py`). They are env-only by deliberate design: secrets must never leak into the `/admin/server-config` echo or get persisted as cleartext into the `instance.yaml` overlay (where `${ENV_VAR}` references are resolved on write).
+
+That design is correct for the *config overlay*, but it leaves an operator with no way to set or rotate the bot tokens without SSH or Terraform. Meanwhile the platform already has an encrypted secret vault (Fernet, `app/secrets_vault.py`), now fully dual-backend through the repository factory (`shared_secrets_repo()` / `per_user_secrets_repo()` route on `use_pg()`; PG siblings in `src/repositories/secrets_vault_pg.py`). The vault is the right home for UI-managed secrets — encrypted at rest, write-only in the UI, never echoed.
+
+The MCP vault scopes (`mcp_secrets`, `mcp_user_secrets`) are keyed by `source_id` and are semantically about MCP data sources, so the Slack bot tokens do not belong there.
+
+## Goal
+
+Resolve each Slack bot secret as **`env > vault > none`**:
+
+1. **env** — if the environment variable is set, use it. Environment always wins, so Terraform / secret-manager-driven deployments are unaffected and an operator cannot accidentally override an env-pinned value from the UI.
+2. **vault** — otherwise, read the value from a new `system_secrets` vault scope, settable from the admin UI.
+3. **none** — if neither is present, behaviour is exactly as today: the feature stays disabled, fail-closed (Socket Mode logs the reason and does not start; signature verification rejects).
+
+## Non-goals (YAGNI)
+
+- **Not** a generic "manage any system secret from the UI" feature. The `system_secrets` table is generic, but the resolver and UI are hard-limited to the three known Slack token names via an allow-list. Extending to other secrets (SMTP password, OpenMetadata token, etc.) is a future, separate effort and needs no migration.
+- **No** per-user Slack bot tokens — per-user vault secrets remain MCP-passthrough only.
+- **No** vault-key rotation tooling — separate concern, unchanged here.
+- **No** caching of vault reads (see Decisions).
+
+## Architecture
+
+Four layers, each mirroring the proven MCP vault pattern.
+
+### 1. Storage — new `system_secrets` scope
+
+New table, server-wide, keyed by secret name:
+
+```
+system_secrets(
+  name              TEXT       PRIMARY KEY,   -- e.g. "SLACK_BOT_TOKEN"
+  secret_value_enc  BLOB,                     -- Fernet ciphertext
+  updated_at        TIMESTAMP
+)
+```
+
+- **DuckDB:** new migration step `_v71_to_v72` in `src/db.py`; bump `SCHEMA_VERSION` 71 → 72.
+- **Postgres:** matching Alembic migration `0019_system_secrets_v72.py`.
+- Both ladders reach the same schema endpoint; `tests/test_db_schema_version.py` is the integration gate.
+- Reuses the existing Fernet helpers `encrypt_secret` / `decrypt_secret` from `app/secrets_vault.py` — no new crypto.
+
+### 2. Repositories (dual-backend, via factory)
+
+Signature-compatible with the existing `SharedSecretsRepository`:
+
+- `SystemSecretsRepository` (DuckDB) in `app/secrets_vault.py`:
+  - `upsert(name, value)` — encrypt + ON CONFLICT replace.
+  - `get(name) -> str | None` — decrypt; on `InvalidToken` (key rotated) log a warning and return `None` so the caller falls back to env / disabled (same tolerance as `SharedSecretsRepository.get`).
+  - `delete(name)`, `has(name) -> bool`.
+- `SystemSecretsPgRepository` in `src/repositories/secrets_vault_pg.py` — same signature, SQLAlchemy against the PG `system_secrets` table.
+- Factory `system_secrets_repo()` in `src/repositories/__init__.py`, routing on `use_pg()` exactly like `shared_secrets_repo()`.
+- Cross-engine contract test `tests/db_pg/test_system_secrets_contract.py` parametrizing both backends through one assertion set (upsert/get/has/delete, junk-decrypt → None).
+
+### 3. Resolver — single accessor `env > vault > none`
+
+New function `slack_secret(name: str) -> str | None` in `services/slack_bot/` (e.g. `services/slack_bot/secrets.py`):
+
+```
+ALLOWED = {"SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_SIGNING_SECRET"}
+
+def slack_secret(name):
+    assert name in ALLOWED            # never resolve arbitrary names via vault
+    env = os.environ.get(name)
+    if env:
+        return env                    # env wins (Terraform override)
+    return system_secrets_repo().get(name)   # vault, or None
+```
+
+- The **allow-list** prevents using the vault namespace to exfiltrate arbitrary environment variables.
+- Replaces all 15 `os.environ.get("SLACK_…")` read sites with `slack_secret(...)`. This centralises resolution in one place.
+- **No caching** (Decisions): each resolution checks env first (cheap); the vault DB-read + Fernet-decrypt only happens when env is unset *and* a vault value exists. `SLACK_SIGNING_SECRET` is read on every inbound HTTP Slack request, so deployments that put the signing secret in the vault pay one DB read + decrypt per request — accepted in exchange for zero added complexity and instant rotation.
+
+### 4. Admin API + UI
+
+New endpoints under `/api/admin/`, mirroring the MCP source secret control shipped in #530:
+
+- `PUT /api/admin/slack-secrets/{name}` — set / rotate. Write-only: the value is accepted, never returned. Returns **409 `vault_key_not_configured`** when `AGNES_VAULT_KEY` is unset outside `LOCAL_DEV_MODE` (reuse `VaultKeyNotConfiguredError`). `name` must be in the allow-list, else **400**.
+- `DELETE /api/admin/slack-secrets/{name}` — clear the vault value (falls back to env / disabled).
+- `GET /api/admin/slack-secrets` — status only, never values: for each of the three names `{name, source: "env" | "vault" | "unset", has_value: bool}`. `source` is `env` when the env var is set (env wins), `vault` when only a vault row exists, `unset` when neither.
+
+All gated by `require_admin`. Set/rotate/clear are audit-logged with the value masked (reuse `_SECRET_KEY_PATTERNS`).
+
+**UI** — a "Slack" subsection on the existing `/admin/server-config` page (`app/web/templates/admin_server_config.html`), co-located with the transport selector (`chat.slack.transport`) that already lives there. Per token: a status badge (`env` / `vault` / `unset`) and a write-only set / rotate / clear control (input cleared after submit; 409 shown inline). When `source == "env"`, the control is shown read-only with an explanation that the value is pinned via the environment and cannot be overridden from the UI.
+
+**Critical invariant:** the set/rotate control POSTs to the **vault endpoint**, never to the `instance.yaml` overlay write path. Secrets never touch the config overlay — the existing no-leak / no-cleartext-on-disk guarantees are preserved. (Two write targets coexist on one page: the rest of the form patches the yaml overlay; this section writes the vault. The UI must make that boundary clear in code structure.)
+
+`GET /api/health` already reports `vault_key_configured`; the UI surfaces a hint when a vault secret is requested but the key is unset.
+
+## Behaviour matrix
+
+| env set | vault row | `source` | resolved value |
+|---|---|---|---|
+| yes | — | `env` | env value (vault ignored) |
+| no | yes | `vault` | decrypted vault value |
+| no | no | `unset` | `None` → feature disabled, fail-closed |
+| no | yes but key rotated | `vault`* | `None` (junk-decrypt) → disabled |
+
+\* status reports `vault` (a row exists) but resolution returns `None`; the UI hint about `vault_key_configured` covers the rotated-key case.
+
+## Testing
+
+- **Contract:** `tests/db_pg/test_system_secrets_contract.py` — both backends, full CRUD + junk-decrypt → None.
+- **Resolver:** env-set → env wins (no DB read); env-unset + vault → vault value; neither → None; non-allow-listed name → never reaches the vault (assertion / rejection).
+- **API:** set/rotate/clear/status happy paths; 409 on missing vault key; 400 on non-allow-listed name; `require_admin` gate; value never returned by any endpoint; audit entry masked.
+- **Regression:** existing Slack tests that monkeypatch `os.environ["SLACK_…"]` must still pass unchanged — the accessor checks env first, so env-based tests are unaffected.
+- **Schema:** `tests/test_db_schema_version.py` confirms DuckDB v72 and Alembic 0019 reach the same schema.
+
+## Release
+
+- New admin UI surface + new endpoints = **minor** version bump (precedent: #530 = 0.64.0). Single CHANGELOG `Added` bullet under `[Unreleased]`, plus the release-cut (version bump + CHANGELOG rename + new empty `[Unreleased]`) as the last commit on the PR.
+- Docs to update: `docs/slack-manifest-http.md` and `docs/slack-manifest-socket.md` (note that tokens may be set via the admin UI/vault, not only env), the config-layering notes, and `config/.env.template` (env still wins; vault is the UI-managed fallback).
+
+## Affected files (anticipated)
+
+- `src/db.py` — `_v71_to_v72`, `SCHEMA_VERSION` 71→72.
+- `migrations/versions/0019_system_secrets_v72.py` — new.
+- `app/secrets_vault.py` — `SystemSecretsRepository`.
+- `src/repositories/secrets_vault_pg.py` — `SystemSecretsPgRepository`.
+- `src/repositories/__init__.py` — `system_secrets_repo()`.
+- `services/slack_bot/secrets.py` — `slack_secret()` accessor + allow-list (new).
+- Read-site swaps: `app/main.py`, `app/api/slack.py`, `services/slack_bot/sender.py`, `services/slack_bot/identity.py`, `services/slack_bot/socket_mode_client.py`.
+- `app/api/admin.py` (or a small new router) — `/api/admin/slack-secrets` endpoints.
+- `app/web/templates/admin_server_config.html` — Slack subsection.
+- Tests: `tests/db_pg/test_system_secrets_contract.py`, resolver + API tests, CHANGELOG, docs.

--- a/docs/superpowers/specs/2026-06-04-slack-bot-tokens-vault-design.md
+++ b/docs/superpowers/specs/2026-06-04-slack-bot-tokens-vault-design.md
@@ -45,6 +45,10 @@ system_secrets(
 
 - **DuckDB:** new migration step `_v71_to_v72` in `src/db.py`; bump `SCHEMA_VERSION` 71 → 72.
 - **Postgres:** matching Alembic migration `0019_system_secrets_v72.py`.
+- **SQLAlchemy model (required, not optional).** A `SystemSecrets` ORM model must be declared (e.g. in `src/models/mcp.py` or a new `src/models/vault.py`) **and registered in `src/models/__init__.py`** — precedent: `MCPSecret` registered at `src/models/__init__.py`. Two gates depend on this:
+  - `tests/db_pg/test_schema_parity.py::test_alembic_head_materializes_every_model` (#546) iterates `Base.metadata.sorted_tables`.
+  - The DuckDB→PG state migrator (`scripts/migrate_duckdb_to_pg/__init__.py`) iterates `Base.metadata.sorted_tables` to build its copy task list. **If the table has no model, the migrator silently skips it and vault contents are lost on a DuckDB→Postgres migration.**
+- **Non-`id` primary key.** `system_secrets` is keyed by `name`, not `id`. Add `"system_secrets": ["name"]` to `_PK_COLUMNS` in `scripts/migrate_duckdb_to_pg/__init__.py`, or `tests/db_pg/test_data_migration.py::test_non_id_pk_tables_are_in_pk_columns_map` fails.
 - Both ladders reach the same schema endpoint; `tests/test_db_schema_version.py` is the integration gate.
 - Reuses the existing Fernet helpers `encrypt_secret` / `decrypt_secret` from `app/secrets_vault.py` — no new crypto.
 
@@ -54,11 +58,11 @@ Signature-compatible with the existing `SharedSecretsRepository`:
 
 - `SystemSecretsRepository` (DuckDB) in `app/secrets_vault.py`:
   - `upsert(name, value)` — encrypt + ON CONFLICT replace.
-  - `get(name) -> str | None` — decrypt; on `InvalidToken` (key rotated) log a warning and return `None` so the caller falls back to env / disabled (same tolerance as `SharedSecretsRepository.get`).
+  - `get(name) -> str | None` — decrypt; catch **`(InvalidToken, RuntimeError)`** and return `None` (with a logged warning) so the caller falls back to env / disabled. `InvalidToken` = key rotated; `RuntimeError` = `AGNES_VAULT_KEY` set-but-malformed (raised by `_get_fernet()`). The existing `SharedSecretsRepository.get` only catches `InvalidToken`, so a malformed key would 500 there — we deliberately widen the catch here so a misconfigured key fails closed (feature disabled) instead of 500-ing every inbound Slack request.
   - `delete(name)`, `has(name) -> bool`.
 - `SystemSecretsPgRepository` in `src/repositories/secrets_vault_pg.py` — same signature, SQLAlchemy against the PG `system_secrets` table.
 - Factory `system_secrets_repo()` in `src/repositories/__init__.py`, routing on `use_pg()` exactly like `shared_secrets_repo()`.
-- Cross-engine contract test `tests/db_pg/test_system_secrets_contract.py` parametrizing both backends through one assertion set (upsert/get/has/delete, junk-decrypt → None).
+- Cross-engine contract test `tests/db_pg/test_system_secrets_contract.py` parametrizing both backends through one assertion set (upsert/get/has/delete, junk-decrypt → None, malformed-key → None). **This contract test is mandatory, not optional:** the automatic method-parity sweep (`tests/db_pg/test_repo_method_parity.py`) only scans `src/repositories/*.py` paired with `*_pg.py`, so it will NOT see `SystemSecretsRepository` (which lives in `app/secrets_vault.py`, mirroring the existing `SharedSecretsRepository` placement). The contract test is the only mechanical guard against DuckDB/PG method drift for this repo.
 
 ### 3. Resolver — single accessor `env > vault > none`
 
@@ -76,8 +80,14 @@ def slack_secret(name):
 ```
 
 - The **allow-list** prevents using the vault namespace to exfiltrate arbitrary environment variables.
-- Replaces all 15 `os.environ.get("SLACK_…")` read sites with `slack_secret(...)`. This centralises resolution in one place.
-- **No caching** (Decisions): each resolution checks env first (cheap); the vault DB-read + Fernet-decrypt only happens when env is unset *and* a vault value exists. `SLACK_SIGNING_SECRET` is read on every inbound HTTP Slack request, so deployments that put the signing secret in the vault pay one DB read + decrypt per request — accepted in exchange for zero added complexity and instant rotation.
+- Replaces the **12** direct `os.environ.get("SLACK_…")` read sites with `slack_secret(...)`, centralising resolution in one place. Verified counts on current main (HEAD d237fc03):
+  - `app/main.py` — 2 (`SLACK_APP_TOKEN`, `SLACK_BOT_TOKEN`), read at lines ~324–325 and passed into the `SocketModeDispatcher` constructor.
+  - `app/api/slack.py` — 3 (`SLACK_SIGNING_SECRET`, once per endpoint).
+  - `services/slack_bot/sender.py` — 6 (`SLACK_BOT_TOKEN`, once per send function).
+  - `services/slack_bot/identity.py` — 1 (`SLACK_BOT_TOKEN`).
+  - `services/slack_bot/socket_mode_client.py` — **0**: it receives `app_token`/`bot_token` via its constructor from `app/main.py`, it does not read env itself. It needs no change beyond what `app/main.py` already passes (now the resolved values).
+- **Startup ordering.** `app/main.py` calls `resolve_bot_user_id()` (which now goes through `slack_secret()` → `get_system_db()`) inside the async `lifespan` startup. `get_system_db()` is synchronous and lazily runs `_ensure_schema()` on first call. The implementation must confirm `DATA_DIR` / state dir is available before the Slack-init block in `lifespan()` (it already is for other startup DB reads), so the first vault read at startup does not raise on a missing state dir.
+- **No caching** (Decisions): each resolution checks env first (cheap); the vault DB-read + Fernet-decrypt only happens when env is unset *and* a vault value exists. `SLACK_SIGNING_SECRET` is read on every inbound HTTP Slack request, so deployments that put the signing secret in the vault pay one DB read + decrypt per request. This is the same DuckDB system-connection access pattern the MCP hot path already uses (read-only SELECT on the shared `system.duckdb` connection; safe under concurrent FastAPI threads) — accepted in exchange for zero added complexity and instant rotation.
 
 ### 4. Admin API + UI
 
@@ -87,7 +97,9 @@ New endpoints under `/api/admin/`, mirroring the MCP source secret control shipp
 - `DELETE /api/admin/slack-secrets/{name}` — clear the vault value (falls back to env / disabled).
 - `GET /api/admin/slack-secrets` — status only, never values: for each of the three names `{name, source: "env" | "vault" | "unset", has_value: bool}`. `source` is `env` when the env var is set (env wins), `vault` when only a vault row exists, `unset` when neither.
 
-All gated by `require_admin`. Set/rotate/clear are audit-logged with the value masked (reuse `_SECRET_KEY_PATTERNS`).
+All gated by `require_admin` (imported from `app.auth.access`; it also hard-denies `SessionPrincipal` co-session tokens automatically, which the tests should assert). No new `ResourceType`/`ResourceTypeSpec` — server-wide admin-only secrets belong in the `require_admin` tier, matching the MCP secret endpoints which register none.
+
+**Audit logging — the secret value never enters the audit record.** Set/rotate/clear emit an audit entry with an **empty params dict** (`{}`), carrying only the action name (e.g. `slack.secret.set` / `.clear`) and the token name as the resource ref — exactly as the MCP secret endpoints do (`_audit(conn, user_id, "mcp_source.secret.set", ref, {})`). Do **not** put the value in `params` and rely on masking: `app/api/admin.py`'s `_SECRET_KEY_PATTERNS` / `_mask` are private to that module and fire only on the YAML-overlay diff path — they are not a cross-cutting interceptor and are not reachable from a new router without an ill-advised private import. The request body key `"value"` is also **not** in `admin.py`'s `_SECRET_FIELDS` allow-list, so a naive `params={"value": body.value}` would persist the plaintext token. The correct, leak-proof pattern is the MCP one: empty params, value goes only to `system_secrets_repo().upsert(name, value)`.
 
 **UI** — a "Slack" subsection on the existing `/admin/server-config` page (`app/web/templates/admin_server_config.html`), co-located with the transport selector (`chat.slack.transport`) that already lives there. Per token: a status badge (`env` / `vault` / `unset`) and a write-only set / rotate / clear control (input cleared after submit; 409 shown inline). When `source == "env"`, the control is shown read-only with an explanation that the value is pinned via the environment and cannot be overridden from the UI.
 
@@ -110,24 +122,27 @@ All gated by `require_admin`. Set/rotate/clear are audit-logged with the value m
 
 - **Contract:** `tests/db_pg/test_system_secrets_contract.py` — both backends, full CRUD + junk-decrypt → None.
 - **Resolver:** env-set → env wins (no DB read); env-unset + vault → vault value; neither → None; non-allow-listed name → never reaches the vault (assertion / rejection).
-- **API:** set/rotate/clear/status happy paths; 409 on missing vault key; 400 on non-allow-listed name; `require_admin` gate; value never returned by any endpoint; audit entry masked.
+- **API:** set/rotate/clear/status happy paths; 409 on missing vault key; 400 on non-allow-listed name; `require_admin` gate (including `SessionPrincipal` hard-deny); value never returned by any endpoint; audit entry carries empty params (assert the plaintext value is absent from the persisted audit row).
 - **Regression:** existing Slack tests that monkeypatch `os.environ["SLACK_…"]` must still pass unchanged — the accessor checks env first, so env-based tests are unaffected.
-- **Schema:** `tests/test_db_schema_version.py` confirms DuckDB v72 and Alembic 0019 reach the same schema.
+- **Schema:** `tests/test_db_schema_version.py` confirms DuckDB v72 and Alembic 0019 reach the same schema; `tests/db_pg/test_schema_parity.py` (#546) confirms the new `SystemSecrets` model materialises at Alembic head; `tests/db_pg/test_data_migration.py` confirms the `name` PK is registered for the DuckDB→PG migrator.
 
 ## Release
 
-- New admin UI surface + new endpoints = **minor** version bump (precedent: #530 = 0.64.0). Single CHANGELOG `Added` bullet under `[Unreleased]`, plus the release-cut (version bump + CHANGELOG rename + new empty `[Unreleased]`) as the last commit on the PR.
+- New admin UI surface + new endpoints = **minor** version bump. Current version is `0.65.18`, so the target is **`0.66.0`** (precedent: #530 was a comparable minor at 0.64.0). Single CHANGELOG `Added` bullet under `[Unreleased]`, plus the release-cut (version bump + CHANGELOG rename + new empty `[Unreleased]`) as the last commit on the PR.
 - Docs to update: `docs/slack-manifest-http.md` and `docs/slack-manifest-socket.md` (note that tokens may be set via the admin UI/vault, not only env), the config-layering notes, and `config/.env.template` (env still wins; vault is the UI-managed fallback).
 
 ## Affected files (anticipated)
 
 - `src/db.py` — `_v71_to_v72`, `SCHEMA_VERSION` 71→72.
-- `migrations/versions/0019_system_secrets_v72.py` — new.
+- `migrations/versions/0019_system_secrets_v72.py` — new Alembic migration.
+- `src/models/mcp.py` (or new `src/models/vault.py`) — `SystemSecrets` ORM model.
+- `src/models/__init__.py` — register the new model (so it lands in `Base.metadata`).
+- `scripts/migrate_duckdb_to_pg/__init__.py` — add `"system_secrets": ["name"]` to `_PK_COLUMNS`.
 - `app/secrets_vault.py` — `SystemSecretsRepository`.
 - `src/repositories/secrets_vault_pg.py` — `SystemSecretsPgRepository`.
-- `src/repositories/__init__.py` — `system_secrets_repo()`.
+- `src/repositories/__init__.py` — `system_secrets_repo()` factory.
 - `services/slack_bot/secrets.py` — `slack_secret()` accessor + allow-list (new).
-- Read-site swaps: `app/main.py`, `app/api/slack.py`, `services/slack_bot/sender.py`, `services/slack_bot/identity.py`, `services/slack_bot/socket_mode_client.py`.
-- `app/api/admin.py` (or a small new router) — `/api/admin/slack-secrets` endpoints.
+- Read-site swaps (12 reads): `app/main.py` (2), `app/api/slack.py` (3), `services/slack_bot/sender.py` (6), `services/slack_bot/identity.py` (1). `socket_mode_client.py` unchanged (receives tokens via constructor).
+- `app/api/admin.py` (or a small new router) — `/api/admin/slack-secrets` endpoints, audit with empty params.
 - `app/web/templates/admin_server_config.html` — Slack subsection.
-- Tests: `tests/db_pg/test_system_secrets_contract.py`, resolver + API tests, CHANGELOG, docs.
+- Tests: `tests/db_pg/test_system_secrets_contract.py` (mandatory — not covered by the auto method-parity sweep), resolver + API tests, CHANGELOG, docs.

--- a/docs/superpowers/specs/2026-06-04-slack-bot-tokens-vault-design.md
+++ b/docs/superpowers/specs/2026-06-04-slack-bot-tokens-vault-design.md
@@ -20,6 +20,12 @@ Resolve each Slack bot secret as **`env > vault > none`**:
 2. **vault** — otherwise, read the value from a new `system_secrets` vault scope, settable from the admin UI.
 3. **none** — if neither is present, behaviour is exactly as today: the feature stays disabled, fail-closed (Socket Mode logs the reason and does not start; signature verification rejects).
 
+## Alternative considered — `.env_overlay` (rejected)
+
+Agnes already has a UI-managed-secret mechanism: `app/secrets.py::persist_overlay_token()` writes a key to `${STATE_DIR}/.env_overlay` (chmod 0600) and sets `os.environ` live; startup loads the overlay via `os.environ.setdefault(...)` so real env (Terraform) wins. `ANTHROPIC_API_KEY`, `E2B_API_KEY`, the marketplace PAT, and the initial-workspace PAT all use it (e.g. `app/api/admin_chat.py::set_chat_secrets`). Routing the Slack tokens through it would need **zero** read-site changes and no DB work at all.
+
+It was rejected here in favour of the vault because the vault gives **encryption at rest** (Fernet) and **live rotation without restart** (the `.env_overlay` Socket Mode token would need a restart, and values sit in plaintext on disk). The trade-off is a larger change surface; that cost is accepted deliberately. This is a conscious divergence from how the comparably-sensitive `ANTHROPIC_API_KEY` is handled today.
+
 ## Non-goals (YAGNI)
 
 - **Not** a generic "manage any system secret from the UI" feature. The `system_secrets` table is generic, but the resolver and UI are hard-limited to the three known Slack token names via an allow-list. Extending to other secrets (SMTP password, OpenMetadata token, etc.) is a future, separate effort and needs no migration.

--- a/migrations/versions/0019_system_secrets_v72.py
+++ b/migrations/versions/0019_system_secrets_v72.py
@@ -1,0 +1,44 @@
+"""system_secrets table (DuckDB v72 parity).
+
+Server-wide vault for system-level secrets keyed by name (Slack bot tokens).
+Mirrors DuckDB ``_v71_to_v72``. Additive-only.
+
+Revision ID: 0019_system_secrets_v72
+Revises: 0018_slack_user_id_v71
+Create Date: 2026-06-04
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0019_system_secrets_v72"
+down_revision: Union[str, None] = "0018_slack_user_id_v71"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "system_secrets",
+        sa.Column("name", sa.String(), primary_key=True, nullable=False),
+        sa.Column("secret_value_enc", sa.LargeBinary(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("system_secrets")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.65.20"
+version = "0.66.0"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/scripts/migrate_duckdb_to_pg/__init__.py
+++ b/scripts/migrate_duckdb_to_pg/__init__.py
@@ -102,6 +102,7 @@ _PK_COLUMNS: Dict[str, List[str]] = {
     "tool_grants": ["tool_id", "group_id"],
     "mcp_secrets": ["source_id"],
     "mcp_user_secrets": ["source_id", "user_id"],
+    "system_secrets": ["name"],
     "data_package_tools": ["package_id", "tool_id"],
     # v68 cloud-chat tables (chat_sessions / chat_messages use id PK)
     "user_workdirs": ["user_email"],

--- a/services/slack_bot/identity.py
+++ b/services/slack_bot/identity.py
@@ -6,9 +6,10 @@ _strip_bot_mention can recognise (and ignore) the bot's own posts.
 from __future__ import annotations
 
 import logging
-import os
 
 import httpx
+
+from services.slack_bot.secrets import slack_secret
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +18,7 @@ async def resolve_bot_user_id() -> str | None:
     """Return the bot's Slack user id (``user_id`` from auth.test), or None
     if the token is missing or Slack returns ``ok=false``. Never raises —
     a failure just leaves loop-guard/strip in their None-safe fallback."""
-    token = os.environ.get("SLACK_BOT_TOKEN")
+    token = slack_secret("SLACK_BOT_TOKEN")
     if not token:
         logger.warning("SLACK_BOT_TOKEN missing — cannot resolve bot user id")
         return None

--- a/services/slack_bot/secrets.py
+++ b/services/slack_bot/secrets.py
@@ -1,0 +1,42 @@
+"""Resolve Slack bot secrets: env > vault > None.
+
+Environment variables are authoritative (Terraform / secret-manager
+deployments stay in control); the ``system_secrets`` vault is the
+UI-managed fallback. Only the three known Slack secret names are
+resolvable via the vault — the allow-list prevents using the vault
+namespace to read arbitrary environment variables.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+SLACK_SECRET_NAMES = (
+    "SLACK_BOT_TOKEN",
+    "SLACK_APP_TOKEN",
+    "SLACK_SIGNING_SECRET",
+)
+
+
+def slack_secret(name: str) -> Optional[str]:
+    """Return the value for ``name`` resolving env > vault > None.
+
+    Raises ``ValueError`` for any name outside the Slack allow-list. A vault
+    lookup failure (DB unavailable, etc.) is swallowed and treated as unset
+    so signature verification fails closed (401) rather than 500-ing.
+    """
+    if name not in SLACK_SECRET_NAMES:
+        raise ValueError(f"{name!r} is not a Slack secret name")
+    env = os.environ.get(name)
+    if env:
+        return env
+    try:
+        from src.repositories import system_secrets_repo
+
+        return system_secrets_repo().get(name)
+    except Exception:
+        logger.warning("vault lookup for %s failed; treating as unset", name)
+        return None

--- a/services/slack_bot/sender.py
+++ b/services/slack_bot/sender.py
@@ -2,10 +2,11 @@
 from __future__ import annotations
 
 import logging
-import os
 from typing import Optional
 
 import httpx
+
+from services.slack_bot.secrets import slack_secret
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +33,7 @@ async def open_im(slack_user_id: str) -> Optional[str]:
     not the DM channel — keying a SLACK_DM session on it would break
     dedup. Returns the IM channel id, or None on missing token / error.
     """
-    token = os.environ.get("SLACK_BOT_TOKEN")
+    token = slack_secret("SLACK_BOT_TOKEN")
     if not token:
         logger.error("SLACK_BOT_TOKEN missing — cannot open IM")
         return None
@@ -61,7 +62,7 @@ async def send_ephemeral_to_user(channel: str, slack_user_id: str, text: str) ->
     Distinct from the Phase-2 ``send_ephemeral(response_url, ...)`` helper —
     that one POSTs to a slash-command response_url, this one calls the Web API.
     """
-    token = os.environ.get("SLACK_BOT_TOKEN")
+    token = slack_secret("SLACK_BOT_TOKEN")
     if not token:
         logger.error("SLACK_BOT_TOKEN missing — cannot post ephemeral")
         return
@@ -79,7 +80,7 @@ async def post_thread_reply_with_blocks(
     """Post a threaded reply with Block Kit blocks; return the message ts
     (so the caller can later chat.update it to strip the buttons), or None
     on failure."""
-    token = os.environ.get("SLACK_BOT_TOKEN")
+    token = slack_secret("SLACK_BOT_TOKEN")
     if not token:
         logger.error("SLACK_BOT_TOKEN missing — cannot reply")
         return None
@@ -98,7 +99,7 @@ async def post_thread_reply_with_blocks(
 
 async def update_message(channel: str, ts: str, text: str, blocks: list[dict]) -> None:
     """Edit an existing message (used to strip the Stop button at turn end)."""
-    token = os.environ.get("SLACK_BOT_TOKEN")
+    token = slack_secret("SLACK_BOT_TOKEN")
     if not token:
         logger.error("SLACK_BOT_TOKEN missing — cannot update")
         return
@@ -115,7 +116,7 @@ async def update_message(channel: str, ts: str, text: str, blocks: list[dict]) -
 
 async def post_channel_message(channel: str, text: str) -> None:
     """Public, non-threaded channel post (Share-to-channel promotion)."""
-    token = os.environ.get("SLACK_BOT_TOKEN")
+    token = slack_secret("SLACK_BOT_TOKEN")
     if not token:
         logger.error("SLACK_BOT_TOKEN missing — cannot post")
         return
@@ -135,7 +136,7 @@ async def respond_via_response_url(response_url: str, body: dict) -> None:
 
 
 async def send_thread_reply(channel: str, thread_ts: str, text: str) -> None:
-    token = os.environ.get("SLACK_BOT_TOKEN")
+    token = slack_secret("SLACK_BOT_TOKEN")
     if not token:
         logger.error("SLACK_BOT_TOKEN missing — cannot reply")
         return

--- a/services/slack_bot/socket_mode_client.py
+++ b/services/slack_bot/socket_mode_client.py
@@ -101,8 +101,9 @@ class SocketModeDispatcher:
         self._client = SocketModeClient(
             app_token=self._app_token,
             # web_client=None → slack_sdk builds an UNAUTHENTICATED AsyncWebClient.
-            # Fine for Phase 0: inbound event receipt only; outbound replies use
-            # SLACK_BOT_TOKEN from env (sender.py). self._bot_token is collected now
+            # Fine for Phase 0: inbound event receipt only; outbound replies
+            # resolve SLACK_BOT_TOKEN via slack_secret (env > vault) in sender.py.
+            # self._bot_token is collected now
             # and gets wired here (AsyncWebClient(token=self._bot_token)) when Web API
             # calls are needed in a later phase.
             web_client=None,

--- a/src/db.py
+++ b/src/db.py
@@ -47,7 +47,7 @@ from src.duckdb_conn import _open_duckdb  # noqa: F401, E402  (re-export)
 
 _SAFE_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,63}$")
 
-SCHEMA_VERSION = 71
+SCHEMA_VERSION = 72
 
 _SYSTEM_SCHEMA = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -4902,6 +4902,28 @@ def _v70_to_v71(conn: duckdb.DuckDBPyConnection) -> None:
     conn.execute("UPDATE schema_version SET version = 71")
 
 
+def _v71_to_v72(conn: duckdb.DuckDBPyConnection) -> None:
+    """v72: ``system_secrets`` table — server-wide vault for system-level
+    secrets keyed by name (Slack bot tokens).
+
+    Distinct from ``mcp_secrets`` (keyed by ``source_id``, MCP data sources):
+    this scope holds server-wide secrets that are not tied to any MCP source,
+    starting with the three Slack bot tokens. Fernet-encrypted at rest, read
+    via ``env > vault`` by ``services/slack_bot/secrets.slack_secret``.
+
+    Idempotent CREATE TABLE IF NOT EXISTS — safe on fresh and upgrade paths.
+    """
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS system_secrets (
+            name             VARCHAR PRIMARY KEY,
+            secret_value_enc BLOB NOT NULL,
+            created_at       TIMESTAMP NOT NULL DEFAULT current_timestamp,
+            updated_at       TIMESTAMP NOT NULL DEFAULT current_timestamp
+        )
+    """)
+    conn.execute("UPDATE schema_version SET version = 72")
+
+
 def _v57_to_v58(conn: duckdb.DuckDBPyConnection) -> None:
     """v55: ``memory_domain_suggestions`` table — non-admin "Suggest a
     domain" affordance + admin moderation queue.
@@ -5225,6 +5247,8 @@ def _ensure_schema(conn: duckdb.DuckDBPyConnection) -> None:
             # v70→v71: formalize users.slack_user_id. _SYSTEM_SCHEMA already
             # creates it on fresh installs (no-op here).
             _v70_to_v71(conn)
+            # v71→v72: system_secrets — server-wide vault for Slack bot tokens.
+            _v71_to_v72(conn)
             # Fresh-install seed is handled by the unconditional
             # _seed_core_roles call at the bottom of _ensure_schema —
             # left as a no-op branch here so the migration ladder still
@@ -5420,6 +5444,8 @@ def _ensure_schema(conn: duckdb.DuckDBPyConnection) -> None:
                 _v69_to_v70(conn)
             if current < 71:
                 _v70_to_v71(conn)
+            if current < 72:
+                _v71_to_v72(conn)
             conn.execute(
                 "UPDATE schema_version SET version = ?, applied_at = current_timestamp",
                 [SCHEMA_VERSION],

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -70,6 +70,7 @@ from src.models.rbac import (
     UserGroup,
     UserGroupMember,
 )
+from src.models.vault import SystemSecret
 
 
 __all__ = [
@@ -108,6 +109,7 @@ __all__ = [
     "StoreSubmission",
     "SyncHistory",
     "SyncState",
+    "SystemSecret",
     "TableProfile",
     "TableRegistry",
     "TelegramLink",

--- a/src/models/vault.py
+++ b/src/models/vault.py
@@ -1,0 +1,35 @@
+"""SQLAlchemy model for the system-secrets vault.
+
+Mirrors:
+  - system_secrets (src/db.py v72)
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, LargeBinary, String, text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.db_pg import Base
+
+
+class SystemSecret(Base):
+    """Server-wide vault for system-level secrets keyed by name (v72).
+
+    Holds the Fernet ciphertext of server-wide secrets not tied to an MCP
+    source — currently the three Slack bot tokens.
+    """
+    __tablename__ = "system_secrets"
+
+    name: Mapped[str] = mapped_column(String, primary_key=True)
+    secret_value_enc: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=text("CURRENT_TIMESTAMP"),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=text("CURRENT_TIMESTAMP"),
+        nullable=False,
+    )

--- a/src/repositories/__init__.py
+++ b/src/repositories/__init__.py
@@ -107,6 +107,7 @@ __all__ = [
     "mcp_sources_repo",
     "per_user_secrets_repo",
     "shared_secrets_repo",
+    "system_secrets_repo",
     "tool_registry_repo",
     "setup_tokens_repo",
     # Cloud chat
@@ -346,6 +347,10 @@ _REGISTRY: dict[str, dict[str, tuple[str, str]]] = {
         DUCKDB: ("app.secrets_vault", "SharedSecretsRepository"),
         PG: ("src.repositories.secrets_vault_pg", "SharedSecretsPgRepository"),
     },
+    "system_secrets": {
+        DUCKDB: ("app.secrets_vault", "SystemSecretsRepository"),
+        PG: ("src.repositories.secrets_vault_pg", "SystemSecretsPgRepository"),
+    },
     "tool_registry": {
         DUCKDB: ("src.repositories.tool_registry", "ToolRegistryRepository"),
         PG: ("src.repositories.tool_registry_pg", "ToolRegistryPgRepository"),
@@ -449,6 +454,7 @@ def user_stack_subscriptions_repo() -> Any: return _build("user_stack_subscripti
 def mcp_sources_repo() -> Any: return _build("mcp_sources")
 def per_user_secrets_repo() -> Any: return _build("per_user_secrets")
 def shared_secrets_repo() -> Any: return _build("shared_secrets")
+def system_secrets_repo() -> Any: return _build("system_secrets")
 def tool_registry_repo() -> Any: return _build("tool_registry")
 def setup_tokens_repo() -> Any: return _build("setup_tokens")
 

--- a/src/repositories/secrets_vault_pg.py
+++ b/src/repositories/secrets_vault_pg.py
@@ -99,6 +99,69 @@ class SharedSecretsPgRepository:
         return row is not None
 
 
+class SystemSecretsPgRepository:
+    """Server-wide system secrets keyed by ``name`` (PG).
+
+    Signature-compatible with ``app.secrets_vault.SystemSecretsRepository``.
+    """
+
+    def __init__(self, engine: Engine):
+        self._engine = engine
+
+    def upsert(self, name: str, value: str) -> None:
+        token = encrypt_secret(value)
+        with self._engine.begin() as conn:
+            conn.execute(
+                sa.text(
+                    """INSERT INTO system_secrets
+                           (name, secret_value_enc, updated_at)
+                       VALUES (:name, :token, CURRENT_TIMESTAMP)
+                       ON CONFLICT (name) DO UPDATE SET
+                           secret_value_enc = EXCLUDED.secret_value_enc,
+                           updated_at       = EXCLUDED.updated_at"""
+                ),
+                {"name": name, "token": token},
+            )
+
+    def get(self, name: str) -> Optional[str]:
+        with self._engine.connect() as conn:
+            row = conn.execute(
+                sa.text(
+                    "SELECT secret_value_enc FROM system_secrets WHERE name = :name"
+                ),
+                {"name": name},
+            ).fetchone()
+        if row is None:
+            return None
+        token = row[0]
+        if not isinstance(token, (bytes, bytearray, memoryview)):
+            return None
+        try:
+            return decrypt_secret(bytes(token))
+        except (InvalidToken, RuntimeError):
+            logger.warning(
+                "system_secrets row for %s failed to decrypt — vault key "
+                "rotated or malformed? Treating as unset.",
+                name,
+            )
+            return None
+
+    def delete(self, name: str) -> None:
+        with self._engine.begin() as conn:
+            conn.execute(
+                sa.text("DELETE FROM system_secrets WHERE name = :name"),
+                {"name": name},
+            )
+
+    def has(self, name: str) -> bool:
+        with self._engine.connect() as conn:
+            row = conn.execute(
+                sa.text("SELECT 1 FROM system_secrets WHERE name = :name LIMIT 1"),
+                {"name": name},
+            ).fetchone()
+        return row is not None
+
+
 class PerUserSecretsPgRepository:
     """Per-user MCP source secrets (PG). One row per ``(source_id, user_id)``.
 

--- a/tests/db_pg/test_system_secrets_contract.py
+++ b/tests/db_pg/test_system_secrets_contract.py
@@ -1,0 +1,71 @@
+"""Cross-engine contract for the system_secrets vault (Slack bot tokens).
+
+This repo lives in app/secrets_vault.py (DuckDB) + src/repositories/
+secrets_vault_pg.py (PG), so the automatic method-parity sweep
+(tests/db_pg/test_repo_method_parity.py, which only scans
+src/repositories/*.py) does NOT cover it. This test is the sole mechanical
+guard against DuckDB/PG drift — keep it in lockstep with the repo methods.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _vault_key(monkeypatch):
+    from cryptography.fernet import Fernet
+
+    monkeypatch.setenv("AGNES_VAULT_KEY", Fernet.generate_key().decode("ascii"))
+
+
+@pytest.fixture
+def _env(state_backend, tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    for sub in ("extracts", "analytics", "state", "notifications"):
+        (tmp_path / sub).mkdir(exist_ok=True)
+    if state_backend == "duckdb":
+        from src.db import close_system_db, get_system_db
+
+        close_system_db()
+        get_system_db()
+    return state_backend
+
+
+def test_system_secret_round_trip_both_backends(_env):
+    from src.repositories import system_secrets_repo
+
+    repo = system_secrets_repo()
+    repo.upsert("SLACK_BOT_TOKEN", "xoxb-original")
+    assert repo.has("SLACK_BOT_TOKEN") is True
+    assert repo.get("SLACK_BOT_TOKEN") == "xoxb-original"
+
+    # rotate
+    repo.upsert("SLACK_BOT_TOKEN", "xoxb-rotated")
+    assert repo.get("SLACK_BOT_TOKEN") == "xoxb-rotated"
+
+    repo.delete("SLACK_BOT_TOKEN")
+    assert repo.has("SLACK_BOT_TOKEN") is False
+    assert repo.get("SLACK_BOT_TOKEN") is None
+
+
+def test_system_secret_absent_returns_none_both_backends(_env):
+    from src.repositories import system_secrets_repo
+
+    assert system_secrets_repo().get("SLACK_APP_TOKEN") is None
+    assert system_secrets_repo().has("SLACK_APP_TOKEN") is False
+
+
+def test_malformed_key_fails_closed_both_backends(_env, monkeypatch):
+    """A set-but-malformed AGNES_VAULT_KEY must make get() return None
+    (fail closed), not raise — the (InvalidToken, RuntimeError) catch.
+    has() still reports presence (it doesn't decrypt)."""
+    from src.repositories import system_secrets_repo
+
+    repo = system_secrets_repo()
+    repo.upsert("SLACK_SIGNING_SECRET", "shh-valid")
+    assert repo.get("SLACK_SIGNING_SECRET") == "shh-valid"
+
+    # Corrupt the vault key: _get_fernet() now raises RuntimeError.
+    monkeypatch.setenv("AGNES_VAULT_KEY", "not-a-valid-fernet-key")
+    assert repo.get("SLACK_SIGNING_SECRET") is None   # swallowed → fail closed
+    assert repo.has("SLACK_SIGNING_SECRET") is True   # presence unaffected

--- a/tests/test_admin_slack_secrets.py
+++ b/tests/test_admin_slack_secrets.py
@@ -1,0 +1,97 @@
+"""Tests for /api/admin/slack-secrets — admin-gated, write-only, vault-backed."""
+from __future__ import annotations
+
+import pytest
+from cryptography.fernet import Fernet
+
+from app.secrets_vault import _reset_ephemeral_key_for_tests
+
+
+@pytest.fixture(autouse=True)
+def _stable_vault_key(monkeypatch):
+    monkeypatch.setenv("AGNES_VAULT_KEY", Fernet.generate_key().decode())
+    _reset_ephemeral_key_for_tests()
+    yield
+    _reset_ephemeral_key_for_tests()
+
+
+def test_set_requires_admin(seeded_app):
+    client = seeded_app["client"]
+    r = client.put(
+        "/api/admin/slack-secrets/SLACK_BOT_TOKEN",
+        headers={"Authorization": f"Bearer {seeded_app['analyst_token']}"},
+        json={"value": "xoxb-x"},
+    )
+    assert r.status_code == 403
+
+
+def test_set_rejects_unknown_name(seeded_app):
+    client = seeded_app["client"]
+    r = client.put(
+        "/api/admin/slack-secrets/DATABASE_URL",
+        headers={"Authorization": f"Bearer {seeded_app['admin_token']}"},
+        json={"value": "x"},
+    )
+    assert r.status_code == 400
+
+
+def test_set_rejects_empty(seeded_app):
+    client = seeded_app["client"]
+    r = client.put(
+        "/api/admin/slack-secrets/SLACK_BOT_TOKEN",
+        headers={"Authorization": f"Bearer {seeded_app['admin_token']}"},
+        json={"value": ""},
+    )
+    assert r.status_code == 400
+
+
+def test_set_then_status_reports_vault(seeded_app, monkeypatch):
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+    client = seeded_app["client"]
+    admin = {"Authorization": f"Bearer {seeded_app['admin_token']}"}
+
+    r = client.put(
+        "/api/admin/slack-secrets/SLACK_BOT_TOKEN", headers=admin,
+        json={"value": "xoxb-secret"},
+    )
+    assert r.status_code == 204
+
+    r = client.get("/api/admin/slack-secrets", headers=admin)
+    assert r.status_code == 200
+    by_name = {s["name"]: s for s in r.json()["secrets"]}
+    assert by_name["SLACK_BOT_TOKEN"]["source"] == "vault"
+    assert by_name["SLACK_BOT_TOKEN"]["has_value"] is True
+    assert "value" not in by_name["SLACK_BOT_TOKEN"]
+
+
+def test_env_shadows_vault_in_status(seeded_app, monkeypatch):
+    # Populate the vault first, THEN set env — proves env wins over a
+    # populated vault (the actual env > vault precedence), not just
+    # "env-set reports env".
+    monkeypatch.delenv("SLACK_APP_TOKEN", raising=False)
+    client = seeded_app["client"]
+    admin = {"Authorization": f"Bearer {seeded_app['admin_token']}"}
+    client.put(
+        "/api/admin/slack-secrets/SLACK_APP_TOKEN", headers=admin,
+        json={"value": "xapp-vault"},
+    )
+    monkeypatch.setenv("SLACK_APP_TOKEN", "xapp-env")
+    r = client.get("/api/admin/slack-secrets", headers=admin)
+    by_name = {s["name"]: s for s in r.json()["secrets"]}
+    assert by_name["SLACK_APP_TOKEN"]["source"] == "env"
+
+
+def test_delete_clears(seeded_app, monkeypatch):
+    monkeypatch.delenv("SLACK_SIGNING_SECRET", raising=False)
+    client = seeded_app["client"]
+    admin = {"Authorization": f"Bearer {seeded_app['admin_token']}"}
+    client.put(
+        "/api/admin/slack-secrets/SLACK_SIGNING_SECRET", headers=admin,
+        json={"value": "shh"},
+    )
+    r = client.delete("/api/admin/slack-secrets/SLACK_SIGNING_SECRET", headers=admin)
+    assert r.status_code == 204
+    r = client.get("/api/admin/slack-secrets", headers=admin)
+    by_name = {s["name"]: s for s in r.json()["secrets"]}
+    assert by_name["SLACK_SIGNING_SECRET"]["source"] == "unset"
+    assert by_name["SLACK_SIGNING_SECRET"]["has_value"] is False

--- a/tests/test_slack_secret_resolver.py
+++ b/tests/test_slack_secret_resolver.py
@@ -1,0 +1,64 @@
+"""Unit tests for the env > vault > none Slack secret resolver."""
+from __future__ import annotations
+
+import pytest
+
+from services.slack_bot.secrets import SLACK_SECRET_NAMES, slack_secret
+
+
+def test_env_wins_over_vault(monkeypatch):
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-from-env")
+    # Even if the vault would return something, env must win and the vault
+    # must not be consulted. Make the vault raise to prove it isn't called.
+    def _boom():
+        raise AssertionError("vault must not be consulted when env is set")
+
+    monkeypatch.setattr(
+        "src.repositories.system_secrets_repo", _boom, raising=False
+    )
+    assert slack_secret("SLACK_BOT_TOKEN") == "xoxb-from-env"
+
+
+def test_vault_used_when_env_unset(monkeypatch):
+    monkeypatch.delenv("SLACK_APP_TOKEN", raising=False)
+
+    class _Repo:
+        def get(self, name):
+            return "xapp-from-vault" if name == "SLACK_APP_TOKEN" else None
+
+    monkeypatch.setattr("src.repositories.system_secrets_repo", lambda: _Repo())
+    assert slack_secret("SLACK_APP_TOKEN") == "xapp-from-vault"
+
+
+def test_none_when_neither(monkeypatch):
+    monkeypatch.delenv("SLACK_SIGNING_SECRET", raising=False)
+
+    class _Repo:
+        def get(self, name):
+            return None
+
+    monkeypatch.setattr("src.repositories.system_secrets_repo", lambda: _Repo())
+    assert slack_secret("SLACK_SIGNING_SECRET") is None
+
+
+def test_non_allow_listed_name_raises(monkeypatch):
+    with pytest.raises(ValueError):
+        slack_secret("DATABASE_URL")
+
+
+def test_vault_failure_is_swallowed(monkeypatch):
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+
+    def _boom():
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr("src.repositories.system_secrets_repo", _boom)
+    assert slack_secret("SLACK_BOT_TOKEN") is None
+
+
+def test_allow_list_contents():
+    assert SLACK_SECRET_NAMES == (
+        "SLACK_BOT_TOKEN",
+        "SLACK_APP_TOKEN",
+        "SLACK_SIGNING_SECRET",
+    )


### PR DESCRIPTION
## Why

Slack bot tokens (`SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, `SLACK_SIGNING_SECRET`) were env-only: an operator had no way to set or rotate them without shell/Terraform access. This adds UI-managed storage via the existing encrypted vault, while keeping environment variables authoritative so infra-driven deployments are unaffected.

## What

Resolution is now **`env > vault > none`**:

1. **env** — if the variable is set, it wins (Terraform / secret-manager stays in control).
2. **vault** — otherwise read from a new `system_secrets` scope, settable from the admin UI.
3. **none** — neither present → unchanged fail-closed behavior (feature disabled; Socket Mode logs and stays off; signature verification rejects).

### Changes
- **Storage:** new `system_secrets` table (server-wide, keyed by name), dual-backend — DuckDB migration `_v71_to_v72` (`SCHEMA_VERSION` 72) + Alembic `0019` + `SystemSecret` ORM model + DuckDB→PG migrator PK entry.
- **Repositories:** `SystemSecretsRepository` (DuckDB) + `SystemSecretsPgRepository` (PG), routed through a new `system_secrets_repo()` factory. `get()` fails closed on both `InvalidToken` (rotated key) and `RuntimeError` (malformed `AGNES_VAULT_KEY`).
- **Resolver:** `services/slack_bot/secrets.py::slack_secret()` with a three-name allow-list (no arbitrary-env reads via the vault namespace). Replaces the 12 direct `os.environ.get("SLACK_…")` reads.
- **Admin API:** `GET/PUT/DELETE /api/admin/slack-secrets[/{name}]` — presence-status, set/rotate, clear. `require_admin`-gated, write-only (values never returned), audit rows carry empty params (the value never enters the audit log). Writes go to the vault, never the `instance.yaml` overlay.
- **Admin UI:** a "Slack bot secrets" section on `/admin/server-config` (set/rotate/clear + per-token `env`/`vault`/`unset` status), mirroring the existing Cloud-chat secret control.

A simpler `.env_overlay` alternative (as used by `ANTHROPIC_API_KEY`) was considered and deliberately rejected in favor of encryption-at-rest + live rotation — see the design doc.

## Security

- Secret values are never returned by any endpoint and never logged.
- Environment precedence preserved (a `env`-pinned token cannot be overridden from the UI).
- Vault is encrypted at rest (Fernet, `AGNES_VAULT_KEY`); missing key → 409 on write, fail-closed on read.

## Testing

- Cross-engine contract test (DuckDB + Postgres), incl. malformed-key fail-closed.
- Resolver unit tests (env-wins, vault fallback, none, allow-list, swallowed vault failure).
- Admin API tests (admin gate, allow-list 400, 409, status, no-leak, env-shadows-populated-vault).
- Full suite green; backend-split guard, schema-version, and design-system contract gates pass.

## Docs

CHANGELOG (`### Added`), `config/.env.template`, and both `docs/slack-manifest-*.md` updated. Design + implementation plan under `docs/superpowers/`.

Release-cut to **0.66.0** (minor — additive admin surface) is the last commit.
