### PR TITLE
feat(cowork): bundle a skill-router agent into bundle.zip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ## [Unreleased]
 
+### Added
+- **Cowork bundle ships a `skill-router` agent.** Every generated
+  `bundle.zip` now includes `.claude/agents/skill-router.md` alongside the
+  curated skills — a lightweight subagent that inventories the workspace
+  skills, selects the ones that fit the user's task, and activates them via
+  the Skill tool. Bundled because Cowork's Customize → Skills panel does not
+  list workspace skills (a known Claude Code UI bug), so users otherwise
+  can't see what's available. The name is reserved (`_CURATED_AGENT_NAMES`)
+  so a marketplace plugin can't shadow it.
+
 ## [0.66.0] — 2026-06-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
   list workspace skills (a known Claude Code UI bug), so users otherwise
   can't see what's available. The name is reserved (`_CURATED_AGENT_NAMES`)
   so a marketplace plugin can't shadow it.
+
 ## [0.66.1] — 2026-06-05
 
 ### Internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
+### Internal
+
+## [0.67.0] — 2026-06-05
+
+### Added
 - **Cowork bundle ships a `skill-router` agent.** Every generated
   `bundle.zip` now includes `.claude/agents/skill-router.md` alongside the
   curated skills — a lightweight subagent that inventories the workspace

--- a/app/api/cowork_bundle.py
+++ b/app/api/cowork_bundle.py
@@ -120,6 +120,12 @@ _CURATED_SKILL_NAMES: frozenset[str] = frozenset({
     "setup-cowork", "explore-data", "query-data", "new-skill",
 })
 
+# Names reserved for Agnes curated agents — same protection as curated skills,
+# so a marketplace plugin can't shadow the bundled skill-router agent.
+_CURATED_AGENT_NAMES: frozenset[str] = frozenset({
+    "skill-router",
+})
+
 
 def _filter_skill_for_bundle(text: str, name: str) -> str:
     """Keep name/description/compatibility; drop Claude-Code-only keys.
@@ -167,7 +173,7 @@ def _collect_marketplace_content(
         return skills, agents
 
     seen_skill: set[str] = set(_CURATED_SKILL_NAMES)  # reserves curated names
-    seen_agent: set[str] = set()
+    seen_agent: set[str] = set(_CURATED_AGENT_NAMES)  # reserves curated agents
 
     for plugin in plugins:
         plugin_dir = plugin.get("plugin_dir")
@@ -1206,6 +1212,55 @@ def _skill_new_skill() -> str:
     """)
 
 
