### PR TITLE
feat(toolbar): add Postgres debug-toolbar panel + ship toolbar in the image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 
 ### Internal
 
+## [0.67.1] — 2026-06-05
+
+### Added
+- **Postgres debug-toolbar panel.** The FastAPI debug toolbar (mounted only when `DEBUG=1`) now has a Postgres panel alongside the DuckDB one — captures every state-layer SQL statement through SQLAlchemy `before/after_cursor_execute` + `handle_error` event listeners into a contextvar-scoped, request-scoped store, then renders timings/params/errors per request. Closes the toolbar gap that opened when app state moved from `system.duckdb` to Cloud SQL Postgres (state SQL was invisible; only analytics DuckDB queries showed). The toolbar background-poll fix-up also pins panel state to document navigations so background polls (e.g. usage telemetry) don't reset the query panel mid-request. (#553)
+
+### Internal
+- `fastapi-debug-toolbar` moves from the `[dev]` extra to the `[server]` extra so it ships inside the single production image (build-once / promote-the-same-artifact discipline — the image validated in dev is the exact one promoted to prod, differing only by the `DEBUG` env var). The toolbar middleware is mounted only when `DEBUG=1` in `app/main.py`, which prod never sets, so the dep is inert in prod. (#553)
+
 ## [0.67.0] — 2026-06-05
 
 ### Added

--- a/app/debug/postgres_panel.py
+++ b/app/debug/postgres_panel.py
@@ -1,0 +1,162 @@
+"""Per-request Postgres query capture for the dev debug toolbar.
+
+The Postgres equivalent of ``app/debug/duckdb_panel.py``. Where DuckDB is
+captured by wrapping the connection (``InstrumentedConnection``), Postgres goes
+through SQLAlchemy, so we hook the engine's ``before_cursor_execute`` /
+``after_cursor_execute`` / ``handle_error`` events and record each statement
+into a contextvar-scoped store. The toolbar's ``PostgresPanel`` reads that store
+at response time.
+
+When the contextvar is unset (outside a debug request, or in prod), recording
+is a no-op — the event listeners return immediately, so there is no measurable
+overhead on the normal request path. ``instrument_engine()`` is called once from
+``src/db_pg.py::get_engine()`` and is idempotent.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import time
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class Query:
+    db: str
+    sql: str
+    params: Any
+    ms: float
+    rows: int | None
+    error: str | None = None
+
+
+# Per-request query buffer. Mirrors duckdb_panel: request-scoped, unbounded
+# (dev-only), garbage-collected with the asyncio Task that owns the contextvar.
+_request_store: contextvars.ContextVar[list[Query] | None] = contextvars.ContextVar(
+    "postgres_panel_store", default=None
+)
+
+
+def get_request_store() -> list[Query] | None:
+    """Return the current request's query buffer, or None outside a debug request."""
+    return _request_store.get()
+
+
+def record_query(
+    db: str,
+    sql: str,
+    params: Any,
+    started: float,
+    rows: int | None,
+    error: str | None = None,
+) -> None:
+    store = _request_store.get()
+    if store is None:
+        return
+    store.append(
+        Query(
+            db=db,
+            sql=sql,
+            params=params,
+            ms=(time.perf_counter() - started) * 1000.0,
+            rows=rows,
+            error=error,
+        )
+    )
+
+
+def instrument_engine(engine: Any) -> None:
+    """Attach query-capture listeners to a SQLAlchemy engine (idempotent).
+
+    Listeners short-circuit when no request store is active, so this is safe to
+    call unconditionally — it is a no-op on every non-debug request and in prod.
+    """
+    if getattr(engine, "_agnes_pg_instrumented", False):
+        return
+    try:
+        from sqlalchemy import event
+    except Exception:
+        return
+
+    @event.listens_for(engine, "before_cursor_execute")
+    def _before(conn, cursor, statement, parameters, context, executemany):  # noqa: ANN001
+        if _request_store.get() is None:
+            return
+        context._agnes_pg_start = time.perf_counter()
+
+    @event.listens_for(engine, "after_cursor_execute")
+    def _after(conn, cursor, statement, parameters, context, executemany):  # noqa: ANN001
+        if _request_store.get() is None:
+            return
+        started = getattr(context, "_agnes_pg_start", None)
+        if started is None:
+            return
+        rows: int | None = None
+        try:
+            rows = cursor.rowcount
+        except Exception:
+            pass
+        record_query("postgres", statement, parameters, started, rows)
+
+    @event.listens_for(engine, "handle_error")
+    def _error(exc_ctx):  # noqa: ANN001
+        if _request_store.get() is None:
+            return
+        ec = exc_ctx.execution_context
+        started = getattr(ec, "_agnes_pg_start", None) if ec is not None else None
+        if started is None:
+            started = time.perf_counter()
+        record_query(
+            "postgres",
+            exc_ctx.statement or "",
+            exc_ctx.parameters,
+            started,
+            None,
+            repr(exc_ctx.original_exception),
+        )
+
+    engine._agnes_pg_instrumented = True
+
+
+# Toolbar Panel — only available when fastapi-debug-toolbar is installed.
+# The try/except keeps this module import-safe everywhere; the listeners above
+# do not depend on the toolbar.
+try:
+    from fastapi import Request, Response
+    from debug_toolbar.panels import Panel
+
+    class PostgresPanel(Panel):
+        """fastapi-debug-toolbar panel rendering captured Postgres queries."""
+
+        title = "Postgres"
+        template = "panels/postgres.html"
+
+        @property
+        def nav_subtitle(self) -> str:
+            stats = self.get_stats()
+            queries = stats.get("queries", []) if stats else []
+            total_ms = stats.get("total_ms", 0.0) if stats else 0.0
+            return f"{len(queries)} queries · {total_ms:.1f} ms"
+
+        async def process_request(self, request: Request) -> Response:
+            _request_store.set([])
+            return await super().process_request(request)
+
+        async def generate_stats(self, request: Request, response: Response) -> dict:
+            store = _request_store.get() or []
+            queries = [q.__dict__ for q in store]
+            total_ms = sum(q.ms for q in store)
+            return {
+                "queries": queries,
+                "total_ms": total_ms,
+            }
+
+        async def generate_server_timing(
+            self, request: Request, response: Response
+        ) -> list[tuple[str, str, float]]:
+            store = _request_store.get() or []
+            return [("Postgres", "Postgres queries", sum(q.ms for q in store))]
+
+except ImportError:
+    PostgresPanel = None  # type: ignore[assignment, misc]

--- a/app/debug/templates/panels/postgres.html
+++ b/app/debug/templates/panels/postgres.html
@@ -1,0 +1,20 @@
+<h4>Postgres queries — {{ queries|length }} ({{ "%.1f"|format(total_ms) }} ms total)</h4>
+<table class="djdt-table">
+  <thead>
+    <tr><th>#</th><th>ms</th><th>rows</th><th>SQL</th><th>params</th></tr>
+  </thead>
+  <tbody>
+  {% for q in queries %}
+    <tr class="{{ 'djdt-error' if q.error else '' }}">
+      <td>{{ loop.index }}</td>
+      <td>{{ "%.2f"|format(q.ms) }}</td>
+      <td>{{ q.rows if q.rows is not none else '—' }}</td>
+      <td>
+        <pre>{{ q.sql }}</pre>
+        {% if q.error %}<div class="djdt-error">{{ q.error }}</div>{% endif %}
+      </td>
+      <td><code>{{ q.params }}</code></td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>

--- a/app/main.py
+++ b/app/main.py
@@ -891,6 +891,7 @@ def create_app() -> FastAPI:
                     "debug_toolbar.panels.timer.TimerPanel",
                     "debug_toolbar.panels.logging.LoggingPanel",
                     "app.debug.duckdb_panel.DuckDBPanel",
+                    "app.debug.postgres_panel.PostgresPanel",
                 ],
                 jinja_loaders=[FileSystemLoader(str(_debug_templates_dir))],
                 show_toolbar_callback="app.main._toolbar_show_callback",

