### PR TITLE
fix(ui): edit-group modal adopts canonical .modal-card (#497 §8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 ### Changed
 
 ### Fixed
+- **Edit-group modal now flips in dark mode.** `admin_group_detail`'s edit modal hardcoded a white card (`background: #fff`) with `#e5e7eb`-bordered inputs, so it stayed a white island in the dark theme. It now adopts the canonical global `.modal-card` — whose token-driven rules (`var(--surface)`/`var(--text-primary)`/`var(--border)`) style the card plus its labels and inputs — and the description field uses the `.form-textarea` canonical. Light mode is unchanged (`--ds-surface` resolves to `#ffffff`, the prior literal); dark mode flips the card, inputs, and labels together. Part of the #497 §8 form-input audit. (#497)
 
 ### Removed
 

--- a/app/web/templates/admin_group_detail.html
+++ b/app/web/templates/admin_group_detail.html
@@ -211,12 +211,12 @@
 
 <!-- Edit group modal -->
 <div class="modal-backdrop" id="edit-modal" role="dialog" aria-modal="true" style="position: fixed; inset: 0; background: rgba(15, 23, 42, 0.55); display: none; align-items: center; justify-content: center; z-index: 1000; padding: 16px;">
-  <div style="background: #fff; border-radius: 12px; padding: 24px; width: 100%; max-width: 480px; box-shadow: 0 20px 60px rgba(0, 0, 0, 0.25);">
+  <div class="modal-card" style="max-width: 480px;">
     <h3 style="margin:0 0 12px;">Edit group</h3>
-    <label style="display:block; font-size:12px; color:#6b7280; margin: 12px 0 6px;">Name</label>
-    <input id="edit-name" type="text" style="width:100%; padding:9px 12px; border:1px solid #e5e7eb; border-radius:8px; font-size:13px; box-sizing:border-box;">
-    <label style="display:block; font-size:12px; color:#6b7280; margin: 12px 0 6px;">Description</label>
-    <textarea id="edit-desc" style="width:100%; padding:9px 12px; border:1px solid #e5e7eb; border-radius:8px; font-size:13px; box-sizing:border-box; min-height:60px;"></textarea>
+    <label>Name</label>
+    <input id="edit-name" type="text">
+    <label>Description</label>
+    <textarea id="edit-desc" class="form-textarea"></textarea>
     <div style="display:flex; gap:8px; justify-content:flex-end; margin-top:18px;">
       {{ ds.button('Cancel', variant='secondary', id='edit-cancel-btn') }}
       {{ ds.button('Save', variant='primary', id='edit-save-btn') }}


### PR DESCRIPTION
## What
`admin_group_detail`'s **Edit group** modal hand-rolled a white card (`background: #fff`) with `#e5e7eb`-bordered inputs — a hardcoded white island that stayed white in the dark theme. It now adopts the canonical global **`.modal-card`** (whose token-driven rules style the card + its labels/inputs via `var(--surface)`/`var(--text-primary)`/`var(--border)`), and the description field uses the **`.form-textarea`** canonical.

## Why
Part of the #497 §8 *form inputs / selects* audit. This is the one clean, self-contained "white card with inputs" case — it now flips light↔dark like every other design-system modal.

## Diff — one template, 5 lines
- card `<div style="background:#fff;…">` → `<div class="modal-card" style="max-width:480px;">`
- the two `<label>`s + the name `<input>` drop their inline styles (the `.modal-card` descendant rules cover them, including the exact `12px 0 6px` label margin)
- description `<textarea>` → `class="form-textarea"`

## Verification — real browser, dev server, both themes
| | card bg | input bg | text |
|---|---|---|---|
| **Light** | `#ffffff` | `#ffffff` | `rgb(14,21,37)` dark |
| **Dark** | `rgb(20,26,48)` | `rgb(20,26,48)` | `rgb(243,246,255)` light |

Light mode is byte-for-byte unchanged (`--ds-surface` resolves to `#ffffff`, the prior literal). Dark flips the card, inputs, and labels together; the textarea renders in the sans-serif body font (`.form-textarea`), not the browser's monospace default.

## Scope note
§8's broader "systemic white inputs in dark" goal turned out to be ~95% already handled — most controls already carry CSS `var()` backgrounds and flip fine. The remaining gap (a global `color-scheme` + tokenizing a few hardcoded-white **panel** pages like `_profile_tokens`, `store_upload`, `news_editor`) is a larger dark-mode (§9) pass, deliberately deferred. This PR ships the one clean modal fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)