+def _bundle_agent_skill_router() -> str:
+    """Return .claude/agents/skill-router.md for the bundle.
+
+    A lightweight subagent that inventories the workspace skills, picks the
+    ones that fit the user's request, and activates them. Bundled because
+    Cowork's Customize panel does not list workspace skills (a known Claude
+    Code UI bug), so users often cannot see what is available to choose from.
+    """
+    return textwrap.dedent("""\
+        ---
+        name: skill-router
+        description: Selects and activates the Agnes Cowork skills relevant to the current task. Use at the start of a task when it is unclear which skill applies, or when the user asks which skill to use.
+        tools: Read, Glob, Bash, Skill
+        ---
+
+        You route a request to the right Agnes skill(s) and activate them. In
+        Cowork the Customize - Skills panel does not list workspace skills (a
+        known Claude Code UI bug), so users often cannot see what is available.
+        Discover the skills yourself, pick the ones that fit, and run them.
+
+        ## Steps
+
+        1. Enumerate available skills. They live in `.claude/skills/`:
+           - directory form: `.claude/skills/<name>/SKILL.md`
+           - flat form:      `.claude/skills/<name>.md`
+           Glob `.claude/skills/**/*.md`, then Read each file's frontmatter
+           `name` + `description`. Build a short inventory.
+
+        2. Match against the user's request. Compare the task to each skill's
+           `description` and choose the smallest set that covers it — usually one
+           skill, occasionally two complementary ones. The description must
+           actually fit the goal; do not match on a keyword alone.
+
+        3. Activate the chosen skill(s) with the Skill tool, in the order they
+           should run. Pass along any argument the user supplied (e.g. a table
+           name).
+
+        4. If nothing fits, say so plainly and list the available skills with
+           their one-line descriptions so the user can choose. Never invent a
+           skill that is not in the inventory.
+
+        ## Output
+
+        State which skills you activated and why (one line each), then hand back
+        so the activated skill's workflow can run. You are a router, not the
+        destination — keep it short.
+    """)
+
+
 def _build_bundle_zip(
     server_url: str,
     setup_token: str,
@@ -1240,6 +1295,7 @@ def _build_bundle_zip(
         │   │   ├── new-skill/SKILL.md     ← /new-skill — design + write a new skill
         │   │   └── <marketplace skill>/SKILL.md (+ supporting files), per RBAC grants
         │   └── agents/
+        │       ├── skill-router.md   ← selects + activates the right skill(s)
         │       └── <marketplace agents per user's RBAC grants>
         └── CLAUDE.md                 ← user + agent guidance (Bash-first)
 
@@ -1273,6 +1329,9 @@ def _build_bundle_zip(
         zf.writestr(f"{folder_name}/.claude/skills/explore-data/SKILL.md", _skill_explore_data())
         zf.writestr(f"{folder_name}/.claude/skills/query-data/SKILL.md", _skill_query_data())
         zf.writestr(f"{folder_name}/.claude/skills/new-skill/SKILL.md", _skill_new_skill())
+        # Agnes curated agents — the skill-router picks + activates the right
+        # skill(s) for a task (Cowork's Customize panel can't list them).
+        zf.writestr(f"{folder_name}/.claude/agents/skill-router.md", _bundle_agent_skill_router())
         # Marketplace skills + agents from the user's RBAC-granted plugins.
         for arcname, content in (marketplace_skills or []):
             zf.writestr(f"{folder_name}/{arcname}", content)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.66.0"
+version = "0.67.0"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/tests/test_cowork_bundle.py
+++ b/tests/test_cowork_bundle.py
@@ -102,6 +102,15 @@ class TestGenerateBundle:
         for path in curated:
             assert path in names, f"Curated skill missing from bundle: {path}"
 
+        # The skill-router agent must ship in every bundle, with frontmatter and
+        # the Skill tool so it can activate the skills it selects.
+        router = f"{folder}/.claude/agents/skill-router.md"
+        assert router in names, f"skill-router agent missing from bundle: {router}"
+        router_md = zf.read(router).decode()
+        assert router_md.startswith("---"), "skill-router must have YAML frontmatter"
+        assert "name: skill-router" in router_md
+        assert "Skill" in router_md, "skill-router must be allowed the Skill tool"
+
     def test_bundled_scripts_verify_tls_by_default(self, seeded_app):
         """mcp_server.py / agnes.py / setup.py must verify TLS against the
         bundled CA by default; CERT_NONE is only reachable via the explicit


### PR DESCRIPTION
## What

Ships a new curated agent `.claude/agents/skill-router.md` in every generated Cowork `bundle.zip`, alongside the curated skills.

The subagent:
1. inventories the workspace skills in `.claude/skills/` (handles both `<name>/SKILL.md` and flat `<name>.md`),
2. selects the smallest set that fits the user's task (matches on `description`, not keywords),
3. activates them via the Skill tool,
4. if nothing fits, lists what's available — never invents a skill.

## Why

In Cowork, workspace skills load at runtime but the Customize → Skills panel does not list them (a known Claude Code UI bug), so users often can't see what's available to pick. The router discovers and activates the right skill(s) for them.

## Changes

- `app/api/cowork_bundle.py` — `_bundle_agent_skill_router()`, `_CURATED_AGENT_NAMES` (reserves the name so a marketplace plugin can't shadow it), a `writestr` into the zip, docstring diagram update.
- `tests/test_cowork_bundle.py` — asserts the agent ships with frontmatter + the Skill tool.
- `CHANGELOG.md` — Added bullet under `[Unreleased]`.

## Scope notes

- Additive only — no endpoint, gate, or `ResourceType` change. RBAC filtering of marketplace content is untouched.
- Agents are flat `.claude/agents/<name>.md` (directory-format requirement is skills-only).
- Only affects newly generated bundles; the deployed server must run this build.

## Testing

- `tests/test_cowork_bundle.py` — 25 passed.
- Convention + RBAC reviewer agents: clean.