--- a/app/main.py
+++ b/app/main.py
@@ -809,8 +809,32 @@ def _toolbar_show_callback(request, settings) -> bool:
     Starlette's debug-only ServerErrorMiddleware, but we still want the
     toolbar mounted. Read DEBUG / LOCAL_DEV_MODE env directly so operators who
     flip the env at runtime (rare) see the change without re-import.
+
+    Only top-level document navigations (and the toolbar's own
+    ``/_debug_toolbar`` endpoints) are instrumented. Background ``fetch``/XHR —
+    notably the dashboard's ``/api/...`` polling — must NOT be instrumented:
+    each instrumented response rewrites the ``dtRefresh`` cookie, and the
+    toolbar's ``refresh.js`` then repoints to that request's store and wipes the
+    open panel's content (re-showing the loader). For request-scoped query
+    panels (DuckDB/Postgres) that meant the queries from the page you navigated
+    to flickered and reset to the latest poll's count. Gating on
+    ``Sec-Fetch-Dest`` keeps the toolbar pinned to the page under inspection.
     """
-    return _is_truthy_env("DEBUG") or _is_truthy_env("LOCAL_DEV_MODE")
+    if not (_is_truthy_env("DEBUG") or _is_truthy_env("LOCAL_DEV_MODE")):
+        return False
+    path = request.url.path
+    # The toolbar's own render_panel + static endpoints are XHR — always allow,
+    # or panels can never lazy-load their content.
+    if path.startswith("/_debug_toolbar"):
+        return True
+    # Background fetch/XHR (Sec-Fetch-Dest is "empty"/"cors"/... not "document")
+    # and API polls do not own the toolbar — skip so they don't reset it.
+    dest = request.headers.get("sec-fetch-dest")
+    if dest and dest != "document":
+        return False
+    if path.startswith("/api/"):
+        return False
+    return True
 
 
 def create_app() -> FastAPI:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.67.0"
+version = "0.67.1"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,13 @@ dependencies = [
 # `uv pip install --system --no-cache .[server]`.
 server = [
     "kbcstorage>=0.9.0",
+    # FastAPI debug toolbar. Shipped in the single production image
+    # (build-once / promote-the-same-artifact): the image validated in dev is
+    # the exact one promoted to prod, differing only by the DEBUG env var.
+    # INERT in prod — the toolbar middleware is only mounted when DEBUG=1
+    # (app/main.py), which prod never sets; dev/staging do. Moved here from the
+    # `dev` extra so it lands in the Dockerfile's `.[server]` install.
+    "fastapi-debug-toolbar>=0.6.3",
 ]
 observability = [
     # Already in base dependencies — listed here so operators who want to
@@ -180,10 +187,8 @@ dev = [
     # under tests/test_corporate_memory_v1.py (extraction.json, correction.json,
     # confidence_calibration.json). Production code does not depend on it.
     "jsonschema>=4.0.0",
-    # FastAPI debug toolbar — gated behind DEBUG=1 env var in app/main.py.
-    # Provides per-request panels (headers, routes, timer, profiling, etc.)
-    # for local development. Never loaded in production (no DEBUG=1 there).
-    "fastapi-debug-toolbar>=0.6.3",
+    # NOTE: fastapi-debug-toolbar moved to the `server` extra (build-once —
+    # ships in the production image, inert unless DEBUG=1). See `server` above.
     # Browser automation for the cloud-chat E2E suite (tests/e2e/test_chat_web.py).
     # Pure-Python wheel; the Chromium binary is downloaded separately via
     # `playwright install chromium --with-deps`. Imports are wrapped behind a

--- a/src/db_pg.py
+++ b/src/db_pg.py
@@ -103,6 +103,14 @@ def get_engine() -> sa.Engine:
                 pool_pre_ping=True,
             )
             _session_factory = sessionmaker(bind=_engine, future=True, expire_on_commit=False)
+            # Attach the dev debug-toolbar query capture (idempotent; a no-op on
+            # every non-debug request and in prod — see app/debug/postgres_panel.py).
+            try:
+                from app.debug.postgres_panel import instrument_engine
+
+                instrument_engine(_engine)
+            except Exception:
+                pass
         return _engine
 
 

--- a/tests/test_postgres_panel.py
+++ b/tests/test_postgres_panel.py
@@ -1,0 +1,84 @@
+import sqlalchemy as sa
+import pytest
+
+from app.debug.postgres_panel import (
+    _request_store,
+    get_request_store,
+    instrument_engine,
+    record_query,
+)
+
+
+@pytest.fixture
+def store_token():
+    """Provide a fresh request-scoped store."""
+    token = _request_store.set([])
+    yield
+    _request_store.reset(token)
+
+
+@pytest.fixture
+def engine():
+    """In-memory SQLite engine, instrumented like the real PG engine.
+
+    The capture is driven by SQLAlchemy ``before/after_cursor_execute`` +
+    ``handle_error`` events, which are engine-agnostic — SQLite exercises the
+    exact code path used against Cloud SQL Postgres without a live PG.
+    """
+    eng = sa.create_engine("sqlite://")
+    instrument_engine(eng)
+    return eng
+
+
+def test_records_query(store_token, engine):
+    with engine.connect() as conn:
+        conn.execute(sa.text("SELECT 1"))
+    store = get_request_store()
+    assert len(store) == 1
+    q = store[0]
+    assert q.db == "postgres"
+    assert "SELECT 1" in q.sql
+    assert q.error is None
+    assert q.ms >= 0
+
+
+def test_records_query_with_params(store_token, engine):
+    with engine.connect() as conn:
+        conn.execute(sa.text("SELECT :x"), {"x": 42})
+    store = get_request_store()
+    assert len(store) == 1
+    assert "42" in str(store[0].params)
+
+
+def test_records_error(store_token, engine):
+    with pytest.raises(sa.exc.SQLAlchemyError):
+        with engine.connect() as conn:
+            conn.execute(sa.text("SELECT * FROM bogus_table_xyz"))
+    store = get_request_store()
+    assert len(store) >= 1
+    errored = [q for q in store if q.error is not None]
+    assert errored, "expected the failed query to be recorded with an error"
+    assert "bogus_table_xyz" in errored[-1].error or "no such table" in errored[-1].error.lower()
+
+
+def test_no_op_outside_request(engine):
+    """When _request_store is None (outside a debug request), do not record or raise."""
+    assert get_request_store() is None
+    with engine.connect() as conn:
+        conn.execute(sa.text("SELECT 1"))  # must not raise
+    assert get_request_store() is None
+
+
+def test_instrument_engine_idempotent(store_token):
+    """Re-instrumenting must not double-register listeners (no duplicate rows)."""
+    eng = sa.create_engine("sqlite://")
+    instrument_engine(eng)
+    instrument_engine(eng)
+    with eng.connect() as conn:
+        conn.execute(sa.text("SELECT 1"))
+    assert len(get_request_store()) == 1
+
+
+def test_record_query_no_op_when_store_none():
+    """record_query is safe to call when no store is set."""
+    record_query("postgres", "SELECT 1", None, 0.0, None)  # must not raise

--- a/tests/test_toolbar_show_callback.py
+++ b/tests/test_toolbar_show_callback.py
@@ -1,0 +1,50 @@
+"""_toolbar_show_callback gates which requests own the debug toolbar.
+
+Background fetch/XHR (incl. the dashboard's /api polling) must NOT be
+instrumented, or each one rewrites the dtRefresh cookie and refresh.js wipes the
+request-scoped query panels (DuckDB/Postgres) the developer is viewing. Only
+document navigations and the toolbar's own /_debug_toolbar endpoints qualify.
+"""
+import pytest
+
+from app.main import _toolbar_show_callback
+
+
+class _Req:
+    def __init__(self, path, dest=None):
+        self.url = type("U", (), {"path": path})()
+        self.headers = {"sec-fetch-dest": dest} if dest else {}
+
+
+@pytest.fixture(autouse=True)
+def _debug_on(monkeypatch):
+    monkeypatch.setenv("DEBUG", "1")
+
+
+def test_document_navigation_instrumented():
+    assert _toolbar_show_callback(_Req("/dashboard", "document"), None) is True
+
+
+def test_non_browser_request_instrumented():
+    # curl / tests send no Sec-Fetch-Dest — keep the toolbar working there.
+    assert _toolbar_show_callback(_Req("/dashboard", None), None) is True
+
+
+def test_toolbar_own_endpoints_always_allowed():
+    # render_panel + static are XHR; must stay allowed or panels never load.
+    assert _toolbar_show_callback(_Req("/_debug_toolbar", "empty"), None) is True
+
+
+def test_background_xhr_skipped():
+    assert _toolbar_show_callback(_Req("/dashboard", "empty"), None) is False
+
+
+def test_api_poll_skipped():
+    assert _toolbar_show_callback(_Req("/api/memory/stats", "empty"), None) is False
+    assert _toolbar_show_callback(_Req("/api/anything", "document"), None) is False
+
+
+def test_disabled_when_debug_off(monkeypatch):
+    monkeypatch.delenv("DEBUG", raising=False)
+    monkeypatch.delenv("LOCAL_DEV_MODE", raising=False)
+    assert _toolbar_show_callback(_Req("/dashboard", "document"), None) is False


### PR DESCRIPTION
## Problem
The dev debug toolbar has a **DuckDB** panel but no **Postgres** panel. Once app state moved to Cloud SQL Postgres, the state-layer SQL became invisible in the toolbar (only the analytics DuckDB queries show).

## Change
Adds a parallel **`PostgresPanel`**, mirroring `app/debug/duckdb_panel.py`:
- `app/debug/postgres_panel.py` — captures queries via SQLAlchemy `before/after_cursor_execute` + `handle_error` event listeners into a contextvar-scoped, request-scoped store. `instrument_engine()` is idempotent and **short-circuits when no request store is active** → zero overhead off the debug path and in prod.
- `src/db_pg.py::get_engine()` — instruments the singleton engine (import-safe).
- `app/main.py` — registers `PostgresPanel` next to `DuckDBPanel`.
- `app/debug/templates/panels/postgres.html` — renders captured queries.
- `tests/test_postgres_panel.py` — capture / params / error / no-op-outside-request / idempotent (SQLite exercises the engine-agnostic listener path; 6 tests pass).

## Build-once
Moves `fastapi-debug-toolbar` from the `[dev]` extra into **`[server]`** so the **single production image** carries it. It stays **inert in prod** — the toolbar middleware is only mounted `if DEBUG:` (`app/main.py`), and prod never sets `DEBUG=1`; dev/staging do. This honors *build-once / promote-the-same-artifact*: the image validated in dev is the exact one promoted to prod, differing only by the `DEBUG` env var — no separately-built prod image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/553" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->