### PR TITLE
fix(web): no-store on server-rendered HTML so a stale setup page can't 404 the install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 ### Changed
 
 ### Fixed
+- **Setup page no longer serves a stale install script after a redeploy.** Server-rendered HTML responses now carry `Cache-Control: no-store`, so browsers re-render `/home`, `/setup`, and `/install` against the live build on every load. Previously the page had no cache directive: a browser-cached setup hero kept handing out the wheel filename baked in at its original render time, and after a redeploy that version-pinned `/cli/wheel/{name}` URL 404s (the new build replaced the wheel on disk), breaking a fresh install end-to-end. Scoped to `text/html` — JSON APIs and the immutable-cached static / marketplace-image assets are untouched.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,15 @@ CalVer image tags (`stable-YYYY.MM.N`, `dev-YYYY.MM.N`) are produced for every C
 ### Changed
 
 ### Fixed
-- **Setup page no longer serves a stale install script after a redeploy.** Server-rendered HTML responses now carry `Cache-Control: no-store`, so browsers re-render `/home`, `/setup`, and `/install` against the live build on every load. Previously the page had no cache directive: a browser-cached setup hero kept handing out the wheel filename baked in at its original render time, and after a redeploy that version-pinned `/cli/wheel/{name}` URL 404s (the new build replaced the wheel on disk), breaking a fresh install end-to-end. Scoped to `text/html` — JSON APIs and the immutable-cached static / marketplace-image assets are untouched.
 
 ### Removed
 
 ### Internal
+
+## [0.68.1] — 2026-06-06
+
+### Fixed
+- **Setup page no longer serves a stale install script after a redeploy.** Server-rendered HTML responses now carry `Cache-Control: no-store`, so browsers re-render `/home`, `/setup`, and `/install` against the live build on every load. Previously the page had no cache directive: a browser-cached setup hero kept handing out the wheel filename baked in at its original render time, and after a redeploy that version-pinned `/cli/wheel/{name}` URL 404s (the new build replaced the wheel on disk), breaking a fresh install end-to-end. Scoped to `text/html` — JSON APIs and the immutable-cached static / marketplace-image assets are untouched. (#569)
 
 ## [0.68.0] — 2026-06-05
 

--- a/app/main.py
+++ b/app/main.py
@@ -887,6 +887,20 @@ def create_app() -> FastAPI:
         if request.url.path.startswith("/api/"):
             response.headers["X-Agnes-Latest-Version"] = APP_VERSION
             response.headers["X-Agnes-Min-Version"] = MIN_COMPAT_CLI_VERSION
+        # Server-rendered HTML must not be heuristically cached by the browser.
+        # The setup hero (/home, /setup, /install) bakes build-pinned values
+        # into the markup at render time — most importantly the current wheel
+        # filename, served from the version-pinned `/cli/wheel/{name}` endpoint
+        # that 404s for any name but the wheel currently on disk. Without an
+        # explicit directive a browser reuses the cached document, so after a
+        # redeploy a user is handed a stale page whose baked wheel URL now 404s
+        # (the new build replaced the wheel). `no-store` forces a fresh render
+        # on every load. Scoped to text/html so JSON APIs and the
+        # immutable-cached static / marketplace-image assets are untouched; an
+        # explicit Cache-Control set by a route still wins.
+        ctype = response.headers.get("content-type", "")
+        if ctype.startswith("text/html") and "cache-control" not in response.headers:
+            response.headers["Cache-Control"] = "no-store"
         return response
 
     # FastAPI debug toolbar — only when DEBUG=1 in env. Injects per-request

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnes-the-ai-analyst"
-version = "0.68.0"
+version = "0.68.1"
 description = "Agnes — AI Data Analyst platform for AI analytical systems"
 requires-python = ">=3.11,<3.14"
 license = "MIT"

--- a/tests/test_html_cache_control.py
+++ b/tests/test_html_cache_control.py
@@ -1,0 +1,33 @@
+"""Server-rendered HTML must carry `Cache-Control: no-store`.
+
+Regression guard for the stale-`/home` install bug: the setup hero bakes the
+current wheel filename into the markup at render time, and that filename is
+served from the version-pinned `/cli/wheel/{name}` endpoint which 404s for any
+name but the wheel currently on disk. If the browser heuristically caches the
+HTML, a redeploy (new wheel on disk) leaves the user with a stale page whose
+baked wheel URL now 404s. The middleware sets `no-store` on text/html so every
+load re-renders against the live build.
+"""
+
+from fastapi.testclient import TestClient
+
+
+def test_html_page_carries_no_store():
+    from app.main import app
+    client = TestClient(app)
+    # /login is an unauthenticated HTML page (renders the provider form).
+    resp = client.get("/login")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/html")
+    assert resp.headers.get("cache-control") == "no-store"
+
+
+def test_json_api_is_not_marked_no_store():
+    from app.main import app
+    client = TestClient(app)
+    # /api/version is JSON (application/json) — the no-store rule is text/html
+    # only, so it must not pick up the directive.
+    resp = client.get("/api/version")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("application/json")
+    assert resp.headers.get("cache-control") != "no-store"


### PR DESCRIPTION
## Problem

A fresh install from the setup page (`/home#install-hero`) breaks end-to-end after a redeploy. Reported from a live instance: the page handed out an install script pinned to an old wheel version whose `/cli/wheel/<name>.whl` URL 404s, because the new build replaced the wheel on disk.

Root cause (verified against `main`): server-rendered HTML carries **no cache directive**, so browsers heuristically cache the document. The setup hero bakes the current wheel filename into the markup at render time (`app/web/router.py` → `_find_wheel()`), served from the version-pinned `/cli/wheel/{name}` endpoint that 404s for any name but the wheel currently on disk (`app/api/cli_artifacts.py`). A browser-cached page keeps handing out the stale filename; after a redeploy that URL 404s and the install dies at step 1.

## Fix

Set `Cache-Control: no-store` on `text/html` responses in the existing version-headers middleware, so `/home`, `/setup`, and `/install` re-render against the live build on every load — the baked wheel filename is always current.

Scoped to `text/html`:
- JSON APIs (`application/json`) are untouched.
- Immutable-cached static / marketplace-image assets (their own `Cache-Control: public, max-age=…, immutable`) are untouched.
- An explicit `Cache-Control` set by a route still wins (guard checks for an existing header).

## Out of scope (defense-in-depth, intentionally skipped)

A version-agnostic wheel URL (e.g. `/cli/wheel/latest`). With `no-store` the baked filename is always fresh, and the only proxy in front (Caddy) does not cache, so this is redundant here. It's also non-trivial — `uv tool install <url>` validates the PEP 427 filename in the URL path, so a stable alias needs a redirect that uv honours. Happy to add as a follow-up if we want belt-and-suspenders against caches we don't control.

## Tests

`tests/test_html_cache_control.py` — asserts an HTML page (`/login`) carries `no-store` and a JSON endpoint (`/api/version`) does not.

> Note: TestClient tests that import `app.main` can't run on the Windows dev box (`import fcntl` in `src/db_state_machine.py` is Unix-only — the pre-existing `test_version_headers_middleware.py` fails identically). CI (Linux) exercises it.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/agnes-the-ai-analyst/pull/569" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->