### PR TITLE
fix(store): stuck-review reaper works on Postgres backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 ### Changed
 
 ### Fixed
+- The stuck-review reaper now works on Postgres-backed instances. It was DuckDB-only: `POST /api/admin/run-reap-stuck-reviews` injected a DuckDB connection and the reaper ran raw DuckDB SQL against it, so on a Postgres deployment it queried an empty local DuckDB, found nothing, and returned `200 reaped=0` every 15 minutes while real `pending_llm` submissions sat in Postgres forever. A flea-market submission whose LLM review never completed (e.g. the LLM provider key was unset when it was uploaded, so no review was scheduled) would then show "Under review" indefinitely instead of flipping to `review_error` with a Retry button. The flip SQL now lives on the repositories (`reap_stuck_pending_llm` on both the DuckDB and Postgres `store_submissions` repos) and the reaper resolves the repo from the factory, so it flips rows on whichever backend holds them. Covered by a cross-engine contract test.
 
 ### Removed
 

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -4661,7 +4661,6 @@ async def run_blocked_purge(
 @router.post("/run-reap-stuck-reviews")
 async def run_reap_stuck_reviews(
     user: dict = Depends(require_admin),
-    conn: duckdb.DuckDBPyConnection = Depends(_get_db),
 ):
     """Trigger the stuck-review reaper.
 
@@ -4670,12 +4669,18 @@ async def run_reap_stuck_reviews(
     demand if a worker crash is suspected. Flips any
     ``status='pending_llm'`` row older than the configured grace to
     ``review_error`` so the queue stops growing indefinitely.
+
+    No DuckDB ``conn`` dependency: the reaper resolves the submissions
+    repo from the factory so it flips rows on whichever backend holds
+    them. Injecting a DuckDB ``conn`` here was the bug that made the
+    reaper a silent no-op on Postgres-backed instances — the rows live
+    in PG, the conn pointed at an empty local DuckDB.
     """
     from app.instance_config import get_guardrails_stuck_review_grace_seconds
     from src.store_guardrails.reaper import reap_stuck_llm_reviews
 
     grace = get_guardrails_stuck_review_grace_seconds()
-    result = reap_stuck_llm_reviews(conn, grace_seconds=grace)
+    result = reap_stuck_llm_reviews(grace_seconds=grace)
 
     audit_repo().log(
         user_id=user.get("id"),

--- a/src/repositories/store_submissions.py
+++ b/src/repositories/store_submissions.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import json
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 import duckdb
@@ -286,6 +286,61 @@ class StoreSubmissionsRepository:
                 WHERE id = ?""",
             [admin_user_id, reason, datetime.now(timezone.utc), id],
         )
+
+    def reap_stuck_pending_llm(
+        self,
+        *,
+        grace_seconds: int,
+        error_payload: Dict[str, Any],
+    ) -> List[Tuple[str, str]]:
+        """Flip every ``pending_llm`` row older than ``grace_seconds`` to
+        ``review_error``, stamping ``llm_findings`` with ``error_payload``.
+
+        Returns ``[(submission_id, submitter_id), …]`` for the rows that
+        were actually flipped so the caller can write one audit row each.
+        Scoped strictly to ``pending_llm`` — the per-row CAS in the WHERE
+        clause keeps it idempotent and never touches a row that another
+        worker resolved in between. Engine-specific SQL lives here (not in
+        the reaper) so the Postgres sibling can mirror it; see
+        ``store_submissions_pg.StoreSubmissionsPgRepository``.
+        """
+        cutoff = datetime.now(timezone.utc) - timedelta(seconds=grace_seconds)
+        rows = self.conn.execute(
+            """SELECT id, submitter_id
+                 FROM store_submissions
+                WHERE status = 'pending_llm'
+                  AND created_at < ?""",
+            [cutoff],
+        ).fetchall()
+        if not rows:
+            return []
+        now = datetime.now(timezone.utc)
+        payload = json.dumps(error_payload)
+        reaped: List[Tuple[str, str]] = []
+        for sub_id, submitter_id in rows:
+            result = self.conn.execute(
+                """UPDATE store_submissions
+                      SET status = 'review_error',
+                          llm_findings = ?,
+                          updated_at = ?
+                    WHERE id = ?
+                      AND status = 'pending_llm'""",
+                [payload, now, sub_id],
+            )
+            # Only report a row as reaped when the CAS actually flipped it.
+            # If a concurrent worker resolved the row between the SELECT
+            # above and this UPDATE, the row count is 0 — skip it so the
+            # caller doesn't write a phantom audit entry. Mirrors the PG
+            # sibling's atomic UPDATE … RETURNING semantics. DuckDB returns
+            # the affected-row count in row 0, col 0 of the UPDATE relation.
+            try:
+                row = result.fetchone()
+                flipped = int(row[0]) if row else 0
+            except Exception:
+                flipped = 0
+            if flipped:
+                reaped.append((sub_id, submitter_id))
+        return reaped
 
     def count_for_submitter(self, submitter_id: str, exclude_id: Optional[str] = None) -> int:
         """Number of submissions by a single user. Used by the detail page

--- a/src/repositories/store_submissions_pg.py
+++ b/src/repositories/store_submissions_pg.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import json
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 import sqlalchemy as sa
@@ -220,6 +220,39 @@ class StoreSubmissionsPgRepository:
                     "id": id,
                 },
             )
