### PR TITLE
feat(web): walking guide — interactive product tour across the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 ## [Unreleased]
 
 ### Added
+- **Walking guide (product tour).** A client-side spotlight tour that walks a signed-in user through the primary navigation (Home, Chat, Marketplace, Data Packages, Memory, profile menu). Auto-starts once on a user's first authed visit and can be reopened anytime from the profile menu → "Take a tour". Progress + "seen" state live in `localStorage` (no backend state); steps whose nav anchor is absent for the viewer (e.g. Chat without a grant) are skipped automatically. Styles read the `--ds-*` design tokens so the overlay flips with the blue/dark themes. New `app/web/static/css/tour.css`, `app/web/static/js/tour.js`, and `_tour.html` partial included by both base layouts.
 
 ### Changed
 

--- a/app/web/static/css/tour.css
+++ b/app/web/static/css/tour.css
@@ -1,0 +1,193 @@
+/* Walking guide / product tour — a client-side spotlight overlay that
+ * walks a user through the primary nav the first time they sign in (and
+ * on demand from the user menu → "Take a tour").
+ *
+ * Self-contained: every selector is `.agnes-tour*`-scoped so it cannot
+ * leak into page chrome, and all colours read the canonical `--ds-*`
+ * design tokens so the overlay flips with the blue/dark themes for free.
+ * No `:root {}`, no `.container:has()`, no `var(--primary)` — passes
+ * tests/test_design_system_contract.py.
+ *
+ * Layering: backdrop (click-trap) < spot (visual dimmer + ring) < pop
+ * (the card). The dimming is done with one giant box-shadow spread on
+ * `.agnes-tour__spot` so the highlighted element reads as a lit cut-out
+ * without needing four mask panels.
+ */
+
+.agnes-tour[hidden] {
+    display: none;
+}
+
+.agnes-tour {
+    position: fixed;
+    inset: 0;
+    z-index: 10000;
+    font-family: var(--ds-font);
+}
+
+/* Transparent full-screen click-trap so the page underneath can't be
+   interacted with mid-tour. Sits below the spot + pop. */
+.agnes-tour__backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 10000;
+    background: transparent;
+}
+
+/* The lit cut-out: positioned over the target element. The huge
+   box-shadow spread paints the dim everywhere EXCEPT this box, and the
+   ring + glow draw the eye. pointer-events:none so it never eats clicks
+   (the backdrop below handles those). */
+.agnes-tour__spot {
+    position: fixed;
+    z-index: 10001;
+    border-radius: 10px;
+    box-shadow:
+        0 0 0 9999px rgba(14, 21, 37, 0.62),
+        0 0 0 3px var(--ds-primary),
+        0 0 0 7px rgba(46, 168, 119, 0.28);
+    pointer-events: none;
+    transition: top .22s ease, left .22s ease, width .22s ease, height .22s ease;
+}
+
+/* When a step has no target (welcome / closing card) the spot is hidden
+   and the dim is supplied by the backdrop instead. */
+.agnes-tour__backdrop.is-dim {
+    background: rgba(14, 21, 37, 0.62);
+}
+
+/* The instruction card. */
+.agnes-tour__pop {
+    position: fixed;
+    z-index: 10002;
+    width: min(360px, calc(100vw - 32px));
+    background: var(--ds-surface);
+    color: var(--ds-text-primary);
+    border: 1px solid var(--ds-border);
+    border-radius: 14px;
+    box-shadow: var(--ds-shadow-lg);
+    padding: 20px;
+    transition: top .22s ease, left .22s ease;
+}
+
+/* Centered variant for target-less steps. */
+.agnes-tour__pop.is-centered {
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+}
+
+.agnes-tour__eyebrow {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+    color: var(--ds-primary);
+    margin: 0 0 6px;
+}
+
+.agnes-tour__title {
+    font-size: 18px;
+    font-weight: 700;
+    line-height: 1.25;
+    margin: 0 0 8px;
+    color: var(--ds-text-primary);
+}
+
+.agnes-tour__body {
+    font-size: 14px;
+    line-height: 1.55;
+    color: var(--ds-text-secondary);
+    margin: 0 0 18px;
+}
+
+.agnes-tour__foot {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.agnes-tour__dots {
+    display: flex;
+    gap: 6px;
+    flex: 1;
+}
+
+.agnes-tour__dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--ds-border);
+    transition: background .18s ease, transform .18s ease;
+}
+
+.agnes-tour__dot.is-on {
+    background: var(--ds-primary);
+    transform: scale(1.25);
+}
+
+.agnes-tour__btns {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.agnes-tour__btn {
+    font: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    border-radius: 8px;
+    padding: 7px 14px;
+    cursor: pointer;
+    border: 1px solid transparent;
+    transition: background .15s ease, border-color .15s ease, color .15s ease;
+}
+
+.agnes-tour__btn--ghost {
+    background: transparent;
+    color: var(--ds-text-muted);
+    padding: 7px 6px;
+}
+
+.agnes-tour__btn--ghost:hover {
+    color: var(--ds-text-primary);
+}
+
+.agnes-tour__btn--secondary {
+    background: var(--ds-surface);
+    border-color: var(--ds-border);
+    color: var(--ds-text-secondary);
+}
+
+.agnes-tour__btn--secondary:hover {
+    border-color: var(--ds-primary);
+    color: var(--ds-text-primary);
+}
+
+.agnes-tour__btn--primary {
+    background: var(--ds-primary);
+    color: var(--ds-text-inverse);
+}
+
+.agnes-tour__btn--primary:hover {
+    background: var(--ds-primary-dark);
+}
+
+.agnes-tour__btn:focus-visible {
+    outline: var(--ds-focus-outline);
+    outline-offset: var(--ds-focus-outline-offset);
+}
+
+.agnes-tour__btn[disabled] {
+    opacity: .45;
+    cursor: default;
+    pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .agnes-tour__spot,
+    .agnes-tour__pop,
+    .agnes-tour__dot {
+        transition: none;
+    }
+}

--- a/app/web/static/js/tour.js
+++ b/app/web/static/js/tour.js
@@ -1,0 +1,256 @@
+/* Walking guide / product tour engine.
+ *
+ * A small, dependency-free spotlight tour that walks a signed-in user
+ * through the primary navigation. The nav lives in `_app_header.html`
+ * and renders on every authed page, so the whole tour runs in place on
+ * whatever page the user happens to be on — no cross-page state machine,
+ * no backend persistence. Progress + "already seen" live in
+ * localStorage, mirroring the existing `agnes-admin-nav-*` pattern.
+ *
+ * Entry points:
+ *   • Auto: first authed visit (no `seen` flag) → starts after a beat.
+ *   • Manual: any element with [data-tour-start] (user menu item).
+ *
+ * Steps target [data-tour="<key>"] anchors in the header. Steps whose
+ * target is absent (e.g. Chat link hidden without a grant) are skipped
+ * automatically, so the same step list works for every user.
+ */
+(function () {
+    "use strict";
+
+    var SEEN_KEY = "agnes-tour-v1-seen";
+    var root = document.getElementById("agnesTour");
+    if (!root) return;
+
+    var instance = root.getAttribute("data-instance") || "Agnes";
+
+    // Step list. `target` is a [data-tour] key or null for a centered card.
+    var STEPS = [
+        {
+            target: null,
+            eyebrow: "Quick tour",
+            title: "Welcome to " + instance,
+            body: "Take 30 seconds to see how things are laid out. You can skip anytime and reopen this from your profile menu."
+        },
+        {
+            target: "nav-home",
+            eyebrow: "Step",
+            title: "Home",
+            body: "Your starting point — a dashboard of what's available to you and shortcuts to get going."
+        },
+        {
+            target: "nav-chat",
+            eyebrow: "Step",
+            title: "Chat",
+            body: "Ask questions about your data in natural language, right in the browser."
+        },
+        {
+            target: "nav-marketplace",
+            eyebrow: "Step",
+            title: "Marketplace",
+            body: "Discover skills and plugins that extend what your AI agent can do — install them into your workspace."
+        },
+        {
+            target: "nav-catalog",
+            eyebrow: "Step",
+            title: "Data Packages",
+            body: "Browse the datasets you have access to. Each package shows its tables, schema, and how to query it locally."
+        },
+        {
+            target: "nav-memory",
+            eyebrow: "Step",
+            title: "Memory",
+            body: "Shared organizational knowledge — canonical metric definitions and business rules your agent should follow."
+        },
+        {
+            target: "user-menu",
+            eyebrow: "Step",
+            title: "Your menu",
+            body: "Your profile, AI Cowork setup, recent activity, and sign-out all live here."
+        },
+        {
+            target: null,
+            eyebrow: "All set",
+            title: "You're ready to go",
+            body: "That's the lay of the land. Reopen this tour anytime from your profile menu → “Take a tour”."
+        }
+    ];
+
+    var els = {
+        backdrop: root.querySelector(".agnes-tour__backdrop"),
+        spot: root.querySelector(".agnes-tour__spot"),
+        pop: root.querySelector(".agnes-tour__pop"),
+        eyebrow: root.querySelector(".agnes-tour__eyebrow"),
+        title: root.querySelector(".agnes-tour__title"),
+        body: root.querySelector(".agnes-tour__body"),
+        dots: root.querySelector(".agnes-tour__dots"),
+        skip: root.querySelector('[data-act="skip"]'),
+        back: root.querySelector('[data-act="back"]'),
+        next: root.querySelector('[data-act="next"]')
+    };
+
+    var active = [];   // steps whose target resolves (or is null)
+    var idx = 0;
+
+    function resolve(step) {
+        if (!step.target) return null;
+        var el = document.querySelector('[data-tour="' + step.target + '"]');
+        // Treat off-screen / display:none anchors as absent.
+        if (el && el.offsetParent === null && el.getClientRects().length === 0) {
+            return false;
+        }
+        return el || false;
+    }
+
+    function buildActive() {
+        active = STEPS.filter(function (s) {
+            return s.target === null || resolve(s) !== false;
+        });
+    }
+
+    function renderDots() {
+        els.dots.innerHTML = "";
+        for (var i = 0; i < active.length; i++) {
+            var d = document.createElement("span");
+            d.className = "agnes-tour__dot" + (i === idx ? " is-on" : "");
+            els.dots.appendChild(d);
+        }
+    }
+
+    function placePop(rect) {
+        var pop = els.pop;
+        pop.classList.remove("is-centered");
+        // Measure after content is set.
+        var pw = pop.offsetWidth;
+        var ph = pop.offsetHeight;
+        var gap = 14;
+        var vw = window.innerWidth;
+        var vh = window.innerHeight;
+
+        var top, left;
+        // Prefer below the target; flip above if it would overflow.
+        if (rect.bottom + gap + ph <= vh) {
+            top = rect.bottom + gap;
+        } else if (rect.top - gap - ph >= 0) {
+            top = rect.top - gap - ph;
+        } else {
+            top = Math.max(gap, (vh - ph) / 2);
+        }
+        // Align left edge to target, clamped to viewport.
+        left = rect.left;
+        left = Math.min(left, vw - pw - gap);
+        left = Math.max(gap, left);
+
+        pop.style.top = top + "px";
+        pop.style.left = left + "px";
+    }
+
+    function render() {
+        var step = active[idx];
+        var el = step.target ? resolve(step) : null;
+
+        els.eyebrow.textContent = step.eyebrow || "";
+        els.title.textContent = step.title;
+        els.body.textContent = step.body;
+
+        els.back.disabled = idx === 0;
+        els.next.textContent = idx === active.length - 1 ? "Done" : "Next";
+
+        renderDots();
+
+        if (el && el.getBoundingClientRect) {
+            el.scrollIntoView({ block: "nearest", inline: "nearest" });
+            var r = el.getBoundingClientRect();
+            var pad = 6;
+            els.spot.hidden = false;
+            els.backdrop.classList.remove("is-dim");
+            els.spot.style.top = (r.top - pad) + "px";
+            els.spot.style.left = (r.left - pad) + "px";
+            els.spot.style.width = (r.width + pad * 2) + "px";
+            els.spot.style.height = (r.height + pad * 2) + "px";
+            placePop(r);
+        } else {
+            // Target-less step → dim via backdrop, center the card.
+            els.spot.hidden = true;
+            els.backdrop.classList.add("is-dim");
+            els.pop.classList.add("is-centered");
+            els.pop.style.top = "";
+            els.pop.style.left = "";
+        }
+    }
+
+    function reposition() {
+        if (root.hidden) return;
+        render();
+    }
+
+    function open() {
+        // Close any open header dropdowns so they don't overlap the spot.
+        Array.prototype.forEach.call(
+            document.querySelectorAll(".app-user-menu-panel, .app-nav-menu-panel"),
+            function (p) { p.hidden = true; }
+        );
+        Array.prototype.forEach.call(
+            document.querySelectorAll('[aria-haspopup="menu"]'),
+            function (t) { t.setAttribute("aria-expanded", "false"); }
+        );
+
+        buildActive();
+        if (!active.length) return;
+        idx = 0;
+        root.hidden = false;
+        render();
+        els.next.focus();
+        window.addEventListener("resize", reposition);
+        window.addEventListener("scroll", reposition, true);
+    }
+
+    function close() {
+        root.hidden = true;
+        window.removeEventListener("resize", reposition);
+        window.removeEventListener("scroll", reposition, true);
+        try { localStorage.setItem(SEEN_KEY, "1"); } catch (e) {}
+    }
+
+    function next() {
+        if (idx >= active.length - 1) { close(); return; }
+        idx++;
+        render();
+    }
+
+    function back() {
+        if (idx === 0) return;
+        idx--;
+        render();
+    }
+
+    els.next.addEventListener("click", next);
+    els.back.addEventListener("click", back);
+    els.skip.addEventListener("click", close);
+
+    document.addEventListener("keydown", function (e) {
+        if (root.hidden) return;
+        if (e.key === "Escape") { e.preventDefault(); close(); }
+        else if (e.key === "ArrowRight" || e.key === "Enter") { e.preventDefault(); next(); }
+        else if (e.key === "ArrowLeft") { e.preventDefault(); back(); }
+    });
+
+    // Manual launchers.
+    Array.prototype.forEach.call(
+        document.querySelectorAll("[data-tour-start]"),
+        function (btn) {
+            btn.addEventListener("click", function (e) {
+                e.preventDefault();
+                open();
+            });
+        }
+    );
+
+    // Auto-start on first authed visit.
+    var seen;
+    try { seen = localStorage.getItem(SEEN_KEY); } catch (e) { seen = "1"; }
+    if (!seen) {
+        // Let the header settle (fonts, dropdown wiring) before measuring.
+        setTimeout(open, 800);
+    }
+})();

--- a/app/web/static/style-custom.css
+++ b/app/web/static/style-custom.css
@@ -3484,6 +3484,12 @@ a.app-header-logo:focus-visible {
 }
 .app-user-menu-item:hover { background: var(--border-light, #f3f4f6); }
 .app-user-menu-item.is-active { background: var(--primary-light); color: var(--primary); font-weight: 500; }
+/* When the menu item is a <button> (e.g. "Take a tour"), reset native
+   chrome so it reads identically to the <a> items above it. */
+button.app-user-menu-item {
+    width: 100%; text-align: left; border: 0; background: none;
+    font-family: inherit; cursor: pointer;
+}
 
 /* ── Admin nav dropdown — same vocabulary as user menu, scoped under nav links ── */
 .app-nav-menu { position: relative; display: inline-flex; }

--- a/app/web/templates/_app_header.html
+++ b/app/web/templates/_app_header.html
@@ -21,7 +21,7 @@
            Setup local agent + My Stack used to live in the nav too;
            Setup is reached from /home's install flow and My Stack
            lives inside /marketplace as a tab. #}
-        <a class="app-nav-link {% if _path == _home or _path == '/' or _path == '/dashboard' or _path == '/home' %}is-active{% endif %}" href="{{ _home }}">Home</a>
+        <a class="app-nav-link {% if _path == _home or _path == '/' or _path == '/dashboard' or _path == '/home' %}is-active{% endif %}" href="{{ _home }}" data-tour="nav-home">Home</a>
         {# Cloud chat entry — shown only when chat is enabled AND one of the
            viewer's groups holds an explicit chat grant (``can_chat`` from
            _build_context, via has_explicit_grant). Default-deny: with no grant
@@ -29,17 +29,17 @@
            (god-mode on the route guard). Gated server-side, so this is just
            UX — no trap. #}
         {% if can_chat %}
-        <a class="app-nav-link {% if _path == '/chat' or _path.startswith('/chat/') %}is-active{% endif %}" href="/chat">Chat</a>
+        <a class="app-nav-link {% if _path == '/chat' or _path.startswith('/chat/') %}is-active{% endif %}" href="/chat" data-tour="nav-chat">Chat</a>
         {% endif %}
-        <a class="app-nav-link {% if _path == '/marketplace' or _path.startswith('/marketplace/') %}is-active{% endif %}" href="/marketplace">Marketplace</a>
-        <a class="app-nav-link {% if _path.startswith('/catalog') %}is-active{% endif %}" href="/catalog">Data Packages</a>
+        <a class="app-nav-link {% if _path == '/marketplace' or _path.startswith('/marketplace/') %}is-active{% endif %}" href="/marketplace" data-tour="nav-marketplace">Marketplace</a>
+        <a class="app-nav-link {% if _path.startswith('/catalog') %}is-active{% endif %}" href="/catalog" data-tour="nav-catalog">Data Packages</a>
         {# Curated Memory is the analyst-facing read surface for shared
            organizational knowledge — not admin-gated (the route runs on
            get_current_user, same as the /api/memory/* endpoints), so it
            sits in the primary nav next to Data Packages, visible to all
            authenticated users. The admin review queue is separate:
            /admin/corporate-memory, in the Admin dropdown below. #}
-        <a class="app-nav-link {% if _path == '/corporate-memory' %}is-active{% endif %}" href="/corporate-memory">Memory</a>
+        <a class="app-nav-link {% if _path == '/corporate-memory' %}is-active{% endif %}" href="/corporate-memory" data-tour="nav-memory">Memory</a>
 
         {# Admin menu: admin-only. Backend gates the routes via
            require_admin (see app/web/router.py for /admin/*, including
@@ -117,6 +117,7 @@
 
         <div class="app-user-menu" id="userMenu">
             <button type="button" class="app-user-menu-trigger" id="userMenuTrigger"
+                    data-tour="user-menu"
                     aria-haspopup="menu" aria-expanded="false" aria-controls="userMenuPanel">
                 {% if session.user.picture %}
                 <img src="{{ session.user.picture }}" alt="" class="app-avatar-img">
@@ -137,6 +138,8 @@
                 <a class="app-user-menu-item {% if _path == '/me/profile' %}is-active{% endif %}" role="menuitem" href="/me/profile">Profile</a>
                 <a class="app-user-menu-item {% if _path.startswith('/me/cowork') or _path.startswith('/me/mcp') %}is-active{% endif %}" role="menuitem" href="/me/cowork">AI Cowork</a>
                 <a class="app-user-menu-item {% if _path.startswith('/me/activity') %}is-active{% endif %}" role="menuitem" href="/me/activity">My activity</a>
+                {# Re-open the walking-guide tour. tour.js binds [data-tour-start]. #}
+                <button type="button" class="app-user-menu-item" role="menuitem" data-tour-start>Take a tour</button>
                 <a class="app-user-menu-item" role="menuitem" href="{{ url_for('auth.logout') }}">Logout</a>
             </div>
         </div>

--- a/app/web/templates/_tour.html
+++ b/app/web/templates/_tour.html
@@ -1,0 +1,30 @@
+{# Walking guide / product tour overlay.
+
+   Included once near the end of <body> by base.html and base_ds.html, so
+   it ships on every authed page. The markup is inert until tour.js
+   un-hides #agnesTour (auto on first visit, or via [data-tour-start] in
+   the user menu). Styles live in static/css/tour.css; the engine in
+   static/js/tour.js. Both bases also <link> tour.css in <head>.
+
+   Authed-only: the tour walks the primary nav, which only renders for
+   signed-in users (see _app_header.html `{% if session.user %}`). #}
+{% if session.user %}
+<div id="agnesTour" class="agnes-tour" data-instance="{{ config.INSTANCE_NAME or 'Agnes' }}" hidden>
+    <div class="agnes-tour__backdrop"></div>
+    <div class="agnes-tour__spot" hidden></div>
+    <div class="agnes-tour__pop" role="dialog" aria-modal="true" aria-labelledby="agnesTourTitle">
+        <p class="agnes-tour__eyebrow"></p>
+        <h3 class="agnes-tour__title" id="agnesTourTitle"></h3>
+        <p class="agnes-tour__body"></p>
+        <div class="agnes-tour__foot">
+            <span class="agnes-tour__dots" aria-hidden="true"></span>
+            <div class="agnes-tour__btns">
+                <button type="button" class="agnes-tour__btn agnes-tour__btn--ghost" data-act="skip">Skip</button>
+                <button type="button" class="agnes-tour__btn agnes-tour__btn--secondary" data-act="back">Back</button>
+                <button type="button" class="agnes-tour__btn agnes-tour__btn--primary" data-act="next">Next</button>
+            </div>
+        </div>
+    </div>
+</div>
+<script src="{{ static_url('js/tour.js') }}" defer></script>
+{% endif %}

--- a/app/web/templates/base.html
+++ b/app/web/templates/base.html
@@ -32,6 +32,9 @@
     {# Shared stack card styles — drives /catalog + /memory Browse/My Stack
        cards (matches marketplace.html .mp-card visual language). #}
     <link rel="stylesheet" href="{{ static_url('css/stack_card.css') }}">
+    {# Walking-guide / product-tour overlay styles (inert until tour.js
+       un-hides the overlay). Markup + engine in _tour.html. #}
+    <link rel="stylesheet" href="{{ static_url('css/tour.css') }}">
     {# app.js loaded by _app_header.html itself so pages that include
        the header directly without extending base.html (e.g. admin_tables)
        still get the nav-dropdown wiring. #}
@@ -82,6 +85,8 @@
        other admin/user page (#L85). #}
     {% block extra_scripts %}{% endblock %}
     {% include "_app_scripts.html" %}
+    {# Walking-guide / product-tour overlay (authed-only; self-guarded). #}
+    {% include "_tour.html" %}
     {% block scripts %}{% endblock %}
     {# Operator-injected scripts (placement=body_end) — for vendors that
        explicitly want bottom placement. Admin-only, see

--- a/app/web/templates/base_ds.html
+++ b/app/web/templates/base_ds.html
@@ -61,6 +61,9 @@
     <link rel="stylesheet" href="{{ static_url('css/design-tokens.css') }}">
     <link rel="stylesheet" href="{{ static_url('css/components.css') }}">
     <link rel="stylesheet" href="{{ static_url('css/stack_card.css') }}">
+    {# Walking-guide / product-tour overlay styles (inert until tour.js
+       un-hides the overlay). Markup + engine in _tour.html. #}
+    <link rel="stylesheet" href="{{ static_url('css/tour.css') }}">
 
     {% block head_extra %}{% endblock %}
     {% include '_theme.html' ignore missing %}
@@ -130,6 +133,8 @@
        pages migrated from base.html → base_ds.html keep parity with
        zero behaviour drift. #}
     {% include "_app_scripts.html" %}
+    {# Walking-guide / product-tour overlay (authed-only; self-guarded). #}
+    {% include "_tour.html" %}
     {% block scripts %}{% endblock %}
     {# Operator-injected scripts (placement=body_end) — for vendors that
        explicitly want bottom placement. Admin-only, see

--- a/tests/test_home_route_resolution.py
+++ b/tests/test_home_route_resolution.py
@@ -8,6 +8,7 @@ default rather than producing an external-host redirect.
 
 from __future__ import annotations
 
+import re
 import tempfile
 import uuid
 
@@ -325,8 +326,10 @@ def test_navbar_home_link_uses_home_route(fresh_db, monkeypatch):
     resp = c.get("/home", cookies={"access_token": sess})
     assert resp.status_code == 200
     # Navbar link href reflects the resolved home_route, not hard-coded /dashboard.
-    # Label is "Home" (was "Dashboard" before the nav reorg).
-    assert 'href="/home">Home' in resp.text
+    # Label is "Home" (was "Dashboard" before the nav reorg). The link may
+    # carry extra attributes between href and the label (e.g. data-tour) —
+    # match href + label without assuming attribute adjacency.
+    assert re.search(r'href="/home"[^>]*>Home', resp.text)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_web_tour.py
+++ b/tests/test_web_tour.py
@@ -1,0 +1,44 @@
+"""Walking guide / product tour overlay.
+
+The tour ships on every authed page via `_tour.html` (included by both base
+layouts). It walks the primary nav, so its markup + assets must render for
+signed-in users and stay out of the way otherwise. The engine is
+client-side; these tests guard the server-rendered scaffolding the engine
+binds to.
+"""
+
+from __future__ import annotations
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_tour_overlay_renders_on_authed_page(seeded_app):
+    """An authed page carries the tour overlay root, the CSS, and the JS."""
+    c = seeded_app["client"]
+    body = c.get("/dashboard", headers=_auth(seeded_app["analyst_token"])).text
+
+    assert 'id="agnesTour"' in body
+    assert "css/tour.css" in body
+    assert "js/tour.js" in body
+
+
+def test_tour_anchors_present_on_nav(seeded_app):
+    """The nav exposes the data-tour anchors the engine spotlights, plus the
+    manual "Take a tour" launcher in the user menu."""
+    c = seeded_app["client"]
+    body = c.get("/dashboard", headers=_auth(seeded_app["analyst_token"])).text
+
+    for key in ("nav-home", "nav-marketplace", "nav-catalog", "nav-memory", "user-menu"):
+        assert f'data-tour="{key}"' in body, f"missing data-tour anchor: {key}"
+    assert "data-tour-start" in body
+    assert ">Take a tour<" in body
+
+
+def test_tour_not_rendered_when_unauthenticated(seeded_app):
+    """No session → no tour. The overlay is guarded by `session.user`, so an
+    anonymous request (which redirects to login) never ships the overlay."""
+    c = seeded_app["client"]
+    resp = c.get("/login")
+    assert "id=\"agnesTour\"" not in resp.text


### PR DESCRIPTION
## What

Adds an **interactive, client-side product tour** ("walking guide") that walks a signed-in user through the primary navigation — Home, Chat, Marketplace, Data Packages, Memory, and the profile menu.

- **Auto-starts once** on a user's first authed visit (after the header settles).
- **Reopenable anytime** from the profile menu → **"Take a tour"**.
- **No backend state** — progress + a `seen` flag live in `localStorage` (mirrors the existing `agnes-admin-nav-*` pattern).
- **Role-aware** — steps whose nav anchor is absent for the viewer (e.g. Chat without a `can_chat` grant) are skipped automatically, so one step list serves every user.

## How it works

The nav lives in `_app_header.html` and renders on every authed page, so the whole tour runs in place on whatever page the user is on — no cross-page state machine. Steps target `[data-tour="<key>"]` anchors; the engine spotlights each (one `box-shadow` "hole"), positions an instruction card, and supports keyboard nav (Esc / ←/→/Enter).

## Files

- **New** `app/web/static/css/tour.css` — overlay styles, scoped `.agnes-tour*`, `--ds-*` tokens (flips with blue/dark themes), respects `prefers-reduced-motion`.
- **New** `app/web/static/js/tour.js` — dependency-free engine.
- **New** `app/web/templates/_tour.html` — authed-only partial; included by `base.html` + `base_ds.html` (both also `<link>` tour.css).
- `app/web/templates/_app_header.html` — `data-tour` anchors on nav links + "Take a tour" launcher in the user menu.
- `app/web/static/style-custom.css` — reset native chrome on `<button>.app-user-menu-item` so the launcher matches the `<a>` menu items.

## Design-system compliance

Passes `tests/test_design_system_contract.py` (16 ✓): scoped classes, `--ds-*` tokens only, no `:root{}` / `.container:has()` / `var(--primary)`, CSS in a dedicated sheet (no inline `<style>`).

## Tests

- **New** `tests/test_web_tour.py` — render scaffolding on an authed page, `data-tour` anchors + launcher present, no overlay when unauthenticated.
- Relaxed `test_navbar_home_link_uses_home_route` to not assume `href`/label adjacency (the Home link now carries a `data-tour` attribute).

## Verified locally

Built + ran the image (`docker compose -f docker-compose.yml -f docker-compose.local-dev.yml up -d --build app`); `/dashboard` renders the overlay root, both assets (200), all anchors, and the launcher.

## Pre-existing unrelated test failures

The full suite has some failures **unrelated to this diff** (this PR touches only web templates/static + one test):
- CLI JSON tests (`test_cli_*`) → `json.decoder.JSONDecodeError` — the CLI emits a non-JSON line before its output in this environment.
- `test_chat_e2b_*` → `ModuleNotFoundError: No module named 'e2b'` — optional dependency not installed in the local venv.

## Follow-ups (out of scope)

- Cross-page tour (a step that navigates to another page and continues there).
- Admin-specific tour through the Admin dropdown.
