### PR TITLE
fix(ui): dark mode — form controls + surfaces stop rendering white (#497 §9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 ### Changed
 
 ### Fixed
+- **Dark mode: form controls and their surfaces no longer render white.** Two parts. (1) `color-scheme: light`/`dark` is now set on the theme roots (`design-tokens.css`) so browser-default inputs/selects/textareas + scrollbars adopt the dark UA palette instead of staying white. (2) The hardcoded-white form surfaces that `color-scheme` can't reach are tokenized to `var(--ds-surface)`/`var(--ds-border)`/`var(--ds-text-*)`: the search/filter inputs on `admin_sync`/`admin_groups`/`admin_mcp_sources`/`admin_access`, the `store_upload` fields + type-tiles + drop-zone, the `news_editor` panels/textareas/preview/labels (it was a fully hardcoded-light admin page), the `catalog` hero search-row, and the JS-built `chip-input` component (container + dropdown). The `marketplace` page was light-locked via a full light palette scoped to `.mp-page` (`--surface`/`--text-primary`/`--text-secondary`/`--border-light` pinned to fixed values) — those now flip to the design-system tokens, plus its hero search-row. Verified across ~28 routes with an in-browser crawler: every previously-white form surface now flips light↔dark, and light mode is unchanged. Complements the edit-group modal fix (#560). Part of #497 §8/§9. (#497)
 
 ### Removed
 

--- a/app/web/static/css/admin_access.css
+++ b/app/web/static/css/admin_access.css
@@ -202,7 +202,7 @@
   width: 100%; padding: 7px 10px 7px 30px;
   border: 1px solid var(--border, #e5e7eb); border-radius: 6px;
   font-size: 12px;
-  background: #fff url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2'><circle cx='11' cy='11' r='8'/><path d='m21 21-4.35-4.35'/></svg>") no-repeat 9px center;
+  background: var(--ds-surface) url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2'><circle cx='11' cy='11' r='8'/><path d='m21 21-4.35-4.35'/></svg>") no-repeat 9px center;
 }
 
 .ax-btn {

--- a/app/web/static/css/design-tokens.css
+++ b/app/web/static/css/design-tokens.css
@@ -18,6 +18,12 @@
  */
 
 :root {
+    /* Native form controls (inputs/selects/textareas) + scrollbars render in
+       the light UA palette; `[data-theme="dark"]` below flips this to `dark`
+       so a default-styled field with no explicit background doesn't stay
+       white on a dark surface. */
+    color-scheme: light;
+
     /* Brand surface — green/navy palette. Opted into via the
        `.home-mock` / `.advanced-mock` scopes. */
     --ds-primary: #2ea877;          /* brand-dark green */
@@ -211,6 +217,11 @@
    surfaces audited by the chat page are guaranteed AA-clean.
    Other pages may need touch-ups when their templates next change. */
 :root[data-theme="dark"] {
+    /* Flip native controls (inputs, selects, textareas, scrollbars) to the
+       dark UA palette so browser-default form fields aren't white-on-dark.
+       Higher specificity than `:root`; `auto` + OS-dark resolves here too. */
+    color-scheme: dark;
+
     /* Brand surface — same hue, lighter for AA contrast on dark fills */
     --ds-primary: #4ec096;
     --ds-primary-dark: #2ea877;

--- a/app/web/static/css/marketplace.css
+++ b/app/web/static/css/marketplace.css
@@ -7,11 +7,11 @@
  */
 
   .mp-page {
-    --surface: #ffffff;
+    --surface: var(--ds-surface);
     --primary-light: color-mix(in srgb, var(--ds-primary) 12%, transparent);
-    --border-light: #eceff1;
-    --text-primary: #202124;
-    --text-secondary: #5f6368;
+    --border-light: var(--ds-border);
+    --text-primary: var(--ds-text-primary);
+    --text-secondary: var(--ds-text-secondary);
     --success-color: #10b77f;
     --warn-color: #b45309;
     --font-medium: 500;
@@ -45,7 +45,7 @@
   .mp-hero .search-row {
     display: flex; align-items: stretch;
     margin-top: 18px;
-    background: #fff;
+    background: var(--ds-surface);
     border-radius: 10px;
     padding: 4px;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);

--- a/app/web/static/css/stack_card.css
+++ b/app/web/static/css/stack_card.css
@@ -55,7 +55,7 @@
   display: flex;
   align-items: stretch;
   margin-top: 18px;
-  background: #fff;
+  background: var(--ds-surface);
   border-radius: 10px;
   padding: 4px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);

--- a/app/web/static/js/components/chip-input.js
+++ b/app/web/static/js/components/chip-input.js
@@ -41,7 +41,7 @@
     host.innerHTML = '';
     host.style.cssText = host.style.cssText +
       ';display:flex;flex-wrap:wrap;gap:6px;align-items:center;' +
-      'border:1px solid #e5e7eb;border-radius:8px;padding:6px;position:relative;background:#fff;';
+      'border:1px solid var(--ds-border);border-radius:8px;padding:6px;position:relative;background:var(--ds-surface);';
 
     const chipsHost = document.createElement('div');
     chipsHost.style.cssText = 'display:flex;flex-wrap:wrap;gap:6px;align-items:center;flex:1;min-width:120px;';
@@ -64,8 +64,8 @@
 
     const dropdown = document.createElement('div');
     dropdown.setAttribute('role', 'listbox');
-    dropdown.style.cssText = 'position:absolute;left:0;right:0;top:100%;background:#fff;' +
-      'border:1px solid #e5e7eb;border-radius:8px;margin-top:4px;max-height:240px;' +
+    dropdown.style.cssText = 'position:absolute;left:0;right:0;top:100%;background:var(--ds-surface);' +
+      'border:1px solid var(--ds-border);border-radius:8px;margin-top:4px;max-height:240px;' +
       'overflow-y:auto;display:none;z-index:1000;box-shadow:0 4px 12px rgba(0,0,0,0.08);';
     host.appendChild(dropdown);
 
@@ -135,7 +135,7 @@
         const createRow = document.createElement('div');
         createRow.setAttribute('role', 'option');
         createRow.style.cssText = 'padding:6px 12px;cursor:pointer;font-size:13px;' +
-          'border-top:1px solid #e5e7eb;color:#0073D1;';
+          'border-top:1px solid var(--ds-border);color:#0073D1;';
         createRow.textContent = '+ Create new "' + filter + '"…';
         createRow.dataset.create = '1';
         createRow.dataset.name = filter;

--- a/app/web/templates/admin/news_editor.html
+++ b/app/web/templates/admin/news_editor.html
@@ -6,23 +6,23 @@
 <style>
 body.news-admin .container { max-width: 1280px; padding: 0 32px 48px; }
 body.news-admin h1 { font-size: 22px; margin: 24px 0 10px; }
-body.news-admin h2 { font-size: 16px; margin: 18px 0 8px; color: #374151; }
+body.news-admin h2 { font-size: 16px; margin: 18px 0 8px; color: var(--ds-text-primary); }
 
 body.news-admin .panel {
-    background: white;
-    border: 1px solid #E5E7EB;
+    background: var(--ds-surface);
+    border: 1px solid var(--ds-border);
     border-radius: 12px;
     padding: 22px 26px;
     margin-bottom: 18px;
 }
 body.news-admin .meta {
     font-size: 12px;
-    color: #6B7280;
+    color: var(--ds-text-secondary);
     margin-bottom: 10px;
     text-transform: uppercase;
     letter-spacing: 0.6px;
 }
-body.news-admin .empty { color: #6B7280; font-style: italic; }
+body.news-admin .empty { color: var(--ds-text-secondary); font-style: italic; }
 
 body.news-admin .editor-row {
     display: grid;
@@ -33,7 +33,7 @@ body.news-admin .editor-col label {
     display: block;
     font-size: 12px;
     font-weight: 600;
-    color: #374151;
+    color: var(--ds-text-primary);
     margin-bottom: 6px;
     text-transform: uppercase;
     letter-spacing: 0.4px;
@@ -44,7 +44,7 @@ body.news-admin textarea {
     font-family: ui-monospace, "SF Mono", Consolas, monospace;
     font-size: 13px;
     padding: 10px 12px;
-    border: 1px solid #D1D5DB;
+    border: 1px solid var(--ds-border);
     border-radius: 6px;
     resize: vertical;
     box-sizing: border-box;
@@ -53,9 +53,9 @@ body.news-admin textarea#content { min-height: 360px; }
 body.news-admin .preview-frame {
     width: 100%;
     min-height: 360px;
-    border: 1px solid #E5E7EB;
+    border: 1px solid var(--ds-border);
     border-radius: 6px;
-    background: white;
+    background: var(--ds-surface);
 }
 
 body.news-admin .row-actions {
@@ -77,16 +77,16 @@ body.news-admin button.primary {
 body.news-admin button.primary:hover { background: #0056A3; }
 body.news-admin button.primary:disabled { opacity: 0.5; cursor: not-allowed; }
 body.news-admin button.ghost {
-    background: white;
-    color: #374151;
-    border: 1px solid #D1D5DB;
+    background: var(--ds-surface);
+    color: var(--ds-text-primary);
+    border: 1px solid var(--ds-border);
     padding: 8px 14px;
     border-radius: 6px;
     font-size: 13px;
     cursor: pointer;
 }
 body.news-admin button.ghost:hover { border-color: var(--ds-primary); color: var(--ds-primary); }
-body.news-admin .status { font-size: 13px; color: #6B7280; margin-left: 6px; }
+body.news-admin .status { font-size: 13px; color: var(--ds-text-secondary); margin-left: 6px; }
 
 body.news-admin table.versions {
     width: 100%;
@@ -113,14 +113,14 @@ body.news-admin .badge-published { background: #D1FAE5; color: #047857; }
 body.news-admin details.format-help {
     margin-top: 14px;
     background: #F9FAFB;
-    border: 1px solid #E5E7EB;
+    border: 1px solid var(--ds-border);
     border-radius: 6px;
     padding: 10px 14px;
 }
 body.news-admin details.format-help summary {
     cursor: pointer;
     font-weight: 600;
-    color: #374151;
+    color: var(--ds-text-primary);
     font-size: 13px;
 }
 body.news-admin details.format-help pre {
@@ -156,7 +156,7 @@ document.addEventListener('DOMContentLoaded', function () {
             // through. Empty sandbox = strictest possible posture.
             var html = '<style>body{font-family:Inter,system-ui,sans-serif;font-size:14px;color:#111827;margin:0;padding:18px;}</style>'
                 + '<div>' + (data.intro || '') + '</div>'
-                + '<hr style="border:0;border-top:1px solid #E5E7EB;margin:14px 0">'
+                + '<hr style="border:0;border-top:1px solid var(--ds-border);margin:14px 0">'
                 + '<div>' + (data.content || '') + '</div>';
             previewFrame.setAttribute('srcdoc', html);
         }).catch(function () { /* ignore preview failures silently */ });

--- a/app/web/templates/admin_groups.html
+++ b/app/web/templates/admin_groups.html
@@ -15,7 +15,7 @@
     padding: 8px 12px 8px 32px; min-width: 280px;
     border: 1px solid var(--border, #e5e7eb); border-radius: 8px;
     font-size: 13px;
-    background: #fff url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2'><circle cx='11' cy='11' r='8'/><path d='m21 21-4.35-4.35'/></svg>") no-repeat 10px center;
+    background: var(--ds-surface) url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2'><circle cx='11' cy='11' r='8'/><path d='m21 21-4.35-4.35'/></svg>") no-repeat 10px center;
   }
 
 

--- a/app/web/templates/admin_mcp_sources.html
+++ b/app/web/templates/admin_mcp_sources.html
@@ -14,7 +14,7 @@
     padding: 8px 12px 8px 32px; min-width: 280px;
     border: 1px solid var(--border, #e5e7eb); border-radius: 8px;
     font-size: 13px;
-    background: #fff url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2'><circle cx='11' cy='11' r='8'/><path d='m21 21-4.35-4.35'/></svg>") no-repeat 10px center;
+    background: var(--ds-surface) url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2'><circle cx='11' cy='11' r='8'/><path d='m21 21-4.35-4.35'/></svg>") no-repeat 10px center;
   }
 
   .mcp-name {

--- a/app/web/templates/admin_sync.html
+++ b/app/web/templates/admin_sync.html
@@ -49,7 +49,7 @@
   .search-input {
     padding: 8px 12px 8px 32px; min-width: 260px;
     border: 1px solid var(--border, #e5e7eb); border-radius: 8px; font-size: 13px;
-    background: #fff url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2'><circle cx='11' cy='11' r='8'/><path d='m21 21-4.35-4.35'/></svg>") no-repeat 10px center;
+    background: var(--ds-surface) url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2'><circle cx='11' cy='11' r='8'/><path d='m21 21-4.35-4.35'/></svg>") no-repeat 10px center;
   }
 
   .toast-stack { position: fixed; bottom: 24px; right: 24px; z-index: 2000; display: flex; flex-direction: column; gap: 8px; pointer-events: none; }

--- a/app/web/templates/store_upload.html
+++ b/app/web/templates/store_upload.html
@@ -68,7 +68,7 @@
     width: 100%; padding: 10px 12px;
     border: 1px solid var(--border, #d1d5db); border-radius: 8px;
     font-size: 14px; font-family: var(--font-primary, inherit);
-    box-sizing: border-box; background: #fff;
+    box-sizing: border-box; background: var(--ds-surface);
     transition: border-color 0.15s ease, box-shadow 0.15s ease;
   }
   .field textarea { min-height: 90px; resize: vertical; }
@@ -86,7 +86,7 @@
     cursor: pointer; padding: 14px 12px;
     border: 1px solid var(--border, #e5e7eb); border-radius: 10px;
     text-align: center; transition: all 0.15s ease;
-    background: #fff;
+    background: var(--ds-surface);
   }
   .type-tiles label:hover { border-color: #c7d2fe; }
   .type-tiles label.is-active {
@@ -108,9 +108,9 @@
     display: flex; align-items: center; gap: 12px;
     transition: all 0.15s ease;
   }
-  .file-drop:hover { border-color: var(--ds-primary); background: #fff; }
+  .file-drop:hover { border-color: var(--ds-primary); background: var(--ds-surface); }
   .file-drop.is-dragover {
-    border-color: var(--ds-primary); background: #fff;
+    border-color: var(--ds-primary); background: var(--ds-surface);
     box-shadow: 0 0 0 4px rgba(46, 168, 119, 0.15);
     transform: scale(1.005);
   }
@@ -130,7 +130,7 @@
   .file-drop input[type=file] { display: none; }
   .file-drop button {
     appearance: none; padding: 7px 14px;
-    border: 1px solid var(--border, #d1d5db); background: #fff;
+    border: 1px solid var(--border, #d1d5db); background: var(--ds-surface);
     color: var(--text-primary, #111827); border-radius: 8px;
     font-size: 12px; font-weight: 500; cursor: pointer;
     flex-shrink: 0; font-family: var(--font-primary, inherit);


### PR DESCRIPTION
## Problem
In dark mode, many form controls and the panels behind them stayed **white** — search boxes, the store-upload form, the news editor, the package chip-input on admin/tables, and the whole marketplace page. Reported as "fix all the dark inputs on white pages."

## Root cause + fix (two parts)
**1. No `color-scheme` was ever set.** Browser-default inputs/selects/textareas (and scrollbars) render white unless the page declares `color-scheme: dark`. Added `color-scheme: light`/`dark` to the theme roots in `design-tokens.css` — this alone flips every *bare* control + scrollbars.

**2. Tokenized the hardcoded-white surfaces `color-scheme` can't override** (`#fff`/`white` → `var(--ds-surface)`/`var(--ds-border)`/`var(--ds-text-*)`):
| Surface | File |
|---|---|
| search / filter inputs | `admin_sync`, `admin_groups`, `admin_mcp_sources`, `admin_access.css` |
| form fields + type-tiles + drop-zone | `store_upload.html` |
| panels, textareas, preview, labels (page was fully hardcoded-light) | `admin/news_editor.html` |
| hero search-row | `stack_card.css` (catalog) |
| chip-input container + dropdown (JS inline styles) | `js/components/chip-input.js` |
| **light-locked palette** (`.mp-page` pinned `--surface`/`--text-primary`/`--text-secondary`/`--border-light` to fixed light values) + hero search-row | `marketplace.css` |

The marketplace one is the notable find — it wasn't a stray white, it was a *full light palette scoped to `.mp-page`* that overrode the theme. Flipping those four tokens to `var(--ds-*)` makes the whole page theme-aware.

## How it was found + verified
Empirical, not guesswork: ran the app in dark mode and crawled **~28 routes** with a DOM detector that flags any control whose own background — or nearest opaque ancestor — is light. That produced the exact fix list (10 surfaces); the other ~18 routes were already clean. After the fixes, **re-crawled every flagged page → 0 white issues.**

Visually confirmed in a real browser, **both themes**:
- **Marketplace** — dark: coherent dark page (search row, cards, callout, sort select all flip); light: unchanged.
- **News editor** — dark: panels + both textareas + preview pane flip; light: unchanged.

Light mode is unchanged everywhere (`--ds-surface` is `#ffffff` in light = the prior literal; marketplace token shifts are imperceptible).

## Scope notes
- Intentional light elements left alone: the `_profile_tokens` amber "new token" callout, `setup_advanced`/`home-mock` preview scopes, badge pills, toggle knobs.
- Complements the edit-group modal fix (#560). Part of the #497 §8/§9 audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)