+
+    def reap_stuck_pending_llm(
+        self,
+        *,
+        grace_seconds: int,
+        error_payload: Dict[str, Any],
+    ) -> List[Tuple[str, str]]:
+        """Postgres mirror of
+        ``StoreSubmissionsRepository.reap_stuck_pending_llm``. One atomic
+        ``UPDATE … WHERE status='pending_llm' AND created_at < cutoff
+        RETURNING`` does the flip and reports the reaped rows so the
+        reaper writes audit entries without a second round-trip.
+        """
+        cutoff = datetime.now(timezone.utc) - timedelta(seconds=grace_seconds)
+        now = datetime.now(timezone.utc)
+        with self._engine.begin() as conn:
+            rows = conn.execute(
+                sa.text(
+                    """UPDATE store_submissions
+                          SET status = 'review_error',
+                              llm_findings = CAST(:lf AS JSONB),
+                              updated_at = :now
+                        WHERE status = 'pending_llm'
+                          AND created_at < :cutoff
+                    RETURNING id, submitter_id"""
+                ),
+                {
+                    "lf": json.dumps(error_payload),
+                    "now": now,
+                    "cutoff": cutoff,
+                },
+            ).all()
+        return [(r[0], r[1]) for r in rows]
 
     def count_for_submitter(self, submitter_id: str, exclude_id: Optional[str] = None) -> int:
         with self._engine.connect() as conn:

--- a/src/store_guardrails/reaper.py
+++ b/src/store_guardrails/reaper.py
@@ -14,29 +14,42 @@ sees the entry under the *Needs review* chip with a Retry button.
 Idempotent: runs at any cadence; only flips rows that have been pending
 longer than the grace. Safe to call directly outside the scheduler for
 on-demand cleanup.
+
+Backend-agnostic: the flip itself is an engine-specific UPDATE that lives
+on the repository (``StoreSubmissionsRepository.reap_stuck_pending_llm``
+for DuckDB, ``StoreSubmissionsPgRepository`` for Postgres). This module
+only orchestrates — it resolves the right repo + audit sink from the
+factory so it works on whichever backend the deployment runs. Passing a
+raw DuckDB ``conn`` (the pre-fix API) silently no-ops on Postgres-backed
+instances because the rows live in PG, not the local DuckDB; the factory
+path closes that gap.
 """
 
 from __future__ import annotations
 
-import json
 import logging
-from datetime import datetime, timedelta, timezone
 from typing import Any, Dict
-
-import duckdb
-
-from src.repositories.audit import AuditRepository
 
 logger = logging.getLogger(__name__)
 
 
 def reap_stuck_llm_reviews(
-    conn: duckdb.DuckDBPyConnection,
     *,
     grace_seconds: int = 1800,
+    subs_repo: Any = None,
+    audit: Any = None,
 ) -> Dict[str, Any]:
     """Flip every ``pending_llm`` submission older than ``grace_seconds``
     to ``review_error``. Returns a summary dict for telemetry.
+
+    Backend resolution: ``subs_repo`` / ``audit`` are resolved from the
+    repository factory (``store_submissions_repo()`` / ``audit_repo()``)
+    unless injected explicitly (tests). The factory picks DuckDB or
+    Postgres per ``use_pg()`` — the only resolution correct on PG
+    instances. The pre-fix API took a raw DuckDB ``conn`` and ran the
+    flip SQL against it directly, which silently no-op'd on
+    Postgres-backed deployments (rows live in PG, the conn pointed at an
+    empty local DuckDB); that path is gone.
 
     ``grace_seconds`` should comfortably exceed the p99 LLM-review wall
     time. Default 1800s (30 min) covers Sonnet/Opus reviews of large
@@ -45,19 +58,13 @@ def reap_stuck_llm_reviews(
     if grace_seconds <= 0:
         return {"skipped": True, "reaped": 0, "grace_seconds": grace_seconds}
 
-    cutoff = datetime.now(timezone.utc) - timedelta(seconds=grace_seconds)
-    rows = conn.execute(
-        """SELECT id, submitter_id, entity_id
-             FROM store_submissions
-            WHERE status = 'pending_llm'
-              AND created_at < ?""",
-        [cutoff],
-    ).fetchall()
+    if subs_repo is None:
+        from src.repositories import store_submissions_repo
+        subs_repo = store_submissions_repo()
+    if audit is None:
+        from src.repositories import audit_repo
+        audit = audit_repo()
 
-    if not rows:
-        return {"skipped": False, "reaped": 0, "grace_seconds": grace_seconds}
-
-    audit = AuditRepository(conn)
     error_payload = {
         "risk_level": None,
         "summary": None,
@@ -66,19 +73,13 @@ def reap_stuck_llm_reviews(
         "reviewed_by_model": None,
         "error": "timeout_or_crash",
     }
-    now = datetime.now(timezone.utc)
 
-    reaped = 0
-    for sub_id, submitter_id, _entity_id in rows:
-        conn.execute(
-            """UPDATE store_submissions
-                  SET status = 'review_error',
-                      llm_findings = ?,
-                      updated_at = ?
-                WHERE id = ?
-                  AND status = 'pending_llm'""",
-            [json.dumps(error_payload), now, sub_id],
-        )
+    reaped_rows = subs_repo.reap_stuck_pending_llm(
+        grace_seconds=grace_seconds,
+        error_payload=error_payload,
+    )
+
+    for sub_id, submitter_id in reaped_rows:
         audit.log(
             user_id=submitter_id,
             action="store.submission.review_error",
@@ -89,11 +90,12 @@ def reap_stuck_llm_reviews(
             },
             result="error",
         )
-        reaped += 1
 
-    logger.info(
-        "reaper: flipped %d pending_llm rows to review_error "
-        "(grace=%ds)",
-        reaped, grace_seconds,
-    )
+    reaped = len(reaped_rows)
+    if reaped:
+        logger.info(
+            "reaper: flipped %d pending_llm rows to review_error "
+            "(grace=%ds)",
+            reaped, grace_seconds,
+        )
     return {"skipped": False, "reaped": reaped, "grace_seconds": grace_seconds}

--- a/tests/db_pg/test_store_contract.py
+++ b/tests/db_pg/test_store_contract.py
@@ -9,8 +9,11 @@ Follows the pattern established in test_audit_contract.py.
 """
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
 import duckdb
 import pytest
+import sqlalchemy as sa
 
 
 # ---------------------------------------------------------------------------
@@ -269,3 +272,83 @@ def test_archived_entity_visible_with_list(store_repos):
     items_all, total_all = repos["entities"].list()
     ids_all = [i["id"] for i in items_all]
     assert "entity-1" in ids_all
+
+
+def _backdate_created_at(repos, conn, backend, sub_id, ts):
+    """Force a submission's created_at into the past on either backend —
+    repo.create() always stamps NOW()."""
+    if backend == "duckdb":
+        conn.execute(
+            "UPDATE store_submissions SET created_at = ? WHERE id = ?",
+            [ts, sub_id],
+        )
+    else:
+        with repos["submissions"]._engine.begin() as c:
+            c.execute(
+                sa.text(
+                    "UPDATE store_submissions SET created_at = :ts WHERE id = :id"
+                ),
+                {"ts": ts, "id": sub_id},
+            )
+
+
+def test_reap_stuck_pending_llm_contract(store_repos):
+    """reap_stuck_pending_llm must behave identically on both backends:
+    flip aged pending_llm → review_error, leave fresh rows + non-pending
+    rows alone, and be idempotent. This is the parity the DuckDB-only
+    reaper silently failed on Postgres-backed instances."""
+    repos, conn, backend = store_repos
+    subs = repos["submissions"]
+    repos["users"].create(id="user-1", email="alice@x.com", name="Alice")
+
+    # Aged pending_llm — should be reaped.
+    _make_entity(repos["entities"], id="entity-old", name="old-skill")
+    old_id = subs.create(
+        submitter_id="user-1", submitter_email="alice@x.com",
+        type="skill", name="old-skill", version="abc123",
+        status="pending_llm", entity_id="entity-old",
+    )
+    _backdate_created_at(
+        repos, conn, backend, old_id,
+        datetime.now(timezone.utc) - timedelta(hours=1),
+    )
+
+    # Fresh pending_llm — within grace, must survive.
+    _make_entity(repos["entities"], id="entity-fresh", name="fresh-skill")
+    fresh_id = subs.create(
+        submitter_id="user-1", submitter_email="alice@x.com",
+        type="skill", name="fresh-skill", version="abc123",
+        status="pending_llm", entity_id="entity-fresh",
+    )
+
+    err = {"error": "timeout_or_crash"}
+    reaped = subs.reap_stuck_pending_llm(grace_seconds=1800, error_payload=err)
+
+    assert [r[0] for r in reaped] == [old_id]
+    assert reaped[0][1] == "user-1"  # submitter_id surfaced for audit
+
+    old_row = subs.get(old_id)
+    assert old_row["status"] == "review_error"
+    assert (old_row["llm_findings"] or {}).get("error") == "timeout_or_crash"
+
+    assert subs.get(fresh_id)["status"] == "pending_llm"
+
+    # Idempotent — the now-review_error row is not pending_llm anymore.
+    reaped_again = subs.reap_stuck_pending_llm(grace_seconds=1800, error_payload=err)
+    assert reaped_again == []
+
+    # Scoped strictly to pending_llm: an aged row in any other status must
+    # survive, on both backends (parity with the DuckDB unit suite's
+    # test_does_not_flip_other_statuses).
+    _make_entity(repos["entities"], id="entity-appr", name="appr-skill")
+    appr_id = subs.create(
+        submitter_id="user-1", submitter_email="alice@x.com",
+        type="skill", name="appr-skill", version="abc123",
+        status="approved", entity_id="entity-appr",
+    )
+    _backdate_created_at(
+        repos, conn, backend, appr_id,
+        datetime.now(timezone.utc) - timedelta(hours=24),
+    )
+    assert subs.reap_stuck_pending_llm(grace_seconds=1800, error_payload=err) == []
+    assert subs.get(appr_id)["status"] == "approved"

--- a/tests/test_backend_split_guard.py
+++ b/tests/test_backend_split_guard.py
@@ -172,7 +172,9 @@ _GRANDFATHERED_DIRECT_INSTANTIATION: dict[str, set[str]] = {
     # factory; entry removed.
     # src/profiler.py — get_table_map migrated to metric_repo(); entry removed.
     "src/store_guardrails/purge.py": {"StoreEntitiesRepository", "StoreSubmissionsRepository"},
-    "src/store_guardrails/reaper.py": {"AuditRepository"},
+    # src/store_guardrails/reaper.py — flip SQL moved onto the repos and the
+    # reaper now resolves submissions_repo()/audit_repo() from the factory
+    # (the DuckDB-only direct instantiation was the Postgres no-op bug); entry removed.
     "src/store_guardrails/runner.py": {"AuditRepository", "StoreEntitiesRepository", "StoreSubmissionsRepository"},
     "src/welcome_template.py": {"WelcomeTemplateRepository"},
 }

--- a/tests/test_store_guardrails_reaper.py
+++ b/tests/test_store_guardrails_reaper.py
@@ -65,7 +65,7 @@ def _seed_pending(conn, name: str, age_seconds: int) -> str:
 class TestReaper:
     def test_reaps_old_pending_llm(self, conn):
         sub_id = _seed_pending(conn, "old-stuck", age_seconds=3600)
-        result = reap_stuck_llm_reviews(conn, grace_seconds=1800)
+        result = reap_stuck_llm_reviews(grace_seconds=1800)
         assert result["reaped"] == 1
 
         sub = StoreSubmissionsRepository(conn).get(sub_id)
@@ -81,7 +81,7 @@ class TestReaper:
 
     def test_skips_recent_pending_llm(self, conn):
         sub_id = _seed_pending(conn, "fresh", age_seconds=60)  # 1 min old
-        result = reap_stuck_llm_reviews(conn, grace_seconds=1800)
+        result = reap_stuck_llm_reviews(grace_seconds=1800)
         assert result["reaped"] == 0
 
         sub = StoreSubmissionsRepository(conn).get(sub_id)
@@ -89,7 +89,7 @@ class TestReaper:
 
     def test_grace_zero_short_circuits(self, conn):
         sub_id = _seed_pending(conn, "old-but-disabled", age_seconds=10000)
-        result = reap_stuck_llm_reviews(conn, grace_seconds=0)
+        result = reap_stuck_llm_reviews(grace_seconds=0)
         assert result["skipped"] is True
 
         sub = StoreSubmissionsRepository(conn).get(sub_id)
@@ -97,8 +97,8 @@ class TestReaper:
 
     def test_idempotent(self, conn):
         sub_id = _seed_pending(conn, "twice", age_seconds=3600)
-        first = reap_stuck_llm_reviews(conn, grace_seconds=1800)
-        second = reap_stuck_llm_reviews(conn, grace_seconds=1800)
+        first = reap_stuck_llm_reviews(grace_seconds=1800)
+        second = reap_stuck_llm_reviews(grace_seconds=1800)
         assert first["reaped"] == 1
         assert second["reaped"] == 0
 
@@ -106,7 +106,7 @@ class TestReaper:
         assert sub["status"] == "review_error"
 
     def test_no_pending_rows_is_noop(self, conn):
-        result = reap_stuck_llm_reviews(conn, grace_seconds=1800)
+        result = reap_stuck_llm_reviews(grace_seconds=1800)
         assert result["reaped"] == 0
         assert result["skipped"] is False
 
@@ -132,7 +132,7 @@ class TestReaper:
             [backdated, sub_id],
         )
 
-        result = reap_stuck_llm_reviews(conn, grace_seconds=1800)
+        result = reap_stuck_llm_reviews(grace_seconds=1800)
         assert result["reaped"] == 0
 
         sub = StoreSubmissionsRepository(conn).get(sub_id)


### PR DESCRIPTION
## Problem

A flea-market submission can sit at `pending_llm` ("Under review") forever on a Postgres-backed instance.

Two independent defects compound:

1. **Orphan at submit time.** When guardrails are enabled but the LLM provider key is unset (`provider_ready=False`), a submission is parked at `pending_llm` with **no** background review scheduled (`app/api/store.py`, fail-closed branch). It cannot self-resolve.
2. **The safety net is dead on Postgres.** The stuck-review reaper is supposed to flip orphaned `pending_llm` rows older than the grace (default 30 min) to `review_error` (→ "Needs review" + Retry). But it was **DuckDB-only**: `POST /api/admin/run-reap-stuck-reviews` injected a DuckDB connection (`_get_db` → `get_system_db()` always returns DuckDB) and `reap_stuck_llm_reviews` ran raw DuckDB SQL against it. On a Postgres-backed deployment the rows live in PG, so the reaper queried an empty local DuckDB, found nothing, and returned `200 reaped=0` every 15 minutes — observed live (scheduler healthy, reaps firing, row never flipped).

This PR fixes **#2** (the parity gap). #1 is mitigated as a side effect: with a working reaper, an orphaned submission now becomes `review_error` after the grace instead of "Under review" indefinitely.

## Fix

- Add `reap_stuck_pending_llm(grace_seconds, error_payload)` to **both** `store_submissions` repositories (DuckDB + Postgres). Engine-specific flip SQL lives on the repo; returns the reaped `(id, submitter_id)` rows so the reaper can audit each.
- `reap_stuck_llm_reviews` now resolves the submissions repo + audit sink from the **factory** (`store_submissions_repo()` / `audit_repo()`), so it flips rows on whichever backend `use_pg()` selects. Explicit `subs_repo` / `audit` injection retained for tests.
- Drop the DuckDB `conn` dependency from the endpoint.
- Cross-engine contract test (`tests/db_pg/test_store_contract.py`): aged `pending_llm` → `review_error`, fresh row survives, idempotent — asserted identically on DuckDB and Postgres.
- Remove the now-stale `reaper.py` `AuditRepository` entry from the backend-split allow-list.

## Testing

- `tests/test_store_guardrails_reaper.py` (6) — green (now exercises the factory path).
- `tests/db_pg/test_store_contract.py::test_reap_stuck_pending_llm_contract` — green on both backends.
- `tests/test_backend_split_guard.py`, `tests/test_openapi_snapshot.py` — green.
- Full suite run: the new/changed tests pass; remaining failures are unrelated (an env-local `da` binary on PATH; PG-testcontainer setup timeouts under `-n auto` that pass in isolation).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->